### PR TITLE
PO-1447-results-refactor-with-lite-entity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -326,6 +326,8 @@ dependencies {
   integrationTestCompileOnly 'org.projectlombok:lombok:1.18.34'
   integrationTestAnnotationProcessor 'org.projectlombok:lombok:1.18.34'
 
+  implementation 'org.mapstruct:mapstruct:1.6.3'
+  annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
 
   implementation group: 'org.apache.xmlgraphics', name: 'fop', version: '2.11'
   implementation group: 'org.apache.xmlgraphics', name: 'fop-core', version: '2.10'

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
@@ -14,7 +14,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.dto.ToJsonString;
-import uk.gov.hmcts.opal.entity.projection.ResultReferenceData;
+import uk.gov.hmcts.opal.dto.reference.ResultReferenceData;
+import uk.gov.hmcts.opal.dto.reference.ResultReferenceDataResponse;
 import uk.gov.hmcts.opal.service.opal.JsonSchemaValidationService;
 import uk.gov.hmcts.opal.service.opal.ResultService;
 
@@ -72,27 +73,28 @@ class ResultControllerIntegrationTest {
             .andExpect(status().isNotFound());
     }
 
-
     @Test
     @DisplayName("Get all results from endpoint [@PO-703, PO-304]")
     void testGetResultsRefData() throws Exception {
-        List<ResultReferenceData> resultList = List.of(
-            new ResultReferenceData("ABC",
+        ResultReferenceDataResponse response = ResultReferenceDataResponse.builder()
+            .refData(List.of(
+                new ResultReferenceData("ABC",
                                     "Result AAA-BBB",
                                     "Result AAA-BBB Cy",
                                     false,
                                     "ResType-XX",
                                     "AAA-01234",
                                     (short)9),
-            new ResultReferenceData("DEF",
+                new ResultReferenceData("DEF",
                                     "Result CCC-DDD",
                                     "Result CCC-DDD Cy",
                                     true, "ResType-YY",
                                     "BBB-56789",
                                     (short)5)
-        );
+            ))
+            .build();
 
-        when(resultService.getAllResults()).thenReturn(resultList);
+        when(resultService.getAllResults()).thenReturn(response);
 
         ResultActions actions = mockMvc.perform(get(URL_BASE));
 
@@ -113,23 +115,25 @@ class ResultControllerIntegrationTest {
     @Test
     @DisplayName("Get all results by ID [@PO-703, PO-304]")
     void getResultsByIds() throws Exception {
-        List<ResultReferenceData> resultList = List.of(
-            new ResultReferenceData("ABC",
+        ResultReferenceDataResponse response = ResultReferenceDataResponse.builder()
+            .refData(List.of(
+                new ResultReferenceData("ABC",
                                     "Result AAA-BBB",
                                     "Result AAA-BBB Cy",
                                     false,
                                     "ResType-XX",
                                     "AAA-01234",
                                     (short)9),
-            new ResultReferenceData("DEF",
+                new ResultReferenceData("DEF",
                                     "Result CCC-DDD",
                                     "Result CCC-DDD Cy",
                                     true, "ResType-YY",
                                     "BBB-56789",
                                     (short)5)
-        );
+            ))
+            .build();
 
-        when(resultService.getResultsByIds(List.of("ABC", "DEF"))).thenReturn(resultList);
+        when(resultService.getResultsByIds(List.of("ABC", "DEF"))).thenReturn(response);
 
         mockMvc.perform(get(URL_BASE + "?result_ids=ABC,DEF"))
             .andExpect(status().isOk())

--- a/src/main/java/uk/gov/hmcts/opal/controllers/ResultController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/ResultController.java
@@ -10,8 +10,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.hmcts.opal.dto.reference.ResultReferenceDataResults;
-import uk.gov.hmcts.opal.entity.projection.ResultReferenceData;
+import uk.gov.hmcts.opal.dto.reference.ResultReferenceData;
+import uk.gov.hmcts.opal.dto.reference.ResultReferenceDataResponse;
 import uk.gov.hmcts.opal.service.opal.ResultService;
 
 import java.util.List;
@@ -50,18 +50,17 @@ public class ResultController {
 
     @GetMapping
     @Operation(summary = "Returns all results or results for the given resultIds.")
-    @Cacheable(value = "resultsCache", key = "#root.method.name + '_' + #resultIds.orElse('ALL_RESULTS')")
-    public ResponseEntity<ResultReferenceDataResults> getResults(
+    public ResponseEntity<ResultReferenceDataResponse> getResults(
         @RequestParam(name = "result_ids") Optional<List<String>> resultIds) {
 
         log.debug("GET:getResults: resultIds: {}", resultIds);
 
-        List<ResultReferenceData> refData = resultIds
+        ResultReferenceDataResponse refDataResponse = resultIds
             .filter(ids -> !ids.isEmpty())
             .map(resultService::getResultsByIds)
             .orElseGet(resultService::getAllResults);
 
-        return buildResponse(ResultReferenceDataResults.builder().refData(refData).build());
+        return buildResponse(refDataResponse);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/search/LegacyResultSearchResults.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/search/LegacyResultSearchResults.java
@@ -6,7 +6,7 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import lombok.Builder;
 import lombok.Data;
-import uk.gov.hmcts.opal.entity.ResultEntity;
+import uk.gov.hmcts.opal.entity.result.ResultEntityLite;
 
 import java.util.List;
 
@@ -17,6 +17,6 @@ import java.util.List;
 public class LegacyResultSearchResults {
 
     @XmlElement(name = "resultEntity")
-    private List<ResultEntity> resultEntities;
+    private List<ResultEntityLite> resultEntities;
     private int totalCount;
 }

--- a/src/main/java/uk/gov/hmcts/opal/dto/reference/ResultReferenceData.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/reference/ResultReferenceData.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.opal.entity.projection;
+package uk.gov.hmcts.opal.dto.reference;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/uk/gov/hmcts/opal/dto/reference/ResultReferenceDataResponse.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/reference/ResultReferenceDataResponse.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import uk.gov.hmcts.opal.entity.projection.ResultReferenceData;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,18 +12,19 @@ import java.util.Optional;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class ResultReferenceDataResults {
+public class ResultReferenceDataResponse {
     private Integer count;
     private List<ResultReferenceData> refData;
 
-    public static class ResultReferenceDataResultsBuilder {
-        public ResultReferenceDataResults.ResultReferenceDataResultsBuilder refData(
+    public static class ResultReferenceDataResponseBuilder {
+
+        public ResultReferenceDataResponse.ResultReferenceDataResponseBuilder refData(
             List<ResultReferenceData> refData) {
             this.refData = refData;
             return this.count(Optional.ofNullable(refData).map(List::size).orElse(0));
         }
 
-        private ResultReferenceDataResults.ResultReferenceDataResultsBuilder count(Integer count) {
+        private ResultReferenceDataResponse.ResultReferenceDataResponseBuilder count(Integer count) {
             this.count = count;
             return this;
         }

--- a/src/main/java/uk/gov/hmcts/opal/entity/result/AbstractResultEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/result/AbstractResultEntity.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.opal.entity.result;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.Column;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@MappedSuperclass
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+public abstract class AbstractResultEntity {
+
+    @Id
+    @Column(name = "result_id")
+    private String resultId;
+
+    @Column(name = "result_title", length = 50, nullable = false)
+    private String resultTitle;
+
+    @Column(name = "result_title_cy", length = 50, nullable = false)
+    private String resultTitleCy;
+
+    @Column(name = "result_type", length = 10, nullable = false)
+    private String resultType;
+
+    @Column(name = "active", nullable = false)
+    private boolean active;
+
+    // maps to imposition_allocation_order in the DTO
+    @Column(name = "imposition_allocation_priority")
+    private Short impositionAllocationPriority;
+
+    @Column(name = "imposition_creditor", length = 10)
+    private String impositionCreditor;
+}

--- a/src/main/java/uk/gov/hmcts/opal/entity/result/ResultEntityFull.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/result/ResultEntityFull.java
@@ -1,43 +1,34 @@
-package uk.gov.hmcts.opal.entity;
+package uk.gov.hmcts.opal.entity.result;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "results")
-@Data
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@Setter
+@Getter
 @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "resultId")
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
-public class ResultEntity {
-
-    @Id
-    private String resultId;
-
-    @Column(name = "result_title", length = 50, nullable = false)
-    private String resultTitle;
-
-    @Column(name = "result_title_cy", length = 50, nullable = false)
-    private String resultTitleCy;
-
-    @Column(name = "result_type", length = 10, nullable = false)
-    private String resultType;
-
-    @Column(name = "active", nullable = false)
-    private boolean active;
+public class ResultEntityFull extends AbstractResultEntity {
 
     @Column(name = "imposition", nullable = false)
     private boolean imposition;
@@ -45,14 +36,8 @@ public class ResultEntity {
     @Column(name = "imposition_category", length = 30)
     private String impositionCategory;
 
-    @Column(name = "imposition_allocation_priority")
-    private Short impositionAllocationPriority;
-
     @Column(name = "imposition_accruing")
     private Boolean impositionAccruing;
-
-    @Column(name = "imposition_creditor", length = 10)
-    private String impositionCreditor;
 
     @Column(name = "enforcement", nullable = false)
     private boolean enforcement;

--- a/src/main/java/uk/gov/hmcts/opal/entity/result/ResultEntityLite.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/result/ResultEntityLite.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.opal.entity.result;
+
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "results")
+@Getter
+@Setter
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@NoArgsConstructor
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "resultId")
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Result")
+public class ResultEntityLite extends AbstractResultEntity {
+
+}

--- a/src/main/java/uk/gov/hmcts/opal/mapper/ResultMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/mapper/ResultMapper.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.opal.mapper;
+
+import uk.gov.hmcts.opal.dto.reference.ResultReferenceData;
+import uk.gov.hmcts.opal.dto.reference.ResultReferenceDataResponse;
+import uk.gov.hmcts.opal.entity.result.ResultEntityFull;
+import uk.gov.hmcts.opal.entity.result.ResultEntityLite;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface ResultMapper {
+
+    ResultReferenceData toRefData(ResultEntityLite entity);
+
+    ResultReferenceData toRefDataFromFull(ResultEntityFull entity);
+
+    default ResultReferenceDataResponse toReferenceDataResponse(List<ResultEntityLite> entities) {
+        List<ResultReferenceData> dtoList = entities.stream()
+            .map(this::toRefData)
+            .toList();
+
+        return ResultReferenceDataResponse.builder()
+            .refData(dtoList)
+            .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/repository/ResultFullRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/ResultFullRepository.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.opal.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+import uk.gov.hmcts.opal.entity.result.ResultEntityFull;
+
+@Repository
+public interface ResultFullRepository extends
+    JpaRepository<ResultEntityFull, String>,
+    JpaSpecificationExecutor<ResultEntityFull> {
+
+}

--- a/src/main/java/uk/gov/hmcts/opal/repository/ResultLiteRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/ResultLiteRepository.java
@@ -3,12 +3,12 @@ package uk.gov.hmcts.opal.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
-import uk.gov.hmcts.opal.entity.ResultEntity;
+import uk.gov.hmcts.opal.entity.result.ResultEntityLite;
 
 import java.util.List;
 
 @Repository
-public interface ResultRepository extends JpaRepository<ResultEntity, String>,
-    JpaSpecificationExecutor<ResultEntity> {
-    List<ResultEntity> findByResultIdIn(List<String> resultIds);
+public interface ResultLiteRepository extends JpaRepository<ResultEntityLite, String>,
+    JpaSpecificationExecutor<ResultEntityLite> {
+    List<ResultEntityLite> findByResultIdIn(List<String> resultIds);
 }

--- a/src/main/java/uk/gov/hmcts/opal/repository/jpa/ResultSpecs.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/jpa/ResultSpecs.java
@@ -2,14 +2,14 @@ package uk.gov.hmcts.opal.repository.jpa;
 
 import org.springframework.data.jpa.domain.Specification;
 import uk.gov.hmcts.opal.dto.search.ResultSearchDto;
-import uk.gov.hmcts.opal.entity.ResultEntity;
-import uk.gov.hmcts.opal.entity.ResultEntity_;
+import uk.gov.hmcts.opal.entity.result.ResultEntityFull;
+import uk.gov.hmcts.opal.entity.result.ResultEntityFull_;
 
 import java.util.Optional;
 
-public class ResultSpecs extends EntitySpecs<ResultEntity> {
+public class ResultSpecs extends EntitySpecs<ResultEntityFull> {
 
-    public Specification<ResultEntity> findBySearchCriteria(ResultSearchDto criteria) {
+    public Specification<ResultEntityFull> findBySearchCriteria(ResultSearchDto criteria) {
         return Specification.allOf(specificationList(
             notBlank(criteria.getResultId()).map(ResultSpecs::likeResultId),
             notBlank(criteria.getResultTitle()).map(ResultSpecs::likeResultTitle),
@@ -23,71 +23,76 @@ public class ResultSpecs extends EntitySpecs<ResultEntity> {
         ));
     }
 
-    public Specification<ResultEntity> referenceDataFilter(Optional<String> filter) {
+    public Specification<ResultEntityFull> referenceDataFilter(Optional<String> filter) {
         return Specification.allOf(specificationList(
             filter.filter(s -> !s.isBlank()).map(this::likeAnyResult)
         ));
     }
 
-    public static Specification<ResultEntity> equalsResultId(String resultId) {
-        return (root, query, builder) -> builder.equal(root.get(ResultEntity_.resultId), resultId);
+    public static Specification<ResultEntityFull> equalsResultId(String resultId) {
+        return (root, query, builder) -> builder.equal(root.get(ResultEntityFull_.resultId), resultId);
     }
 
-    public static Specification<ResultEntity> likeResultId(String resultId) {
-        return (root, query, builder) -> likeWildcardPredicate(root.get(ResultEntity_.resultId), builder, resultId);
+    public static Specification<ResultEntityFull> likeResultId(String resultId) {
+        return (root, query, builder) -> likeWildcardPredicate(root.get(ResultEntityFull_.resultId), builder, resultId);
     }
 
-    public static Specification<ResultEntity> likeResultTitle(String resultTitle) {
-        return (root, query, builder) -> likeWildcardPredicate(root.get(ResultEntity_.resultTitle), builder,
+    public static Specification<ResultEntityFull> likeResultTitle(String resultTitle) {
+        return (root, query, builder) -> likeWildcardPredicate(root.get(ResultEntityFull_.resultTitle), builder,
                                                                resultTitle);
     }
 
-    public static Specification<ResultEntity> likeResultTitleCy(String resultTitleCy) {
-        return (root, query, builder) -> likeWildcardPredicate(root.get(ResultEntity_.resultTitleCy), builder,
+    public static Specification<ResultEntityFull> likeResultTitleCy(String resultTitleCy) {
+        return (root, query, builder) -> likeWildcardPredicate(root.get(ResultEntityFull_.resultTitleCy), builder,
                                                                resultTitleCy);
     }
 
-    public static Specification<ResultEntity> equalsResultType(String resultType) {
-        return (root, query, builder) -> builder.equal(root.get(ResultEntity_.resultType), resultType);
+    public static Specification<ResultEntityFull> equalsResultType(String resultType) {
+        return (root, query, builder) -> builder.equal(root.get(ResultEntityFull_.resultType), resultType);
     }
 
-    public static Specification<ResultEntity> likeResultType(String resultType) {
-        return (root, query, builder) -> likeWildcardPredicate(root.get(ResultEntity_.resultType), builder, resultType);
+    public static Specification<ResultEntityFull> likeResultType(String resultType) {
+        return (root, query, builder) ->
+            likeWildcardPredicate(root.get(ResultEntityFull_.resultType), builder, resultType);
     }
 
-    public static Specification<ResultEntity> equalsImpositionCategory(String impositionCategory) {
-        return (root, query, builder) -> builder.equal(root.get(ResultEntity_.impositionCategory), impositionCategory);
+    public static Specification<ResultEntityFull> equalsImpositionCategory(String impositionCategory) {
+        return (root, query, builder) ->
+            builder.equal(root.get(ResultEntityFull_.impositionCategory), impositionCategory);
     }
 
-    public static Specification<ResultEntity> likeImpositionCategory(String impositionCategory) {
-        return (root, query, builder) -> likeWildcardPredicate(root.get(ResultEntity_.impositionCategory), builder,
+    public static Specification<ResultEntityFull> likeImpositionCategory(String impositionCategory) {
+        return (root, query, builder) ->
+            likeWildcardPredicate(root.get(ResultEntityFull_.impositionCategory), builder,
                                                                impositionCategory);
     }
 
-    public static Specification<ResultEntity> equalsImpositionAllocationPriority(Short impositionAllocationPriority) {
-        return (root, query, builder) -> builder.equal(root.get(ResultEntity_.impositionAllocationPriority),
+    public static Specification<ResultEntityFull>
+        equalsImpositionAllocationPriority(Short impositionAllocationPriority) {
+        return (root, query, builder) -> builder.equal(root.get(ResultEntityFull_.impositionAllocationPriority),
                                                        impositionAllocationPriority);
     }
 
-    public static Specification<ResultEntity> equalsImpositionCreditor(String impositionCreditor) {
-        return (root, query, builder) -> builder.equal(root.get(ResultEntity_.impositionCreditor), impositionCreditor);
+    public static Specification<ResultEntityFull> equalsImpositionCreditor(String impositionCreditor) {
+        return (root, query, builder) ->
+            builder.equal(root.get(ResultEntityFull_.impositionCreditor), impositionCreditor);
     }
 
-    public static Specification<ResultEntity> likeImpositionCreditor(String impositionCreditor) {
-        return (root, query, builder) -> likeWildcardPredicate(root.get(ResultEntity_.impositionCreditor), builder,
+    public static Specification<ResultEntityFull> likeImpositionCreditor(String impositionCreditor) {
+        return (root, query, builder) -> likeWildcardPredicate(root.get(ResultEntityFull_.impositionCreditor), builder,
                                                                impositionCreditor);
     }
 
-    public static Specification<ResultEntity> equalsResultParameters(String resultParameters) {
-        return (root, query, builder) -> builder.equal(root.get(ResultEntity_.resultParameters), resultParameters);
+    public static Specification<ResultEntityFull> equalsResultParameters(String resultParameters) {
+        return (root, query, builder) -> builder.equal(root.get(ResultEntityFull_.resultParameters), resultParameters);
     }
 
-    public static Specification<ResultEntity> likeResultParameters(String resultParameters) {
-        return (root, query, builder) -> likeWildcardPredicate(root.get(ResultEntity_.resultParameters), builder,
+    public static Specification<ResultEntityFull> likeResultParameters(String resultParameters) {
+        return (root, query, builder) -> likeWildcardPredicate(root.get(ResultEntityFull_.resultParameters), builder,
                                                                resultParameters);
     }
 
-    public Specification<ResultEntity> likeAnyResult(String filter) {
+    public Specification<ResultEntityFull> likeAnyResult(String filter) {
         return Specification.anyOf(
             likeResultId(filter),
             likeResultTitle(filter),

--- a/src/main/java/uk/gov/hmcts/opal/service/ResultServiceInterface.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/ResultServiceInterface.java
@@ -1,13 +1,14 @@
 package uk.gov.hmcts.opal.service;
 
 import uk.gov.hmcts.opal.dto.search.ResultSearchDto;
-import uk.gov.hmcts.opal.entity.ResultEntity;
+import uk.gov.hmcts.opal.entity.result.ResultEntityFull;
+import uk.gov.hmcts.opal.entity.result.ResultEntityLite;
 
 import java.util.List;
 
 public interface ResultServiceInterface {
 
-    ResultEntity getResult(String resultId);
+    ResultEntityLite getResult(String resultId);
 
-    List<ResultEntity> searchResults(ResultSearchDto criteria);
+    List<ResultEntityFull> searchResults(ResultSearchDto criteria);
 }

--- a/src/test/java/uk/gov/hmcts/opal/controllers/ResultControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/ResultControllerTest.java
@@ -7,7 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import uk.gov.hmcts.opal.entity.projection.ResultReferenceData;
+import uk.gov.hmcts.opal.dto.reference.ResultReferenceData;
 import uk.gov.hmcts.opal.service.opal.ResultService;
 
 import java.util.Optional;

--- a/src/test/java/uk/gov/hmcts/opal/mapper/ResultMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/mapper/ResultMapperTest.java
@@ -1,0 +1,110 @@
+package uk.gov.hmcts.opal.mapper;
+
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import uk.gov.hmcts.opal.dto.reference.ResultReferenceData;
+import uk.gov.hmcts.opal.dto.reference.ResultReferenceDataResponse;
+import uk.gov.hmcts.opal.entity.result.ResultEntityFull;
+import uk.gov.hmcts.opal.entity.result.ResultEntityLite;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ResultMapperTest {
+
+    private final ResultMapper resultMapper = Mappers.getMapper(ResultMapper.class);
+
+    @Test
+    void toRefData_shouldMapLiteEntityToDto() {
+        // Arrange
+        ResultEntityLite entity = ResultEntityLite.builder()
+            .resultId("R123")
+            .resultTitle("Test Result")
+            .resultTitleCy("Test Result Welsh")
+            .resultType("FPD")
+            .active(true)
+            .impositionAllocationPriority((short) 1)
+            .impositionCreditor("HMCTS")
+            .build();
+
+        // Act
+        ResultReferenceData result = resultMapper.toRefData(entity);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals("R123", result.resultId());
+        assertEquals("Test Result", result.resultTitle());
+        assertEquals("Test Result Welsh", result.resultTitleCy());
+        assertEquals("FPD", result.resultType());
+        assertEquals(true, result.active());
+        assertEquals((short) 1, result.impositionAllocationPriority());
+        assertEquals("HMCTS", result.impositionCreditor());
+    }
+
+    @Test
+    void toRefDataFromFull_shouldMapFullEntityToDto() {
+        // Arrange
+        ResultEntityFull entity = ResultEntityFull.builder()
+            .resultId("R456")
+            .resultTitle("Full Result")
+            .resultTitleCy("Full Result Welsh")
+            .resultType("FPR")
+            .active(true)
+            .impositionAllocationPriority((short) 2)
+            .impositionCreditor("COURT")
+            // Include additional fields present only in Full entity
+            .imposition(true)
+            .impositionCategory("FINE")
+            .impositionAccruing(false)
+            .build();
+
+        // Act
+        ResultReferenceData result = resultMapper.toRefDataFromFull(entity);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals("R456", result.resultId());
+        assertEquals("Full Result", result.resultTitle());
+        assertEquals("Full Result Welsh", result.resultTitleCy());
+        assertEquals("FPR", result.resultType());
+        assertEquals(true, result.active());
+        assertEquals((short) 2, result.impositionAllocationPriority());
+        assertEquals("COURT", result.impositionCreditor());
+    }
+
+    @Test
+    void toReferenceDataResponse_shouldConvertListToResponse() {
+        // Arrange
+        ResultEntityLite entity1 = ResultEntityLite.builder()
+            .resultId("R1")
+            .resultTitle("Result 1")
+            .resultTitleCy("Result 1 Welsh")
+            .resultType("TYPE1")
+            .active(true)
+            .build();
+
+        ResultEntityLite entity2 = ResultEntityLite.builder()
+            .resultId("R2")
+            .resultTitle("Result 2")
+            .resultTitleCy("Result 2 Welsh")
+            .resultType("TYPE2")
+            .active(false)
+            .build();
+
+        List<ResultEntityLite> entities = List.of(entity1, entity2);
+
+        // Act
+        ResultReferenceDataResponse response = resultMapper.toReferenceDataResponse(entities);
+
+        // Assert
+        assertNotNull(response);
+        assertNotNull(response.getRefData());
+        assertEquals(2, response.getRefData().size());
+        assertEquals("R1", response.getRefData().get(0).resultId());
+        assertEquals("Result 1", response.getRefData().get(0).resultTitle());
+        assertEquals("R2", response.getRefData().get(1).resultId());
+        assertEquals("Result 2", response.getRefData().get(1).resultTitle());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/ResultServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/ResultServiceTest.java
@@ -11,10 +11,14 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.repository.query.FluentQuery;
+import uk.gov.hmcts.opal.dto.reference.ResultReferenceDataResponse;
 import uk.gov.hmcts.opal.dto.search.ResultSearchDto;
-import uk.gov.hmcts.opal.entity.ResultEntity;
-import uk.gov.hmcts.opal.entity.projection.ResultReferenceData;
-import uk.gov.hmcts.opal.repository.ResultRepository;
+import uk.gov.hmcts.opal.entity.result.ResultEntityFull;
+import uk.gov.hmcts.opal.entity.result.ResultEntityLite;
+import uk.gov.hmcts.opal.dto.reference.ResultReferenceData;
+import uk.gov.hmcts.opal.mapper.ResultMapper;
+import uk.gov.hmcts.opal.repository.ResultFullRepository;
+import uk.gov.hmcts.opal.repository.ResultLiteRepository;
 
 import java.util.List;
 import java.util.Optional;
@@ -29,7 +33,13 @@ import static org.mockito.Mockito.when;
 class ResultServiceTest {
 
     @Mock
-    private ResultRepository resultRepository;
+    private ResultLiteRepository resultLiteRepository;
+
+    @Mock
+    private ResultFullRepository resultFullRepository;
+
+    @Mock
+    private ResultMapper resultMapper;
 
     @InjectMocks
     private ResultService resultService;
@@ -38,11 +48,11 @@ class ResultServiceTest {
     void testGetResult() {
         // Arrange
 
-        ResultEntity resultEntity = ResultEntity.builder().build();
-        when(resultRepository.getReferenceById(any())).thenReturn(resultEntity);
+        ResultEntityLite resultEntity = ResultEntityLite.builder().build();
+        when(resultLiteRepository.getReferenceById(any())).thenReturn(resultEntity);
 
         // Act
-        ResultEntity result = resultService.getResult("ABC");
+        ResultEntityLite result = resultService.getResult("ABC");
 
         // Assert
         assertNotNull(result);
@@ -53,8 +63,12 @@ class ResultServiceTest {
     void testGetResultReferenceData() {
         // Arrange
 
-        ResultEntity resultEntity = ResultEntity.builder().build();
-        when(resultRepository.getReferenceById(any())).thenReturn(resultEntity);
+        ResultEntityLite resultEntity = ResultEntityLite.builder().build();
+        ResultReferenceData expectedRefData = new ResultReferenceData(
+            null, null, null, false, null, null, null
+        );
+        when(resultLiteRepository.getReferenceById(any())).thenReturn(resultEntity);
+        when(resultMapper.toRefData(resultEntity)).thenReturn(expectedRefData);
 
         // Act
         ResultReferenceData result = resultService.getResultReferenceData("ABC");
@@ -67,51 +81,45 @@ class ResultServiceTest {
     @Test
     void testGetAllResults() {
         // Arrange
-        ResultEntity resultEntity = ResultEntity.builder().build();
-        when(resultRepository.findAll()).thenReturn(List.of(resultEntity));
+        ResultEntityLite resultEntity = ResultEntityLite.builder().build();
+        List<ResultEntityLite> resultEntities = List.of(resultEntity);
+
+        ResultReferenceDataResponse expectedResponse = ResultReferenceDataResponse.builder()
+            .refData(List.of(new ResultReferenceData(
+                null, null, null, false, null, null, null)))
+            .build();
+
+        when(resultLiteRepository.findAll()).thenReturn(resultEntities);
+        when(resultMapper.toReferenceDataResponse(resultEntities)).thenReturn(expectedResponse);
 
         // Act
-        List<ResultReferenceData> result = resultService.getAllResults();
-
-        ResultReferenceData refData =  new ResultReferenceData(
-            resultEntity.getResultId(),
-            resultEntity.getResultTitle(),
-            resultEntity.getResultTitleCy(),
-            resultEntity.isActive(),
-            resultEntity.getResultType(),
-            resultEntity.getImpositionCreditor(),
-            resultEntity.getImpositionAllocationPriority()
-        );
+        ResultReferenceDataResponse result = resultService.getAllResults();
 
         // Assert
-        assertEquals(List.of(refData), result);
-
+        assertEquals(expectedResponse, result);
     }
 
     @Test
     void testGetResultsByIds() {
         // Arrange
-        ResultEntity resultEntity = ResultEntity.builder().build();
-        when(resultRepository.findByResultIdIn(any())).thenReturn(List.of(resultEntity));
+        ResultEntityLite resultEntity = ResultEntityLite.builder().build();
+        List<ResultEntityLite> resultEntities = List.of(resultEntity);
+        List<String> resultIds = List.of("ABC");
+
+        ResultReferenceDataResponse expectedResponse = ResultReferenceDataResponse.builder()
+            .refData(List.of(new ResultReferenceData(
+                null, null, null, false, null, null, null)))
+            .build();
+
+        when(resultLiteRepository.findByResultIdIn(resultIds)).thenReturn(resultEntities);
+        when(resultMapper.toReferenceDataResponse(resultEntities)).thenReturn(expectedResponse);
 
         // Act
-        List<ResultReferenceData> result = resultService.getResultsByIds(List.of("ABC"));
-
-        ResultReferenceData refData =  new ResultReferenceData(
-            resultEntity.getResultId(),
-            resultEntity.getResultTitle(),
-            resultEntity.getResultTitleCy(),
-            resultEntity.isActive(),
-            resultEntity.getResultType(),
-            resultEntity.getImpositionCreditor(),
-            resultEntity.getImpositionAllocationPriority()
-        );
+        ResultReferenceDataResponse result = resultService.getResultsByIds(resultIds);
 
         // Assert
-        assertEquals(List.of(refData), result);
-
+        assertEquals(expectedResponse, result);
     }
-
 
 
 
@@ -121,19 +129,18 @@ class ResultServiceTest {
         // Arrange
         FluentQuery.FetchableFluentQuery ffq = Mockito.mock(FluentQuery.FetchableFluentQuery.class);
 
-        ResultEntity resultEntity = ResultEntity.builder().build();
-        Page<ResultEntity> mockPage = new PageImpl<>(List.of(resultEntity), Pageable.unpaged(), 999L);
-        when(resultRepository.findBy(any(Specification.class), any())).thenAnswer(iom -> {
+        ResultEntityFull resultEntity = ResultEntityFull.builder().build();
+        Page<ResultEntityFull> mockPage = new PageImpl<>(List.of(resultEntity), Pageable.unpaged(), 999L);
+        when(resultFullRepository.findBy(any(Specification.class), any())).thenAnswer(iom -> {
             iom.getArgument(1, Function.class).apply(ffq);
             return mockPage;
         });
 
         // Act
-        List<ResultEntity> result = resultService.searchResults(ResultSearchDto.builder().build());
+        List<ResultEntityFull> result = resultService.searchResults(ResultSearchDto.builder().build());
 
         // Assert
         assertEquals(List.of(resultEntity), result);
-
     }
 
     @SuppressWarnings("unchecked")
@@ -143,9 +150,14 @@ class ResultServiceTest {
         FluentQuery.FetchableFluentQuery ffq = Mockito.mock(FluentQuery.FetchableFluentQuery.class);
         when(ffq.sortBy(any())).thenReturn(ffq);
 
-        ResultEntity entity = ResultEntity.builder().build();
-        Page<ResultEntity> mockPage = new PageImpl<>(List.of(entity), Pageable.unpaged(), 999L);
-        when(resultRepository.findBy(any(Specification.class), any())).thenAnswer(iom -> {
+        ResultEntityFull entity = ResultEntityFull.builder().build();
+        ResultReferenceData expectedRefData = new ResultReferenceData(
+            null, null, null, false, null, null, null
+        );
+        when(resultMapper.toRefDataFromFull(entity)).thenReturn(expectedRefData);
+
+        Page<ResultEntityFull> mockPage = new PageImpl<>(List.of(entity), Pageable.unpaged(), 999L);
+        when(resultFullRepository.findBy(any(Specification.class), any())).thenAnswer(iom -> {
             iom.getArgument(1, Function.class).apply(ffq);
             return mockPage;
         });
@@ -153,7 +165,7 @@ class ResultServiceTest {
         // Act
         List<ResultReferenceData> result = resultService.getReferenceData(Optional.empty());
 
-        ResultReferenceData refData =  new ResultReferenceData(
+        ResultReferenceData refData = new ResultReferenceData(
             entity.getResultId(),
             entity.getResultTitle(),
             entity.getResultTitleCy(),
@@ -165,6 +177,5 @@ class ResultServiceTest {
 
         // Assert
         assertEquals(List.of(refData), result);
-
     }
 }


### PR DESCRIPTION

### JIRA link (if applicable) ###

[PO-1447] (https://tools.hmcts.net/jira/browse/PO-1447)

### Change description ###

Separation of concerns refactor and introduce lite entity

1. Moved result dto from entity to dtos package
2. Moved dto response creation to service layer from controller
3.  Moved mapping to mapper package - used mapstruct interface
4. created "Lite" and full entities  (I think only Lite is used for current API, but specification code needs more fields - not sure if will be needed in practice?) The Lite reduced the number of fields in the SQL.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
