### PR TITLE
PO-1102 alter court_fees_received, PO-1133 alter fixed_penalty_offences, PO-1810 load reports data

### DIFF
--- a/src/main/resources/db/migration/allEnvs/V20250730_357__alter_court_fees_received.sql
+++ b/src/main/resources/db/migration/allEnvs/V20250730_357__alter_court_fees_received.sql
@@ -1,0 +1,19 @@
+/**
+* CGI OPAL Program
+*
+* MODULE      : alter_court_fees_received.sql
+*
+* DESCRIPTION : Add column RECEIVED_DATE to the COURT_FEES_RECEIVED table and make SUSPENSE_TRANSACTION_ID nullable
+*
+* VERSION HISTORY:
+*
+* Date          Author      Version     Nature of Change
+* ----------    --------    --------    -------------------------------------------------------------------------------------------------------------
+* 30/07/2025    TMc         1.0         PO-1102 - Add column RECEIVED_DATE to the COURT_FEES_RECEIVED table and make SUSPENSE_TRANSACTION_ID nullable
+*
+**/
+ALTER TABLE court_fees_received  
+    ADD COLUMN received_date TIMESTAMP,
+    ALTER COLUMN suspense_transaction_id DROP NOT NULL;
+
+COMMENT ON COLUMN court_fees_received.received_date IS 'Date the court fee was received';

--- a/src/main/resources/db/migration/allEnvs/V20250730_358__alter_fixed_penalty_offences.sql
+++ b/src/main/resources/db/migration/allEnvs/V20250730_358__alter_fixed_penalty_offences.sql
@@ -1,0 +1,22 @@
+/**
+* CGI OPAL Program
+*
+* MODULE      : alter_fixed_penalty_offences.sql
+*
+* DESCRIPTION : Add columns OFFENCE_DATE and OFFENCE_TIME to the FIXED_PENALTY_OFFENCES table and change datatype of ISSUED_DATE to DATE
+*
+* VERSION HISTORY:
+*
+* Date          Author      Version     Nature of Change
+* ----------    --------    --------    ----------------------------------------------------------------------------------------------------------------------------------
+* 25/07/2025    TMc         1.0         PO-1133 - Add columns OFFENCE_DATE and OFFENCE_TIME to the FIXED_PENALTY_OFFENCES table and change datatype of ISSUED_DATE to DATE
+*
+**/
+ALTER TABLE fixed_penalty_offences 
+    ADD COLUMN offence_date DATE,
+    ADD COLUMN offence_time VARCHAR(5),
+    ALTER COLUMN issued_date TYPE DATE;
+
+COMMENT ON COLUMN fixed_penalty_offences.offence_date IS 'Date of offence';
+COMMENT ON COLUMN fixed_penalty_offences.offence_time IS 'Time of offence. Stored as a string, as entered (not converted to UTC): "HH:SS"';
+COMMENT ON COLUMN fixed_penalty_offences.issued_date IS 'Date the ticket was issued';

--- a/src/main/resources/db/migration/allEnvs/V20250730_359__insert_reports.sql
+++ b/src/main/resources/db/migration/allEnvs/V20250730_359__insert_reports.sql
@@ -1,0 +1,21 @@
+/**
+* CGI OPAL Program
+*
+* MODULE      : insert_reports.sql
+*
+* DESCRIPTION : Load the REPORTS table with reference data for the Fines model as per script (load-reports.sql) from Capita
+*
+* VERSION HISTORY:
+*
+* Date          Author      Version     Nature of Change
+* ----------    --------    --------    ---------------------------------------------------------------------------------------------------------------------
+* 30/07/2025    TMc         1.0         PO-1810 - Load the REPORTS table with reference data for the Fines model as per script (load-reports.sql) from Capita
+*
+**/
+DELETE FROM reports;
+
+INSERT INTO reports (report_id, report_title, report_group, report_parameters, audited_report) VALUES
+('tfo_in_register', 'Transfer of Fine Orders In Register', 'Fines', NULL, TRUE),
+('fp_register', 'Fixed Penalty Register', 'Fines', NULL, TRUE),
+('list_amendments', 'List Amendments', 'Account Management', '[{ "name":"amendment_date", "prompt":"Amendment Date", "type":"date" }]', TRUE),
+('list_extend_ttp', 'List of Extensions of Time to Pay', 'Account Management', NULL, TRUE);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-1102
https://tools.hmcts.net/jira/browse/PO-1133
https://tools.hmcts.net/jira/browse/PO-1810

### Change description ###
PO-1102 alter court_fees_received. New column (received_date), suspense_transaction_id made nullable
PO-1133 alter fixed_penalty_offences. New columns (offence_date, offence_time), issued_date datatype changed to DATE
PO-1810 load reports table with reference data from Capita

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
