### PR TITLE
PO-957: Add fields to DraftAccountSummaryDto and use DraftAccountMapper

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/dto/DraftAccountSummaryDto.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/DraftAccountSummaryDto.java
@@ -9,6 +9,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.opal.entity.DraftAccountStatus;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 
 @Data
@@ -54,4 +55,16 @@ public class DraftAccountSummaryDto implements ToJsonString {
 
     @JsonProperty("account_id")
     private Long accountId;
+
+    @JsonProperty("submitted_by_name")
+    private String submittedByName;
+
+    @JsonProperty("account_status_date")
+    private LocalDate accountStatusDate;
+
+    @JsonProperty("status_message")
+    private String statusMessage;
+
+    @JsonProperty("version_number")
+    private Long versionNumber;
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/DraftAccountMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/DraftAccountMapper.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.opal.service.opal;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import uk.gov.hmcts.opal.dto.DraftAccountSummaryDto;
+import uk.gov.hmcts.opal.entity.DraftAccountEntity;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+@Mapper(componentModel = "spring")
+public interface DraftAccountMapper {
+
+    @Mapping(source = "version", target = "versionNumber")
+    @Mapping(source = "createdDate", target = "createdDate", qualifiedByName = "toOffsetDateTime")
+    @Mapping(source = "validatedDate", target = "validatedDate", qualifiedByName = "toOffsetDateTime")
+    @Mapping(source = "businessUnit.businessUnitId", target = "businessUnitId")
+    DraftAccountSummaryDto toDto(DraftAccountEntity entity);
+
+    @Named("toOffsetDateTime")
+    static OffsetDateTime toOffsetDateTime(LocalDateTime localDateTime) {
+        return localDateTime == null ? null : localDateTime.atOffset(ZoneOffset.UTC);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/DraftAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/DraftAccountService.java
@@ -22,11 +22,9 @@ import uk.gov.hmcts.opal.entity.DraftAccountEntity;
 import uk.gov.hmcts.opal.entity.DraftAccountStatus;
 import uk.gov.hmcts.opal.repository.BusinessUnitRepository;
 import uk.gov.hmcts.opal.service.opal.jpa.DraftAccountTransactions;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-
 import static uk.gov.hmcts.opal.util.DateTimeUtils.toUtcDateTime;
 import static uk.gov.hmcts.opal.util.VersionUtils.verifyUpdated;
 
@@ -50,6 +48,8 @@ public class DraftAccountService {
     private final BusinessUnitRepository businessUnitRepository;
 
     private final JsonSchemaValidationService jsonSchemaValidationService;
+
+    private final DraftAccountMapper draftAccountMapper;
 
     public DraftAccountResponseDto getDraftAccount(long draftAccountId, String authHeaderValue) {
 
@@ -219,19 +219,6 @@ public class DraftAccountService {
     }
 
     public DraftAccountSummaryDto toSummaryDto(DraftAccountEntity entity) {
-        return DraftAccountSummaryDto.builder()
-            .draftAccountId(entity.getDraftAccountId())
-            .businessUnitId(entity.getBusinessUnit().getBusinessUnitId())
-            .createdDate(toUtcDateTime(entity.getCreatedDate()))
-            .submittedBy(entity.getSubmittedBy())
-            .validatedDate(toUtcDateTime(entity.getValidatedDate()))
-            .validatedBy(entity.getValidatedBy())
-            .validatedByName(entity.getValidatedByName())
-            .accountSnapshot(entity.getAccountSnapshot())
-            .accountType(entity.getAccountType())
-            .accountStatus(entity.getAccountStatus())
-            .accountNumber(entity.getAccountNumber())
-            .accountId(entity.getAccountId())
-            .build();
+        return draftAccountMapper.toDto(entity);
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/DraftAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/DraftAccountServiceTest.java
@@ -52,6 +52,9 @@ class DraftAccountServiceTest {
     @Mock
     private DraftAccountTransactions draftAccountTransactions;
 
+    @Mock
+    private DraftAccountMapper draftAccountMapper;
+
     @InjectMocks
     private DraftAccountService draftAccountService;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-957

### Change description ###
Changes made to support PO-957:

- Created `DraftAccountMapper` to convert entity to DTO
- Updated `DraftAccountSummaryDto` to include:
  - submitted_by_name
  - account_status_date
  - status_message
  - version_number
- Refactored `DraftAccountService` to use the new mapper
- Updated `DraftAccountServiceTest` to include a mocked mapper

Tested locally using Postman with BE_DEV_ROLE_PERMISSIONS set.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
