### PR TITLE
Lock the Schema Validator to v1 as v2 makes breaking changes.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,13 @@
       "versioning": "fixed"
     },
     {
+      "description": "Lock the Schema Validator to v1.x.y to avoid major issues with v2+",
+      "matchManagers": ["gradle"],
+      "matchPackageNames": ["json-schema-validator"],
+      "matchPackagePrefixes": "com.networknt",
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
       "matchDatasources": ["docker"],
       "matchPackageNames": ["postgres"],
       "enabled": false


### PR DESCRIPTION
Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[*] No
```
