### PR TITLE
Defendant account enforcement status schemas

### DIFF
--- a/src/main/resources/jsonSchemas/legacy/common-objects/collectionOrderLegacy.json
+++ b/src/main/resources/jsonSchemas/legacy/common-objects/collectionOrderLegacy.json
@@ -13,5 +13,6 @@
       "format": "date",
       "description": "The date when the collection order was applied"
     }
-  }
+  },
+  "required": ["collection_order_flag", "collection_order_date"]
 }

--- a/src/main/resources/jsonSchemas/legacy/common-objects/enforcementOverrideLegacy.json
+++ b/src/main/resources/jsonSchemas/legacy/common-objects/enforcementOverrideLegacy.json
@@ -5,6 +5,8 @@
   "additionalProperties": false,
   "properties": {
     "enforcement_override_id": { "type": "string" },
-    "enforcement_override_title": { "type": "string" }
+    "enforcement_override_title": { "type": "string" },
+    "enforcer": {"type": "string"},
+    "lja": {"type": "string"}
   }
 }

--- a/src/main/resources/jsonSchemas/legacy/getDefendantAccountEnforcementStatusLegacyResponse.json
+++ b/src/main/resources/jsonSchemas/legacy/getDefendantAccountEnforcementStatusLegacyResponse.json
@@ -17,7 +17,7 @@
       "oneOf": [
         {
           "type": "string",
-          "pattern": "^[A-Za-z0-9]{6}(,[A-Za-z0-9]{6})*$"
+          "pattern": "^[A-Za-z0-9]{1,6}(,[A-Za-z0-9]{1,6})*$"
         },
         {
           "type": "string",

--- a/src/main/resources/jsonSchemas/legacy/getDefendantAccountEnforcementStatusLegacyResponse.json
+++ b/src/main/resources/jsonSchemas/legacy/getDefendantAccountEnforcementStatusLegacyResponse.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Get Defendant Account Enforcement Status Legacy Response",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "enforcement_overview": {
+      "$ref": "#/$defs/enforcementOverview"
+    },
+    "enforcement_override": {
+      "$ref": "resource:/jsonSchemas/legacy/common-objects/enforcementOverrideLegacy.json"
+    },
+    "last_enforcement_action": {
+      "$ref": "#/$defs/enforcementAction"
+    },
+    "next_enforcement_action_data": {
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9]{6}(,[A-Za-z0-9]{6})*$"
+        },
+        {
+          "type": "string",
+          "const": "all"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A comma-separated list of result IDs, 'all' , or null ."
+    },
+    "defendant_account_type": {
+      "type": "string",
+      "enum": [
+        "adult",
+        "company",
+        "youth"
+      ]
+    },
+    "account_status": {
+      "$ref": "resource:/jsonSchemas/legacy/common-objects/accountStatusReferenceLegacy.json"
+    },
+    "employer_flag": {
+      "type": "boolean"
+    },
+    "version": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "enforcement_overview",
+    "defendant_account_type",
+    "account_status",
+    "employer_flag",
+    "version"
+  ],
+  "$defs": {
+    "enforcementOverview": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collection_order": {
+          "$ref": "resource:/jsonSchemas/legacy/common-objects/collectionOrderLegacy.json"
+        },
+        "days_in_default": {
+          "type": "integer"
+        },
+        "enforcement_court": {
+          "$ref": "resource:/jsonSchemas/legacy/common-objects/enforcementCourtLegacy.json"
+        }
+      },
+      "required": [
+        "collection_order",
+        "enforcement_court"
+      ]
+    },
+    "enforcementAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enforcement_action": {
+          "$ref": "resource:/jsonSchemas/legacy/common-objects/resultReferenceLegacy.json"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "enforcer": {
+          "$ref": "resource:/jsonSchemas/legacy/common-objects/enforcerReferenceLegacy.json"
+        },
+        "warrant_number": {
+          "type": "string"
+        },
+        "date_added": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "result_responses": {
+          "type": "array",
+          "items": {
+            "$ref": "resource:/jsonSchemas/legacy/common-objects/resultResponsesLegacy.json"
+          }
+        }
+      },
+      "required": [
+        "enforcement_action",
+        "date_added"
+      ]
+    }
+  }
+}
+
+

--- a/src/main/resources/jsonSchemas/legacy/getDefendantAccountEnforcementStatusLegacyResponse.json
+++ b/src/main/resources/jsonSchemas/legacy/getDefendantAccountEnforcementStatusLegacyResponse.json
@@ -66,7 +66,7 @@
           "type": "integer"
         },
         "enforcement_court": {
-          "$ref": "resource:/jsonSchemas/legacy/common-objects/enforcementCourtLegacy.json"
+          "$ref": "resource:/jsonSchemas/legacy/common-objects/courtReferenceLegacy.json"
         }
       },
       "required": [

--- a/src/main/resources/jsonSchemas/opal/common-objects/accountStatusReference.json
+++ b/src/main/resources/jsonSchemas/opal/common-objects/accountStatusReference.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Account Status Reference Legacy",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "account_status_code": {
+      "type": "string",
+      "enum": ["L", "C", "TO", "TS", "TA", "CS", "WO"]
+    },
+    "account_status_display_name": {
+      "type": "string",
+      "enum": [
+        "Live", "Completed", "TFO to be acknowledged",
+        "TFO to NI/Scotland to be acknowledged",
+        "TFO acknowledged", "Account consolidated", "Account written off"
+      ]
+    }
+  },
+  "required": ["account_status_code", "account_status_display_name"]
+}

--- a/src/main/resources/jsonSchemas/opal/common-objects/collectionOrder.json
+++ b/src/main/resources/jsonSchemas/opal/common-objects/collectionOrder.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Collection Order Legacy",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "collection_order_flag": {
+      "type": "boolean",
+      "description": "Flag indicating if a collection order is applied to the account"
+    },
+    "collection_order_date": {
+      "type": "string",
+      "format": "date",
+      "description": "The date when the collection order was applied"
+    }
+  },
+  "required": ["collection_order_flag", "collection_order_date"]
+}

--- a/src/main/resources/jsonSchemas/opal/common-objects/courtReference.json
+++ b/src/main/resources/jsonSchemas/opal/common-objects/courtReference.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Court Reference",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "court_id": { "type": "integer" },
+    "court_name": { "type": "string" }
+  },
+  "required": ["court_id", "court_name"]
+}

--- a/src/main/resources/jsonSchemas/opal/common-objects/enforcementOverride.json
+++ b/src/main/resources/jsonSchemas/opal/common-objects/enforcementOverride.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Enforcement Override",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "enforcement_override_id": { "type": ["string","null"]},
+    "enforcement_override_title": { "type": ["string","null"] },
+    "enforcer": {"type": ["string","null"]},
+    "lja": {"type": ["string","null"]}
+  },
+  "required": ["enforcement_override_id", "enforcement_override_title", "enforcer", "lja"]
+}

--- a/src/main/resources/jsonSchemas/opal/common-objects/enforcerReference.json
+++ b/src/main/resources/jsonSchemas/opal/common-objects/enforcerReference.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Enforcer Reference",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "warrant_enforcer_id": { "type": "integer" },
+    "warrant_enforcer_name": { "type": "string" }
+  },
+  "required": ["warrant_enforcer_id", "warrant_enforcer_name"]
+}

--- a/src/main/resources/jsonSchemas/opal/common-objects/resultReference.json
+++ b/src/main/resources/jsonSchemas/opal/common-objects/resultReference.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Result Reference",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "result_id": { "type": "integer" },
+    "result_title": { "type": "string" }
+  },
+  "required": ["result_id", "result_title"]
+}

--- a/src/main/resources/jsonSchemas/opal/common-objects/resultResponses.json
+++ b/src/main/resources/jsonSchemas/opal/common-objects/resultResponses.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Result Responses",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "parameter_name": { "type": "string" },
+    "response": { "type": "string" }
+  },
+  "required": ["parameter_name", "response"]
+}

--- a/src/main/resources/jsonSchemas/opal/defendant-account/getDefendantAccountEnforcementStatusResponse.json
+++ b/src/main/resources/jsonSchemas/opal/defendant-account/getDefendantAccountEnforcementStatusResponse.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Get Defendant Account Enforcement Status Response",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "enforcement_overview": {
+      "$ref": "#/$defs/enforcementOverview"
+    },
+    "enforcement_override": {
+      "oneOf": [
+        {
+          "$ref": "resource:/jsonSchemas/opal/common-objects/enforcementOverride.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "last_enforcement_action": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/enforcementAction"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "next_enforcement_action_data": {
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9]{1,6}(,[A-Za-z0-9]{1,6})*$"
+        },
+        {
+          "type": "string",
+          "const": "all"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A comma-separated list of result IDs, 'all' , or null ."
+    },
+    "defendant_account_type": {
+      "type": "string",
+      "enum": [
+        "adult",
+        "company",
+        "youth"
+      ]
+    },
+    "account_status": {
+      "$ref": "resource:/jsonSchemas/opal/common-objects/accountStatusReference.json"
+    },
+    "employer_flag": {
+      "type": "boolean"
+    },
+    "version": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "enforcement_overview",
+    "enforcement_override",
+    "last_enforcement_action",
+    "next_enforcement_action_data",
+    "defendant_account_type",
+    "account_status",
+    "employer_flag",
+    "version"
+  ],
+  "$defs": {
+    "enforcementOverview": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "collection_order": {
+          "$ref": "resource:/jsonSchemas/opal/common-objects/collectionOrder.json"
+        },
+        "days_in_default": {
+          "type": ["integer", "null"]
+        },
+        "enforcement_court": {
+          "$ref": "resource:/jsonSchemas/opal/common-objects/courtReference.json"
+        }
+      },
+      "required": [
+        "collection_order",
+        "days_in_default",
+        "enforcement_court"
+      ]
+    },
+    "enforcementAction": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enforcement_action": {
+          "$ref": "resource:/jsonSchemas/opal/common-objects/resultReference.json"
+        },
+        "reason": {
+          "type": ["string", "null"]
+        },
+        "enforcer": {
+          "oneOf": [
+            {
+              "$ref": "resource:/jsonSchemas/opal/common-objects/enforcerReference.json"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "warrant_number": {
+          "type": ["string", "null"]
+        },
+        "date_added": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "result_responses": {
+          "type": ["array","null"],
+          "items": {
+            "$ref": "resource:/jsonSchemas/opal/common-objects/resultResponses.json"
+          }
+        }
+      },
+      "required": [
+        "enforcement_action",
+        "reason",
+        "enforcer",
+        "warrant_number",
+        "date_added",
+        "result_responses"
+      ]
+    }
+  }
+}
+
+


### PR DESCRIPTION
### Change description ###

Created legacy and opal schemas based on logical api spec 
[Get Defendant Account Enforcement Status ](https://tools.hmcts.net/confluence/display/PO/Get+Defendant+Account+Enforcement+Status)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
