### PR TITLE
OpalPO-1567: Update DraftAccountStatus enum and schema

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerIntegrationTest.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.opal.authentication.service.AccessTokenService;
 import uk.gov.hmcts.opal.authorisation.model.Permissions;
 import uk.gov.hmcts.opal.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.ToJsonString;
+import uk.gov.hmcts.opal.entity.DraftAccountStatus;
 import uk.gov.hmcts.opal.service.opal.JsonSchemaValidationService;
 import uk.gov.hmcts.opal.service.opal.UserStateService;
 
@@ -39,7 +40,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.gov.hmcts.opal.controllers.util.UserStateUtil.allPermissionsUser;
 import static uk.gov.hmcts.opal.controllers.util.UserStateUtil.noPermissionsUser;
 import static uk.gov.hmcts.opal.controllers.util.UserStateUtil.permissionUser;
-import static uk.gov.hmcts.opal.entity.DraftAccountStatus.ERROR_IN_PUBLISHING;
 
 @Slf4j(topic = "opal.DraftAccountControllerIntegrationTest")
 @Sql(scripts = "classpath:db/draftAccounts/insert_into_draft_accounts.sql",
@@ -106,7 +106,7 @@ class DraftAccountControllerIntegrationTest extends AbstractIntegrationTest {
             .andExpect(jsonPath("$.summaries[2].account_type")
                            .value("Fixed Penalty Registration"))
             .andExpect(jsonPath("$.summaries[2].submitted_by").value("user_003"))
-            .andExpect(jsonPath("$.summaries[2].account_status").value("Error in publishing"))
+            .andExpect(jsonPath("$.summaries[2].account_status").value("Publishing Failed"))
             .andReturn().getResponse().getContentAsString();
 
         log.info(":testGetDraftAccountsSummaries_noParams: body:\n" + ToJsonString.toPrettyJson(body));
@@ -132,7 +132,7 @@ class DraftAccountControllerIntegrationTest extends AbstractIntegrationTest {
             .andExpect(jsonPath("$.summaries[0].account_type")
                            .value("Fixed Penalty Registration"))
             .andExpect(jsonPath("$.summaries[0].submitted_by").value("user_003"))
-            .andExpect(jsonPath("$.summaries[0].account_status").value("Error in publishing"))
+            .andExpect(jsonPath("$.summaries[0].account_status").value("Publishing Failed"))
             .andReturn().getResponse().getContentAsString();
 
         log.info(":testGetDraftAccountsSummaries_permission: body:\n" + ToJsonString.toPrettyJson(body));
@@ -148,8 +148,9 @@ class DraftAccountControllerIntegrationTest extends AbstractIntegrationTest {
 
         String body = mockMvc.perform(get(URL_BASE)
                                           .header("authorization", "Bearer some_value")
-                                          .param("status", ERROR_IN_PUBLISHING.getLabel())
-                                          .contentType(MediaType.APPLICATION_JSON))
+                                          .param("status", DraftAccountStatus.PUBLISHING_FAILED.name())
+
+                .contentType(MediaType.APPLICATION_JSON))
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.count").value(1))
             .andExpect(jsonPath("$.summaries[0].draft_account_id").value(3))
@@ -157,7 +158,7 @@ class DraftAccountControllerIntegrationTest extends AbstractIntegrationTest {
             .andExpect(jsonPath("$.summaries[0].account_type")
                            .value("Fixed Penalty Registration"))
             .andExpect(jsonPath("$.summaries[0].submitted_by").value("user_003"))
-            .andExpect(jsonPath("$.summaries[0].account_status").value("Error in publishing"))
+            .andExpect(jsonPath("$.summaries[0].account_status").value("Publishing Failed"))
             .andReturn().getResponse().getContentAsString();
 
         log.info(":testGetDraftAccountsSummaries_permission: body:\n" + ToJsonString.toPrettyJson(body));
@@ -1015,7 +1016,7 @@ class DraftAccountControllerIntegrationTest extends AbstractIntegrationTest {
 
     private static String validUpdateRequestBody(String delta) {
         return "{\n"
-            + "    \"account_status\": \"PENDING\",\n"
+            + "    \"account_status\": \"PUBLISHING_PENDING\",\n"
             + "    \"validated_by\": \"BUUID1" + delta + "\",\n"
             + "    \"validated_by_name\": \"" + delta + "\",\n"
             + "    \"business_unit_id\": 78,\n"

--- a/src/integrationTest/resources/db/draftAccounts/insert_into_draft_accounts.sql
+++ b/src/integrationTest/resources/db/draftAccounts/insert_into_draft_accounts.sql
@@ -194,7 +194,7 @@ VALUES
     '{
        "snapshot": "opal-test"
       }',
-    'ERROR_IN_PUBLISHING',
+    'PUBLISHING_FAILED',
     '[
          {
            "username": "opal-test",

--- a/src/main/java/uk/gov/hmcts/opal/entity/DraftAccountStatus.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/DraftAccountStatus.java
@@ -12,8 +12,10 @@ public enum DraftAccountStatus {
     DELETED("Deleted"),
     APPROVED("Approved"),
     RESUBMITTED("Resubmitted"),
-    PENDING("Pending"),
-    ERROR_IN_PUBLISHING("Error in publishing");
+    PUBLISHING_PENDING("Publishing Pending"),
+    PUBLISHED("Published"),
+    PUBLISHING_FAILED("Publishing Failed");
+
 
     private final String label;
 

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactions.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactions.java
@@ -47,7 +47,7 @@ public class DraftAccountTransactions implements DraftAccountTransactionsProxy {
     private static final String DEFENDANT_JSON_PATH = "$.defendant";
 
     private static final EnumSet<DraftAccountStatus> VALID_UPDATE_STATUSES =
-        EnumSet.of(DraftAccountStatus.PENDING, DraftAccountStatus.REJECTED, DraftAccountStatus.DELETED);
+        EnumSet.of(DraftAccountStatus.PUBLISHING_PENDING, DraftAccountStatus.REJECTED, DraftAccountStatus.DELETED);
 
     private final DraftAccountRepository draftAccountRepository;
 
@@ -155,7 +155,7 @@ public class DraftAccountTransactions implements DraftAccountTransactionsProxy {
         existingAccount.setAccountStatus(newStatus);
         existingAccount.setVersion(dto.getVersion());
 
-        if (newStatus == DraftAccountStatus.PENDING) {
+        if (newStatus == DraftAccountStatus.PUBLISHING_PENDING) {
             existingAccount.setValidatedDate(LocalDateTime.now());
             existingAccount.setValidatedBy(dto.getValidatedBy());
             existingAccount.setValidatedByName(dto.getValidatedByName());

--- a/src/main/resources/jsonSchemas/getDraftAccountResponse.json
+++ b/src/main/resources/jsonSchemas/getDraftAccountResponse.json
@@ -44,7 +44,17 @@
     },
     "account_status": {
       "type": "string",
-      "description": "Status of the Draft Account - one of Submitted, Resubmitted, Rejected, Approved, Deleted"
+      "description": "Status of the Draft Account - one of Submitted, Resubmitted, Rejected, Approved, Deleted, Publishing Pending, Published, Publishing Failed",
+      "enum": [
+        "Submitted",
+        "Resubmitted",
+        "Rejected",
+        "Approved",
+        "Deleted",
+        "Publishing Pending",
+        "Published",
+        "Publishing Failed"
+      ]
     },
     "timeline_data": {
       "$ref": "resource:/jsonSchemas/timelineData.json",

--- a/src/test/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerTest.java
@@ -86,7 +86,7 @@ class DraftAccountControllerTest {
         // Act
         ResponseEntity<DraftAccountsResponseDto> response = draftAccountController
             .getDraftAccountSummaries(Optional.of(List.of(BU_ID)),
-                                      Optional.of(List.of(DraftAccountStatus.PENDING)),
+                                      Optional.of(List.of(DraftAccountStatus.PUBLISHING_PENDING)),
                                       Optional.of(List.of()),
                                       Optional.of(List.of()), BEARER_TOKEN);
         DraftAccountsResponseDto dto = response.getBody();

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/DraftAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/DraftAccountServiceTest.java
@@ -110,7 +110,7 @@ class DraftAccountServiceTest {
             DraftAccountSearchDto.builder().build(), "authHeaderValue");
 
         // Assert
-        assertEquals(accountText, result.getFirst().getAccount());
+        assertEquals(accountText, result.get(0).getAccount());
 
     }
 
@@ -320,7 +320,7 @@ class DraftAccountServiceTest {
 
         DraftAccountEntity updatedAccount = DraftAccountEntity.builder()
             .draftAccountId(draftAccountId)
-            .accountStatus(DraftAccountStatus.PENDING)
+            .accountStatus(DraftAccountStatus.PUBLISHING_PENDING)
             .validatedBy("TestValidator")
             .validatedByName("Tester McValidator")
             .validatedDate(LocalDateTime.now())
@@ -339,7 +339,7 @@ class DraftAccountServiceTest {
         // Assert
         assertNotNull(result);
         assertEquals(draftAccountId, result.getDraftAccountId());
-        assertEquals(DraftAccountStatus.PENDING, result.getAccountStatus());
+        assertEquals(DraftAccountStatus.PUBLISHING_PENDING, result.getAccountStatus());
         assertEquals("TestValidator", result.getValidatedBy());
         assertEquals("Tester McValidator", result.getValidatedByName());
         assertNotNull(result.getValidatedDate());

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionsTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionsTest.java
@@ -110,7 +110,7 @@ class DraftAccountTransactionsTest {
             DraftAccountSearchDto.builder().build());
 
         // Assert
-        assertEquals(accountText, result.getFirst().getAccount());
+        assertEquals(accountText, result.get(0).getAccount());
 
     }
 
@@ -335,7 +335,7 @@ class DraftAccountTransactionsTest {
         // Arrange
         Long draftAccountId = 1L;
         UpdateDraftAccountRequestDto updateDto = UpdateDraftAccountRequestDto.builder()
-            .accountStatus("PENDING")
+            .accountStatus(DraftAccountStatus.PUBLISHING_PENDING.name())
             .validatedBy("TestValidator")
             .timelineData(createTimelineDataString())
             .businessUnitId((short) 2)
@@ -353,7 +353,7 @@ class DraftAccountTransactionsTest {
 
         DraftAccountEntity updatedAccount = DraftAccountEntity.builder()
             .draftAccountId(draftAccountId)
-            .accountStatus(DraftAccountStatus.PENDING)
+            .accountStatus(DraftAccountStatus.PUBLISHING_PENDING)
             .validatedBy("TestValidator")
             .validatedByName("Tester McValidator")
             .validatedDate(LocalDateTime.now())
@@ -372,7 +372,7 @@ class DraftAccountTransactionsTest {
         // Assert
         assertNotNull(result);
         assertEquals(draftAccountId, result.getDraftAccountId());
-        assertEquals(DraftAccountStatus.PENDING, result.getAccountStatus());
+        assertEquals(DraftAccountStatus.PUBLISHING_PENDING, result.getAccountStatus());
         assertEquals("TestValidator", result.getValidatedBy());
         assertEquals("Tester McValidator", result.getValidatedByName());
         assertNotNull(result.getValidatedDate());


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-1567 


### Change description ###
- Added new status values: `Publishing Pending`, `Published`, `Publishing Failed`
- Removed deprecated values: `Pending`, `Error in Publishing`
- Updated all usages in service, controller, and integration tests
- Fixed SQL test data
- Updated JSON schema to enforce allowed `account_status` values



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
