### PR TITLE
Align REST endpoints for consistency

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/opal/steps/DefendantAccountDetailsStefDef.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/steps/DefendantAccountDetailsStefDef.java
@@ -23,7 +23,7 @@ public class DefendantAccountDetailsStefDef extends BaseStepDef {
             .header("Authorization", "Bearer " + getToken())
             .contentType("application/json")
             .when()
-            .get(getTestUrl() + "/api/defendant-account/details?defendantAccountId=" + idToSend.get("defendantID"));
+            .get(getTestUrl() + "/api/defendant-account/" + idToSend.get("defendantID"));
     }
 
     @When("I make an unauthenticated request to the defendant account details api with")
@@ -33,7 +33,7 @@ public class DefendantAccountDetailsStefDef extends BaseStepDef {
             .accept("*/*")
             .contentType("application/json")
             .when()
-            .get(getTestUrl() + "/api/defendant-account/details?defendantAccountId=" + idToSend.get("defendantID"));
+            .get(getTestUrl() + "/api/defendant-account/" + idToSend.get("defendantID"));
     }
 
     @When("I make a request to the defendant account details api with an invalid token")
@@ -44,7 +44,7 @@ public class DefendantAccountDetailsStefDef extends BaseStepDef {
             .header("Authorization", "Bearer invalidToken")
             .contentType("application/json")
             .when()
-            .get(getTestUrl() + "/api/defendant-account/details?defendantAccountId=" + idToSend.get("defendantID"));
+            .get(getTestUrl() + "/api/defendant-account/" + idToSend.get("defendantID"));
     }
 
     @Then("the response from the defendant account details api is")

--- a/src/main/java/uk/gov/hmcts/opal/controllers/AccountTransferController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/AccountTransferController.java
@@ -22,7 +22,7 @@ import static uk.gov.hmcts.opal.util.ResponseUtil.buildResponse;
 
 
 @RestController
-@RequestMapping("/api/accountTransfers")
+@RequestMapping("/api/account-transfer")
 @Slf4j(topic = "AccountTransferController")
 @Tag(name = "AccountTransfer Controller")
 public class AccountTransferController {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/BusinessUnitController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/BusinessUnitController.java
@@ -22,7 +22,7 @@ import static uk.gov.hmcts.opal.util.ResponseUtil.buildResponse;
 
 
 @RestController
-@RequestMapping("/api/businessUnits")
+@RequestMapping("/api/business-unit")
 @Slf4j(topic = "BusinessUnitController")
 @Tag(name = "BusinessUnit Controller")
 public class BusinessUnitController {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/CommittalWarrantProgressController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/CommittalWarrantProgressController.java
@@ -22,7 +22,7 @@ import static uk.gov.hmcts.opal.util.ResponseUtil.buildResponse;
 
 
 @RestController
-@RequestMapping("/api/committalWarrantProgress")
+@RequestMapping("/api/committal-warrant-progress")
 @Slf4j(topic = "CommittalWarrantProgressController")
 @Tag(name = "CommittalWarrantProgress Controller")
 public class CommittalWarrantProgressController {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/CourtController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/CourtController.java
@@ -22,7 +22,7 @@ import static uk.gov.hmcts.opal.util.ResponseUtil.buildResponse;
 
 
 @RestController
-@RequestMapping("/api/courts")
+@RequestMapping("/api/court")
 @Slf4j(topic = "CourtController")
 @Tag(name = "Court Controller")
 public class CourtController {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/DebtorDetailController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/DebtorDetailController.java
@@ -22,7 +22,7 @@ import static uk.gov.hmcts.opal.util.ResponseUtil.buildResponse;
 
 
 @RestController
-@RequestMapping("/api/debtorDetails")
+@RequestMapping("/api/debtor-detail")
 @Slf4j(topic = "DebtorDetailController")
 @Tag(name = "DebtorDetail Controller")
 public class DebtorDetailController {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/DefendantAccountController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/DefendantAccountController.java
@@ -82,22 +82,9 @@ public class DefendantAccountController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping(value = "/{businessUnit}")
-    @Operation(summary = "Returns all defendant accounts within a business unit")
-    public ResponseEntity<List<DefendantAccountEntity>> getDefendantAccountsByBusinessUnit(
-        @PathVariable short businessUnit) {
-
-        log.info(":GET:getDefendantAccountsByBusinessUnit: busUnit: {}", businessUnit);
-        List<DefendantAccountEntity> response = defendantAccountService
-            .getDefendantAccountsByBusinessUnit(businessUnit);
-
-        return buildResponse(response);
-    }
-
-    @GetMapping(value = "/details")
+    @GetMapping(value = "/{defendantAccountId}")
     @Operation(summary = "Get defendant account details by providing the defendant account summary")
-    public ResponseEntity<AccountDetailsDto> getAccountDetailsByAccountSummary(
-        @RequestParam(name = "defendantAccountId") Long defendantAccountId) {
+    public ResponseEntity<AccountDetailsDto> getAccountDetailsByAccountSummary(@PathVariable Long defendantAccountId) {
 
         AccountDetailsDto response = defendantAccountService.getAccountDetailsByDefendantAccountId(defendantAccountId);
 

--- a/src/main/java/uk/gov/hmcts/opal/controllers/DocumentController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/DocumentController.java
@@ -22,7 +22,7 @@ import static uk.gov.hmcts.opal.util.ResponseUtil.buildResponse;
 
 
 @RestController
-@RequestMapping("/api/documents")
+@RequestMapping("/api/document")
 @Slf4j(topic = "DocumentController")
 @Tag(name = "Document Controller")
 public class DocumentController {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/DocumentInstanceController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/DocumentInstanceController.java
@@ -22,7 +22,7 @@ import static uk.gov.hmcts.opal.util.ResponseUtil.buildResponse;
 
 
 @RestController
-@RequestMapping("/api/documentInstances")
+@RequestMapping("/api/document-instance")
 @Slf4j(topic = "DocumentInstanceController")
 @Tag(name = "DocumentInstance Controller")
 public class DocumentInstanceController {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/EnforcementController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/EnforcementController.java
@@ -22,7 +22,7 @@ import static uk.gov.hmcts.opal.util.ResponseUtil.buildResponse;
 
 
 @RestController
-@RequestMapping("/api/enforcements")
+@RequestMapping("/api/enforcement")
 @Slf4j(topic = "EnforcementController")
 @Tag(name = "Enforcement Controller")
 public class EnforcementController {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/EnforcerController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/EnforcerController.java
@@ -22,7 +22,7 @@ import static uk.gov.hmcts.opal.util.ResponseUtil.buildResponse;
 
 
 @RestController
-@RequestMapping("/api/enforcers")
+@RequestMapping("/api/enforcer")
 @Slf4j(topic = "EnforcerController")
 @Tag(name = "Enforcer Controller")
 public class EnforcerController {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/LocalJusticeAreaController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/LocalJusticeAreaController.java
@@ -22,7 +22,7 @@ import static uk.gov.hmcts.opal.util.ResponseUtil.buildResponse;
 
 
 @RestController
-@RequestMapping("/api/localJusticeAreas")
+@RequestMapping("/api/local-justice-area")
 @Slf4j(topic = "LocalJusticeAreaController")
 @Tag(name = "LocalJusticeArea Controller")
 public class LocalJusticeAreaController {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/MisDebtorController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/MisDebtorController.java
@@ -22,7 +22,7 @@ import static uk.gov.hmcts.opal.util.ResponseUtil.buildResponse;
 
 
 @RestController
-@RequestMapping("/api/misDebtors")
+@RequestMapping("/api/mis-debtor")
 @Slf4j(topic = "MisDebtorController")
 @Tag(name = "MisDebtor Controller")
 public class MisDebtorController {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/NoteController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/NoteController.java
@@ -23,7 +23,7 @@ import static uk.gov.hmcts.opal.util.ResponseUtil.buildResponse;
 
 
 @RestController
-@RequestMapping("/api/notes")
+@RequestMapping("/api/note")
 @Slf4j(topic = "NoteController")
 @Tag(name = "Notes Controller")
 public class NoteController {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/PaymentInController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/PaymentInController.java
@@ -22,7 +22,7 @@ import static uk.gov.hmcts.opal.util.ResponseUtil.buildResponse;
 
 
 @RestController
-@RequestMapping("/api/paymentIns")
+@RequestMapping("/api/payment-in")
 @Slf4j(topic = "PaymentInController")
 @Tag(name = "PaymentIn Controller")
 public class PaymentInController {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/PaymentTermsController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/PaymentTermsController.java
@@ -22,7 +22,7 @@ import static uk.gov.hmcts.opal.util.ResponseUtil.buildResponse;
 
 
 @RestController
-@RequestMapping("/api/paymentTerms")
+@RequestMapping("/api/payment-terms")
 @Slf4j(topic = "PaymentTermsController")
 @Tag(name = "PaymentTerms Controller")
 public class PaymentTermsController {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/PrisonController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/PrisonController.java
@@ -22,7 +22,7 @@ import static uk.gov.hmcts.opal.util.ResponseUtil.buildResponse;
 
 
 @RestController
-@RequestMapping("/api/prisons")
+@RequestMapping("/api/prison")
 @Slf4j(topic = "PrisonController")
 @Tag(name = "Prison Controller")
 public class PrisonController {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/TillController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/TillController.java
@@ -22,7 +22,7 @@ import static uk.gov.hmcts.opal.util.ResponseUtil.buildResponse;
 
 
 @RestController
-@RequestMapping("/api/tills")
+@RequestMapping("/api/till")
 @Slf4j(topic = "TillController")
 @Tag(name = "Till Controller")
 public class TillController {

--- a/src/test/java/uk/gov/hmcts/opal/controllers/DefendantAccountControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/DefendantAccountControllerTest.java
@@ -93,25 +93,6 @@ class DefendantAccountControllerTest {
     }
 
     @Test
-    public void testGetDefendantAccounts_Success() {
-        // Arrange
-        List<DefendantAccountEntity> mockResponse = List.of(new DefendantAccountEntity());
-
-        when(defendantAccountService.getDefendantAccountsByBusinessUnit(any(Short.class))).thenReturn(mockResponse);
-
-        // Act
-        ResponseEntity<List<DefendantAccountEntity>> responseEntity = defendantAccountController
-            .getDefendantAccountsByBusinessUnit(any(Short.class));
-
-        // Assert
-        assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
-        assertEquals(mockResponse, responseEntity.getBody());
-        verify(defendantAccountService, times(1)).getDefendantAccountsByBusinessUnit(any(
-            Short.class));
-
-    }
-
-    @Test
     public void testGetDefendantAccountDetails_Success() {
         // Arrange
         AccountDetailsDto mockResponse = new AccountDetailsDto();


### PR DESCRIPTION
The breaking change is that the `/api/defendant-account/details` endpoint has been changed to `/api/defendant-account/xxxxxx`, where xxxxxx is the defendant account id.

**Does this PR introduce a breaking change?** (check one with "x")

```
[*] Yes
[ ] No
```
