### PR TITLE
PO-1019: Add validation for submitted_by, submitted_by_name, and acco…

### DIFF
--- a/src/functionalTest/resources/features/opalMode/manualAccountCreation/draftAccounts/addDraftAccount/PO-936-postDraftAccountSubmittedByName.feature
+++ b/src/functionalTest/resources/features/opalMode/manualAccountCreation/draftAccounts/addDraftAccount/PO-936-postDraftAccountSubmittedByName.feature
@@ -7,7 +7,7 @@
         | business_unit_id  | 73                                          |
         | account           | draftAccounts/accountJson/adultAccount.json |
         | account_type      | Fine                                        |
-        | account_status    |                                             |
+        | account_status    | Submitted                                   |
         | submitted_by      | BUUID                                       |
         | submitted_by_name | Laura Clerk1                                |
         | timeline_data     | draftAccounts/timelineJson/default.json     |

--- a/src/functionalTest/resources/features/opalMode/manualAccountCreation/draftAccounts/getDraftAccountsMulti/PO-829_getDraftAccountsAuthorization.feature
+++ b/src/functionalTest/resources/features/opalMode/manualAccountCreation/draftAccounts/getDraftAccountsMulti/PO-829_getDraftAccountsAuthorization.feature
@@ -5,12 +5,13 @@ Feature: PO-829 Authorization for Get Draft Accounts
   Scenario: Get Draft Accounts - No Permission
     Given I am testing as the "opal-test@hmcts.net" user
     When I create a draft account with the following details
-      | business_unit_id | 78                                          |
-      | account          | draftAccounts/accountJson/adultAccount.json |
-      | account_type     | Fine                                        |
-      | account_status   | Submitted                                   |
-      | submitted_by     | BUUID                                       |
-      | timeline_data    | draftAccounts/timelineJson/default.json     |
+      | business_unit_id  | 78                                          |
+      | account           | draftAccounts/accountJson/adultAccount.json |
+      | account_type      | Fine                                        |
+      | account_status    | Submitted                                   |
+      | submitted_by      | BUUID                                       |
+      | submitted_by_name | Laura Clerk                                 |
+      | timeline_data     | draftAccounts/timelineJson/default.json     |
 
     Then The draft account response returns 201
     And I store the created draft account ID
@@ -28,35 +29,38 @@ Feature: PO-829 Authorization for Get Draft Accounts
   Scenario: Get Draft Accounts - account created in BU requesting user doesn't have permission to
     Given I am testing as the "opal-test@hmcts.net" user
     When I create a draft account with the following details
-      | business_unit_id | 73                                          |
-      | account          | draftAccounts/accountJson/adultAccount.json |
-      | account_type     | Fine                                        |
-      | account_status   | Submitted                                   |
-      | submitted_by     | BUUID                                       |
-      | timeline_data    | draftAccounts/timelineJson/default.json     |
+      | business_unit_id  | 73                                          |
+      | account           | draftAccounts/accountJson/adultAccount.json |
+      | account_type      | Fine                                        |
+      | account_status    | Submitted                                   |
+      | submitted_by      | BUUID                                       |
+      | submitted_by_name | Laura Clerk                                 |
+      | timeline_data     | draftAccounts/timelineJson/default.json     |
 
     Then The draft account response returns 201
     And I store the created draft account ID
 
     When I create a draft account with the following details
-      | business_unit_id | 80                                          |
-      | account          | draftAccounts/accountJson/adultAccount.json |
-      | account_type     | Fine                                        |
-      | account_status   | Submitted                                   |
-      | submitted_by     | BUUID                                       |
-      | timeline_data    | draftAccounts/timelineJson/default.json     |
+      | business_unit_id | 80                                           |
+      | account           | draftAccounts/accountJson/adultAccount.json |
+      | account_type      | Fine                                        |
+      | account_status    | Submitted                                   |
+      | submitted_by      | BUUID                                       |
+      | submitted_by_name | Laura Clerk                                 |
+      | timeline_data     | draftAccounts/timelineJson/default.json     |
 
     Then The draft account response returns 201
     And I store the created draft account ID
 
     Given I am testing as the "opal-test-3@hmcts.net" user
     When I create a draft account with the following details
-      | business_unit_id | 26                                          |
-      | account          | draftAccounts/accountJson/adultAccount.json |
-      | account_type     | Fine                                        |
-      | account_status   | Submitted                                   |
-      | submitted_by     | BUUID                                       |
-      | timeline_data    | draftAccounts/timelineJson/default.json     |
+      | business_unit_id  | 26                                          |
+      | account           | draftAccounts/accountJson/adultAccount.json |
+      | account_type      | Fine                                        |
+      | account_status    | Submitted                                   |
+      | submitted_by      | BUUID                                       |
+      | submitted_by_name | Laura Clerk                                 |
+      | timeline_data     | draftAccounts/timelineJson/default.json     |
 
     Then The draft account response returns 201
     And I store the created draft account ID

--- a/src/functionalTest/resources/features/opalMode/manualAccountCreation/draftAccounts/getDraftAccountsMulti/PO-829_getDraftAccountsAuthorization.feature
+++ b/src/functionalTest/resources/features/opalMode/manualAccountCreation/draftAccounts/getDraftAccountsMulti/PO-829_getDraftAccountsAuthorization.feature
@@ -8,7 +8,7 @@ Feature: PO-829 Authorization for Get Draft Accounts
       | business_unit_id | 78                                          |
       | account          | draftAccounts/accountJson/adultAccount.json |
       | account_type     | Fine                                        |
-      | account_status   |                                             |
+      | account_status   | Submitted                                   |
       | submitted_by     | BUUID                                       |
       | timeline_data    | draftAccounts/timelineJson/default.json     |
 
@@ -31,7 +31,7 @@ Feature: PO-829 Authorization for Get Draft Accounts
       | business_unit_id | 73                                          |
       | account          | draftAccounts/accountJson/adultAccount.json |
       | account_type     | Fine                                        |
-      | account_status   |                                             |
+      | account_status   | Submitted                                   |
       | submitted_by     | BUUID                                       |
       | timeline_data    | draftAccounts/timelineJson/default.json     |
 
@@ -42,7 +42,7 @@ Feature: PO-829 Authorization for Get Draft Accounts
       | business_unit_id | 80                                          |
       | account          | draftAccounts/accountJson/adultAccount.json |
       | account_type     | Fine                                        |
-      | account_status   |                                             |
+      | account_status   | Submitted                                   |
       | submitted_by     | BUUID                                       |
       | timeline_data    | draftAccounts/timelineJson/default.json     |
 
@@ -54,7 +54,7 @@ Feature: PO-829 Authorization for Get Draft Accounts
       | business_unit_id | 26                                          |
       | account          | draftAccounts/accountJson/adultAccount.json |
       | account_type     | Fine                                        |
-      | account_status   |                                             |
+      | account_status   | Submitted                                   |
       | submitted_by     | BUUID                                       |
       | timeline_data    | draftAccounts/timelineJson/default.json     |
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerIntegrationTest.java
@@ -392,6 +392,52 @@ class DraftAccountControllerIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @DisplayName("Should return 400 when submitted_by_name is blank")
+    void shouldReturn400WhenSubmittedByNameIsBlank() throws Exception {
+        String request = validCreateRequestBody()
+            .replace("\"submitted_by_name\": \"John\"", "\"submitted_by_name\": \"\"");
+
+        when(userStateService.checkForAuthorisedUser(any())).thenReturn(allPermissionsUser());
+
+        mockMvc.perform(post(URL_BASE)
+                .header("Authorization", "Bearer some_value")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(request))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Should return 400 when submitted_by is blank")
+    void shouldReturn400WhenSubmittedByIsBlank() throws Exception {
+        String request = validCreateRequestBody()
+            .replace("\"submitted_by\": \"BUUID1\"", "\"submitted_by\": \"\"");
+
+        when(userStateService.checkForAuthorisedUser(any())).thenReturn(allPermissionsUser());
+
+        mockMvc.perform(post(URL_BASE)
+                .header("Authorization", "Bearer some_value")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(request))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Should return 400 when account_type is blank")
+    void shouldReturn400WhenAccountTypeIsBlank() throws Exception {
+        String request = validCreateRequestBody()
+            .replace("\"account_type\": \"Fines\"", "\"account_type\": \"\"");
+
+        when(userStateService.checkForAuthorisedUser(any())).thenReturn(allPermissionsUser());
+
+        mockMvc.perform(post(URL_BASE)
+                .header("Authorization", "Bearer some_value")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(request))
+            .andExpect(status().isBadRequest());
+    }
+
+
+    @Test
     @DisplayName("Update draft account - Should return updated account details [@PO-973, @PO-745]")
     void testUpdateDraftAccount_success() throws Exception {
 

--- a/src/main/java/uk/gov/hmcts/opal/controllers/DraftAccountController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/DraftAccountController.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.opal.controllers;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
@@ -92,7 +93,7 @@ public class DraftAccountController {
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Creates a Draft Account Entity in the DB based upon data in request body")
     @CheckAcceptHeader
-    public ResponseEntity<DraftAccountResponseDto> postDraftAccount(@RequestBody AddDraftAccountRequestDto dto,
+    public ResponseEntity<DraftAccountResponseDto> postDraftAccount(@Valid @RequestBody AddDraftAccountRequestDto dto,
                 @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
 
         log.debug(":POST:postDraftAccount: creating a new draft account entity: \n{}", dto.toPrettyJson());

--- a/src/main/java/uk/gov/hmcts/opal/dto/AddDraftAccountRequestDto.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/AddDraftAccountRequestDto.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import jakarta.validation.constraints.NotBlank;
 import uk.gov.hmcts.opal.util.KeepAsJsonDeserializer;
 
 import java.time.OffsetDateTime;
@@ -47,6 +48,7 @@ public class AddDraftAccountRequestDto implements ToJsonString, DraftAccountRequ
     private String accountSnapshot;
 
     @JsonProperty(value = "account_type", required = true)
+    @NotBlank(message = "account_type must not be blank")
     private String accountType;
 
     @JsonProperty(value = "timeline_data", required = true)
@@ -55,8 +57,10 @@ public class AddDraftAccountRequestDto implements ToJsonString, DraftAccountRequ
     private String timelineData;
 
     @JsonProperty(value = "submitted_by", required = true)
+    @NotBlank(message = "submitted_by must not be blank")
     private String submittedBy;
 
     @JsonProperty(value = "submitted_by_name", required = true)
+    @NotBlank(message = "submitted_by_name must not be blank")
     private String submittedByName;
 }

--- a/src/main/resources/jsonSchemas/addDraftAccountRequest.json
+++ b/src/main/resources/jsonSchemas/addDraftAccountRequest.json
@@ -9,10 +9,12 @@
     },
     "submitted_by": {
       "type": "string",
+      "minLength": 1,
       "description": "ID of the User that last submitted the Draft Account for checking"
     },
     "submitted_by_name": {
       "type": "string",
+      "minLength": 1,
       "description": "Value of the name claim in the AAD Acces Token"
     },
     "account": {
@@ -21,14 +23,17 @@
     },
     "account_type": {
       "type": "string",
+      "minLength": 1,
       "description": "Type of Account, such as Fixed Penalty Registration"
     },
     "account_status": {
       "type": ["string", "null"],
+      "minLength": 1,
       "description": "Status of the Draft Account - one of Submitted, Resubmitted, Rejected, Approved, Deleted"
     },
     "status_message": {
       "type": ["string", "null"],
+      "minLength": 1,
       "description": "System message related to the account_status"
     },
     "timeline_data": {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-1019 

### Change description ###
This update adds validation to prevent blank input for key fields when creating draft accounts.

- @Valid added to postDraftAccount() controller method
- @NotBlank added to submitted_by, submitted_by_name, and account_type in the DTO
- minLength: 1 added to matching fields in addDraftAccountRequest.json
- Integration tests added to verify 400 responses on invalid input



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
