### PR TITLE
PO-1904: Refactor offence search date filter and align tests

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/opal/steps/offences/SearchOffencesResponseStepDef.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/steps/offences/SearchOffencesResponseStepDef.java
@@ -6,6 +6,7 @@ import net.serenitybdd.rest.SerenityRest;
 import uk.gov.hmcts.opal.steps.BaseStepDef;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
@@ -53,8 +54,7 @@ public class SearchOffencesResponseStepDef extends BaseStepDef {
     @Then("the offences in the response are before {string} only")
     public void offenceResponseBeforeDate(String activeDate) {
         // Format the active date string to a LocalDateTime object
-        DateTimeFormatter activeDateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-        LocalDateTime parsedActiveDate = LocalDateTime.parse(activeDate, activeDateFormatter);
+        OffsetDateTime parsedActiveDate = OffsetDateTime.parse(activeDate, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
 
         // Extract the list of dates from the response
         List<String> usedFromDates = SerenityRest.then().extract().jsonPath().getList("searchData.date_used_from");
@@ -63,7 +63,7 @@ public class SearchOffencesResponseStepDef extends BaseStepDef {
         // Iterate through each date in the response
         for (String dateFromResponse : usedFromDates) {
             // Parse the date from the response to a LocalDateTime object
-            LocalDateTime parsedDateFromResponse = LocalDateTime.parse(dateFromResponse);
+            OffsetDateTime parsedDateFromResponse = OffsetDateTime.parse(dateFromResponse);
             // Assert that the date from the response is before the active date
             assertTrue(parsedDateFromResponse.isBefore(parsedActiveDate),
                     "Response date is not before Active date: "
@@ -72,8 +72,7 @@ public class SearchOffencesResponseStepDef extends BaseStepDef {
         }
         for (String dateFromResponse : usedToDates) {
             // Parse the date from the response to a LocalDateTime object
-            LocalDateTime parsedDateFromResponse = LocalDateTime.parse(dateFromResponse);
-            // Assert that the active date is before the used to date from the response
+            OffsetDateTime parsedDateFromResponse = OffsetDateTime.parse(dateFromResponse);            // Assert that the active date is before the used to date from the response
             assertTrue(parsedActiveDate.isBefore(parsedDateFromResponse),
                     "Active date is not before Response date: "
                             + "\n Date from response: " + parsedDateFromResponse

--- a/src/functionalTest/resources/features/opalMode/manualAccountCreation/offences/PO-614_newFieldsInOffenceAPI.feature
+++ b/src/functionalTest/resources/features/opalMode/manualAccountCreation/offences/PO-614_newFieldsInOffenceAPI.feature
@@ -10,7 +10,7 @@ Feature: PO-614 Introduce the new OFFENCE table columns into the OFFENCES entity
       | business_unit_id  | null                                                                                                        |
       | offence_title     | Fail to wear protective clothing/footwear and meets other criteria when entering quarantine centre/facility |
       | offence_title_cy  | null                                                                                                        |
-      | date_used_from    | 2006-11-01T00:00:00                                                                                         |
-      | date_used_to      | 2007-06-30T00:00:00                                                                                         |
+      | date_used_from    | 2006-11-01T00:00:00Z                                                                                        |
+      | date_used_to      | 2007-06-30T00:00:00Z                                                                                        |
       | offence_oas       | null                                                                                                        |
       | offence_oas_cy    | null                                                                                                        |

--- a/src/functionalTest/resources/features/opalMode/manualAccountCreation/offences/PO-926_offencesSearchApi.feature
+++ b/src/functionalTest/resources/features/opalMode/manualAccountCreation/offences/PO-926_offencesSearchApi.feature
@@ -82,14 +82,14 @@ Feature: PO-926 Offences Search API
   Scenario: Offence Search API - Search by Active Date
     Given I am testing as the "opal-test@hmcts.net" user
     When I make a request to the offence search api filtering by
-      | cjs_code        | PA1101              |
-      | title           |                     |
-      | act_and_section |                     |
-      | active_date     | 1920-03-12 00:00:00 |
-      | max_results     | 100                 |
+      | cjs_code        | PA1101               |
+      | title           |                      |
+      | act_and_section |                      |
+      | active_date     | 1920-03-12T00:00:00Z |
+      | max_results     | 100                  |
 
     Then The offence search response returns 200
-    Then the offences in the response are before "1920-03-12 00:00:00" only
+    Then the offences in the response are before "1920-03-12T00:00:00Z" only
 
   Scenario: Offence Search API - Inactive Offences - Active Date Null - Inactive offences returned
     Given I am testing as the "opal-test@hmcts.net" user
@@ -105,11 +105,11 @@ Feature: PO-926 Offences Search API
   Scenario: Offence Search API - Inactive Offences - Active Date populated - Inactive offences not returned
     Given I am testing as the "opal-test@hmcts.net" user
     When I make a request to the offence search api filtering by
-      | cjs_code        | PA1101              |
-      | title           |                     |
-      | act_and_section |                     |
-      | active_date     | 2024-03-12 00:00:00 |
-      | max_results     | 100                 |
+      | cjs_code        | PA1101               |
+      | title           |                      |
+      | act_and_section |                      |
+      | active_date     | 2024-03-12T00:00:00Z |
+      | max_results     | 100                  |
     Then The offence search response returns 200
     And there are 0 offences in the response
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OffenceControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OffenceControllerIntegrationTest.java
@@ -95,7 +95,7 @@ class OffenceControllerIntegrationTest extends AbstractIntegrationTest {
             .andExpect(jsonPath("$.searchData[0].offence_id").value(33430))
             .andExpect(jsonPath("$.searchData[0].cjs_code").value("IC01001"))
             .andExpect(jsonPath("$.searchData[0].offence_title").value("Genocide"))
-            .andExpect(jsonPath("$.searchData[0].date_used_from").value("2001-09-01T00:00:00"))
+            .andExpect(jsonPath("$.searchData[0].date_used_from").value("2001-09-01T00:00:00Z"))
             .andExpect(jsonPath("$.searchData[0].offence_oas")
                 .value("Contrary to sections 51 and 53 of the International Criminal Court Act 2001."))
             .andReturn();
@@ -153,5 +153,27 @@ class OffenceControllerIntegrationTest extends AbstractIntegrationTest {
             .andExpect(jsonPath("$.refData", hasSize(2)))
             .andExpect(jsonPath("$.count").value(2))
             .andExpect(jsonPath("$.refData[*].cjs_code", containsInAnyOrder("WT67003","ZP97010")));
+    }
+
+    @Test
+    @DisplayName("Post offence search with valid active_date in Zulu format [PO-1904]")
+    void testPostOffencesSearchWithActiveDate() throws Exception {
+        ResultActions actions = mockMvc.perform(post("/offences/search")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""
+            {
+                "cjs_code": "IC01001",
+                "active_date": "2001-09-01T00:00:00Z"
+            }
+            """));
+
+        String body = actions.andReturn().getResponse().getContentAsString();
+        log.info(":testPostOffencesSearchWithActiveDate: Response body:\n" + ToJsonString.toPrettyJson(body));
+
+        actions.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.searchData[0].offence_id").value(33430))
+            .andExpect(jsonPath("$.searchData[0].cjs_code").value("IC01001"))
+            .andExpect(jsonPath("$.searchData[0].offence_title").value("Genocide"));
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/dto/reference/OffenceReferenceData.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/reference/OffenceReferenceData.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.opal.dto.reference;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record OffenceReferenceData(
@@ -12,8 +12,8 @@ public record OffenceReferenceData(
     @JsonProperty("business_unit_id") Short businessUnitId,
     @JsonProperty("offence_title") String offenceTitle,
     @JsonProperty("offence_title_cy") String offenceTitleCy,
-    @JsonProperty("date_used_from") LocalDateTime dateUsedFrom,
-    @JsonProperty("date_used_to") LocalDateTime dateUsedTo,
+    @JsonProperty("date_used_from") OffsetDateTime dateUsedFrom,
+    @JsonProperty("date_used_to") OffsetDateTime dateUsedTo,
     @JsonProperty("offence_oas") String offenceOas,
     @JsonProperty("offence_oas_cy") String offenceOasCy) {
 }

--- a/src/main/java/uk/gov/hmcts/opal/dto/reference/OffenceSearchData.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/reference/OffenceSearchData.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.opal.dto.reference;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record OffenceSearchData(
@@ -11,8 +11,8 @@ public record OffenceSearchData(
     @JsonProperty("cjs_code") String cjsCode,
     @JsonProperty("offence_title") String offenceTitle,
     @JsonProperty("offence_title_cy") String offenceTitleCy,
-    @JsonProperty("date_used_from") LocalDateTime dateUsedFrom,
-    @JsonProperty("date_used_to") LocalDateTime dateUsedTo,
+    @JsonProperty("date_used_from") OffsetDateTime dateUsedFrom,
+    @JsonProperty("date_used_to") OffsetDateTime dateUsedTo,
     @JsonProperty("offence_oas") String offenceOas,
     @JsonProperty("offence_oas_cy") String offenceOasCy) {
 }

--- a/src/main/java/uk/gov/hmcts/opal/dto/search/OffenceSearchDto.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/search/OffenceSearchDto.java
@@ -1,14 +1,11 @@
 package uk.gov.hmcts.opal.dto.search;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import lombok.Builder;
 import lombok.Data;
 import uk.gov.hmcts.opal.dto.ToJsonString;
-import uk.gov.hmcts.opal.util.LocalDateTimeAdapter;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 @Data
 @Builder
@@ -26,10 +23,8 @@ public class OffenceSearchDto implements ToJsonString {
     @JsonProperty("act_and_section")
     private String actSection;
 
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    @XmlJavaTypeAdapter(LocalDateTimeAdapter.class)
     @JsonProperty("active_date")
-    private LocalDateTime activeDate;
+    private OffsetDateTime activeDate;
 
     @JsonProperty("max_results")
     private Integer maxResults;

--- a/src/main/java/uk/gov/hmcts/opal/mapper/OffenceMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/mapper/OffenceMapper.java
@@ -1,14 +1,29 @@
 package uk.gov.hmcts.opal.mapper;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
 import uk.gov.hmcts.opal.dto.reference.OffenceReferenceData;
 import uk.gov.hmcts.opal.dto.reference.OffenceSearchData;
 import uk.gov.hmcts.opal.entity.offence.OffenceEntity;
 
 @Mapper(componentModel = "spring")
 public interface OffenceMapper {
-
+    @Mapping(target = "dateUsedFrom", source = "dateUsedFrom", qualifiedByName = "toOffset")
+    @Mapping(target = "dateUsedTo", source = "dateUsedTo", qualifiedByName = "toOffset")
     OffenceReferenceData toRefData(OffenceEntity entity);
 
+    @Mapping(target = "dateUsedFrom", source = "dateUsedFrom", qualifiedByName = "toOffset")
+    @Mapping(target = "dateUsedTo", source = "dateUsedTo", qualifiedByName = "toOffset")
     OffenceSearchData toSearchData(OffenceEntity entity);
+
+    @Named("toOffset")
+    static OffsetDateTime toOffset(LocalDateTime localDateTime) {
+        return localDateTime == null ? null : localDateTime.atOffset(ZoneOffset.UTC);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/opal/repository/jpa/OffenceSpecs.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/jpa/OffenceSpecs.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.opal.dto.search.OffenceSearchDto;
 import uk.gov.hmcts.opal.entity.offence.OffenceEntity;
 import uk.gov.hmcts.opal.entity.offence.OffenceEntity_;
 
+import java.time.OffsetDateTime;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
@@ -21,8 +22,12 @@ public class OffenceSpecs extends EntitySpecs<OffenceEntity> {
         return Specification.allOf(specificationList(
             notBlank(criteria.getOffenceId()).map(OffenceSpecs::equalsOffenceId),
             notBlank(criteria.getCjsCode()).map(OffenceSpecs::likeCjsCodeStartsWith),
-            notNullLocalDateTime(criteria.getActiveDate()).map(OffenceSpecs::usedFromDateLessThenEqualToDate),
-            notNullLocalDateTime(criteria.getActiveDate()).map(OffenceSpecs::usedToDateGreaterThenEqualToDate),
+            Optional.ofNullable(criteria.getActiveDate())
+                .map(OffsetDateTime::toLocalDateTime)
+                .map(OffenceSpecs::usedFromDateLessThenEqualToDate),
+            Optional.ofNullable(criteria.getActiveDate())
+                .map(OffsetDateTime::toLocalDateTime)
+                .map(OffenceSpecs::usedToDateGreaterThenEqualToDate),
             notBlank(criteria.getTitle()).map(OffenceSpecs::likeEitherTitle),
             notBlank(criteria.getActSection()).map(OffenceSpecs::likeEitherOas)
         ));

--- a/src/test/java/uk/gov/hmcts/opal/controllers/OffenceControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/OffenceControllerTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.opal.entity.offence.OffenceEntityFull;
 import uk.gov.hmcts.opal.service.opal.OffenceService;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 
@@ -96,14 +97,14 @@ class OffenceControllerTest {
     private OffenceReferenceData createOffenceReferenceData() {
         return new OffenceReferenceData(1L, "TH123456", (short)007,
                                         "Thief of Time", null,
-                                        LocalDateTime.of(1909, 3, 3, 3, 30),
+                                        LocalDateTime.of(1909, 3, 3, 3, 30).atOffset(ZoneOffset.UTC),
                                         null, "", "");
     }
 
     private OffenceSearchData createOffenceSearchData() {
         return new OffenceSearchData(1L, "TH123456",
                                         "Thief of Time", null,
-                                        LocalDateTime.of(1909, 3, 3, 3, 30),
+                                        LocalDateTime.of(1909, 3, 3, 3, 30).atOffset(ZoneOffset.UTC),
                                         null, "", "");
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OffenceServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OffenceServiceTest.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.opal.repository.OffenceRepository;
 import uk.gov.hmcts.opal.repository.OffenceRepositoryFull;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -108,7 +109,7 @@ class OffenceServiceTest {
                                        null,
                                        "Theft from a Palace",
                                        null,
-                                       LocalDateTime.of(1909, 3, 3, 3, 30),
+                                       LocalDateTime.of(1909, 3, 3, 3, 30).atOffset(ZoneOffset.UTC),
                                        null, "A", "B");
         when(offenceMapper.toRefData(offenceEntity)).thenReturn(mappedRefData);
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-1904


### Change description ###

- Replaced all LocalDateTime fields with OffsetDateTime in DTOs and test data to handle ISO 8601 timestamps with time zone suffixes
- Updated SearchOffencesResponseStepDef.java to parse date strings using OffsetDateTime.parse(...) and DateTimeFormatter.ISO_OFFSET_DATE_TIME
- Modified functional test payloads and expectations to use UTC/Zulu suffix (Z) in .feature files
- Introduced @Named("toOffset") mapper method in OffenceMapper.java to consistently convert LocalDateTime to OffsetDateTime
- Adapted JPA specs in OffenceSpecs.java to support OffsetDateTime-based queries
- Added integration test for offence search by active date with timezone-aware format


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
