### PR TITLE
PO-1588_Opal_get_defendant_account_party_api

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountsControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountsControllerIntegrationTest.java
@@ -50,6 +50,9 @@ abstract class DefendantAccountsControllerIntegrationTest extends AbstractIntegr
     void setupUserState() {
         Mockito.when(userState.anyBusinessUnitUserHasPermission(Mockito.any()))
             .thenReturn(true);
+
+        Mockito.when(userStateService.checkForAuthorisedUser(Mockito.any()))
+            .thenReturn(userState);
     }
 
     @DisplayName("Get header summary for defendant account [@PO-985]")
@@ -1861,6 +1864,60 @@ abstract class DefendantAccountsControllerIntegrationTest extends AbstractIntegr
             .andExpect(jsonPath("$.defendant_accounts[0].defendant_account_id").value("555"))
             .andExpect(jsonPath("$.defendant_accounts[0].organisation").value(true))
             .andExpect(jsonPath("$.defendant_accounts[0].postcode").value("B15 3TG"));
+    }
+
+    public void opalGetDefendantAccountParty_Happy(Logger log) throws Exception {
+        ResultActions actions = mockMvc.perform(get("/defendant-accounts/77/defendant-account-parties/77")
+            .header("Authorization", "Bearer test-token"));
+        log.info("Opal happy path response:\n" + actions.andReturn().getResponse().getContentAsString());
+        actions.andExpect(status().isOk())
+            .andExpect(jsonPath("$.defendant_account_party.defendant_account_party_type").value("Defendant"))
+            .andExpect(jsonPath("$.defendant_account_party.is_debtor").value(true))
+            .andExpect(jsonPath("$.defendant_account_party.party_details.party_id").value("77"))
+            .andExpect(jsonPath("$.defendant_account_party.party_details.individual_details.surname").value("Graham"))
+            .andExpect(jsonPath("$.defendant_account_party.address.address_line_1").value("Lumber House"));
+    }
+
+    public void opalGetDefendantAccountParty_Organisation(Logger log) throws Exception {
+        ResultActions actions = mockMvc.perform(get("/defendant-accounts/555/defendant-account-parties/555")
+            .header("Authorization", "Bearer test-token"));
+        log.info("Organisation response:\n" + actions.andReturn().getResponse().getContentAsString());
+        actions.andExpect(status().isOk())
+            .andExpect(jsonPath("$.defendant_account_party.party_details.organisation_flag").value(true))
+            .andExpect(jsonPath("$.defendant_account_party.party_details.organisation_details.organisation_name").value("TechCorp Solutions Ltd"))
+            .andExpect(jsonPath("$.defendant_account_party.party_details.individual_details").doesNotExist());
+    }
+
+    public void opalGetDefendantAccountParty_NullFields(Logger log) throws Exception {
+        ResultActions actions = mockMvc.perform(get("/defendant-accounts/88/defendant-account-parties/88")
+            .header("Authorization", "Bearer test-token"));
+        log.info("Null fields response:\n" + actions.andReturn().getResponse().getContentAsString());
+        actions.andExpect(status().isOk())
+            .andExpect(jsonPath("$.defendant_account_party.party_details.individual_details.surname").doesNotExist())
+            .andExpect(jsonPath("$.defendant_account_party.address.address_line_1").doesNotExist());
+    }
+
+    public void opalGetDefendantAccountParty_404(Logger log) throws Exception {
+        ResultActions actions = mockMvc.perform(get("/defendant-accounts/999999/defendant-account-parties/999999")
+            .header("Authorization", "Bearer test-token"));
+        log.info("404 response:\n" + actions.andReturn().getResponse().getContentAsString());
+        actions.andExpect(status().isNotFound());
+    }
+
+    public void opalGetDefendantAccountParty_401(Logger log) throws Exception {
+        ResultActions actions = mockMvc.perform(get("/defendant-accounts/77/defendant-account-parties/77"));
+        log.info("401 response:\n" + actions.andReturn().getResponse().getContentAsString());
+        actions.andExpect(status().isUnauthorized());
+    }
+
+    public void opalGetDefendantAccountParty_403(Logger log) throws Exception {
+        // This assumes your code throws a Forbidden/AccessDenied exception.
+        // Mock the userStateService or other permission mechanism here as needed:
+        when(userStateService.checkForAuthorisedUser(any())).thenThrow(new RuntimeException("Forbidden"));
+        ResultActions actions = mockMvc.perform(get("/defendant-accounts/77/defendant-account-parties/77")
+            .header("Authorization", "Bearer forbidden-token"));
+        log.info("403 response:\n" + actions.andReturn().getResponse().getContentAsString());
+        actions.andExpect(status().isForbidden());
     }
 
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantAccountsIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantAccountsIntegrationTest.java
@@ -3,9 +3,16 @@ package uk.gov.hmcts.opal.controllers;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import uk.gov.hmcts.opal.SchemaPaths;
+import uk.gov.hmcts.opal.entity.DefendantAccountEntity;
+import uk.gov.hmcts.opal.entity.DefendantAccountPartiesEntity;
+import uk.gov.hmcts.opal.repository.DefendantAccountPartiesRepository;
+import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
+
+import java.util.List;
 
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_CLASS;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_CLASS;
@@ -247,4 +254,46 @@ class OpalDefendantAccountsIntegrationTest extends DefendantAccountsControllerIn
     String getHeaderSummaryResponseSchemaLocation() {
         return SchemaPaths.DEFENDANT_ACCOUNT + "/getDefendantAccountHeaderSummaryResponse.json";
     }
+
+    @Test
+    void opal_getDefendantAccountParty_happy() throws Exception {
+        super.opalGetDefendantAccountParty_Happy(log);
+    }
+
+    @Test
+    void opal_getDefendantAccountParty_organisation() throws Exception {
+        super.opalGetDefendantAccountParty_Organisation(log);
+    }
+
+    @Test
+    void opal_getDefendantAccountParty_nullFields() throws Exception {
+        super.opalGetDefendantAccountParty_NullFields(log);
+    }
+
+    @Test
+    void opal_getDefendantAccountParty_404() throws Exception {
+        super.opalGetDefendantAccountParty_404(log);
+    }
+
+    @Test
+    void opal_getDefendantAccountParty_401() throws Exception {
+        super.opalGetDefendantAccountParty_401(log);
+    }
+
+    @Test
+    void opal_getDefendantAccountParty_403() throws Exception {
+        super.opalGetDefendantAccountParty_403(log);
+    }
+    @Autowired
+    private DefendantAccountRepository defendantAccountRepository;
+
+    @Test
+    void debugLoadAccountAndParties() {
+        var account = defendantAccountRepository.findById(88L).orElseThrow();
+        System.out.println("Parties: " + account.getParties().size());
+        for (DefendantAccountPartiesEntity party : account.getParties()) {
+            System.out.println("Party DAP ID: " + party.getDefendantAccountPartyId());
+        }
+    }
+
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantAccountsIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantAccountsIntegrationTest.java
@@ -3,16 +3,9 @@ package uk.gov.hmcts.opal.controllers;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import uk.gov.hmcts.opal.SchemaPaths;
-import uk.gov.hmcts.opal.entity.DefendantAccountEntity;
-import uk.gov.hmcts.opal.entity.DefendantAccountPartiesEntity;
-import uk.gov.hmcts.opal.repository.DefendantAccountPartiesRepository;
-import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
-
-import java.util.List;
 
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_CLASS;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_CLASS;
@@ -283,17 +276,6 @@ class OpalDefendantAccountsIntegrationTest extends DefendantAccountsControllerIn
     @Test
     void opal_getDefendantAccountParty_403() throws Exception {
         super.opalGetDefendantAccountParty_403(log);
-    }
-    @Autowired
-    private DefendantAccountRepository defendantAccountRepository;
-
-    @Test
-    void debugLoadAccountAndParties() {
-        var account = defendantAccountRepository.findById(88L).orElseThrow();
-        System.out.println("Parties: " + account.getParties().size());
-        for (DefendantAccountPartiesEntity party : account.getParties()) {
-            System.out.println("Party DAP ID: " + party.getDefendantAccountPartyId());
-        }
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/controllers/DefendantAccountController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/DefendantAccountController.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.opal.dto.search.AccountSearchDto;
 import uk.gov.hmcts.opal.dto.search.DefendantAccountSearchResultsDto;
 import uk.gov.hmcts.opal.service.DefendantAccountService;
 import uk.gov.hmcts.opal.service.opal.UserStateService;
+import uk.gov.hmcts.opal.dto.GetDefendantAccountPartyResponse;
 
 
 import static uk.gov.hmcts.opal.util.HttpUtil.buildResponse;
@@ -49,6 +50,23 @@ public class DefendantAccountController {
         log.debug(":GET:getHeaderSummary: for defendant id: {}", defendantAccountId);
 
         return buildResponse(defendantAccountService.getHeaderSummary(defendantAccountId, authHeaderValue));
+    }
+
+    @GetMapping(value = "/{defendantAccountId}/defendant-account-parties/{defendantAccountPartyId}")
+    @Operation(summary = "Get details for a defendant account party")
+    public ResponseEntity<GetDefendantAccountPartyResponse> getDefendantAccountParty(
+        @PathVariable Long defendantAccountId,
+        @PathVariable Long defendantAccountPartyId,
+        @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
+
+        log.debug(":GET:getDefendantAccountParty: for accountId={}, partyId={}", defendantAccountId,
+            defendantAccountPartyId);
+
+        GetDefendantAccountPartyResponse response =
+            defendantAccountService.getDefendantAccountParty(defendantAccountId, defendantAccountPartyId,
+                authHeaderValue);
+
+        return buildResponse(response);
     }
 
     @PostMapping(value = "/search", consumes = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/uk/gov/hmcts/opal/controllers/DefendantAccountController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/DefendantAccountController.java
@@ -18,7 +18,6 @@ import uk.gov.hmcts.opal.dto.DefendantAccountHeaderSummary;
 import uk.gov.hmcts.opal.dto.search.AccountSearchDto;
 import uk.gov.hmcts.opal.dto.search.DefendantAccountSearchResultsDto;
 import uk.gov.hmcts.opal.service.DefendantAccountService;
-import uk.gov.hmcts.opal.service.opal.UserStateService;
 import uk.gov.hmcts.opal.dto.GetDefendantAccountPartyResponse;
 
 

--- a/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
@@ -466,4 +466,18 @@ public class GlobalExceptionHandler {
             return UNKNOWN;
         }
     }
+
+    @ExceptionHandler(uk.gov.hmcts.opal.authentication.exception.AuthenticationException.class)
+    public ResponseEntity<ProblemDetail> handleAuthenticationException(
+        uk.gov.hmcts.opal.authentication.exception.AuthenticationException ex) {
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.UNAUTHORIZED,
+            "Unauthorized",
+            "Authentication failed or missing. Please provide a valid Authorization header.",
+            "unauthorized",
+            ex
+        );
+        return responseWithProblemDetail(HttpStatus.UNAUTHORIZED, problemDetail);
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/opal/dto/GetDefendantAccountPartyResponse.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/GetDefendantAccountPartyResponse.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.opal.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.opal.dto.common.PartyDetails;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GetDefendantAccountPartyResponse {
+
+    @JsonProperty("defendant_account_party")
+    private PartyDetails defendantAccountParty;
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/common/AddressDetails.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/common/AddressDetails.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.opal.dto.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AddressDetails {
+
+    @JsonProperty("address_line_1")
+    private String addressLine1;
+
+    @JsonProperty("address_line_2")
+    private String addressLine2;
+
+    @JsonProperty("address_line_3")
+    private String addressLine3;
+
+    @JsonProperty("address_line_4")
+    private String addressLine4;
+
+    @JsonProperty("address_line_5")
+    private String addressLine5;
+
+    @JsonProperty("postcode")
+    private String postcode;
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/common/ContactDetails.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/common/ContactDetails.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.opal.dto.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ContactDetails {
+
+    @JsonProperty("primary_email_address")
+    private String primaryEmailAddress;
+
+    @JsonProperty("secondary_email_address")
+    private String secondaryEmailAddress;
+
+    @JsonProperty("mobile_telephone_number")
+    private String mobileTelephoneNumber;
+
+    @JsonProperty("home_telephone_number")
+    private String homeTelephoneNumber;
+
+    @JsonProperty("work_telephone_number")
+    private String workTelephoneNumber;
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/common/DefendantAccountParty.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/common/DefendantAccountParty.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.opal.dto.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DefendantAccountParty {
+
+    @JsonProperty("defendant_account_party_type")
+    private String defendantAccountPartyType;
+
+    @JsonProperty("is_debtor")
+    private Boolean isDebtor;
+
+    @JsonProperty("party_details")
+    private PartyDetails partyDetails;
+
+    @JsonProperty("address")
+    private AddressDetails address;
+
+    @JsonProperty("contact_details")
+    private ContactDetails contactDetails;
+
+    @JsonProperty("vehicle_details")
+    private VehicleDetails vehicleDetails;
+
+    @JsonProperty("employer_details")
+    private EmployerDetails employerDetails;
+
+    @JsonProperty("language_preferences")
+    private LanguagePreferences languagePreferences;
+
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/common/EmployerDetails.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/common/EmployerDetails.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.opal.dto.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EmployerDetails {
+
+    @JsonProperty("employer_name")
+    private String employerName;
+
+    @JsonProperty("employer_reference")
+    private String employerReference;
+
+    @JsonProperty("employer_email_address")
+    private String employerEmailAddress;
+
+    @JsonProperty("employer_telephone_number")
+    private String employerTelephoneNumber;
+
+    @JsonProperty("employer_address")
+    private AddressDetails employerAddress;
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/common/LanguagePreferences.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/common/LanguagePreferences.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.opal.dto.common;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class LanguagePreferences {
+
+    @JsonProperty("document_language_preference")
+    private LanguagePreference documentLanguagePreference;
+
+    @JsonProperty("hearing_language_preference")
+    private LanguagePreference hearingLanguagePreference;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class LanguagePreference {
+
+        @JsonProperty("language_code")
+        private String languageCode;
+
+        @JsonProperty("language_display_name")
+        private String languageDisplayName;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/common/VehicleDetails.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/common/VehicleDetails.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.opal.dto;
+package uk.gov.hmcts.opal.dto.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -6,15 +6,17 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import uk.gov.hmcts.opal.dto.common.DefendantAccountParty;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class GetDefendantAccountPartyResponse {
+public class VehicleDetails {
 
-    @JsonProperty("defendant_account_party")
-    private DefendantAccountParty defendantAccountParty;
+    @JsonProperty("vehicle_make_and_model")
+    private String vehicleMakeAndModel;
+
+    @JsonProperty("vehicle_registration")
+    private String vehicleRegistration;
 }

--- a/src/main/java/uk/gov/hmcts/opal/entity/DefendantAccountEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/DefendantAccountEntity.java
@@ -86,11 +86,11 @@ public class DefendantAccountEntity {
     private LocalDate completedDate;
 
     @ManyToOne
-    @JoinColumn(name = "enforcing_court_id", referencedColumnName = "court_id", nullable = false)
+    @JoinColumn(name = "enforcing_court_id", referencedColumnName = "court_id")
     private CourtEntity enforcingCourt;
 
     @ManyToOne
-    @JoinColumn(name = "last_hearing_court_id", referencedColumnName = "court_id", nullable = false)
+    @JoinColumn(name = "last_hearing_court_id", referencedColumnName = "court_id")
     private CourtEntity lastHearingCourt;
 
     @Column(name = "last_hearing_date")

--- a/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountService.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.opal.service;
 
-
+import uk.gov.hmcts.opal.dto.GetDefendantAccountPartyResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -44,6 +44,23 @@ public class DefendantAccountService {
         if (userState.anyBusinessUnitUserHasPermission(Permissions.SEARCH_AND_VIEW_ACCOUNTS)) {
 
             return defendantAccountServiceProxy.searchDefendantAccounts(accountSearchDto);
+        } else {
+            throw new PermissionNotAllowedException(Permissions.SEARCH_AND_VIEW_ACCOUNTS);
+        }
+    }
+
+    public GetDefendantAccountPartyResponse getDefendantAccountParty(
+        Long defendantAccountId,
+        Long defendantAccountPartyId,
+        String authHeaderValue) {
+
+        log.debug(":getDefendantAccountParty:");
+
+        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+
+        if (userState.anyBusinessUnitUserHasPermission(Permissions.SEARCH_AND_VIEW_ACCOUNTS)) {
+
+            return defendantAccountServiceProxy.getDefendantAccountParty(defendantAccountId, defendantAccountPartyId);
         } else {
             throw new PermissionNotAllowedException(Permissions.SEARCH_AND_VIEW_ACCOUNTS);
         }

--- a/src/main/java/uk/gov/hmcts/opal/service/iface/DefendantAccountServiceInterface.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/iface/DefendantAccountServiceInterface.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service.iface;
 
+import uk.gov.hmcts.opal.dto.GetDefendantAccountPartyResponse;
 import uk.gov.hmcts.opal.dto.DefendantAccountHeaderSummary;
 import uk.gov.hmcts.opal.dto.search.AccountSearchDto;
 import uk.gov.hmcts.opal.dto.search.DefendantAccountSearchResultsDto;
@@ -8,4 +9,7 @@ public interface DefendantAccountServiceInterface {
     DefendantAccountHeaderSummary getHeaderSummary(Long defendantAccountId);
 
     DefendantAccountSearchResultsDto searchDefendantAccounts(AccountSearchDto accountSearchDto);
+
+    GetDefendantAccountPartyResponse getDefendantAccountParty(Long defendantAccountId, Long defendantAccountPartyId);
+
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.opal.config.properties.LegacyGatewayProperties;
 import uk.gov.hmcts.opal.dto.DefendantAccountHeaderSummary;
+import uk.gov.hmcts.opal.dto.GetDefendantAccountPartyResponse;
 import uk.gov.hmcts.opal.dto.common.AccountStatusReference;
 import uk.gov.hmcts.opal.dto.common.BusinessUnitSummary;
 import uk.gov.hmcts.opal.dto.common.IndividualAlias;
@@ -212,5 +213,11 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
         return BigDecimal.ZERO;
     }
 
+    @Override
+    public GetDefendantAccountPartyResponse getDefendantAccountParty(Long defendantAccountId,
+                                                                     Long defendantAccountPartyId) {
+        throw new UnsupportedOperationException("getDefendantAccountParty is not implemented in"
+            + " LegacyDefendantAccountService");
+    }
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
@@ -219,3 +219,4 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
         throw new UnsupportedOperationException("getDefendantAccountParty is not implemented in"
             + " LegacyDefendantAccountService");
     }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
@@ -258,7 +258,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
                     + ", partyId=" + defendantAccountPartyId));
 
         // Map entity to PartyDetails DTO
-        DefendantAccountParty defendantAccountParty = mapDefendantAccountParty(account, party);
+        DefendantAccountParty defendantAccountParty = mapDefendantAccountParty(party);
 
         return GetDefendantAccountPartyResponse.builder()
             .defendantAccountParty(defendantAccountParty)
@@ -267,7 +267,6 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
     }
 
     private DefendantAccountParty mapDefendantAccountParty(
-        DefendantAccountEntity account,
         DefendantAccountPartiesEntity partyEntity
     ) {
         PartyEntity party = partyEntity.getParty();

--- a/src/main/java/uk/gov/hmcts/opal/service/proxy/DefendantAccountServiceProxy.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/proxy/DefendantAccountServiceProxy.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service.proxy;
 
+import uk.gov.hmcts.opal.dto.GetDefendantAccountPartyResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,6 +32,11 @@ public class DefendantAccountServiceProxy implements DefendantAccountServiceInte
     @Override
     public DefendantAccountSearchResultsDto searchDefendantAccounts(AccountSearchDto accountSearchDto) {
         return getCurrentModeService().searchDefendantAccounts(accountSearchDto);
+    }
+
+    public GetDefendantAccountPartyResponse getDefendantAccountParty(Long defendantAccountId,
+                                                                     Long defendantAccountPartyId) {
+        return getCurrentModeService().getDefendantAccountParty(defendantAccountId, defendantAccountPartyId);
     }
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-1588


### Change description ###
Change description

This PR implements the new endpoint for retrieving a specific Defendant Account Party in Opal mode:

- Introduced GET endpoint:
- /defendant-accounts/{defendantAccountId}/defendant-account-parties/{defendantAccountPartyId}
- Returns Defendant Account Party details in a schema-compliant response object.
- Response models and mapping:
- Added DTOs for DefendantAccountParty and related value objects.
- Implemented mapping logic in the service layer.
- Error handling & integration tests:
- Added full suite of integration tests covering:
- Happy path (valid/organization/individual/optional fields)
- 404 Not Found (nonexistent account or party)
- 401 Unauthorized (missing/invalid auth header, handled via new @ExceptionHandler for AuthenticationException)
- 403 Forbidden (insufficient permissions, handled via AccessDeniedException/PermissionNotAllowedException)
- Added @ExceptionHandler in GlobalExceptionHandler for 401 Unauthorized.
- All integration tests passing.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
