### PR TITLE
Pass Business Unit Id to/from FE

### DIFF
--- a/src/functionalTest/resources/features/opalMode/PO-184-187-188-192_addNote_postedBy_postedByAAD.feature
+++ b/src/functionalTest/resources/features/opalMode/PO-184-187-188-192_addNote_postedBy_postedByAAD.feature
@@ -9,7 +9,7 @@ Feature: tests for changes to postedBy and postedByAAD
     And the add notes response contains
       | associatedRecordId | 500000010                                |
       | noteText           | test postedBy and PostedByAAD Opal user1 |
-      | postedBy           | L070KG                                   |
+      | postedBy           | L017KG                                   |
       | postedByAAD        | gl.userfour                              |
 
     Given I am testing as the "opal-test-2@hmcts.net" user
@@ -39,5 +39,5 @@ Feature: tests for changes to postedBy and postedByAAD
     And the add notes response contains
       | associatedRecordId | 500000010                                |
       | noteText           | test postedBy and PostedByAAD Opal user4 |
-      | postedBy           | L096GH                                   |
+      | postedBy           | L095GH                                   |
       | postedByAAD        | humber.usertwo                           |

--- a/src/integrationTest/java/uk/gov/hmcts/opal/authentication/controller/AuthenticationInternalUserControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/authentication/controller/AuthenticationInternalUserControllerTest.java
@@ -66,7 +66,7 @@ public class AuthenticationInternalUserControllerTest {
             .userName("name")
             .userId("123")
             .roles(Set.of(Role.builder()
-                              .businessUnit("B123")
+                              .businessUnitId((short)123)
                               .businessUserId("BU123")
                               .permissions(Set.of(
                                   Permission.builder()

--- a/src/main/java/uk/gov/hmcts/opal/authorisation/model/Role.java
+++ b/src/main/java/uk/gov/hmcts/opal/authorisation/model/Role.java
@@ -15,7 +15,7 @@ public class Role {
     String businessUserId;
 
     @NonNull
-    String businessUnit;
+    Short businessUnitId;
 
     @EqualsAndHashCode.Exclude
     @NonNull

--- a/src/main/java/uk/gov/hmcts/opal/controllers/DefendantAccountController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/DefendantAccountController.java
@@ -85,7 +85,7 @@ public class DefendantAccountController {
 
     @GetMapping(value = "/{defendantAccountId}")
     @Operation(summary = "Get defendant account details by providing the defendant account summary")
-    public ResponseEntity<AccountDetailsDto> getAccountDetailsByAccountSummary(@PathVariable Long defendantAccountId) {
+    public ResponseEntity<AccountDetailsDto> getAccountDetails(@PathVariable Long defendantAccountId) {
 
         AccountDetailsDto response = defendantAccountService.getAccountDetailsByDefendantAccountId(defendantAccountId);
 

--- a/src/main/java/uk/gov/hmcts/opal/dto/AccountDetailsDto.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/AccountDetailsDto.java
@@ -24,8 +24,11 @@ public class AccountDetailsDto implements ToJsonString {
     // parties.surname, parties,initials, parties.forenames, parties.title
     private String fullName;
 
-    // business_units.business_unit_type
+    // business_units.business_unit_name
     private String accountCT;
+
+    // business_units.business_unit_id
+    private Short businessUnitId;
 
     //parties.address_line_(*)
     private String address;

--- a/src/main/java/uk/gov/hmcts/opal/dto/AddNoteDto.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/AddNoteDto.java
@@ -14,5 +14,6 @@ import lombok.extern.jackson.Jacksonized;
 @Jacksonized
 public class AddNoteDto implements ToJsonString {
     private String associatedRecordId;
+    private Short businessUnitId;
     private String noteText;
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/BusinessUnitUserService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/BusinessUnitUserService.java
@@ -49,7 +49,7 @@ public class BusinessUnitUserService implements BusinessUnitUserServiceInterface
 
         return buuList.stream().map(buu -> Role.builder()
             .businessUserId(buu.getBusinessUnitUserId())
-            .businessUnit(buu.getBusinessUnit().getBusinessUnitId().toString())
+            .businessUnitId(buu.getBusinessUnit().getBusinessUnitId())
             .permissions(userEntitlementService.getPermissionsByBusinessUnitUserId(buu.getBusinessUnitUserId()))
             .build()).collect(Collectors.toSet());
 
@@ -65,7 +65,7 @@ public class BusinessUnitUserService implements BusinessUnitUserServiceInterface
 
         return buuList.stream().map(buu -> Role.builder()
             .businessUserId(buu.getBusinessUnitUserId())
-            .businessUnit(buu.getBusinessUnit().getBusinessUnitId().toString())
+            .businessUnitId(buu.getBusinessUnit().getBusinessUnitId())
             .permissions(Collections.emptySet()) // We are assuming that Permissions exist for this Role.
             .build()).collect(Collectors.toSet());
 

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/DefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/DefendantAccountService.java
@@ -190,6 +190,7 @@ public class DefendantAccountService implements DefendantAccountServiceInterface
                           ? partyEntity.getFullName()
                           : partyEntity.getOrganisationName())
             .accountCT(defendantAccountEntity.getBusinessUnit().getBusinessUnitName())
+            .businessUnitId(defendantAccountEntity.getBusinessUnit().getBusinessUnitId())
             .address(fullAddress)
             .postCode(partyEntity.getPostcode())
             .dob(partyEntity.getDateOfBirth())

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/UserEntitlementService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/UserEntitlementService.java
@@ -82,7 +82,7 @@ public class UserEntitlementService implements UserEntitlementServiceInterface {
             .userName(u.getUsername())
             .roles(businessUnitUsers.stream().map(buu -> Role.builder()
                 .businessUserId(buu.getBusinessUnitUserId())
-                .businessUnit(buu.getBusinessUnit().getBusinessUnitId().toString())
+                .businessUnitId(buu.getBusinessUnit().getBusinessUnitId())
                 .permissions(toPermissions(entitlementsMap.get(buu.getBusinessUnitUserId())))
                 .build()).collect(toSet()))
             .build());

--- a/src/test/java/uk/gov/hmcts/opal/controllers/DefendantAccountControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/DefendantAccountControllerTest.java
@@ -108,7 +108,7 @@ class DefendantAccountControllerTest {
 
         // Act
         ResponseEntity<AccountDetailsDto> responseEntity = defendantAccountController
-            .getAccountDetailsByAccountSummary(1L);
+            .getAccountDetails(1L);
 
         // Assert
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());


### PR DESCRIPTION
This is the first step for PO-235, passing the business unit id to the FE.
After The FE has coded changes to return that business unit id to us as part of an 'add notes' call, we can then check that the user has a role associated with that business unit that also has the 'add note' permission,.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[*] No
```
