### PR TITLE
Remove direct dependency management of netty packages was due to CVE.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -255,7 +255,6 @@ dependencyUpdates {
 ext {
   log4JVersion = "2.25.2"
   serenityVersion = "4.2.34"
-  nettyVersion = "4.1.127.Final"
 }
 
 dependencyManagement {
@@ -269,15 +268,6 @@ dependencyManagement {
 
   dependencies {
     dependency group: 'com.google.guava', name: 'guava', version: '33.5.0-jre'
-    //Added to override dependency version to resolve vulnerability
-    dependency group: 'io.netty', name: 'netty-codec', version: nettyVersion
-    dependency group: 'io.netty', name: 'netty-buffer', version: nettyVersion
-    dependency group: 'io.netty', name: 'netty-common', version: nettyVersion
-    dependency group: 'io.netty', name: 'netty-handler', version: nettyVersion
-    dependency group: 'io.netty', name: 'netty-resolver', version: nettyVersion
-    dependency group: 'io.netty', name: 'netty-transport', version: nettyVersion
-    dependency group: 'io.netty', name: 'netty-transport-native-unix-common', version: nettyVersion
-    //END
   }
 }
 


### PR DESCRIPTION
Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[*] No
```
