### PR TITLE
Make repository search code more generic

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/controllers/DefendantAccountController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/DefendantAccountController.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.opal.dto.AccountSearchDto;
 import uk.gov.hmcts.opal.dto.AccountSearchResultsDto;
 import uk.gov.hmcts.opal.dto.AddNoteDto;
 import uk.gov.hmcts.opal.dto.NoteDto;
+import uk.gov.hmcts.opal.dto.NotesSearchDto;
 import uk.gov.hmcts.opal.entity.DefendantAccountEntity;
 import uk.gov.hmcts.opal.service.DefendantAccountServiceInterface;
 import uk.gov.hmcts.opal.service.NoteServiceInterface;
@@ -146,5 +147,25 @@ public class DefendantAccountController {
         }
 
         return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @GetMapping(value = "/notes/{defendantId}")
+    @Operation(summary = "Returns all notes for an associated defendant account id.")
+    public ResponseEntity<List<NoteDto>> getNotesForDefendantAccount(@PathVariable String defendantId) {
+
+        log.info(":GET:getNotesForDefendantAccount: defendant account id: {}", defendantId);
+
+        NotesSearchDto criteria = NotesSearchDto.builder()
+            .associatedType(NOTE_ASSOC_REC_TYPE)
+            .associatedId(defendantId)
+            .build();
+
+        List<NoteDto> response = noteService.searchNotes(criteria);
+
+        if (response == null) {
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/controllers/NoteController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/NoteController.java
@@ -2,20 +2,27 @@ package uk.gov.hmcts.opal.controllers;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.opal.dto.NoteDto;
+import uk.gov.hmcts.opal.dto.NotesSearchDto;
 import uk.gov.hmcts.opal.service.NoteServiceInterface;
+
+import java.util.List;
 
 
 @RestController
 @RequestMapping("/api/notes")
+@Slf4j(topic = "NoteController")
 @Tag(name = "Notes Controller")
 public class NoteController {
 
@@ -30,6 +37,44 @@ public class NoteController {
     public ResponseEntity<NoteDto> createNote(@RequestBody NoteDto noteDto) {
         NoteDto savedNoteDto = noteService.saveNote(noteDto);
         return new ResponseEntity<>(savedNoteDto, HttpStatus.CREATED);
+    }
+
+    @GetMapping(value = "/{associatedType}/{associatedId}")
+    @Operation(summary = "Returns all notes for an associated type & id.")
+    public ResponseEntity<List<NoteDto>> getNotesByAssociatedRecord(
+        @PathVariable String associatedType, @PathVariable String associatedId) {
+
+        log.info(":GET:getNotesByAssociatedRecord: associated record type: '{}'; id: {}", associatedType, associatedId);
+
+        NotesSearchDto criteria = NotesSearchDto.builder()
+            .associatedType(associatedType)
+            .associatedId(associatedId)
+            .build();
+
+        List<NoteDto> response = noteService
+            .searchNotes(criteria);
+
+        if (response == null) {
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping(value = "/search", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "Searches notes based upon criteria in request body")
+    public ResponseEntity<List<NoteDto>> postNotesSearch(
+        @RequestBody NotesSearchDto criteria) {
+        log.info(":POST:postNotesSearch: query: \n{}", criteria.toPrettyJson());
+
+        List<NoteDto> response = noteService
+            .searchNotes(criteria);
+
+        if (response == null) {
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.ok(response);
     }
 
 

--- a/src/main/java/uk/gov/hmcts/opal/dto/NotesSearchDto.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/NotesSearchDto.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.opal.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class NotesSearchDto implements ToJsonString {
+    private String associatedType;
+    private String associatedId;
+    private String noteType;
+    private String postedBy;
+    private DateDto postedDate;  // This is currently a placeholder, and does not work ATM.
+}

--- a/src/main/java/uk/gov/hmcts/opal/repository/NoteRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/NoteRepository.java
@@ -1,13 +1,14 @@
 package uk.gov.hmcts.opal.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.opal.entity.NoteEntity;
 
 import java.util.List;
 
 @Repository
-public interface NoteRepository extends JpaRepository<NoteEntity, Long> {
+public interface NoteRepository extends JpaRepository<NoteEntity, Long>, JpaSpecificationExecutor<NoteEntity> {
 
     List<NoteEntity> findByAssociatedRecordIdAndNoteType(String associatedRecordId, String noteType);
 

--- a/src/main/java/uk/gov/hmcts/opal/repository/jpa/DefendantAccountSpecs.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/jpa/DefendantAccountSpecs.java
@@ -6,7 +6,6 @@ import jakarta.persistence.criteria.ListJoin;
 import jakarta.persistence.criteria.Root;
 import org.springframework.data.jpa.domain.Specification;
 import uk.gov.hmcts.opal.dto.AccountSearchDto;
-import uk.gov.hmcts.opal.dto.DateDto;
 import uk.gov.hmcts.opal.entity.CourtsEntity;
 import uk.gov.hmcts.opal.entity.CourtsEntity_;
 import uk.gov.hmcts.opal.entity.DefendantAccountEntity;
@@ -17,14 +16,12 @@ import uk.gov.hmcts.opal.entity.PartyEntity;
 import uk.gov.hmcts.opal.entity.PartyEntity_;
 
 import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
-public class DefendantAccountSpecs {
+public class DefendantAccountSpecs extends EntitySpecs<DefendantAccountEntity> {
 
-    public static Specification<DefendantAccountEntity> findByAccountSearch(AccountSearchDto accountSearchDto) {
+    public static final String DEFENDANT_ASSOC_TYPE = "Defendant";
+
+    public Specification<DefendantAccountEntity> findByAccountSearch(AccountSearchDto accountSearchDto) {
         return Specification.allOf(specificationList(
             notBlank(accountSearchDto.getSurname()).map(DefendantAccountSpecs::likeSurname),
             notBlank(accountSearchDto.getForename()).map(DefendantAccountSpecs::likeForename),
@@ -34,23 +31,6 @@ public class DefendantAccountSpecs {
             notNullLocalDate(accountSearchDto.getDateOfBirth()).map(DefendantAccountSpecs::equalsDateOfBirth),
             accountSearchDto.getNumericCourt().map(DefendantAccountSpecs::equalsAnyCourtId)
         ));
-    }
-
-    @SafeVarargs
-    public static List<Specification<DefendantAccountEntity>> specificationList(
-        Optional<Specification<DefendantAccountEntity>>... optionalSpecs) {
-        return Arrays.stream(optionalSpecs)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .collect(Collectors.toList());
-    }
-
-    public static Optional<String> notBlank(String candidate) {
-        return Optional.ofNullable(candidate).filter(s -> !s.isBlank());
-    }
-
-    public static Optional<LocalDate> notNullLocalDate(DateDto candidate) {
-        return Optional.ofNullable(candidate).map(DateDto::toLocalDate);
     }
 
     public static Specification<DefendantAccountEntity> equalsAccountNumber(String accountNo) {
@@ -86,49 +66,49 @@ public class DefendantAccountSpecs {
 
     public static Specification<DefendantAccountEntity> likeSurname(String surname) {
         return (root, query, builder) -> {
-            return builder.like(builder.lower(joinPartyOnAssociationType(root, builder, "Defendant")
+            return builder.like(builder.lower(joinPartyOnAssociationType(root, builder, DEFENDANT_ASSOC_TYPE)
                           .get(PartyEntity_.surname)), "%" + surname.toLowerCase() + "%");
         };
     }
 
     public static Specification<DefendantAccountEntity> likeForename(String forename) {
         return (root, query, builder) -> {
-            return builder.like(builder.lower(joinPartyOnAssociationType(root, builder, "Defendant")
+            return builder.like(builder.lower(joinPartyOnAssociationType(root, builder, DEFENDANT_ASSOC_TYPE)
                           .get(PartyEntity_.forenames)), "%" + forename.toLowerCase() + "%");
         };
     }
 
     public static Specification<DefendantAccountEntity> likeOrganisationName(String organisation) {
         return (root, query, builder) -> {
-            return builder.like(builder.lower(joinPartyOnAssociationType(root, builder, "Defendant")
+            return builder.like(builder.lower(joinPartyOnAssociationType(root, builder, DEFENDANT_ASSOC_TYPE)
                           .get(PartyEntity_.organisationName)), "%" + organisation.toLowerCase() + "%");
         };
     }
 
     public static Specification<DefendantAccountEntity> equalsDateOfBirth(LocalDate dob) {
         return (root, query, builder) -> {
-            return builder.equal(joinPartyOnAssociationType(root, builder, "Defendant")
+            return builder.equal(joinPartyOnAssociationType(root, builder, DEFENDANT_ASSOC_TYPE)
                           .get(PartyEntity_.dateOfBirth), dob);
         };
     }
 
     public static Specification<DefendantAccountEntity> likeNiNumber(String niNumber) {
         return (root, query, builder) -> {
-            return builder.like(builder.lower(joinPartyOnAssociationType(root, builder, "Defendant")
+            return builder.like(builder.lower(joinPartyOnAssociationType(root, builder, DEFENDANT_ASSOC_TYPE)
                           .get(PartyEntity_.niNumber)), "%" + niNumber.toLowerCase() + "%");
         };
     }
 
     public static Specification<DefendantAccountEntity> likeAddressLine1(String addressLine) {
         return (root, query, builder) -> {
-            return builder.like(builder.lower(joinPartyOnAssociationType(root, builder, "Defendant")
+            return builder.like(builder.lower(joinPartyOnAssociationType(root, builder, DEFENDANT_ASSOC_TYPE)
                           .get(PartyEntity_.addressLine1)), "%" + addressLine.toLowerCase() + "%");
         };
     }
 
     public static Specification<DefendantAccountEntity> likeInitials(String initials) {
         return (root, query, builder) -> {
-            return builder.like(builder.lower(joinPartyOnAssociationType(root, builder, "Defendant")
+            return builder.like(builder.lower(joinPartyOnAssociationType(root, builder, DEFENDANT_ASSOC_TYPE)
                           .get(PartyEntity_.initials)), "%" + initials.toLowerCase() + "%");
         };
     }
@@ -142,8 +122,8 @@ public class DefendantAccountSpecs {
     }
 
     public static Join<DefendantAccountPartiesEntity, PartyEntity> joinPartyOnAssociationType(
-        Root<DefendantAccountEntity> root, CriteriaBuilder builder, String type) {
-        return onAssociationType(builder, root.join(DefendantAccountEntity_.parties), type)
+        Root<DefendantAccountEntity> root, CriteriaBuilder builder, String assocType) {
+        return onAssociationType(builder, root.join(DefendantAccountEntity_.parties), assocType)
             .join(DefendantAccountPartiesEntity_.party);
     }
 
@@ -151,7 +131,7 @@ public class DefendantAccountSpecs {
     public static ListJoin<DefendantAccountEntity, DefendantAccountPartiesEntity> onAssociationType(
         CriteriaBuilder builder,
         ListJoin<DefendantAccountEntity, DefendantAccountPartiesEntity> parties,
-        String type) {
-        return parties.on(builder.equal(parties.get(DefendantAccountPartiesEntity_.associationType), type));
+        String assocType) {
+        return parties.on(builder.equal(parties.get(DefendantAccountPartiesEntity_.associationType), assocType));
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/repository/jpa/EntitySpecs.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/jpa/EntitySpecs.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.opal.repository.jpa;
+
+import org.springframework.data.jpa.domain.Specification;
+import uk.gov.hmcts.opal.dto.DateDto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public abstract class EntitySpecs<E> {
+
+    @SafeVarargs
+    public final List<Specification<E>> specificationList(
+        Optional<Specification<E>>... optionalSpecs) {
+        return Arrays.stream(optionalSpecs)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(Collectors.toList());
+    }
+
+    public Optional<String> notBlank(String candidate) {
+        return Optional.ofNullable(candidate).filter(s -> !s.isBlank());
+    }
+
+    public Optional<LocalDate> notNullLocalDate(DateDto candidate) {
+        return Optional.ofNullable(candidate).map(DateDto::toLocalDate);
+    }
+
+    public Optional<LocalDateTime> notNullLocalDateTime(DateDto candidate) {
+        return Optional.ofNullable(candidate).map(DateDto::toLocalDate).map(d -> d.atTime(0, 0, 0));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/repository/jpa/NoteSpecs.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/jpa/NoteSpecs.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.opal.repository.jpa;
+
+import org.springframework.data.jpa.domain.Specification;
+import uk.gov.hmcts.opal.dto.NotesSearchDto;
+import uk.gov.hmcts.opal.entity.NoteEntity;
+import uk.gov.hmcts.opal.entity.NoteEntity_;
+
+import java.time.LocalDateTime;
+
+public class NoteSpecs extends EntitySpecs<NoteEntity> {
+
+    public Specification<NoteEntity> findBySearchCriteria(NotesSearchDto criteria) {
+        return Specification.allOf(specificationList(
+            notBlank(criteria.getAssociatedType()).map(NoteSpecs::equalsAssociatedType),
+            notBlank(criteria.getAssociatedId()).map(NoteSpecs::equalsAssociatedId),
+            notBlank(criteria.getNoteType()).map(NoteSpecs::equalsNoteType),
+            notBlank(criteria.getPostedBy()).map(NoteSpecs::equalsPostedBy),
+            notNullLocalDateTime(criteria.getPostedDate()).map(NoteSpecs::equalsPostedDate)
+        ));
+    }
+
+    public static Specification<NoteEntity> equalsAssociatedType(String associatedType) {
+        return (root, query, builder) -> {
+            return builder.equal(builder.lower(root.get(NoteEntity_.associatedRecordType)),
+                                 associatedType.toLowerCase());
+        };
+    }
+
+    public static Specification<NoteEntity> equalsAssociatedId(String associatedId) {
+        return (root, query, builder) -> {
+            return builder.equal(root.get(NoteEntity_.associatedRecordId), associatedId);
+        };
+    }
+
+    public static Specification<NoteEntity> equalsNoteType(String noteType) {
+        return (root, query, builder) -> {
+            return builder.equal(builder.lower(root.get(NoteEntity_.noteType)),
+                                 noteType.toLowerCase());
+        };
+    }
+
+    public static Specification<NoteEntity> equalsPostedBy(String postedBy) {
+        return (root, query, builder) -> {
+            return builder.equal(builder.lower(root.get(NoteEntity_.postedBy)),
+                                 postedBy.toLowerCase());
+        };
+    }
+
+    public static Specification<NoteEntity> equalsPostedDate(LocalDateTime posted) {
+        return (root, query, builder) -> {
+            return builder.equal(root.get(NoteEntity_.postedDate), posted);
+        };
+    }
+
+
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/NoteServiceInterface.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/NoteServiceInterface.java
@@ -1,7 +1,12 @@
 package uk.gov.hmcts.opal.service;
 
 import uk.gov.hmcts.opal.dto.NoteDto;
+import uk.gov.hmcts.opal.dto.NotesSearchDto;
+
+import java.util.List;
 
 public interface NoteServiceInterface {
     NoteDto saveNote(NoteDto noteDto);
+
+    List<NoteDto> searchNotes(NotesSearchDto searchCriteria);
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNoteService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNoteService.java
@@ -6,9 +6,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 import uk.gov.hmcts.opal.dto.NoteDto;
+import uk.gov.hmcts.opal.dto.NotesSearchDto;
 import uk.gov.hmcts.opal.dto.legacy.LegacySaveNoteRequestDto;
 import uk.gov.hmcts.opal.dto.legacy.LegacySaveNoteResponseDto;
 import uk.gov.hmcts.opal.service.NoteServiceInterface;
+
+import java.util.List;
 
 @Service
 @Slf4j(topic = "LegacyNoteService")
@@ -32,6 +35,11 @@ public class LegacyNoteService extends LegacyService implements NoteServiceInter
         return postToGateway(POST_ACCOUNT_NOTES,
                     LegacySaveNoteResponseDto.class, LegacySaveNoteRequestDto.fromNoteDto(noteDto))
             .createClonedAndUpdatedDto(noteDto);
+    }
+
+    @Override
+    public List<NoteDto> searchNotes(NotesSearchDto searchCriteria) {
+        throw new LegacyGatewayResponseException("Not Yet Implemented");
     }
 
 

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/DefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/DefendantAccountService.java
@@ -60,6 +60,8 @@ public class DefendantAccountService implements DefendantAccountServiceInterface
 
     private final NoteRepository noteRepository;
 
+    private final DefendantAccountSpecs specs = new DefendantAccountSpecs();
+
     @Override
     public DefendantAccountEntity getDefendantAccount(AccountEnquiryDto request) {
 
@@ -99,7 +101,7 @@ public class DefendantAccountService implements DefendantAccountServiceInterface
         }
 
         Page<DefendantAccountSummary> summariesPage = defendantAccountRepository
-            .findBy(DefendantAccountSpecs.findByAccountSearch(accountSearchDto),
+            .findBy(specs.findByAccountSearch(accountSearchDto),
                     ffq -> ffq.as(DefendantAccountSummary.class).page(Pageable.unpaged()));
 
         List<AccountSummaryDto> dtos = summariesPage.getContent().stream()

--- a/src/main/java/uk/gov/hmcts/opal/service/proxy/NoteServiceProxy.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/proxy/NoteServiceProxy.java
@@ -4,10 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.opal.dto.NoteDto;
+import uk.gov.hmcts.opal.dto.NotesSearchDto;
 import uk.gov.hmcts.opal.service.DynamicConfigService;
 import uk.gov.hmcts.opal.service.NoteServiceInterface;
 import uk.gov.hmcts.opal.service.legacy.LegacyNoteService;
 import uk.gov.hmcts.opal.service.opal.NoteService;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -25,5 +28,10 @@ public class NoteServiceProxy implements NoteServiceInterface, ProxyInterface {
     @Override
     public NoteDto saveNote(NoteDto noteDto) {
         return getCurrentModeService().saveNote(noteDto);
+    }
+
+    @Override
+    public List<NoteDto> searchNotes(NotesSearchDto searchCriteria) {
+        return getCurrentModeService().searchNotes(searchCriteria);
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/controllers/DefendantAccountControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/DefendantAccountControllerTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.opal.dto.AccountSearchDto;
 import uk.gov.hmcts.opal.dto.AccountSearchResultsDto;
 import uk.gov.hmcts.opal.dto.AddNoteDto;
 import uk.gov.hmcts.opal.dto.NoteDto;
+import uk.gov.hmcts.opal.dto.NotesSearchDto;
 import uk.gov.hmcts.opal.entity.DefendantAccountEntity;
 import uk.gov.hmcts.opal.service.opal.DefendantAccountService;
 import uk.gov.hmcts.opal.service.opal.NoteService;
@@ -183,5 +184,39 @@ class DefendantAccountControllerTest {
         assertEquals(HttpStatus.NO_CONTENT, responseEntity.getStatusCode());
         verify(noteService, times(1)).saveNote(any(
             NoteDto.class));
+    }
+
+    @Test
+    public void testNotes_Success() {
+        // Arrange
+        NoteDto mockNote = new NoteDto();
+        List<NoteDto> mockResponse = List.of(mockNote);
+
+        when(noteService.searchNotes(any(NotesSearchDto.class))).thenReturn(mockResponse);
+
+        // Act
+        AddNoteDto addNote = AddNoteDto.builder().build();
+        ResponseEntity<List<NoteDto>> responseEntity = defendantAccountController.getNotesForDefendantAccount("1");
+
+        // Assert
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertEquals(mockResponse, responseEntity.getBody());
+        verify(noteService, times(1)).searchNotes(any(
+            NotesSearchDto.class));
+
+    }
+
+    @Test
+    public void testNotes_NoContent() {
+        when(noteService.searchNotes(any(NotesSearchDto.class))).thenReturn(null);
+
+        // Act
+        AddNoteDto addNote = AddNoteDto.builder().build();
+        ResponseEntity<List<NoteDto>> responseEntity = defendantAccountController.getNotesForDefendantAccount("1");
+
+        // Assert
+        assertEquals(HttpStatus.NO_CONTENT, responseEntity.getStatusCode());
+        verify(noteService, times(1)).searchNotes(any(
+            NotesSearchDto.class));
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/controllers/NoteControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/NoteControllerTest.java
@@ -8,7 +8,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.opal.dto.NoteDto;
+import uk.gov.hmcts.opal.dto.NotesSearchDto;
 import uk.gov.hmcts.opal.service.opal.NoteService;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -42,5 +45,70 @@ class NoteControllerTest {
         verify(noteService, times(1)).saveNote(any(NoteDto.class));
     }
 
+    @Test
+    public void testFindNoteByAssociated_Success() {
+        // Arrange
+        NoteDto mockNote = new NoteDto();
+        List<NoteDto> mockResponse = List.of(mockNote);
 
+        when(noteService.searchNotes(any(NotesSearchDto.class))).thenReturn(mockResponse);
+
+        // Act
+        ResponseEntity<List<NoteDto>> responseEntity = noteController.getNotesByAssociatedRecord("type", "1");
+
+        // Assert
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertEquals(mockResponse, responseEntity.getBody());
+        verify(noteService, times(1)).searchNotes(any(
+            NotesSearchDto.class));
+
+    }
+
+    @Test
+    public void testFindNoteByAssociated_NoContent() {
+        when(noteService.searchNotes(any(NotesSearchDto.class))).thenReturn(null);
+
+        // Act
+        ResponseEntity<List<NoteDto>> responseEntity = noteController.getNotesByAssociatedRecord("type", "1");
+
+        // Assert
+        assertEquals(HttpStatus.NO_CONTENT, responseEntity.getStatusCode());
+        verify(noteService, times(1)).searchNotes(any(
+            NotesSearchDto.class));
+    }
+
+
+    @Test
+    public void testNotesSearch_Success() {
+        // Arrange
+        NoteDto mockNote = new NoteDto();
+        List<NoteDto> mockResponse = List.of(mockNote);
+
+        when(noteService.searchNotes(any(NotesSearchDto.class))).thenReturn(mockResponse);
+
+        // Act
+        NotesSearchDto criteria = NotesSearchDto.builder().build();
+        ResponseEntity<List<NoteDto>> responseEntity = noteController.postNotesSearch(criteria);
+
+        // Assert
+        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        assertEquals(mockResponse, responseEntity.getBody());
+        verify(noteService, times(1)).searchNotes(any(
+            NotesSearchDto.class));
+
+    }
+
+    @Test
+    public void testNotesSearch_NoContent() {
+        when(noteService.searchNotes(any(NotesSearchDto.class))).thenReturn(null);
+
+        // Act
+        NotesSearchDto criteria = NotesSearchDto.builder().build();
+        ResponseEntity<List<NoteDto>> responseEntity = noteController.postNotesSearch(criteria);
+
+        // Assert
+        assertEquals(HttpStatus.NO_CONTENT, responseEntity.getStatusCode());
+        verify(noteService, times(1)).searchNotes(any(
+            NotesSearchDto.class));
+    }
 }

--- a/src/test/java/uk/gov/hmcts/opal/repository/jpa/DefendantAccountSpecsTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/repository/jpa/DefendantAccountSpecsTest.java
@@ -22,7 +22,8 @@ public class DefendantAccountSpecsTest {
         assertNotNull(DefendantAccountSpecs.likeOrganisationName("test"));
         assertNotNull(DefendantAccountSpecs.likeInitials("test"));
 
-        assertNotNull(DefendantAccountSpecs.findByAccountSearch(AccountSearchDto.builder().build()));
+        DefendantAccountSpecs specs = new DefendantAccountSpecs();
+        assertNotNull(specs.findByAccountSearch(AccountSearchDto.builder().build()));
 
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/DefendantAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/DefendantAccountServiceTest.java
@@ -28,7 +28,6 @@ import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
 import uk.gov.hmcts.opal.repository.EnforcersRepository;
 import uk.gov.hmcts.opal.repository.NoteRepository;
 import uk.gov.hmcts.opal.repository.PaymentTermsRepository;
-import uk.gov.hmcts.opal.service.opal.DefendantAccountService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/NoteServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/NoteServiceTest.java
@@ -6,12 +6,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import uk.gov.hmcts.opal.dto.NoteDto;
+import uk.gov.hmcts.opal.dto.NotesSearchDto;
 import uk.gov.hmcts.opal.entity.NoteEntity;
 import uk.gov.hmcts.opal.repository.NoteRepository;
-import uk.gov.hmcts.opal.service.opal.NoteService;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -92,6 +97,23 @@ class NoteServiceTest {
                        && savedNoteDto.getPostedDate().isAfter(LocalDateTime.now().minusMinutes(1)),
                    "Posted date should be around the current time");
         verify(noteRepository, times(1)).save(any(NoteEntity.class));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void testSearchNotes() {
+        // Arrange
+
+        NoteEntity noteEntity = NoteEntity.builder().build();
+        Page<NoteEntity> mockPage = new PageImpl<>(List.of(noteEntity), Pageable.unpaged(), 999L);
+        when(noteRepository.findBy(any(Specification.class), any())).thenReturn(mockPage);
+
+        // Act
+        List<NoteDto> result = noteService.searchNotes(NotesSearchDto.builder().build());
+
+        // Assert
+        assertEquals(1, result.size());
+
     }
 
 


### PR DESCRIPTION
Some code refactoring to make it easier to implement repository searches in repositories other than Defendant Account, tested by implementing a Notes repository search.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[*] No
```
