### PR TITLE
PR1: Legacy common-objects alignment

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/dto/common/AccountStatusReference.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/common/AccountStatusReference.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.opal.dto.common;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AccountStatusReference {
+
+    @JsonProperty("account_status_code")
+    private String accountStatusCode;
+
+    @JsonProperty("account_status_display_name")
+    private String accountStatusDisplayName;
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/common/BusinessUnitSummary.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/common/BusinessUnitSummary.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.opal.dto.common;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class BusinessUnitSummary {
+
+    @JsonProperty("business_unit_id")
+    private String businessUnitId;
+
+    @JsonProperty("business_unit_name")
+    private String businessUnitName;
+
+    @JsonProperty("welsh_speaking")
+    private String welshSpeaking;
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/common/IndividualAlias.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/common/IndividualAlias.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.opal.dto.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class IndividualAlias {
+
+    @JsonProperty("alias_id")
+    private String aliasId;
+
+    @JsonProperty("sequence_number")
+    private Integer sequenceNumber;
+
+    @JsonProperty("surname")
+    private String surname;
+
+    @JsonProperty("forenames")
+    private String forenames;
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/common/IndividualDetails.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/common/IndividualDetails.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.opal.dto.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class IndividualDetails {
+
+    @JsonProperty("title")
+    private String title;
+
+    @JsonProperty("forenames")
+    private String forenames;
+
+    @JsonProperty("surname")
+    private String surname;
+
+    @JsonProperty("date_of_birth")
+    private String dateOfBirth;
+
+    @JsonProperty("age")
+    private String age;
+
+    @JsonProperty("national_insurance_number")
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private String nationalInsuranceNumber;
+
+    @JsonProperty("individual_aliases")
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private List<IndividualAlias> individualAliases;
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/common/OrganisationAlias.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/common/OrganisationAlias.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.opal.dto.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OrganisationAlias {
+
+    @JsonProperty("alias_id")
+    private String aliasId;
+
+    @JsonProperty("sequence_number")
+    private Integer sequenceNumber;
+
+    @JsonProperty("organisation_name")
+    private String organisationName;
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/common/OrganisationDetails.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/common/OrganisationDetails.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.opal.dto.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class OrganisationDetails {
+
+    @JsonProperty("organisation_name")
+    private String organisationName;
+
+    @JsonProperty("organisation_aliases")
+    private List<OrganisationAlias> organisationAliases;
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/common/PartyDetails.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/common/PartyDetails.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.opal.dto.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PartyDetails {
+
+    @JsonProperty("defendant_account_party_id")
+    private String defendantAccountPartyId;
+
+    @JsonProperty("organisation_flag")
+    private Boolean organisationFlag;
+
+    @JsonProperty("organisation_details")
+    private OrganisationDetails organisationDetails;
+
+    @JsonProperty("individual_details")
+    private IndividualDetails individualDetails;
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/common/PaymentStateSummary.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/common/PaymentStateSummary.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.opal.dto.common;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+public class PaymentStateSummary {
+
+    @JsonProperty("imposed_amount")
+    private BigDecimal imposedAmount;
+
+    @JsonProperty("arrears_amount")
+    private BigDecimal arrearsAmount;
+
+    @JsonProperty("paid_amount")
+    private BigDecimal paidAmount;
+
+    @JsonProperty("account_balance")
+    private BigDecimal accountBalance;
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyGetDefendantAccountHeaderSummaryResponse.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyGetDefendantAccountHeaderSummaryResponse.java
@@ -10,10 +10,11 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.opal.dto.ToXmlString;
+import uk.gov.hmcts.opal.dto.legacy.common.LegacyPartyDetails;
 import uk.gov.hmcts.opal.dto.legacy.common.AccountStatusReference;
 import uk.gov.hmcts.opal.dto.legacy.common.BusinessUnitSummary;
-import uk.gov.hmcts.opal.dto.legacy.common.DefendantDetails;
 import uk.gov.hmcts.opal.dto.legacy.common.PaymentStateSummary;
+
 
 @Data
 @Builder
@@ -24,7 +25,7 @@ import uk.gov.hmcts.opal.dto.legacy.common.PaymentStateSummary;
 public class LegacyGetDefendantAccountHeaderSummaryResponse implements ToXmlString {
 
     @XmlElement(name = "version")
-    private Long version;
+    private Integer version; // or Long, just match the schema
 
     @XmlElement(name = "defendant_account_id")
     private String defendantAccountId;
@@ -56,7 +57,7 @@ public class LegacyGetDefendantAccountHeaderSummaryResponse implements ToXmlStri
     @XmlElement(name = "payment_state_summary")
     private PaymentStateSummary paymentStateSummary;
 
-    @XmlElement(name = "defendant_details")
-    private DefendantDetails defendantDetails;
+    @XmlElement(name = "party_details")
+    private LegacyPartyDetails partyDetails;
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/common/LegacyPartyDetails.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/common/LegacyPartyDetails.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.opal.dto.legacy.common;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@XmlRootElement(name = "party_details")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class LegacyPartyDetails {
+    @XmlElement(name = "defendant_account_party_id")
+    private String defendantAccountPartyId;
+
+    @XmlElement(name = "organisation_flag")
+    private Boolean organisationFlag;
+
+    @XmlElement(name = "organisation_details")
+    private OrganisationDetails organisationDetails;
+
+    @XmlElement(name = "individual_details")
+    private IndividualDetails individualDetails;
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
@@ -4,18 +4,26 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.opal.config.properties.LegacyGatewayProperties;
-import uk.gov.hmcts.opal.dto.search.AccountSearchDto;
-import uk.gov.hmcts.opal.service.legacy.GatewayService.Response;
 import uk.gov.hmcts.opal.dto.DefendantAccountHeaderSummary;
-import uk.gov.hmcts.opal.dto.legacy.LegacyGetDefendantAccountHeaderSummaryResponse;
-import uk.gov.hmcts.opal.dto.legacy.LegacyGetDefendantAccountRequest;
-import uk.gov.hmcts.opal.service.iface.DefendantAccountServiceInterface;
+import uk.gov.hmcts.opal.dto.common.AccountStatusReference;
+import uk.gov.hmcts.opal.dto.common.BusinessUnitSummary;
+import uk.gov.hmcts.opal.dto.common.IndividualAlias;
+import uk.gov.hmcts.opal.dto.common.IndividualDetails;
+import uk.gov.hmcts.opal.dto.common.OrganisationAlias;
+import uk.gov.hmcts.opal.dto.common.OrganisationDetails;
+import uk.gov.hmcts.opal.dto.common.PartyDetails;
+import uk.gov.hmcts.opal.dto.common.PaymentStateSummary;
 import uk.gov.hmcts.opal.dto.legacy.LegacyDefendantAccountSearchCriteria;
 import uk.gov.hmcts.opal.dto.legacy.LegacyDefendantAccountsSearchResults;
+import uk.gov.hmcts.opal.dto.legacy.LegacyGetDefendantAccountHeaderSummaryResponse;
+import uk.gov.hmcts.opal.dto.legacy.LegacyGetDefendantAccountRequest;
+import uk.gov.hmcts.opal.dto.response.GetHeaderSummaryResponse;
+import uk.gov.hmcts.opal.dto.search.AccountSearchDto;
 import uk.gov.hmcts.opal.dto.search.DefendantAccountSearchResultsDto;
+import uk.gov.hmcts.opal.service.iface.DefendantAccountServiceInterface;
+import uk.gov.hmcts.opal.service.legacy.GatewayService.Response;
 
 import java.math.BigDecimal;
-import java.util.Optional;
 
 import static uk.gov.hmcts.opal.disco.legacy.LegacyDiscoDefendantAccountService.SEARCH_DEFENDANT_ACCOUNTS;
 
@@ -64,7 +72,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
         LegacyDefendantAccountSearchCriteria criteria =
             LegacyDefendantAccountSearchCriteria.fromAccountSearchDto(accountSearchDto);
         log.debug(":searchDefendantAccounts: criteria: {} via gateway {}", criteria.toJson(),
-                  legacyGatewayProperties.getUrl());
+            legacyGatewayProperties.getUrl());
         Response<LegacyDefendantAccountsSearchResults> response = gatewayService.postToGateway(
             SEARCH_DEFENDANT_ACCOUNTS, LegacyDefendantAccountsSearchResults.class, criteria, null);
 
@@ -80,36 +88,145 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             .build();
     }
 
-    private DefendantAccountHeaderSummary toHeaderSumaryDto(LegacyGetDefendantAccountHeaderSummaryResponse response) {
+
+    @Override
+    public GetHeaderSummaryResponse getHeaderSummaryWithVersion(Long defendantAccountId, String authHeader) {
+        log.debug(":getHeaderSummaryWithVersion: id: {}", defendantAccountId);
+
+        Response<LegacyGetDefendantAccountHeaderSummaryResponse> response = gatewayService.postToGateway(
+            GET_HEADER_SUMMARY, LegacyGetDefendantAccountHeaderSummaryResponse.class,
+            createGetDefendantAccountRequest(defendantAccountId.toString()), null);
+
+        if (response.isError()) {
+            log.error(":getHeaderSummaryWithVersion: Legacy Gateway response: HTTP Response Code: {}", response.code);
+            if (response.isException()) {
+                log.error(":getHeaderSummaryWithVersion:", response.exception);
+            } else if (response.isLegacyFailure()) {
+                log.error(":getHeaderSummaryWithVersion: Legacy Gateway: body: \n{}", response.body);
+                LegacyGetDefendantAccountHeaderSummaryResponse responseEntity = response.responseEntity;
+                log.error(":getHeaderSummaryWithVersion: Legacy Gateway: entity: \n{}", responseEntity.toXml());
+            }
+        } else if (response.isSuccessful()) {
+            log.info(":getHeaderSummaryWithVersion: Legacy Gateway response: Success.");
+        }
+
+        LegacyGetDefendantAccountHeaderSummaryResponse legacyResponse = response.responseEntity;
+        DefendantAccountHeaderSummary dto = toHeaderSumaryDto(legacyResponse);
+        Long version = legacyResponse.getVersion() != null ? legacyResponse.getVersion().longValue() : null;
+
+        return new GetHeaderSummaryResponse(dto, version);
+    }
+
+
+    private DefendantAccountHeaderSummary toHeaderSumaryDto(
+        LegacyGetDefendantAccountHeaderSummaryResponse response) {
+
+        // ----- Legacy -> Opal Party Details -----
+        uk.gov.hmcts.opal.dto.legacy.common.LegacyPartyDetails legacyParty = response.getPartyDetails();
+        PartyDetails opalPartyDetails = null;
+
+        if (legacyParty != null) {
+            uk.gov.hmcts.opal.dto.legacy.common.OrganisationDetails legacyOrg = legacyParty.getOrganisationDetails();
+            uk.gov.hmcts.opal.dto.legacy.common.IndividualDetails legacyInd = legacyParty.getIndividualDetails();
+
+            // organisation aliases
+            java.util.List<OrganisationAlias> orgAliases = null;
+            if (legacyOrg != null && legacyOrg.getOrganisationAliases() != null) {
+                orgAliases = java.util.Arrays.stream(legacyOrg.getOrganisationAliases())
+                    .map(a -> OrganisationAlias.builder()
+                        .aliasId(a.getAliasId())
+                        .sequenceNumber(a.getSequenceNumber() != null ? a.getSequenceNumber().intValue() : null)
+                        .organisationName(a.getOrganisationName())
+                        .build())
+                    .collect(java.util.stream.Collectors.toList());
+            }
+
+            OrganisationDetails opalOrg = legacyOrg == null ? null
+                : OrganisationDetails.builder()
+                    .organisationName(legacyOrg.getOrganisationName())
+                    .organisationAliases(orgAliases)
+                    .build();
+
+            // individual aliases
+            java.util.List<IndividualAlias> indAliases = null;
+            if (legacyInd != null && legacyInd.getIndividualAliases() != null) {
+                indAliases = java.util.Arrays.stream(legacyInd.getIndividualAliases())
+                    .map(a -> IndividualAlias.builder()
+                        .aliasId(a.getAliasId())
+                        .sequenceNumber(a.getSequenceNumber() != null ? a.getSequenceNumber().intValue() : null)
+                        .surname(a.getSurname())
+                        .forenames(a.getForenames())
+                        .build())
+                    .collect(java.util.stream.Collectors.toList());
+            }
+
+            IndividualDetails opalInd = legacyInd == null ? null
+                : IndividualDetails.builder()
+                    .title(legacyInd.getTitle())
+                    .forenames(legacyInd.getFirstNames()) // legacy accessor is getFirstNames()
+                    .surname(legacyInd.getSurname())
+                    .dateOfBirth(legacyInd.getDateOfBirth() != null ? legacyInd.getDateOfBirth().toString() : null)
+                    .age(legacyInd.getAge())
+                    .nationalInsuranceNumber(legacyInd.getNationalInsuranceNumber())
+                    .individualAliases(indAliases) // keep key present (can be empty list)
+                    .build();
+
+            opalPartyDetails = PartyDetails.builder()
+                .defendantAccountPartyId(legacyParty.getDefendantAccountPartyId())
+                .organisationFlag(legacyParty.getOrganisationFlag())
+                .organisationDetails(opalOrg)
+                .individualDetails(opalInd)
+                .build();
+        }
+
+        // ----- Business Unit -----
+        BusinessUnitSummary bu = response.getBusinessUnitSummary() == null ? null
+            : BusinessUnitSummary.builder()
+                .businessUnitId(response.getBusinessUnitSummary().getBusinessUnitId())
+                .businessUnitName(response.getBusinessUnitSummary().getBusinessUnitName())
+                .welshSpeaking("N") // default; legacy schema doesn’t provide it
+                .build();
+
+        // ----- Account Status -----
+        AccountStatusReference status = response.getAccountStatusReference() == null ? null
+            : AccountStatusReference.builder()
+                .accountStatusCode(response.getAccountStatusReference().getAccountStatusCode())
+                .accountStatusDisplayName(response.getAccountStatusReference().getAccountStatusDisplayName())
+                .build();
+
+        // ----- Payment State Summary (never null numbers) -----
+        PaymentStateSummary pay = response.getPaymentStateSummary() == null ? null
+            : PaymentStateSummary.builder()
+                .imposedAmount(toBigDecimalOrZero(response.getPaymentStateSummary().getImposedAmount()))
+                .arrearsAmount(toBigDecimalOrZero(response.getPaymentStateSummary().getArrearsAmount()))
+                .paidAmount(toBigDecimalOrZero(response.getPaymentStateSummary().getPaidAmount()))
+                .accountBalance(toBigDecimalOrZero(response.getPaymentStateSummary().getAccountBalance()))
+                .build();
+
+        // ----- Build Opal DTO (note: NO defendant_account_id in Opal body) -----
         return DefendantAccountHeaderSummary.builder()
-            .defendantAccountId(response.getDefendantAccountId())
-            .version(response.getVersion())
             .accountNumber(response.getAccountNumber())
-            .hasParentGuardian(!Optional.ofNullable(response.getParentGuardianPartyId())
-                .map(String::isBlank).orElse(true))  // TODO - is this the correct way?
-            .debtorType(response.getDefendantDetails().getDebtorType())
-            .organisation(response.getDefendantDetails().getOrganisationFlag())
-            .accountStatusDisplayName(response.getAccountStatusReference().getAccountStatusDisplayName())
+            .defendantPartyId(response.getDefendantPartyId())
+            .parentGuardianPartyId(response.getParentGuardianPartyId())
+            .accountStatusReference(status)
             .accountType(response.getAccountType())
             .prosecutorCaseReference(response.getProsecutorCaseReference())
             .fixedPenaltyTicketNumber(response.getFixedPenaltyTicketNumber())
-            .businessUnitName(response.getBusinessUnitSummary().getBusinessUnitName())
-            .businessUnitId(response.getBusinessUnitSummary().getBusinessUnitId())
-            .businessUnitCode(response.getBusinessUnitSummary().getBusinessUnitCode())
-            .imposed(toBigDecimal(response.getPaymentStateSummary().getImposedAmount()))
-            .arrears(toBigDecimal(response.getPaymentStateSummary().getArrearsAmount()))
-            .paid(toBigDecimal(response.getPaymentStateSummary().getPaidAmount()))
-            .writtenOff(BigDecimal.ZERO) // TODO - how do we derive written off?
-            .accountBalance(toBigDecimal(response.getPaymentStateSummary().getAccountBalance()))
-            .organisationName(response.getDefendantDetails().getOrganisationDetails().getOrganisationName())
-            .isYouth(response.getDefendantDetails().getIsYouthFlag())
-            .title(response.getDefendantDetails().getIndividualDetails().getTitle())
-            .firstnames(response.getDefendantDetails().getIndividualDetails().getFirstNames())
-            .surname(response.getDefendantDetails().getIndividualDetails().getSurname())
+            .businessUnitSummary(bu)
+            .paymentStateSummary(pay)
+            .partyDetails(opalPartyDetails)
             .build();
     }
 
-    private BigDecimal toBigDecimal(String candidate) {
-        return Optional.ofNullable(candidate).filter(s -> s.length() > 1).map(BigDecimal::new).orElse(BigDecimal.ZERO);
+    private static BigDecimal toBigDecimalOrZero(String s) {
+        if (s == null) {
+            return BigDecimal.ZERO;
+        }
+        try {
+            return new BigDecimal(s);
+        } catch (NumberFormatException e) {
+            return BigDecimal.ZERO;
+        }
     }
+
 }

--- a/src/main/resources/jsonSchemas/legacy/common-objects/partyDetailsLegacy.json
+++ b/src/main/resources/jsonSchemas/legacy/common-objects/partyDetailsLegacy.json
@@ -4,7 +4,7 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "party_id": {
+    "defendant_account_party_id": {
       "type": "string"
     },
     "organisation_flag": {
@@ -18,7 +18,7 @@
     }
   },
   "required": [
-    "party_id",
+    "defendant_account_party_id",
     "organisation_flag"
   ],
   "allOf": [

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
@@ -14,15 +14,13 @@ import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.opal.config.properties.LegacyGatewayProperties;
 import uk.gov.hmcts.opal.disco.legacy.LegacyTestsBase;
 import uk.gov.hmcts.opal.dto.DefendantAccountHeaderSummary;
+import uk.gov.hmcts.opal.dto.common.AccountStatusReference;
+import uk.gov.hmcts.opal.dto.common.BusinessUnitSummary;
+import uk.gov.hmcts.opal.dto.common.PartyDetails;
+import uk.gov.hmcts.opal.dto.common.PaymentStateSummary;
 import uk.gov.hmcts.opal.dto.legacy.LegacyCreateDefendantAccountResponse;
 import uk.gov.hmcts.opal.dto.legacy.LegacyDefendantAccountsSearchResults;
 import uk.gov.hmcts.opal.dto.legacy.LegacyGetDefendantAccountHeaderSummaryResponse;
-import uk.gov.hmcts.opal.dto.legacy.common.AccountStatusReference;
-import uk.gov.hmcts.opal.dto.legacy.common.BusinessUnitSummary;
-import uk.gov.hmcts.opal.dto.legacy.common.DefendantDetails;
-import uk.gov.hmcts.opal.dto.legacy.common.IndividualDetails;
-import uk.gov.hmcts.opal.dto.legacy.common.OrganisationDetails;
-import uk.gov.hmcts.opal.dto.legacy.common.PaymentStateSummary;
 import uk.gov.hmcts.opal.dto.search.AccountSearchDto;
 import uk.gov.hmcts.opal.dto.search.DefendantAccountSearchResultsDto;
 
@@ -110,25 +108,66 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
 
     private DefendantAccountHeaderSummary createHeaderSummaryDto() {
         return DefendantAccountHeaderSummary.builder()
-            .hasParentGuardian(false)
-            .imposed(BigDecimal.ZERO)
-            .arrears(BigDecimal.ZERO)
-            .paid(BigDecimal.ZERO)
-            .writtenOff(BigDecimal.ZERO)
-            .accountBalance(BigDecimal.ZERO)
+            .accountNumber("SAMPLE")
+            .accountType("Fine")
+            .accountStatusReference(
+                AccountStatusReference.builder()
+                    .accountStatusCode("L")
+                    .accountStatusDisplayName("Live")
+                    .build()
+            )
+            .businessUnitSummary(
+                BusinessUnitSummary.builder()
+                    .businessUnitId("1")
+                    .businessUnitName("Test BU")
+                    .welshSpeaking("N")
+                    .build()
+            )
+            .paymentStateSummary(
+                PaymentStateSummary.builder()
+                    .imposedAmount(BigDecimal.ZERO)
+                    .arrearsAmount(BigDecimal.ZERO)
+                    .paidAmount(BigDecimal.ZERO)
+                    .accountBalance(BigDecimal.ZERO)
+                    .build()
+            )
+            .partyDetails(
+                PartyDetails.builder().build()
+            )
             .build();
     }
 
+
     private LegacyGetDefendantAccountHeaderSummaryResponse createHeaderSummaryResponse() {
         return LegacyGetDefendantAccountHeaderSummaryResponse.builder()
-            .defendantDetails(
-                DefendantDetails.builder()
-                    .organisationDetails(OrganisationDetails.builder().build())
-                    .individualDetails(IndividualDetails.builder().build())
-                    .build())
-            .accountStatusReference(AccountStatusReference.builder().build())
-            .businessUnitSummary(BusinessUnitSummary.builder().build())
-            .paymentStateSummary(PaymentStateSummary.builder().build())
+            .defendantAccountId("1")
+            .accountNumber("SAMPLE")
+            .accountType("Fine")
+            .accountStatusReference(
+                uk.gov.hmcts.opal.dto.legacy.common.AccountStatusReference.builder()
+                    .accountStatusCode("L")
+                    .accountStatusDisplayName("Live")
+                    .build()
+            )
+            .businessUnitSummary(
+                uk.gov.hmcts.opal.dto.legacy.common.BusinessUnitSummary.builder()
+                    .businessUnitId("1")
+                    .businessUnitName("Test BU")
+                    .welshSpeaking("N")
+                    .build()
+            )
+            .paymentStateSummary(
+                uk.gov.hmcts.opal.dto.legacy.common.PaymentStateSummary.builder()
+                    .imposedAmount("0")
+                    .arrearsAmount("0")
+                    .paidAmount("0")
+                    .accountBalance("0")
+                    .build()
+            )
+            .partyDetails(
+                uk.gov.hmcts.opal.dto.legacy.common.LegacyPartyDetails.builder()
+                    .build()
+            )
             .build();
     }
 


### PR DESCRIPTION
**Description - Scope**

- Align legacy schema and DTOs to new common object structure (PartyDetails, BusinessUnitSummary, PaymentStateSummary, etc.).
- Added new shared common DTOs (AccountStatusReference, BusinessUnitSummary, PaymentStateSummary, etc.).
- Added JAXB legacy DTOs (LegacyPartyDetails, updated LegacyGetDefendantAccountHeaderSummaryResponse).
- Updated LegacyDefendantAccountService to map legacy responses into the common DTOs.
- Updated LegacyDefendantAccountServiceTest to reflect new mapping.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
