### PR TITLE
PO-1790_PO-2130_PO-2232 - Created new procedure p_add_defendant_account_enforcement with concurrency check, and inserted report reference data for Warrant Register

### DIFF
--- a/src/dbUnitTest/addDefendantAccountEnforcementTest/p_add_defendant_account_enforcement_unit_tests.sql
+++ b/src/dbUnitTest/addDefendantAccountEnforcementTest/p_add_defendant_account_enforcement_unit_tests.sql
@@ -1,0 +1,726 @@
+\timing
+
+/**
+* CGI Opal Program
+*
+* MODULE      : p_add_defendant_account_enforcement_unit_tests.sql
+*
+* DESCRIPTION : Unit tests for the stored procedure p_add_defendant_account_enforcement.
+*
+* VERSION HISTORY:
+*
+* Date          Author      Version     Nature of Change
+* ----------    -------     --------    ----------------------------------------------------------------------------------------------------------------
+* 12/09/2025    C Cho       1.0         PO-1790 Unit tests for p_add_defendant_account_enforcement.
+*
+**/
+
+-- Clear out test data before tests
+DO LANGUAGE 'plpgsql' $$
+DECLARE
+
+BEGIN
+    RAISE NOTICE '=== Cleanup data before tests ===';
+    
+    -- Delete test data from related tables in correct order to avoid FK violations
+    DELETE FROM report_entries WHERE associated_record_type = 'Enforcement' AND associated_record_id IN (SELECT enforcement_id::VARCHAR FROM enforcements WHERE defendant_account_id IN (90001, 90002, 90003, 90004));
+    DELETE FROM document_instances WHERE associated_record_type = 'Enforcement' AND associated_record_id IN (SELECT enforcement_id::VARCHAR FROM enforcements WHERE defendant_account_id IN (90001, 90002, 90003, 90004));
+    DELETE FROM warrant_register WHERE enforcement_id IN (SELECT enforcement_id FROM enforcements WHERE defendant_account_id IN (90001, 90002, 90003, 90004));
+    DELETE FROM enforcements WHERE defendant_account_id IN (90001, 90002, 90003, 90004);
+    DELETE FROM aliases WHERE party_id IN (90001, 90002, 90003, 90004);
+    DELETE FROM debtor_detail WHERE party_id IN (90001, 90002, 90003, 90004);
+    DELETE FROM defendant_account_parties WHERE defendant_account_id IN (90001, 90002, 90003, 90004);
+    DELETE FROM defendant_accounts WHERE defendant_account_id IN (90001, 90002, 90003, 90004);
+    DELETE FROM parties WHERE party_id IN (90001, 90002, 90003, 90004);
+    DELETE FROM enforcers WHERE enforcer_id = 90001;
+
+    -- Drop any existing temp tables from previous sessions
+    DROP TABLE IF EXISTS temp_def_ac_amendment_list;
+    DROP TABLE IF EXISTS temp_cred_ac_amendment_list;
+
+    RAISE NOTICE 'Data cleanup before tests completed';
+END $$;
+
+----------------------------------------------------------------------------------------------------------------------
+-- Test 1: Test successful enforcement creation with warrant generation
+----------------------------------------------------------------------------------------------------------------------
+DO LANGUAGE 'plpgsql' $$
+DECLARE
+    v_defendant_account_id       BIGINT := 90001;
+    v_business_unit_id           SMALLINT := 65;
+    v_result_id                  VARCHAR(6);
+    v_enforcer_id                BIGINT := 90001;
+    v_party_id_def               BIGINT;
+    v_enforcement_id             BIGINT;
+    v_record_count               INTEGER;
+    v_warrant_ref                VARCHAR(20);
+    v_jail_days                  INTEGER := 30;
+    v_expected_doc_count         INTEGER;
+    v_current_year               VARCHAR(2);
+BEGIN
+    RAISE NOTICE '=== TEST 1: Test successful enforcement creation with warrant generation ===';
+    
+    -- Setup test data - Create defendant party
+    INSERT INTO parties (
+        party_id, organisation, surname, forenames, title, 
+        address_line_1, address_line_2, address_line_3, postcode,
+        birth_date, national_insurance_number, telephone_home, 
+        telephone_business, telephone_mobile, email_1, email_2
+    ) VALUES (
+        90001, FALSE, 'TestDefendant', 'John', 'Mr',
+        '123 Test Street', 'Test Area', 'Test City', 'TE1 2ST',
+        '1980-01-01'::DATE, 'AB123456C', '01234567890',
+        '01234567891', '07123456789', 'john.test@example.com', 'j.test@example.com'
+    ) RETURNING party_id INTO v_party_id_def;
+
+    -- Create defendant account
+    INSERT INTO defendant_accounts (
+        defendant_account_id, business_unit_id, account_number, account_type,
+        imposed_hearing_date, amount_imposed, amount_paid, account_balance,
+        account_status, cheque_clearance_period, allow_cheques,
+        credit_trans_clearance_period, allow_writeoffs, enforcing_court_id,
+        collection_order, suspended_committal_date, account_comments,
+        account_note_1, account_note_2, account_note_3, jail_days, version_number
+    ) VALUES (
+        v_defendant_account_id, v_business_unit_id, 'TEST001', 'Fine',
+        '2024-01-01'::DATE, 100.00, 50.00, 50.00,
+        'L', 5, TRUE, 3, TRUE, 650000000045,
+        FALSE, NULL, 'Test account comments',
+        'Test note 1', 'Test note 2', 'Test note 3', 0, 1
+    );
+
+    -- Create defendant account parties association
+    INSERT INTO defendant_account_parties (
+        defendant_account_party_id, defendant_account_id, party_id, association_type, debtor
+    ) VALUES (90001, v_defendant_account_id, v_party_id_def, 'Defendant', FALSE);
+
+    -- Get a result that generates warrant from existing data
+    SELECT result_id INTO v_result_id
+    FROM results
+    WHERE generates_warrant = TRUE
+      AND enforcement = TRUE
+      AND active = TRUE
+    LIMIT 1;
+    
+    IF v_result_id IS NULL THEN
+        RAISE EXCEPTION 'No warrant-generating result found in test data';
+    END IF;
+    
+    RAISE NOTICE 'Using result_id: %', v_result_id;
+
+    -- Create enforcer (all fields are non-nullable except warrant_reference_sequence and warrant_register_sequence)
+    INSERT INTO enforcers (
+        enforcer_id, business_unit_id, enforcer_code, name,
+        warrant_reference_sequence
+    ) VALUES (
+        v_enforcer_id, v_business_unit_id, 101, 'Test Enforcer',
+        '101/24/00007'
+    );
+
+    -- Call the procedure
+    CALL p_add_defendant_account_enforcement(
+        pi_result_id := v_result_id,
+        pi_defendant_account_id := v_defendant_account_id,
+        pi_business_unit_id := v_business_unit_id,
+        pi_record_type := 'defendant_accounts',
+        pi_case_reference := 'CASE123',
+        pi_function_code := 'ACCOUNT_ENQUIRY',
+        pi_jail_days := v_jail_days,
+        pi_posted_by := 'USER123',
+        pi_posted_by_name := 'Test User',
+        pi_reason := 'Test enforcement',
+        pi_enforcer_id := v_enforcer_id,
+        pi_result_responses := '{"test": "data"}',
+        pi_earliest_release_date := NULL,
+        pi_version_number := 1,
+        po_enforcement_id := v_enforcement_id
+    );
+
+    -- Verify enforcement was created
+    ASSERT v_enforcement_id IS NOT NULL, 'Enforcement ID should be returned';
+
+    SELECT COUNT(*) INTO v_record_count FROM enforcements WHERE enforcement_id = v_enforcement_id;
+    ASSERT v_record_count = 1, 'Should have exactly 1 enforcement record';
+
+    -- Verify enforcement data
+    PERFORM 1 FROM enforcements 
+    WHERE enforcement_id = v_enforcement_id
+      AND defendant_account_id = v_defendant_account_id
+      AND result_id = v_result_id
+      AND posted_by = 'USER123'
+      AND posted_by_name = 'Test User'
+      AND reason = 'Test enforcement'
+      AND enforcer_id = v_enforcer_id
+      AND jail_days = v_jail_days;
+
+    ASSERT FOUND, 'Enforcement should contain correct data';
+
+    -- Verify defendant account was updated
+    PERFORM 1 FROM defendant_accounts 
+    WHERE defendant_account_id = v_defendant_account_id
+      AND last_enforcement = v_result_id
+      AND jail_days = v_jail_days
+      AND last_movement_date IS NOT NULL;
+
+    ASSERT FOUND, 'Defendant account should be updated with enforcement data';
+
+    -- Verify warrant reference was generated and updated
+    v_current_year := RIGHT(EXTRACT(YEAR FROM CURRENT_TIMESTAMP)::TEXT, 2);
+    SELECT warrant_reference INTO v_warrant_ref FROM enforcements WHERE enforcement_id = v_enforcement_id;
+    ASSERT v_warrant_ref = format('101/%s/00001', v_current_year),
+       format('Warrant reference should be set to 101/%s/00001', v_current_year);
+
+    -- Verify enforcer warrant sequence was updated
+    PERFORM 1 FROM enforcers 
+    WHERE enforcer_id = v_enforcer_id 
+      AND warrant_reference_sequence = v_warrant_ref;
+
+    ASSERT FOUND, 'Enforcer warrant sequence should be updated';
+
+    -- Verify warrant register entry
+    SELECT COUNT(*) INTO v_record_count FROM warrant_register WHERE enforcement_id = v_enforcement_id;
+    ASSERT v_record_count = 1, 'Should have exactly 1 warrant register entry';
+
+    -- Get expected document count for this result
+    SELECT COUNT(*) INTO v_expected_doc_count 
+    FROM result_documents 
+    WHERE result_id = v_result_id;
+
+    -- Verify document instances were created (should match result_documents count)
+    SELECT COUNT(*) INTO v_record_count FROM document_instances 
+    WHERE associated_record_type = 'Enforcement' AND associated_record_id = v_enforcement_id::VARCHAR;
+    ASSERT v_record_count = v_expected_doc_count, FORMAT('Should have exactly %s document instance(s) based on result_documents', v_expected_doc_count);
+
+    -- Verify report entry was created
+    SELECT COUNT(*) INTO v_record_count FROM report_entries 
+    WHERE associated_record_type = 'Enforcement' AND associated_record_id = v_enforcement_id::VARCHAR;
+    ASSERT v_record_count = 1, 'Should have exactly 1 report entry';
+
+    RAISE NOTICE 'TEST 1 PASSED: Enforcement created successfully with warrant generation';
+END $$;
+
+----------------------------------------------------------------------------------------------------------------------
+-- Test 2: Test COLLO enforcement action updates collection order
+----------------------------------------------------------------------------------------------------------------------
+DO LANGUAGE 'plpgsql' $$
+DECLARE
+    v_defendant_account_id       BIGINT := 90002;
+    v_business_unit_id           SMALLINT := 65;
+    v_result_id                  VARCHAR(6) := 'COLLO';
+    v_party_id_def               BIGINT;
+    v_enforcement_id             BIGINT;
+    v_expected_doc_count         INTEGER;
+    v_record_count               INTEGER;
+BEGIN
+    RAISE NOTICE '=== TEST 2: Test COLLO enforcement action updates collection order ===';
+    
+    -- Setup test data
+    INSERT INTO parties (
+        party_id, organisation, surname, forenames, title, 
+        address_line_1, postcode, birth_date
+    ) VALUES (
+        90002, FALSE, 'TestDefendant2', 'Jane', 'Ms',
+        '456 Test Street', 'TE2 3ST', '1985-05-15'::DATE
+    ) RETURNING party_id INTO v_party_id_def;
+
+    INSERT INTO defendant_accounts (
+        defendant_account_id, business_unit_id, account_number, account_type,
+        imposed_hearing_date, amount_imposed, amount_paid, account_balance,
+        account_status, collection_order, collection_order_date, version_number
+    ) VALUES (
+        v_defendant_account_id, v_business_unit_id, 'TEST002', 'Fine',
+        '2024-01-01'::DATE, 200.00, 0.00, 200.00,
+        'L', FALSE, NULL, 1
+    );
+
+    INSERT INTO defendant_account_parties (
+        defendant_account_party_id, defendant_account_id, party_id, association_type, debtor
+    ) VALUES (90002, v_defendant_account_id, v_party_id_def, 'Defendant', FALSE);
+
+    -- Verify COLLO result exists
+    PERFORM 1 FROM results WHERE result_id = v_result_id AND enforcement = TRUE AND active = TRUE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'COLLO result not found in test data';
+    END IF;
+
+    -- Call the procedure
+    CALL p_add_defendant_account_enforcement(
+        pi_result_id := v_result_id,
+        pi_defendant_account_id := v_defendant_account_id,
+        pi_business_unit_id := v_business_unit_id,
+        pi_record_type := 'defendant_accounts',
+        pi_case_reference := NULL,
+        pi_function_code := 'ACCOUNT_ENQUIRY',
+        pi_jail_days := NULL,
+        pi_posted_by := 'USER123',
+        pi_posted_by_name := 'Test User',
+        pi_reason := NULL,
+        pi_enforcer_id := NULL,
+        pi_result_responses := NULL,
+        pi_earliest_release_date := NULL,
+        pi_version_number := 1,
+        po_enforcement_id := v_enforcement_id
+    );
+
+    -- Verify collection order was set
+    PERFORM 1 FROM defendant_accounts 
+    WHERE defendant_account_id = v_defendant_account_id
+      AND collection_order = TRUE
+      AND collection_order_date IS NOT NULL;
+
+    ASSERT FOUND, 'Collection order should be set to TRUE with timestamp';
+
+    -- Get expected document count for this result
+    SELECT COUNT(*) INTO v_expected_doc_count 
+    FROM result_documents 
+    WHERE result_id = v_result_id;
+
+    -- Verify document instances were created (should match result_documents count)
+    SELECT COUNT(*) INTO v_record_count FROM document_instances 
+    WHERE associated_record_type = 'Enforcement' AND associated_record_id = v_enforcement_id::VARCHAR;
+    ASSERT v_record_count = v_expected_doc_count, FORMAT('Should have exactly %s document instance(s) based on result_documents', v_expected_doc_count);
+
+    RAISE NOTICE 'TEST 2 PASSED: COLLO enforcement correctly updates collection order';
+END $$;
+
+----------------------------------------------------------------------------------------------------------------------
+-- Test 3: Test FSN enforcement action sets further steps notice date only if NULL
+----------------------------------------------------------------------------------------------------------------------
+DO LANGUAGE 'plpgsql' $$
+DECLARE
+    v_defendant_account_id       BIGINT := 90003;
+    v_business_unit_id           SMALLINT := 65;
+    v_result_id                  VARCHAR(6) := 'FSN';
+    v_party_id_def               BIGINT;
+    v_enforcement_id             BIGINT;
+    v_original_date              TIMESTAMP := '2024-01-01 10:00:00';
+    BEGIN
+    RAISE NOTICE '=== TEST 3: Test FSN enforcement action sets further steps notice date only if NULL ===';
+    
+    -- Setup test data with existing FSN date
+    INSERT INTO parties (
+        party_id, organisation, surname, forenames, address_line_1, postcode, birth_date
+    ) VALUES (
+        90003, FALSE, 'TestDefendant3', 'Bob', '789 Test Street', 'TE3 4ST', '1990-03-20'::DATE
+    ) RETURNING party_id INTO v_party_id_def;
+
+    INSERT INTO defendant_accounts (
+        defendant_account_id, business_unit_id, account_number, account_type,
+        imposed_hearing_date, amount_imposed, amount_paid, account_balance,
+        account_status, further_steps_notice_date, version_number
+    ) VALUES (
+        v_defendant_account_id, v_business_unit_id, 'TEST003', 'Fine',
+        '2024-01-01'::DATE, 150.00, 25.00, 125.00,
+        'L', v_original_date, 1
+    );
+
+    INSERT INTO defendant_account_parties (
+        defendant_account_party_id, defendant_account_id, party_id, association_type, debtor
+    ) VALUES (90003, v_defendant_account_id, v_party_id_def, 'Defendant', FALSE);
+
+    -- Verify FSN result exists
+    PERFORM 1 FROM results WHERE result_id = v_result_id AND enforcement = TRUE AND active = TRUE;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'FSN result not found in test data';
+    END IF;
+
+    -- Call the procedure
+    CALL p_add_defendant_account_enforcement(
+        pi_result_id := v_result_id,
+        pi_defendant_account_id := v_defendant_account_id,
+        pi_business_unit_id := v_business_unit_id,
+        pi_record_type := 'defendant_accounts',
+        pi_case_reference := NULL,
+        pi_function_code := 'ACCOUNT_ENQUIRY',
+        pi_jail_days := NULL,
+        pi_posted_by := 'USER123',
+        pi_posted_by_name := 'Test User',
+        pi_reason := NULL,
+        pi_enforcer_id := NULL,
+        pi_result_responses := NULL,
+        pi_earliest_release_date := NULL,
+        pi_version_number := 1,
+        po_enforcement_id := v_enforcement_id
+    );
+
+    -- Verify FSN date was NOT changed (should remain original)
+    PERFORM 1 FROM defendant_accounts 
+    WHERE defendant_account_id = v_defendant_account_id
+      AND further_steps_notice_date = v_original_date;
+
+    ASSERT FOUND, 'Further steps notice date should not be overwritten when already exists';
+
+    RAISE NOTICE 'TEST 3 PASSED: FSN enforcement correctly preserves existing further steps notice date';
+END $$;
+
+----------------------------------------------------------------------------------------------------------------------
+-- Test 4: Test error handling - NULL result_id
+----------------------------------------------------------------------------------------------------------------------
+DO LANGUAGE 'plpgsql' $$
+DECLARE
+    v_error_caught               BOOLEAN := FALSE;
+    v_expected_sqlstate          VARCHAR := 'P4001';
+    v_expected_message           VARCHAR := 'Result ID cannot be null';
+    v_enforcement_id             BIGINT;
+BEGIN
+    RAISE NOTICE '=== TEST 4: Test error handling - NULL result_id ===';
+    
+    -- Call the procedure with NULL result_id - should throw P4001 exception
+    BEGIN
+        CALL p_add_defendant_account_enforcement(
+            pi_result_id := NULL,
+            pi_defendant_account_id := 90001::BIGINT,
+            pi_business_unit_id := 65::SMALLINT,
+            pi_record_type := 'defendant_accounts',
+            pi_case_reference := NULL,
+            pi_function_code := 'ACCOUNT_ENQUIRY',
+            pi_jail_days := NULL,
+            pi_posted_by := 'USER123',
+            pi_posted_by_name := 'Test User',
+            pi_reason := NULL,
+            pi_enforcer_id := NULL,
+            pi_result_responses := NULL,
+            pi_earliest_release_date := NULL,
+            pi_version_number := 1,
+            po_enforcement_id := v_enforcement_id
+        );
+    EXCEPTION
+        WHEN SQLSTATE 'P4001' THEN
+            IF SQLERRM = v_expected_message THEN
+                v_error_caught := TRUE;
+                RAISE NOTICE 'Expected error caught: % - %', SQLSTATE, SQLERRM;
+            ELSE 
+                RAISE WARNING 'Expected error SQLSTATE caught but with wrong SQLERRM: % - %', SQLSTATE, SQLERRM;
+            END IF;
+        WHEN OTHERS THEN
+            v_error_caught := FALSE;
+            RAISE NOTICE 'Unexpected error caught: % - %', SQLSTATE, SQLERRM;
+    END;
+
+    -- Verify error was caught
+    ASSERT v_error_caught = TRUE, 'A P4001 error should have been raised due to NULL result_id';
+
+    RAISE NOTICE 'TEST 4 PASSED: Error handling works correctly for NULL result_id';
+END $$;
+
+----------------------------------------------------------------------------------------------------------------------
+-- Test 5: Test error handling - NULL defendant_account_id
+----------------------------------------------------------------------------------------------------------------------
+DO LANGUAGE 'plpgsql' $$
+DECLARE
+    v_error_caught               BOOLEAN := FALSE;
+    v_expected_sqlstate          VARCHAR := 'P4002';
+    v_expected_message           VARCHAR := 'Defendant account ID cannot be null';
+    v_enforcement_id             BIGINT;
+BEGIN
+    RAISE NOTICE '=== TEST 5: Test error handling - NULL defendant_account_id ===';
+    
+    -- Call the procedure with NULL defendant_account_id - should throw P4002 exception
+    BEGIN
+        CALL p_add_defendant_account_enforcement(
+            pi_result_id := 'SUMM',
+            pi_defendant_account_id := NULL::BIGINT,
+            pi_business_unit_id := 65::SMALLINT,
+            pi_record_type := 'defendant_accounts',
+            pi_case_reference := NULL,
+            pi_function_code := 'ACCOUNT_ENQUIRY',
+            pi_jail_days := NULL,
+            pi_posted_by := 'USER123',
+            pi_posted_by_name := 'Test User',
+            pi_reason := NULL,
+            pi_enforcer_id := NULL,
+            pi_result_responses := NULL,
+            pi_earliest_release_date := NULL,
+            pi_version_number := 1,
+            po_enforcement_id := v_enforcement_id
+        );
+    EXCEPTION
+        WHEN SQLSTATE 'P4002' THEN
+            IF SQLERRM = v_expected_message THEN
+                v_error_caught := TRUE;
+                RAISE NOTICE 'Expected error caught: % - %', SQLSTATE, SQLERRM;
+            ELSE 
+                RAISE WARNING 'Expected error SQLSTATE caught but with wrong SQLERRM: % - %', SQLSTATE, SQLERRM;
+            END IF;
+        WHEN OTHERS THEN
+            v_error_caught := FALSE;
+            RAISE NOTICE 'Unexpected error caught: % - %', SQLSTATE, SQLERRM;
+    END;
+
+    -- Verify error was caught
+    ASSERT v_error_caught = TRUE, 'A P4002 error should have been raised due to NULL defendant_account_id';
+
+    RAISE NOTICE 'TEST 5 PASSED: Error handling works correctly for NULL defendant_account_id';
+END $$;
+
+----------------------------------------------------------------------------------------------------------------------
+-- Test 6: Test error handling - Invalid record type
+----------------------------------------------------------------------------------------------------------------------
+DO LANGUAGE 'plpgsql' $$
+DECLARE
+    v_error_caught               BOOLEAN := FALSE;
+    v_expected_sqlstate          VARCHAR := 'P4004';
+    v_enforcement_id             BIGINT;
+BEGIN
+    RAISE NOTICE '=== TEST 6: Test error handling - Invalid record type ===';
+    
+    -- Call the procedure with invalid record type - should throw P4004 exception
+    BEGIN
+        CALL p_add_defendant_account_enforcement(
+            pi_result_id := 'SUMM',
+            pi_defendant_account_id := 90001::BIGINT,
+            pi_business_unit_id := 65::SMALLINT,
+            pi_record_type := 'invalid_type',
+            pi_case_reference := NULL,
+            pi_function_code := 'ACCOUNT_ENQUIRY',
+            pi_jail_days := NULL,
+            pi_posted_by := 'USER123',
+            pi_posted_by_name := 'Test User',
+            pi_reason := NULL,
+            pi_enforcer_id := NULL,
+            pi_result_responses := NULL,
+            pi_earliest_release_date := NULL,
+            pi_version_number := 1,
+            po_enforcement_id := v_enforcement_id
+        );
+    EXCEPTION
+        WHEN SQLSTATE 'P4004' THEN
+            IF SQLERRM LIKE '%Invalid record type%' THEN
+                v_error_caught := TRUE;
+                RAISE NOTICE 'Expected error caught: % - %', SQLSTATE, SQLERRM;
+            ELSE 
+                RAISE WARNING 'Expected error SQLSTATE caught but with wrong SQLERRM: % - %', SQLSTATE, SQLERRM;
+            END IF;
+        WHEN OTHERS THEN
+            v_error_caught := FALSE;
+            RAISE NOTICE 'Unexpected error caught: % - %', SQLSTATE, SQLERRM;
+    END;
+
+    -- Verify error was caught
+    ASSERT v_error_caught = TRUE, 'A P4004 error should have been raised due to invalid record type';
+
+    RAISE NOTICE 'TEST 6 PASSED: Error handling works correctly for invalid record type';
+END $$;
+
+----------------------------------------------------------------------------------------------------------------------
+-- Test 7: Test error handling - Non-existent enforcer_id
+----------------------------------------------------------------------------------------------------------------------
+DO LANGUAGE 'plpgsql' $$
+DECLARE
+    v_error_caught               BOOLEAN := FALSE;
+    v_expected_sqlstate          VARCHAR := 'P4006';
+    v_expected_message           VARCHAR := 'Enforcer not found with ID: 999999';
+    v_non_existent_id            BIGINT := 999999;
+    v_enforcement_id             BIGINT;
+    v_result_id                  VARCHAR(6);
+BEGIN
+    RAISE NOTICE '=== TEST 7: Test error handling - Non-existent enforcer_id ===';
+    
+    -- Get a result that generates warrant from existing data
+    SELECT result_id INTO v_result_id
+    FROM results
+    WHERE generates_warrant = TRUE
+      AND enforcement = TRUE
+      AND active = TRUE
+    LIMIT 1;
+    
+    IF v_result_id IS NULL THEN
+        RAISE EXCEPTION 'No warrant-generating result found in test data';
+    END IF;
+    
+    -- Call the procedure with non-existent enforcer_id for warrant-generating result - should throw P4006 exception
+    BEGIN
+        CALL p_add_defendant_account_enforcement(
+            pi_result_id := v_result_id,
+            pi_defendant_account_id := 90001::BIGINT,
+            pi_business_unit_id := 65::SMALLINT,
+            pi_record_type := 'defendant_accounts',
+            pi_case_reference := NULL,
+            pi_function_code := 'ACCOUNT_ENQUIRY',
+            pi_jail_days := NULL,
+            pi_posted_by := 'USER123',
+            pi_posted_by_name := 'Test User',
+            pi_reason := NULL,
+            pi_enforcer_id := v_non_existent_id,
+            pi_result_responses := NULL,
+            pi_earliest_release_date := NULL,
+            pi_version_number := 1,
+            po_enforcement_id := v_enforcement_id
+        );
+    EXCEPTION
+        WHEN SQLSTATE 'P4006' THEN
+            IF SQLERRM = v_expected_message THEN
+                v_error_caught := TRUE;
+                RAISE NOTICE 'Expected error caught: % - %', SQLSTATE, SQLERRM;
+            ELSE 
+                RAISE WARNING 'Expected error SQLSTATE caught but with wrong SQLERRM: % - %', SQLSTATE, SQLERRM;
+            END IF;
+        WHEN OTHERS THEN
+            v_error_caught := FALSE;
+            RAISE NOTICE 'Unexpected error caught: % - %', SQLSTATE, SQLERRM;
+    END;
+
+    -- Verify error was caught
+    ASSERT v_error_caught = TRUE, 'A P4006 error should have been raised due to non-existent enforcer_id';
+
+    RAISE NOTICE 'TEST 7 PASSED: Error handling works correctly for non-existent enforcer_id';
+END $$;
+
+----------------------------------------------------------------------------------------------------------------------
+-- Test 8: Test error handling - NULL version_number
+----------------------------------------------------------------------------------------------------------------------
+DO LANGUAGE 'plpgsql' $$
+DECLARE
+    v_error_caught               BOOLEAN := FALSE;
+    v_expected_sqlstate          VARCHAR := 'P4007';
+    v_expected_message           VARCHAR := 'Version number cannot be null';
+    v_enforcement_id             BIGINT;
+BEGIN
+    RAISE NOTICE '=== TEST 8: Test error handling - NULL version_number ===';
+    
+    -- Call the procedure with NULL version_number - should throw P4007 exception
+    BEGIN
+        CALL p_add_defendant_account_enforcement(
+            pi_result_id := 'SUMM',
+            pi_defendant_account_id := 90001::BIGINT,
+            pi_business_unit_id := 65::SMALLINT,
+            pi_record_type := 'defendant_accounts',
+            pi_case_reference := NULL,
+            pi_function_code := 'ACCOUNT_ENQUIRY',
+            pi_jail_days := NULL,
+            pi_posted_by := 'USER123',
+            pi_posted_by_name := 'Test User',
+            pi_reason := NULL,
+            pi_enforcer_id := NULL,
+            pi_result_responses := NULL,
+            pi_earliest_release_date := NULL,
+            pi_version_number := NULL,
+            po_enforcement_id := v_enforcement_id
+        );
+    EXCEPTION
+        WHEN SQLSTATE 'P4007' THEN
+            IF SQLERRM = v_expected_message THEN
+                v_error_caught := TRUE;
+                RAISE NOTICE 'Expected error caught: % - %', SQLSTATE, SQLERRM;
+            ELSE 
+                RAISE WARNING 'Expected error SQLSTATE caught but with wrong SQLERRM: % - %', SQLSTATE, SQLERRM;
+            END IF;
+        WHEN OTHERS THEN
+            v_error_caught := FALSE;
+            RAISE NOTICE 'Unexpected error caught: % - %', SQLSTATE, SQLERRM;
+    END;
+
+    -- Verify error was caught
+    ASSERT v_error_caught = TRUE, 'A P4007 error should have been raised due to NULL version_number';
+
+    RAISE NOTICE 'TEST 8 PASSED: Error handling works correctly for NULL version_number';
+END $$;
+
+----------------------------------------------------------------------------------------------------------------------
+-- Test 9: Test error handling - Version number mismatch (concurrency check)
+----------------------------------------------------------------------------------------------------------------------
+DO LANGUAGE 'plpgsql' $$
+DECLARE
+    v_defendant_account_id       BIGINT := 90004;
+    v_business_unit_id           SMALLINT := 65;
+    v_party_id_def               BIGINT;
+    v_error_caught               BOOLEAN := FALSE;
+    v_expected_sqlstate          VARCHAR := 'P4008';
+    v_expected_message           VARCHAR := 'Some information on this page may be out of date.';
+    v_enforcement_id             BIGINT;
+BEGIN
+    RAISE NOTICE '=== TEST 9: Test error handling - Version number mismatch (concurrency check) ===';
+    
+    -- Setup test data for concurrency test
+    INSERT INTO parties (
+        party_id, organisation, surname, forenames, address_line_1, postcode, birth_date
+    ) VALUES (
+        90004, FALSE, 'TestDefendant4', 'Alice', '101 Test Street', 'TE4 5ST', '1995-12-10'::DATE
+    ) RETURNING party_id INTO v_party_id_def;
+
+    INSERT INTO defendant_accounts (
+        defendant_account_id, business_unit_id, account_number, account_type,
+        imposed_hearing_date, amount_imposed, amount_paid, account_balance,
+        account_status, version_number
+    ) VALUES (
+        v_defendant_account_id, v_business_unit_id, 'TEST004', 'Fine',
+        '2024-01-01'::DATE, 300.00, 0.00, 300.00,
+        'L', 1
+    );
+
+    INSERT INTO defendant_account_parties (
+        defendant_account_party_id, defendant_account_id, party_id, association_type, debtor
+    ) VALUES (90004, v_defendant_account_id, v_party_id_def, 'Defendant', FALSE);
+
+    -- Call the procedure with incorrect version number (should be 1, passing 5) - should throw P4008 exception
+    BEGIN
+        CALL p_add_defendant_account_enforcement(
+            pi_result_id := 'SUMM',
+            pi_defendant_account_id := v_defendant_account_id,
+            pi_business_unit_id := v_business_unit_id,
+            pi_record_type := 'defendant_accounts',
+            pi_case_reference := NULL,
+            pi_function_code := 'ACCOUNT_ENQUIRY',
+            pi_jail_days := NULL,
+            pi_posted_by := 'USER123',
+            pi_posted_by_name := 'Test User',
+            pi_reason := 'Test concurrency failure',
+            pi_enforcer_id := NULL,
+            pi_result_responses := NULL,
+            pi_earliest_release_date := NULL,
+            pi_version_number := 5,
+            po_enforcement_id := v_enforcement_id
+        );
+    EXCEPTION
+        WHEN SQLSTATE 'P4008' THEN
+            IF SQLERRM = v_expected_message THEN
+                v_error_caught := TRUE;
+                RAISE NOTICE 'Expected error caught: % - %', SQLSTATE, SQLERRM;
+            ELSE 
+                RAISE WARNING 'Expected error SQLSTATE caught but with wrong SQLERRM: % - %', SQLSTATE, SQLERRM;
+            END IF;
+        WHEN OTHERS THEN
+            v_error_caught := FALSE;
+            RAISE NOTICE 'Unexpected error caught: % - %', SQLSTATE, SQLERRM;
+    END;
+
+    -- Verify error was caught
+    ASSERT v_error_caught = TRUE, 'A P4008 error should have been raised due to version number mismatch';
+
+    -- Verify no enforcement was created due to concurrency failure
+    PERFORM 1 FROM enforcements WHERE defendant_account_id = v_defendant_account_id;
+    ASSERT NOT FOUND, 'No enforcement should be created when concurrency check fails';
+
+    -- Verify defendant account version number remains unchanged
+    PERFORM 1 FROM defendant_accounts 
+    WHERE defendant_account_id = v_defendant_account_id AND version_number = 1;
+    ASSERT FOUND, 'Defendant account version number should remain unchanged when concurrency check fails';
+
+    RAISE NOTICE 'TEST 9 PASSED: Error handling works correctly for version number mismatch (concurrency check)';
+END $$;
+
+-- Cleanup test data
+DO LANGUAGE 'plpgsql' $$
+BEGIN
+    RAISE NOTICE '=== Cleanup test data ===';
+    
+    -- Delete test data from related tables in correct order to avoid FK violations
+    DELETE FROM report_entries WHERE associated_record_type = 'Enforcement' AND associated_record_id IN (SELECT enforcement_id::VARCHAR FROM enforcements WHERE defendant_account_id IN (90001, 90002, 90003, 90004));
+    DELETE FROM document_instances WHERE associated_record_type = 'Enforcement' AND associated_record_id IN (SELECT enforcement_id::VARCHAR FROM enforcements WHERE defendant_account_id IN (90001, 90002, 90003, 90004));
+    DELETE FROM warrant_register WHERE enforcement_id IN (SELECT enforcement_id FROM enforcements WHERE defendant_account_id IN (90001, 90002, 90003, 90004));
+    DELETE FROM enforcements WHERE defendant_account_id IN (90001, 90002, 90003, 90004);
+    DELETE FROM aliases WHERE party_id IN (90001, 90002, 90003, 90004);
+    DELETE FROM debtor_detail WHERE party_id IN (90001, 90002, 90003, 90004);
+    DELETE FROM defendant_account_parties WHERE defendant_account_id IN (90001, 90002, 90003, 90004);
+    DELETE FROM defendant_accounts WHERE defendant_account_id IN (90001, 90002, 90003, 90004);
+    DELETE FROM parties WHERE party_id IN (90001, 90002, 90003, 90004);
+    DELETE FROM enforcers WHERE enforcer_id = 90001;
+
+    -- Drop temporary tables
+    DROP TABLE IF EXISTS temp_def_ac_amendment_list;
+    DROP TABLE IF EXISTS temp_cred_ac_amendment_list;
+    
+    RAISE NOTICE 'Test data cleanup completed';
+END $$;
+
+\timing

--- a/src/dbUnitTest/addDefendantAccountEnforcementTest/test_output.txt
+++ b/src/dbUnitTest/addDefendantAccountEnforcementTest/test_output.txt
@@ -1,0 +1,86 @@
+NOTICE:  === Cleanup data before tests ===
+NOTICE:  table "temp_def_ac_amendment_list" does not exist, skipping
+NOTICE:  table "temp_cred_ac_amendment_list" does not exist, skipping
+NOTICE:  Data cleanup before tests completed
+NOTICE:  === TEST 1: Test successful enforcement creation with warrant generation ===
+NOTICE:  Using result_id: NBWT
+INFO:  p_add_defendant_account_enforcement: Starting with pi_result_id = NBWT, pi_defendant_account_id = 90001, pi_version_number = 1
+INFO:  p_audit_initialise: Starting with pi_associated_account_id = 90001, pi_record_type = defendant_accounts
+NOTICE:  table "temp_def_ac_amendment_list" does not exist, skipping
+INFO:  p_audit_initialise: Created temp_def_ac_amendment_list with 1 records
+INFO:  p_audit_initialise: Successfully completed for record_type = defendant_accounts
+INFO:  p_audit_finalise: Starting with pi_associated_account_id = 90001, pi_record_type = defendant_accounts
+INFO:  p_audit_finalise: Processed defendant account with 0 amendments recorded
+INFO:  p_audit_finalise: Successfully completed with 0 total amendments recorded
+INFO:  p_add_defendant_account_enforcement: Successfully completed. Created enforcement_id = 60000000000001
+NOTICE:  TEST 1 PASSED: Enforcement created successfully with warrant generation
+NOTICE:  === TEST 2: Test COLLO enforcement action updates collection order ===
+INFO:  p_add_defendant_account_enforcement: Starting with pi_result_id = COLLO, pi_defendant_account_id = 90002, pi_version_number = 1
+INFO:  p_audit_initialise: Starting with pi_associated_account_id = 90002, pi_record_type = defendant_accounts
+NOTICE:  table "temp_def_ac_amendment_list" does not exist, skipping
+INFO:  p_audit_initialise: Created temp_def_ac_amendment_list with 1 records
+INFO:  p_audit_initialise: Successfully completed for record_type = defendant_accounts
+INFO:  p_audit_finalise: Starting with pi_associated_account_id = 90002, pi_record_type = defendant_accounts
+INFO:  p_audit_finalise: Processed defendant account with 1 amendments recorded
+INFO:  p_audit_finalise: Successfully completed with 1 total amendments recorded
+INFO:  p_add_defendant_account_enforcement: Successfully completed. Created enforcement_id = 60000000000002
+NOTICE:  TEST 2 PASSED: COLLO enforcement correctly updates collection order
+NOTICE:  === TEST 3: Test FSN enforcement action sets further steps notice date only if NULL ===
+INFO:  p_add_defendant_account_enforcement: Starting with pi_result_id = FSN, pi_defendant_account_id = 90003, pi_version_number = 1
+INFO:  p_audit_initialise: Starting with pi_associated_account_id = 90003, pi_record_type = defendant_accounts
+NOTICE:  table "temp_def_ac_amendment_list" does not exist, skipping
+INFO:  p_audit_initialise: Created temp_def_ac_amendment_list with 1 records
+INFO:  p_audit_initialise: Successfully completed for record_type = defendant_accounts
+INFO:  p_audit_finalise: Starting with pi_associated_account_id = 90003, pi_record_type = defendant_accounts
+INFO:  p_audit_finalise: Processed defendant account with 0 amendments recorded
+INFO:  p_audit_finalise: Successfully completed with 0 total amendments recorded
+INFO:  p_add_defendant_account_enforcement: Successfully completed. Created enforcement_id = 60000000000003
+NOTICE:  TEST 3 PASSED: FSN enforcement correctly preserves existing further steps notice date
+NOTICE:  === TEST 4: Test error handling - NULL result_id ===
+INFO:  p_add_defendant_account_enforcement: Starting with pi_result_id = <NULL>, pi_defendant_account_id = 90001, pi_version_number = 1
+NOTICE:  Error in p_add_defendant_account_enforcement: P4001 - Result ID cannot be null
+NOTICE:  Expected error caught: P4001 - Result ID cannot be null
+NOTICE:  TEST 4 PASSED: Error handling works correctly for NULL result_id
+NOTICE:  === TEST 5: Test error handling - NULL defendant_account_id ===
+INFO:  p_add_defendant_account_enforcement: Starting with pi_result_id = SUMM, pi_defendant_account_id = <NULL>, pi_version_number = 1
+NOTICE:  Error in p_add_defendant_account_enforcement: P4002 - Defendant account ID cannot be null
+NOTICE:  Expected error caught: P4002 - Defendant account ID cannot be null
+NOTICE:  TEST 5 PASSED: Error handling works correctly for NULL defendant_account_id
+NOTICE:  === TEST 6: Test error handling - Invalid record type ===
+INFO:  p_add_defendant_account_enforcement: Starting with pi_result_id = SUMM, pi_defendant_account_id = 90001, pi_version_number = 1
+NOTICE:  Error in p_add_defendant_account_enforcement: P4004 - Invalid record type: invalid_type. Must be defendant_accounts
+NOTICE:  Expected error caught: P4004 - Invalid record type: invalid_type. Must be defendant_accounts
+NOTICE:  TEST 6 PASSED: Error handling works correctly for invalid record type
+NOTICE:  === TEST 7: Test error handling - Non-existent enforcer_id ===
+INFO:  p_add_defendant_account_enforcement: Starting with pi_result_id = NBWT, pi_defendant_account_id = 90001, pi_version_number = 1
+INFO:  p_audit_initialise: Starting with pi_associated_account_id = 90001, pi_record_type = defendant_accounts
+NOTICE:  table "temp_def_ac_amendment_list" does not exist, skipping
+INFO:  p_audit_initialise: Created temp_def_ac_amendment_list with 1 records
+INFO:  p_audit_initialise: Successfully completed for record_type = defendant_accounts
+NOTICE:  Error in p_add_defendant_account_enforcement: P4006 - Enforcer not found with ID: 999999
+NOTICE:  Expected error caught: P4006 - Enforcer not found with ID: 999999
+NOTICE:  TEST 7 PASSED: Error handling works correctly for non-existent enforcer_id
+NOTICE:  === TEST 8: Test error handling - NULL version_number ===
+INFO:  p_add_defendant_account_enforcement: Starting with pi_result_id = SUMM, pi_defendant_account_id = 90001, pi_version_number = <NULL>
+NOTICE:  Error in p_add_defendant_account_enforcement: P4007 - Version number cannot be null
+NOTICE:  Expected error caught: P4007 - Version number cannot be null
+NOTICE:  TEST 8 PASSED: Error handling works correctly for NULL version_number
+NOTICE:  === TEST 9: Test error handling - Version number mismatch (concurrency check) ===
+INFO:  p_add_defendant_account_enforcement: Starting with pi_result_id = SUMM, pi_defendant_account_id = 90004, pi_version_number = 5
+INFO:  p_audit_initialise: Starting with pi_associated_account_id = 90004, pi_record_type = defendant_accounts
+NOTICE:  table "temp_def_ac_amendment_list" does not exist, skipping
+INFO:  p_audit_initialise: Created temp_def_ac_amendment_list with 1 records
+INFO:  p_audit_initialise: Successfully completed for record_type = defendant_accounts
+INFO:  p_audit_finalise: Starting with pi_associated_account_id = 90004, pi_record_type = defendant_accounts
+INFO:  p_audit_finalise: Processed defendant account with 0 amendments recorded
+INFO:  p_audit_finalise: Successfully completed with 0 total amendments recorded
+NOTICE:  Error in p_add_defendant_account_enforcement: P4008 - Some information on this page may be out of date.
+NOTICE:  Expected error caught: P4008 - Some information on this page may be out of date.
+NOTICE:  TEST 9 PASSED: Error handling works correctly for version number mismatch (concurrency check)
+NOTICE:  === Cleanup test data ===
+NOTICE:  table "temp_def_ac_amendment_list" does not exist, skipping
+NOTICE:  table "temp_cred_ac_amendment_list" does not exist, skipping
+NOTICE:  Test data cleanup completed
+DO
+
+Query returned successfully in 776 msec.

--- a/src/main/resources/db/migration/allEnvs/V20251001_418__insert_warrant_register_report.sql
+++ b/src/main/resources/db/migration/allEnvs/V20251001_418__insert_warrant_register_report.sql
@@ -1,0 +1,17 @@
+/**
+* CGI OPAL Program
+*
+* MODULE      : insert_warrant_register_report.sql
+*
+* DESCRIPTION : Load the REPORTS table with warrant register report data for the Fines DB
+*
+* VERSION HISTORY:
+*
+* Date          Author      Version     Nature of Change
+* ----------    --------    --------    ---------------------------------------------------------------------------------------------------------------------
+* 23/09/2025    C Cho       1.0         PO-2232 Insert warrant register report into REPORTS table
+*
+**/
+
+INSERT INTO reports (report_id, report_title, report_group, report_parameters, audited_report) VALUES
+('warrant_register', 'Warrant Register', 'Account Management', '[{ "name":"enforcer", "prompt":"Enforcer", "type":"enforcers", "min":1, "max":1 }]', TRUE);

--- a/src/main/resources/db/migration/allEnvs/V20251001_419__p_add_defendant_account_enforcement.sql
+++ b/src/main/resources/db/migration/allEnvs/V20251001_419__p_add_defendant_account_enforcement.sql
@@ -1,0 +1,345 @@
+CREATE OR REPLACE PROCEDURE p_add_defendant_account_enforcement(
+    IN pi_result_id                 results.result_id%TYPE,
+    IN pi_defendant_account_id      defendant_accounts.defendant_account_id%TYPE,
+    IN pi_business_unit_id          business_units.business_unit_id%TYPE,
+    IN pi_record_type               CHARACTER VARYING,
+    IN pi_case_reference            amendments.case_reference%TYPE,
+    IN pi_function_code             amendments.function_code%TYPE,
+    IN pi_jail_days                 defendant_accounts.jail_days%TYPE,
+    IN pi_posted_by                 VARCHAR(20),
+    IN pi_posted_by_name            VARCHAR(100),
+    IN pi_reason                    enforcements.reason%TYPE,
+    IN pi_enforcer_id               enforcers.enforcer_id%TYPE,
+    IN pi_result_responses          enforcements.result_responses%TYPE,
+    IN pi_earliest_release_date     enforcements.earliest_release_date%TYPE,
+    IN pi_version_number            defendant_accounts.version_number%TYPE,
+    OUT po_enforcement_id           enforcements.enforcement_id%TYPE
+)
+LANGUAGE 'plpgsql'
+AS 
+$BODY$
+/**
+* CGI OPAL Program
+*
+* MODULE      : p_add_defendant_account_enforcement.sql
+*
+* DESCRIPTION : Procedure to add a new enforcement action for a defendant account.
+*               Creates enforcement records and updates defendant account fields as required.
+*               Calls audit procedures to track changes to auditable fields.
+*               Implements concurrency check via version number checking.
+*
+* PARAMETERS : pi_result_id               - The incoming result_id which is the same as the enforcement action
+*            : pi_defendant_account_id    - The Opal defendant account id
+*            : pi_business_unit_id        - Business unit identifier
+*            : pi_record_type             - For audit, this will be 'defendant_accounts'
+*            : pi_case_reference          - For audit, case reference if set by Case Management
+*            : pi_function_code           - For audit, the function from which the Amendment was made
+*            : pi_jail_days               - Number of days in jail the defendant will spend in default of payment
+*            : pi_posted_by               - User ID submitting the request
+*            : pi_posted_by_name          - User name submitting the request
+*            : pi_reason                  - The reason for this enforcement action
+*            : pi_enforcer_id             - The enforcer/process server for this enforcement action
+*            : pi_result_responses        - The result parameters
+*            : pi_earliest_release_date   - The earliest release date for a PRIS enforcement action
+*            : pi_version_number          - Current version number for concurrency check
+*            : po_enforcement_id          - Returns the ID of the new enforcement created
+*
+* VERSION HISTORY:
+*
+* Date          Author      Version     Nature of Change
+* ----------    -------     --------    -------------------------------------------------------------------------
+* 12/09/2025    C Cho       1.0         PO-1790 Initial version - Create add defendant account enforcement procedure.
+* 24/09/2025    C Cho       1.1         PO-2130 Add concurrency check via version number parameter.
+*
+**/
+DECLARE
+    v_pg_exception_detail            TEXT;
+    v_enforcement_id                 BIGINT;
+    v_enforcement_action             VARCHAR(6);
+    v_generates_warrant              BOOLEAN := FALSE;
+    v_enforcer_code                  VARCHAR(4);
+    v_current_warrant_ref            VARCHAR(20);
+    v_warrant_reference              VARCHAR(20);
+    v_current_year                   VARCHAR(2);
+    v_current_ref_year               VARCHAR(2);
+    v_warrant_register_id            BIGINT;
+    v_document_id                    VARCHAR(12);
+    v_document_instance_id           BIGINT;
+    v_fsn_date                       TIMESTAMP;
+    v_fine_reg_date                  TIMESTAMP;
+    v_confiscation_date              TIMESTAMP;
+    v_serial_part                    VARCHAR(5);
+    v_current_serial                 INTEGER;
+    v_rows_updated                   INTEGER;
+    
+BEGIN
+    RAISE INFO 'p_add_defendant_account_enforcement: Starting with pi_result_id = %, pi_defendant_account_id = %, pi_version_number = %', pi_result_id, pi_defendant_account_id, pi_version_number;
+
+    -- Validate input parameters
+    IF pi_result_id IS NULL THEN
+        RAISE EXCEPTION 'Result ID cannot be null'
+            USING ERRCODE = 'P4001'
+                , DETAIL = 'p_add_defendant_account_enforcement: pi_result_id is required';
+    END IF;
+
+    IF pi_defendant_account_id IS NULL THEN
+        RAISE EXCEPTION 'Defendant account ID cannot be null'
+            USING ERRCODE = 'P4002'
+                , DETAIL = 'p_add_defendant_account_enforcement: pi_defendant_account_id is required';
+    END IF;
+
+    IF pi_business_unit_id IS NULL THEN
+        RAISE EXCEPTION 'Business unit ID cannot be null'
+            USING ERRCODE = 'P4003'
+                , DETAIL = 'p_add_defendant_account_enforcement: pi_business_unit_id is required';
+    END IF;
+
+    IF pi_record_type IS NULL OR pi_record_type != 'defendant_accounts' THEN
+        RAISE EXCEPTION 'Invalid record type: %. Must be defendant_accounts', pi_record_type
+            USING ERRCODE = 'P4004'
+                , DETAIL = 'p_add_defendant_account_enforcement: pi_record_type must be defendant_accounts';
+    END IF;
+
+    IF pi_posted_by IS NULL THEN
+        RAISE EXCEPTION 'Posted by cannot be null'
+            USING ERRCODE = 'P4005'
+                , DETAIL = 'p_add_defendant_account_enforcement: pi_posted_by is required';
+    END IF;
+
+    IF pi_version_number IS NULL THEN
+        RAISE EXCEPTION 'Version number cannot be null'
+            USING ERRCODE = 'P4007'
+                , DETAIL = 'p_add_defendant_account_enforcement: pi_version_number is required for concurrency control';
+    END IF;
+
+    -- The incoming result_id is also the enforcement action
+    v_enforcement_action := pi_result_id;
+
+    -- Call audit initialise procedure
+    CALL p_audit_initialise(pi_defendant_account_id, pi_record_type);
+
+    -- Get next enforcement ID
+    v_enforcement_id := nextval('enforcement_id_seq');
+    po_enforcement_id := v_enforcement_id;
+
+    -- Check if this result generates a warrant
+    SELECT generates_warrant INTO v_generates_warrant
+    FROM results
+    WHERE result_id = pi_result_id;
+
+    -- Generate warrant reference if needed
+    IF v_generates_warrant = TRUE AND pi_enforcer_id IS NOT NULL THEN
+        -- Get enforcer code and current warrant reference sequence
+        SELECT enforcer_code, warrant_reference_sequence
+        INTO v_enforcer_code, v_current_warrant_ref
+        FROM enforcers
+        WHERE enforcer_id = pi_enforcer_id;
+
+        IF v_enforcer_code IS NULL THEN
+            RAISE EXCEPTION 'Enforcer not found with ID: %', pi_enforcer_id
+                USING ERRCODE = 'P4006'
+                    , DETAIL = 'p_add_defendant_account_enforcement: enforcer_id not found';
+        END IF;
+
+        -- Get current year suffix (last 2 digits)
+        v_current_year := RIGHT(EXTRACT(YEAR FROM CURRENT_TIMESTAMP)::TEXT, 2);
+
+        -- Check if we have a current warrant reference and extract year and sequence
+        IF v_current_warrant_ref IS NOT NULL AND LENGTH(v_current_warrant_ref) > 0 THEN
+            -- Extract the year part from current warrant reference (format: 101/24/00008)
+            v_current_ref_year := SPLIT_PART(v_current_warrant_ref, '/', 2);
+            
+            -- Check if the year has changed
+            IF v_current_ref_year = v_current_year THEN
+                -- Same year, increment the sequence number
+                v_serial_part := SPLIT_PART(v_current_warrant_ref, '/', 3);
+                v_current_serial := v_serial_part::INTEGER + 1;
+            ELSE
+                -- Different year, reset sequence to 1
+                v_current_serial := 1;
+            END IF;
+        ELSE
+            -- No previous warrant reference, start with 1
+            v_current_serial := 1;
+        END IF;
+
+        -- Generate warrant reference (format: 101/25/00001)
+        v_warrant_reference := LPAD(v_enforcer_code, 3, '0') || '/' || v_current_year || '/' || LPAD(v_current_serial::TEXT, 5, '0');
+
+        -- Update enforcer warrant sequence
+        UPDATE enforcers
+        SET warrant_reference_sequence = v_warrant_reference
+        WHERE enforcer_id = pi_enforcer_id;
+    END IF;
+
+    -- Insert into ENFORCEMENTS table
+    INSERT INTO enforcements (
+        enforcement_id,
+        defendant_account_id,
+        result_id,
+        posted_date,
+        posted_by,
+        posted_by_name,
+        reason,
+        enforcer_id,
+        result_responses,
+        warrant_reference,
+        earliest_release_date,
+        jail_days
+    ) VALUES (
+        v_enforcement_id,
+        pi_defendant_account_id,
+        pi_result_id,
+        CURRENT_TIMESTAMP,
+        pi_posted_by,
+        pi_posted_by_name,
+        pi_reason,
+        pi_enforcer_id,
+        pi_result_responses,
+        v_warrant_reference,
+        CASE WHEN v_enforcement_action = 'PRIS' THEN pi_earliest_release_date ELSE NULL END,
+        pi_jail_days
+    );
+
+    -- Update DEFENDANT_ACCOUNTS table based on enforcement action
+    SELECT further_steps_notice_date, fine_registration_date, confiscation_order_date
+    INTO v_fsn_date, v_fine_reg_date, v_confiscation_date
+    FROM defendant_accounts
+    WHERE defendant_account_id = pi_defendant_account_id;
+
+    UPDATE defendant_accounts
+    SET 
+        last_enforcement = pi_result_id,
+        last_movement_date = CURRENT_TIMESTAMP,
+        jail_days = CASE WHEN pi_jail_days IS NOT NULL THEN pi_jail_days ELSE jail_days END,
+        collection_order = CASE WHEN v_enforcement_action = 'COLLO' THEN TRUE ELSE collection_order END,
+        collection_order_date = CASE WHEN v_enforcement_action = 'COLLO' THEN CURRENT_TIMESTAMP ELSE collection_order_date END,
+        further_steps_notice_date = CASE 
+            WHEN v_enforcement_action = 'FSN' AND v_fsn_date IS NULL THEN CURRENT_TIMESTAMP 
+            ELSE further_steps_notice_date 
+        END,
+        suspended_committal_date = CASE WHEN v_enforcement_action = 'SC' THEN CURRENT_TIMESTAMP ELSE suspended_committal_date END,
+        fine_registration_date = CASE 
+            WHEN v_enforcement_action = 'REGF' AND v_fine_reg_date IS NULL THEN CURRENT_TIMESTAMP 
+            ELSE fine_registration_date 
+        END,
+        confiscation_order_date = CASE 
+            WHEN v_enforcement_action = 'CONF' AND v_confiscation_date IS NULL THEN CURRENT_TIMESTAMP 
+            ELSE confiscation_order_date 
+        END
+    WHERE defendant_account_id = pi_defendant_account_id;
+
+    -- Insert into WARRANT_REGISTER if warrant is generated
+    IF v_generates_warrant = TRUE AND pi_enforcer_id IS NOT NULL THEN
+        v_warrant_register_id := nextval('warrant_register_id_seq');
+        
+        INSERT INTO warrant_register (
+            warrant_register_id,
+            business_unit_id,
+            enforcer_id,
+            enforcement_id
+        ) VALUES (
+            v_warrant_register_id,
+            pi_business_unit_id,
+            pi_enforcer_id,
+            v_enforcement_id
+        );
+    END IF;
+
+    -- Insert into DOCUMENT_INSTANCES for any result documents
+    FOR v_document_id IN (
+        SELECT document_id
+        FROM result_documents
+        WHERE result_id = pi_result_id
+    ) LOOP
+        v_document_instance_id := nextval('document_instance_id_seq');
+        
+        INSERT INTO document_instances (
+            document_instance_id,
+            document_id,
+            business_unit_id,
+            generated_date,
+            generated_by,
+            associated_record_type,
+            associated_record_id,
+            status,
+            printed_date,
+            document_content
+        ) VALUES (
+            v_document_instance_id,
+            v_document_id,
+            pi_business_unit_id,
+            CURRENT_TIMESTAMP,
+            pi_posted_by,
+            'Enforcement',
+            v_enforcement_id,
+            'New',
+            NULL,
+            NULL
+        );
+    END LOOP;
+
+    -- Insert into REPORT_ENTRIES if warrant is generated
+    IF v_generates_warrant = TRUE THEN
+        INSERT INTO report_entries (
+            report_entry_id,
+            business_unit_id,
+            report_id,
+            entry_timestamp,
+            associated_record_type,
+            associated_record_id
+        ) VALUES (
+            nextval('report_entry_id_seq'),
+            pi_business_unit_id,
+            'warrant_register',
+            CURRENT_TIMESTAMP,
+            'Enforcement',
+            v_enforcement_id
+        );
+    END IF;
+
+    -- Call audit finalise procedure
+    CALL p_audit_finalise(
+        pi_defendant_account_id,
+        pi_record_type,
+        pi_business_unit_id,
+        pi_posted_by,
+        pi_case_reference,
+        pi_function_code
+    );
+
+    -- Increment version number by 1
+    UPDATE defendant_accounts
+    SET version_number = version_number + 1
+    WHERE defendant_account_id = pi_defendant_account_id
+      AND version_number = pi_version_number;
+
+    GET DIAGNOSTICS v_rows_updated = ROW_COUNT;
+
+    IF v_rows_updated = 0 THEN
+        RAISE EXCEPTION 'Some information on this page may be out of date.'
+            USING ERRCODE = 'P4008'
+                , DETAIL = 'p_add_defendant_account_enforcement: Concurrency check failed - version number mismatch';
+    END IF;
+
+    RAISE INFO 'p_add_defendant_account_enforcement: Successfully completed. Created enforcement_id = %', v_enforcement_id;
+
+EXCEPTION
+    WHEN SQLSTATE 'P4001' OR SQLSTATE 'P4002' OR SQLSTATE 'P4003' OR 
+         SQLSTATE 'P4004' OR SQLSTATE 'P4005' OR SQLSTATE 'P4006' OR
+         SQLSTATE 'P4007' OR SQLSTATE 'P4008' THEN
+        -- When custom exceptions just re-raise them so they're not manipulated
+        RAISE NOTICE 'Error in p_add_defendant_account_enforcement: % - %', SQLSTATE, SQLERRM;
+        RAISE;
+    WHEN OTHERS THEN
+        -- Output full exception details
+        GET STACKED DIAGNOSTICS v_pg_exception_detail = PG_EXCEPTION_DETAIL;
+        RAISE NOTICE 'Error in p_add_defendant_account_enforcement: % - %', SQLSTATE, SQLERRM;
+        RAISE NOTICE 'Error details: %', v_pg_exception_detail;
+        RAISE EXCEPTION 'Error in p_add_defendant_account_enforcement: % - %', SQLSTATE, SQLERRM 
+            USING DETAIL = v_pg_exception_detail;
+END;
+$BODY$;
+
+COMMENT ON PROCEDURE p_add_defendant_account_enforcement
+    IS 'Procedure to add a new enforcement action for a defendant account with audit tracking, associated record creation, and concurrency check.';


### PR DESCRIPTION
JIRA link (if applicable)

https://tools.hmcts.net/jira/browse/PO-1790

https://tools.hmcts.net/jira/browse/PO-2130

https://tools.hmcts.net/jira/browse/PO-2232

Change description

PO-1790 - Created new procedure p_add_defendant_account_enforcement
PO-2130 - Added concurrency check to procedure p_add_defendant_account_enforcement
PO-2232 - Inserted Report Reference Data for Warrant Register

Does this PR introduce a breaking change?** (check one with "x")

[ ] Yes
[x] No
