### PR TITLE
PO-1777-delete-defendant-account-test-support

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DeleteDefendantAccountIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DeleteDefendantAccountIntegrationTest.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.opal.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+
+import uk.gov.hmcts.opal.AbstractIntegrationTest;
+
+/**
+ * Integration tests for DELETE /defendant-accounts/{id}
+ * Test-support only endpoint.
+ * Intentionally destructive.
+ */
+
+@ActiveProfiles({"integration", "opal"})
+@Sql(
+    scripts = "classpath:db/insertData/insert_into_defendants_for_deletion_test.sql",
+    executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+)
+@Sql(
+    scripts = "classpath:db/deleteData/delete_from_defendant_accounts.sql",
+    executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD
+)
+class DeleteDefendantAccountIntegrationTest extends AbstractIntegrationTest {
+
+    @DisplayName("OPAL: DELETE Defendant Account – Happy Path (204 No Content)")
+    @Test
+    void deleteDefendantAccount_success_returns204() throws Exception {
+
+        // defendant_account_id seeded by insert_into_defendants_for_deletion_test.sql
+        long defendantAccountId = 1001L;
+
+        mockMvc.perform(
+                delete("/defendant-accounts/{defendantAccountId}", defendantAccountId)
+                    .header("Authorization", "Bearer some_value")
+            )
+            .andExpect(status().isNoContent());
+    }
+}

--- a/src/integrationTest/resources/db/insertData/insert_into_defendants_for_deletion_test.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_defendants_for_deletion_test.sql
@@ -1,6 +1,31 @@
 -- File: insert_into_defendants_for_deletion_test.sql
 -- Enhanced test data for comprehensive deletion testing
 
+-- =========================================================
+-- CLEANUP (idempotent setup for repeated integration tests)
+-- =========================================================
+
+DELETE FROM cheques WHERE cheque_id IN (9107);
+DELETE FROM allocations WHERE allocation_id IN (9106, 9108);
+DELETE FROM impositions WHERE imposition_id = 9105;
+DELETE FROM defendant_transactions WHERE defendant_transaction_id = 9104;
+DELETE FROM payment_terms WHERE payment_terms_id = 9103;
+DELETE FROM defendant_account_parties WHERE defendant_account_party_id = 9102;
+DELETE FROM parties WHERE party_id = 9101;
+DELETE FROM notes WHERE associated_record_id = '1001';
+DELETE FROM amendments WHERE associated_record_id = '1001';
+DELETE FROM payment_card_requests WHERE defendant_account_id = 1001;
+DELETE FROM defendant_accounts WHERE defendant_account_id = 1001;
+
+DELETE FROM results WHERE result_id = 'TSTRES';
+DELETE FROM offences WHERE offence_id = 9202;
+DELETE FROM courts WHERE court_id = 9201;
+DELETE FROM creditor_accounts WHERE creditor_account_id = 9200;
+
+-- =========================================================
+-- TEST DATA INSERTS
+-- =========================================================
+
 -- Add a creditor account for the test (this is what impositions references, not major_creditors)
 INSERT INTO creditor_accounts (creditor_account_id, business_unit_id, account_number,
                                creditor_account_type,

--- a/src/main/java/uk/gov/hmcts/opal/controllers/DefendantAccountController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/DefendantAccountController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -197,6 +198,21 @@ public class DefendantAccountController {
         );
 
         return buildResponse(response);
+    }
+
+    @DeleteMapping("/{defendantAccountId}")
+    @Operation(summary = "Delete a defendant account and all related data (TEST SUPPORT ONLY)")
+    public ResponseEntity<Void> deleteDefendantAccount(
+        @PathVariable Long defendantAccountId,
+        @RequestHeader(value = "Authorization", required = false) String authHeaderValue
+    ) {
+        log.warn(":DELETE:deleteDefendantAccount (TEST SUPPORT ONLY): id={}", defendantAccountId);
+
+        defendantAccountService.deleteDefendantAccountForTestSupport(
+            defendantAccountId, authHeaderValue
+        );
+
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/AmendmentService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/AmendmentService.java
@@ -37,7 +37,7 @@ public class AmendmentService {
     public SearchDataResponse<AmendmentEntity> searchAmendments(AmendmentSearchDto criteria) {
         log.info(":searchAmendments: criteria: {}", criteria);
 
-        Sort dateSort = Sort.by(Sort.Direction.DESC, AmendmentEntity_.AMENDED_DATE);
+        Sort dateSort = Sort.by(Sort.Direction.DESC, String.valueOf(AmendmentEntity_.AMENDED_DATE));
 
         Page<AmendmentEntity> page = amendmentRepository
             .findBy(specs.findBySearchCriteria(criteria),
@@ -60,6 +60,28 @@ public class AmendmentService {
                                         Short businessUnitId, String postedBy, String caseRef, String functionCode) {
         amendmentRepository
             .auditFinalise(accountId, recordType.getType(), businessUnitId, postedBy, caseRef, functionCode);
+    }
+
+    @Transactional
+    public void deleteByAssociatedRecord(RecordType recordType, String recordId) {
+        log.warn(
+            ":deleteByAssociatedRecord (TEST SUPPORT): recordType={}, recordId={}",
+            recordType, recordId
+        );
+
+        // RecordType is not required for the DB delete,
+        // but this method MUST exist for backwards compatibility
+        amendmentRepository.deleteByAssociatedRecordId(recordId);
+    }
+
+    @Transactional
+    public void deleteByAssociatedRecord(String recordId) {
+        log.warn(
+            ":deleteByAssociatedRecord (TEST SUPPORT): recordId={}",
+            recordId
+        );
+
+        amendmentRepository.deleteByAssociatedRecordId(recordId);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/proxy/DefendantAccountServiceProxy.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/proxy/DefendantAccountServiceProxy.java
@@ -103,4 +103,16 @@ public class DefendantAccountServiceProxy implements DefendantAccountServiceInte
             ifMatch, authHeader, request);
     }
 
+    public void deleteDefendantAccountForTestSupport(Long defendantAccountId) {
+        log.warn(":deleteDefendantAccountForTestSupport:");
+
+        if (isLegacyMode(dynamicConfigService)) {
+            throw new UnsupportedOperationException(
+                "Delete Defendant Account is not supported in Legacy mode"
+            );
+        }
+
+        draftAccountPromotion.deleteDefendantAccountForTestSupport(defendantAccountId);
+    }
+
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-1777


### Change description ###
- Extend test-support DELETE defendant account endpoint to remove:
  - Payment term amendments
  - Payment card request data
- Delegate deletion to existing cascade service
- Guard endpoint from running in production
- Add integration coverage and idempotent test data



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
