### PR TITLE
Add global Spring json date format as array

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ configurations {
   smokeTestRuntimeOnly.extendsFrom runtimeOnly
 }
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
   options.compilerArgs << "-Xlint:unchecked" << "-Werror"
 }
 
@@ -59,7 +59,7 @@ tasks.withType(JavaExec).configureEach {
   javaLauncher.set(javaToolchains.launcherFor(java.toolchain))
 }
 
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
   useJUnitPlatform()
 
   testLogging {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,6 +20,9 @@ spring:
     import: "optional:configtree:/mnt/secrets/opal/"
   application:
     name: Opal Fines Service
+  jackson:
+    serialization:
+      write_dates_as_timestamps: true
   security:
     oauth2:
       client:


### PR DESCRIPTION
Dates sent to the Front End are formatted as arrays, as detailed in https://tools.hmcts.net/confluence/pages/viewpage.action?spaceKey=PO&title=Data+Formats 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[*] Possibly
[ ] No
```
