### PR TITLE
PO-541 - Drop permissions tables from opal-fines

### DIFF
--- a/src/main/resources/db/migration/allEnvs/V20251021_429__drop_user_permissions_fk_constraints.sql
+++ b/src/main/resources/db/migration/allEnvs/V20251021_429__drop_user_permissions_fk_constraints.sql
@@ -1,0 +1,16 @@
+/**
+* OPAL Program
+*
+* MODULE      : drop_user_permissions_fk_constraints.sql
+*
+* DESCRIPTION : Drop foreign key constraints related to user permissions tables
+* VERSION HISTORY:
+*
+* Date          Author      Version     Nature of Change
+* ----------    -------     --------    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+* 15/10/2025    C Cho       1.0         PO-541 DB – Drop FK constraints before dropping permissions tables from opal-fines DB
+*
+**/
+
+-- Drop the only external FK that points at a target table:
+ALTER TABLE public.log_audit_details DROP CONSTRAINT lad_user_id_fk;

--- a/src/main/resources/db/migration/allEnvs/V20251021_430__drop_user_permissions_related_tables.sql
+++ b/src/main/resources/db/migration/allEnvs/V20251021_430__drop_user_permissions_related_tables.sql
@@ -1,0 +1,21 @@
+/**
+* OPAL Program
+*
+* MODULE      : drop_user_permissions_related_tables.sql
+*
+* DESCRIPTION : Drop user permissions related tables
+* VERSION HISTORY:
+*
+* Date          Author      Version     Nature of Change
+* ----------    -------     --------    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+* 15/10/2025    C Cho       1.0         PO-541 DB – Drop specified permissions tables from opal-fines DB
+*
+**/
+
+-- Drop target tables in dependency-safe order:
+DROP TABLE IF EXISTS public.user_entitlements;
+DROP TABLE IF EXISTS public.template_mappings;
+DROP TABLE IF EXISTS public.business_unit_users;
+DROP TABLE IF EXISTS public.templates;
+DROP TABLE IF EXISTS public.application_functions;
+DROP TABLE IF EXISTS public.users;


### PR DESCRIPTION
JIRA link (if applicable)

https://tools.hmcts.net/jira/browse/PO-541

Change description

PO-541 - Dropped specified permissions-related tables from the opal-fines database following the development and stabilisation of the opal-user-service

Does this PR introduce a breaking change?** (check one with "x")**

[ ] Yes
[x] No