### PR TITLE
Po 2813 : Auth Security Logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -372,7 +372,7 @@ dependencies {
   zephyrCucumberReportProcessor 'uk.gov.hmcts:zephyr-automation:0.0.10'
   testImplementation 'uk.gov.hmcts:zephyr-automation:0.0.10'
 
-  implementation 'uk.gov.hmcts:opal-common-lib:0.1.9'
+  implementation 'uk.gov.hmcts:opal-common-lib:0.2.5'
   openapiImplementation "io.swagger.parser.v3:swagger-parser:2.1.38"
   openapiImplementation "io.swagger.core.v3:swagger-models:2.2.43"
   openapiImplementation "io.swagger.core.v3:swagger-core:2.2.42"

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CommonDefendantsIntegrationTest01.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CommonDefendantsIntegrationTest01.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static uk.gov.hmcts.opal.controllers.util.UserStateUtil.allFinesPermissionUser;
 import static uk.gov.hmcts.opal.controllers.util.UserStateUtil.allPermissionsUser;
 
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.mockito.Mockito;
@@ -31,6 +32,7 @@ import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.SchemaPaths;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
+import uk.gov.hmcts.opal.common.user.authorisation.client.service.UserStateClientService;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.ToJsonString;
 import uk.gov.hmcts.opal.service.UserStateService;
@@ -50,6 +52,9 @@ abstract class CommonDefendantsIntegrationTest01 extends AbstractIntegrationTest
 
     @MockitoBean
     UserStateService userStateService;
+
+    @MockitoBean
+    UserStateClientService userStateClientService;
 
     @Autowired
     JdbcTemplate jdbcTemplate;
@@ -393,6 +398,8 @@ abstract class CommonDefendantsIntegrationTest01 extends AbstractIntegrationTest
     @DisplayName("Get enforcement status - forbidden without permission")
     void testGetEnforcementStatus_forbidden(Logger log, boolean isLegacy) throws Exception {
         when(userStateService.checkForAuthorisedUser(any())).thenReturn(userState);
+        UserState dummyUserState = UserState.builder().userId(123L).build();
+        when(userStateClientService.getUserStateByAuthenticatedUser()).thenReturn(Optional.of(dummyUserState));
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS))
             .thenReturn(false);
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CommonDraftAccountControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CommonDraftAccountControllerIntegrationTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.SchemaPaths;
+import uk.gov.hmcts.opal.common.user.authorisation.client.service.UserStateClientService;
 import uk.gov.hmcts.opal.logging.integration.service.LoggingService;
 import uk.gov.hmcts.opal.service.UserStateService;
 import uk.gov.hmcts.opal.service.opal.JsonSchemaValidationService;
@@ -36,6 +37,9 @@ class CommonDraftAccountControllerIntegrationTest extends AbstractIntegrationTes
 
     @MockitoBean
     UserStateService userStateService;
+
+    @MockitoBean
+    UserStateClientService userStateClientService;
 
     @MockitoBean
     LoggingService loggingService;

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantsIntegrationTest02.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantsIntegrationTest02.java
@@ -864,7 +864,7 @@ class LegacyDefendantsIntegrationTest02 extends AbstractIntegrationTest {
 
     @Test
     @DisplayName("LEGACY: POST Add Payment Terms - Handle 500 error from the gateway")
-    void addPaymentTerms_whenGatewayResponseWithException_thenHandleException() throws Exception {
+    void addPaymentTerms_whenGatewayResponseWithException_thenDoNotReturnEntity() throws Exception {
         when(userStateService.checkForAuthorisedUser(any()))
             .thenReturn(allPermissionsUser());
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantsIntegrationTest02.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantsIntegrationTest02.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.controllers.util.LegacyDefendantsUtil.getPaymentTermsRequestSampleAsJson;
 import static uk.gov.hmcts.opal.controllers.util.UserStateUtil.allPermissionsUser;
 
 import lombok.extern.slf4j.Slf4j;
@@ -834,7 +835,6 @@ class LegacyDefendantsIntegrationTest02 extends AbstractIntegrationTest {
 
     }
 
-    @Disabled("A running instance of Legacy Stub App is required to execute this test")
     @Test
     @DisplayName("LEGACY: POST Add Payment Terms - Success")
     void addPaymentTerms_Success() throws Exception {
@@ -847,40 +847,11 @@ class LegacyDefendantsIntegrationTest02 extends AbstractIntegrationTest {
         headers.add("Business-Unit-Id", "69");
         headers.add(HttpHeaders.IF_MATCH, "\"" + 1 + "\"");
 
-        var body = """
-            {
-              "payment_terms": {
-                "days_in_default": 14,
-                "date_days_in_default_imposed": "2026-02-23",
-                "extension": false,
-                "reason_for_extension": null,
-                "payment_terms_type": {
-                  "payment_terms_type_code": "I",
-                  "payment_terms_type_display_name": "Instalments"
-                },
-                "effective_date": "2026-03-01",
-                "instalment_period": {
-                  "instalment_period_code": "M",
-                  "instalment_period_display_name": "Monthly"
-                },
-                "lump_sum_amount": 100.00,
-                "instalment_amount": 25.00,
-                "posted_details": {
-                  "posted_date": "2026-02-23T10:30:00Z",
-                  "posted_by": "SYSTEM",
-                  "posted_by_name": "System User"
-                }
-              },
-              "request_payment_card": false,
-              "generate_payment_terms_change_letter": true
-            }
-            """;
-
         var response = mockMvc.perform(
             post("/defendant-accounts/69/payment-terms")
                 .headers(headers)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(body)
+                .content(getPaymentTermsRequestSampleAsJson())
         );
 
         response.andExpect(status().isOk())
@@ -891,7 +862,6 @@ class LegacyDefendantsIntegrationTest02 extends AbstractIntegrationTest {
             .andExpect(jsonPath("$.last_enforcement").value("NOTICE_SENT"));
     }
 
-    @Disabled("A running instance of Legacy Stub App is required to execute this test")
     @Test
     @DisplayName("LEGACY: POST Add Payment Terms - 500 Error")
     void addPaymentTerms_500Error() throws Exception {
@@ -904,40 +874,11 @@ class LegacyDefendantsIntegrationTest02 extends AbstractIntegrationTest {
         headers.add("Business-Unit-Id", "500");
         headers.add(HttpHeaders.IF_MATCH, "\"" + 1 + "\"");
 
-        var body = """
-            {
-              "payment_terms": {
-                "days_in_default": 14,
-                "date_days_in_default_imposed": "2026-02-23",
-                "extension": false,
-                "reason_for_extension": null,
-                "payment_terms_type": {
-                  "payment_terms_type_code": "I",
-                  "payment_terms_type_display_name": "Instalments"
-                },
-                "effective_date": "2026-03-01",
-                "instalment_period": {
-                  "instalment_period_code": "M",
-                  "instalment_period_display_name": "Monthly"
-                },
-                "lump_sum_amount": 100.00,
-                "instalment_amount": 25.00,
-                "posted_details": {
-                  "posted_date": "2026-02-23T10:30:00Z",
-                  "posted_by": "SYSTEM",
-                  "posted_by_name": "System User"
-                }
-              },
-              "request_payment_card": false,
-              "generate_payment_terms_change_letter": true
-            }
-            """;
-
         var response = mockMvc.perform(
             post("/defendant-accounts/500/payment-terms")
                 .headers(headers)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(body)
+                .content(getPaymentTermsRequestSampleAsJson())
         );
 
         response.andExpect(status().is5xxServerError())

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantsIntegrationTest02.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantsIntegrationTest02.java
@@ -834,6 +834,7 @@ class LegacyDefendantsIntegrationTest02 extends AbstractIntegrationTest {
 
     }
 
+    @Disabled("A running instance of Legacy Stub App is required to execute this test")
     @Test
     @DisplayName("LEGACY: POST Add Payment Terms - Success")
     void addPaymentTerms_Success() throws Exception {
@@ -890,6 +891,7 @@ class LegacyDefendantsIntegrationTest02 extends AbstractIntegrationTest {
             .andExpect(jsonPath("$.last_enforcement").value("NOTICE_SENT"));
     }
 
+    @Disabled("A running instance of Legacy Stub App is required to execute this test")
     @Test
     @DisplayName("LEGACY: POST Add Payment Terms - 500 Error")
     void addPaymentTerms_500Error() throws Exception {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantsIntegrationTest02.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantsIntegrationTest02.java
@@ -52,7 +52,7 @@ class LegacyDefendantsIntegrationTest02 extends AbstractIntegrationTest {
     static final String URL_BASE = "/defendant-accounts";
     static final String DEFENDANT_PARTY_RESPONSE_SCHEMA = SchemaPaths.DEFENDANT_ACCOUNT
         + "/getDefendantAccountPartyResponse.json";
-    
+
     @MockitoBean
     UserStateService userStateService;
 
@@ -832,5 +832,113 @@ class LegacyDefendantsIntegrationTest02 extends AbstractIntegrationTest {
             .andExpect(jsonPath("$.comments_and_notes.free_text_note_2").value("Preferred contact: letter.")).andExpect(
                 jsonPath("$.comments_and_notes.free_text_note_3").value("Next review due after three payments."));
 
+    }
+
+    @Test
+    @DisplayName("LEGACY: POST Add Payment Terms - Success")
+    void addPaymentTerms_Success() throws Exception {
+        when(userStateService.checkForAuthorisedUser(any()))
+            .thenReturn(allPermissionsUser());
+
+        // headers
+        var headers = new HttpHeaders();
+        headers.setBearerAuth("good_token");
+        headers.add("Business-Unit-Id", "69");
+        headers.add(HttpHeaders.IF_MATCH, "\"" + 1 + "\"");
+
+        var body = """
+            {
+              "payment_terms": {
+                "days_in_default": 14,
+                "date_days_in_default_imposed": "2026-02-23",
+                "extension": false,
+                "reason_for_extension": null,
+                "payment_terms_type": {
+                  "payment_terms_type_code": "I",
+                  "payment_terms_type_display_name": "Instalments"
+                },
+                "effective_date": "2026-03-01",
+                "instalment_period": {
+                  "instalment_period_code": "M",
+                  "instalment_period_display_name": "Monthly"
+                },
+                "lump_sum_amount": 100.00,
+                "instalment_amount": 25.00,
+                "posted_details": {
+                  "posted_date": "2026-02-23T10:30:00Z",
+                  "posted_by": "SYSTEM",
+                  "posted_by_name": "System User"
+                }
+              },
+              "request_payment_card": false,
+              "generate_payment_terms_change_letter": true
+            }
+            """;
+
+        var response = mockMvc.perform(
+            post("/defendant-accounts/69/payment-terms")
+                .headers(headers)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+        );
+
+        response.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.payment_terms").exists())
+            .andExpect(jsonPath("$.payment_terms.days_in_default").value(14))
+            .andExpect(jsonPath("$.payment_card_last_requested").value("2026-02-20"))
+            .andExpect(jsonPath("$.last_enforcement").value("NOTICE_SENT"));
+    }
+
+    @Test
+    @DisplayName("LEGACY: POST Add Payment Terms - 500 Error")
+    void addPaymentTerms_500Error() throws Exception {
+        when(userStateService.checkForAuthorisedUser(any()))
+            .thenReturn(allPermissionsUser());
+
+        // headers
+        var headers = new HttpHeaders();
+        headers.setBearerAuth("good_token");
+        headers.add("Business-Unit-Id", "500");
+        headers.add(HttpHeaders.IF_MATCH, "\"" + 1 + "\"");
+
+        var body = """
+            {
+              "payment_terms": {
+                "days_in_default": 14,
+                "date_days_in_default_imposed": "2026-02-23",
+                "extension": false,
+                "reason_for_extension": null,
+                "payment_terms_type": {
+                  "payment_terms_type_code": "I",
+                  "payment_terms_type_display_name": "Instalments"
+                },
+                "effective_date": "2026-03-01",
+                "instalment_period": {
+                  "instalment_period_code": "M",
+                  "instalment_period_display_name": "Monthly"
+                },
+                "lump_sum_amount": 100.00,
+                "instalment_amount": 25.00,
+                "posted_details": {
+                  "posted_date": "2026-02-23T10:30:00Z",
+                  "posted_by": "SYSTEM",
+                  "posted_by_name": "System User"
+                }
+              },
+              "request_payment_card": false,
+              "generate_payment_terms_change_letter": true
+            }
+            """;
+
+        var response = mockMvc.perform(
+            post("/defendant-accounts/500/payment-terms")
+                .headers(headers)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+        );
+
+        response.andExpect(status().is5xxServerError())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantsIntegrationTest02.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantsIntegrationTest02.java
@@ -837,7 +837,7 @@ class LegacyDefendantsIntegrationTest02 extends AbstractIntegrationTest {
 
     @Test
     @DisplayName("LEGACY: POST Add Payment Terms - Success")
-    void addPaymentTerms_Success() throws Exception {
+    void addPaymentTerms_whenGatewayResponseWithSuccess_thenReturnMappedResponse() throws Exception {
         when(userStateService.checkForAuthorisedUser(any()))
             .thenReturn(allPermissionsUser());
 
@@ -863,8 +863,8 @@ class LegacyDefendantsIntegrationTest02 extends AbstractIntegrationTest {
     }
 
     @Test
-    @DisplayName("LEGACY: POST Add Payment Terms - 500 Error")
-    void addPaymentTerms_500Error() throws Exception {
+    @DisplayName("LEGACY: POST Add Payment Terms - Handle 500 error from the gateway")
+    void addPaymentTerms_whenGatewayResponseWithException_thenHandleException() throws Exception {
         when(userStateService.checkForAuthorisedUser(any()))
             .thenReturn(allPermissionsUser());
 
@@ -882,6 +882,10 @@ class LegacyDefendantsIntegrationTest02 extends AbstractIntegrationTest {
         );
 
         response.andExpect(status().is5xxServerError())
-            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE))
+            .andExpect(jsonPath("$.payment_terms").doesNotExist())
+            .andExpect(jsonPath("$.payment_terms.days_in_default").doesNotExist())
+            .andExpect(jsonPath("$.payment_card_last_requested").doesNotExist())
+            .andExpect(jsonPath("$.last_enforcement").doesNotExist());
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerIntegrationTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.opal.controllers;
 
 import java.util.List;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -11,6 +12,8 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
+import uk.gov.hmcts.opal.common.user.authorisation.client.service.UserStateClientService;
+import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.MinorCreditorSearch;
 import uk.gov.hmcts.opal.dto.ToJsonString;
 import uk.gov.hmcts.opal.service.UserStateService;
@@ -58,6 +61,9 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
 
     @MockitoBean
     UserStateService userStateService;
+
+    @MockitoBean
+    UserStateClientService userStateClientService;
 
     @MockitoSpyBean
     private JsonSchemaValidationService jsonSchemaValidationService;
@@ -333,6 +339,9 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
     void patchMinorCreditor_withoutPermission_returns403() throws Exception {
         when(userStateService.checkForAuthorisedUser(any()))
             .thenReturn(noPermissionsUser());
+
+        UserState userState = UserState.builder().userId(123L).build();
+        when(userStateClientService.getUserStateByAuthenticatedUser()).thenReturn(Optional.of(userState));
 
         Integer currentVersion = getCurrentCreditorAccountVersion(607L);
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/NotesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/NotesIntegrationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.controllers;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +19,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
+import uk.gov.hmcts.opal.common.user.authorisation.client.service.UserStateClientService;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import static uk.gov.hmcts.opal.controllers.util.UserStateUtil.allPermissionsUser;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
@@ -32,6 +34,9 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
 
     @MockitoBean
     UserStateService userStateService;
+
+    @MockitoBean
+    UserStateClientService userStateClientService;
 
     @MockitoBean
     private UserState userState;
@@ -126,6 +131,9 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
             .build();
 
         when(userStateService.checkForAuthorisedUser(any())).thenReturn(restrictedUser);
+
+        UserState userState = UserState.builder().userId(123L).build();
+        when(userStateClientService.getUserStateByAuthenticatedUser()).thenReturn(Optional.of(userState));
 
         Note note = new Note();
         note.setNoteText("test note");

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsIntegrationTest02.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsIntegrationTest02.java
@@ -30,6 +30,7 @@ import java.time.LocalDate;
 import java.time.Period;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,6 +52,7 @@ import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.SchemaPaths;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
+import uk.gov.hmcts.opal.common.user.authorisation.client.service.UserStateClientService;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.controllers.util.UserStateUtil;
 import uk.gov.hmcts.opal.dto.ToJsonString;
@@ -74,6 +76,9 @@ class OpalDefendantsIntegrationTest02 extends AbstractIntegrationTest {
     
     @MockitoBean
     UserStateService userStateService;
+
+    @MockitoBean
+    UserStateClientService userStateClientService;
 
     @Autowired
     JdbcTemplate jdbcTemplate;
@@ -245,6 +250,8 @@ class OpalDefendantsIntegrationTest02 extends AbstractIntegrationTest {
                 .businessUnitUser(java.util.Collections.emptySet())
                 .build()
         );
+        UserState userState = UserState.builder().userId(123L).build();
+        when(userStateClientService.getUserStateByAuthenticatedUser()).thenReturn(Optional.of(userState));
 
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth("token_without_permission");
@@ -1095,6 +1102,8 @@ class OpalDefendantsIntegrationTest02 extends AbstractIntegrationTest {
         when(userStateService.checkForAuthorisedUser(any())).thenReturn(
             UserState.builder().userId(999L).userName("no-perm-user").businessUnitUser(java.util.Collections.emptySet())
                 .build());
+        UserState userState = UserState.builder().userId(123L).build();
+        when(userStateClientService.getUserStateByAuthenticatedUser()).thenReturn(Optional.of(userState));
 
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth("token_without_perm");
@@ -1697,6 +1706,8 @@ class OpalDefendantsIntegrationTest02 extends AbstractIntegrationTest {
                     .businessUnitUser(java.util.Collections.emptySet()) // no BU permissions
                     .build()
             );
+        UserState userState = UserState.builder().userId(123L).build();
+        when(userStateClientService.getUserStateByAuthenticatedUser()).thenReturn(Optional.of(userState));
 
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth("token_without_permission");

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/util/LegacyDefendantsUtil.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/util/LegacyDefendantsUtil.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.opal.controllers.util;
+
+public class LegacyDefendantsUtil {
+
+    private LegacyDefendantsUtil() {
+    }
+
+    public static String getPaymentTermsRequestSampleAsJson() {
+        return """
+            {
+              "payment_terms": {
+                "days_in_default": 14,
+                "date_days_in_default_imposed": "2026-02-23",
+                "extension": false,
+                "reason_for_extension": null,
+                "payment_terms_type": {
+                  "payment_terms_type_code": "I",
+                  "payment_terms_type_display_name": "Instalments"
+                },
+                "effective_date": "2026-03-01",
+                "instalment_period": {
+                  "instalment_period_code": "M",
+                  "instalment_period_display_name": "Monthly"
+                },
+                "lump_sum_amount": 100.00,
+                "instalment_amount": 25.00,
+                "posted_details": {
+                  "posted_date": "2026-02-23T10:30:00Z",
+                  "posted_by": "SYSTEM",
+                  "posted_by_name": "System User"
+                }
+              },
+              "request_payment_card": false,
+              "generate_payment_terms_change_letter": true
+            }
+            """;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/authentication/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/hmcts/opal/authentication/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.authentication.config;
 
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -19,14 +20,11 @@ import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
 import org.springframework.security.oauth2.server.resource.authentication.JwtIssuerAuthenticationManagerResolver;
-import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.access.AccessDeniedHandler;
 import uk.gov.hmcts.opal.authentication.config.internal.InternalAuthConfigurationProperties;
 import uk.gov.hmcts.opal.authentication.config.internal.InternalAuthProviderConfigurationProperties;
-
-import java.util.Map;
-
+import uk.gov.hmcts.opal.common.user.authentication.exception.CustomAuthenticationExceptions;
+import uk.gov.hmcts.opal.common.user.authentication.exception.CustomOauth2AuthenticationEntryPoint;
 
 @Configuration
 @EnableWebSecurity
@@ -37,8 +35,8 @@ public class SecurityConfig {
 
     private final InternalAuthConfigurationProperties internalAuthConfigurationProperties;
     private final InternalAuthProviderConfigurationProperties internalAuthProviderConfigurationProperties;
-    private final AuthenticationEntryPoint customAuthenticationEntryPoint;
-    private final AccessDeniedHandler customAccessDeniedHandler;
+    private final CustomAuthenticationExceptions customAuthenticationExceptions;
+    private final CustomOauth2AuthenticationEntryPoint customOauth2AuthenticationEntryPoint;
 
     private static final String[] AUTH_WHITELIST = {
         "/swagger-ui.html",
@@ -61,21 +59,21 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         applyCommonConfig(http)
             .authorizeHttpRequests(authorize ->
-                                       authorize.requestMatchers(PathRequest.toStaticResources().atCommonLocations())
-                                           .permitAll()
-                                           .requestMatchers(AUTH_WHITELIST)
-                                           .permitAll()
-                                           .anyRequest().authenticated()
+                authorize.requestMatchers(PathRequest.toStaticResources().atCommonLocations())
+                    .permitAll()
+                    .requestMatchers(AUTH_WHITELIST)
+                    .permitAll()
+                    .anyRequest().authenticated()
             )
             .exceptionHandling(exceptionHandling ->
-                                   exceptionHandling
-                                       .authenticationEntryPoint(customAuthenticationEntryPoint)
-                                       .accessDeniedHandler(customAccessDeniedHandler)
+                exceptionHandling
+                    .authenticationEntryPoint(customAuthenticationExceptions)
+                    .accessDeniedHandler(customAuthenticationExceptions)
             )
-            .oauth2ResourceServer(oauth2 ->
-                                      oauth2.authenticationManagerResolver(jwtIssuerAuthenticationManagerResolver())
-            );
-
+            .oauth2ResourceServer(oauth2 -> {
+                oauth2.authenticationManagerResolver(jwtIssuerAuthenticationManagerResolver());
+                oauth2.authenticationEntryPoint(customOauth2AuthenticationEntryPoint);
+            });
         return http.build();
     }
 

--- a/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
@@ -44,7 +44,6 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 import uk.gov.hmcts.opal.common.user.authentication.exception.MissingRequestHeaderException;
 import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
-import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
 import uk.gov.hmcts.opal.exception.JsonSchemaValidationException;
 import uk.gov.hmcts.opal.common.exception.OpalApiException;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
@@ -92,8 +91,8 @@ public class GlobalExceptionHandler {
         return responseWithProblemDetail(HttpStatus.BAD_REQUEST, problemDetail);
     }
 
-    @ExceptionHandler({PermissionNotAllowedException.class, AccessDeniedException.class})
-    public ResponseEntity<ProblemDetail> handlePermissionNotAllowedException(Exception ex,
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ProblemDetail> handleAccessDeniedException(AccessDeniedException ex,
                                                                              HttpServletRequest request) {
         String authorization = request.getHeader(AUTH_HEADER);
         String preferredName = extractUsername(authorization);

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/AddDefendantAccountPaymentTermsLegacyRequest.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/AddDefendantAccountPaymentTermsLegacyRequest.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.opal.dto.legacy;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AddDefendantAccountPaymentTermsLegacyRequest {
+
+    @JsonProperty("defendant_account_id")
+    @NotBlank
+    private String defendantAccountId;
+
+    @JsonProperty("business_unit_id")
+    @NotBlank
+    private String businessUnitId;
+
+    @JsonProperty("business_unit_user_id")
+    @NotBlank
+    private String businessUnitUserId;
+
+    @JsonProperty("version")
+    @NotNull
+    private Integer version;
+
+    @JsonProperty("payment_terms")
+    @NotNull
+    private LegacyPaymentTerms paymentTerms;
+
+    @JsonProperty("request_payment_card")
+    private Boolean requestPaymentCard;
+
+    @JsonProperty("generate_payment_terms_change_letter")
+    private Boolean generatePaymentTermsChangeLetter;
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/AddDefendantAccountPaymentTermsLegacyResponse.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/AddDefendantAccountPaymentTermsLegacyResponse.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.opal.dto.legacy;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.opal.util.LocalDateAdapter;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name = "response")
+public class AddDefendantAccountPaymentTermsLegacyResponse {
+
+    @XmlElement(name = "defendant_account_id")
+    @NotBlank
+    private String defendantAccountId;
+
+    @XmlElement(name = "version")
+    @NotNull
+    private Integer version;
+
+    @XmlElement(name = "payment_terms")
+    @NotNull
+    private LegacyPaymentTerms paymentTerms;
+
+    @XmlElement(name = "payment_card_last_requested")
+    @XmlJavaTypeAdapter(LocalDateAdapter.class)
+    private LocalDate paymentCardLastRequested;
+
+    @XmlElement(name = "last_enforcement")
+    private String lastEnforcement;
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/AddPaymentTermsLegacyRequest.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/AddPaymentTermsLegacyRequest.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class AddDefendantAccountPaymentTermsLegacyRequest {
+public class AddPaymentTermsLegacyRequest {
 
     @JsonProperty("defendant_account_id")
     @NotBlank

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/AddPaymentTermsLegacyRequest.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/AddPaymentTermsLegacyRequest.java
@@ -9,6 +9,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigInteger;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -30,7 +32,7 @@ public class AddPaymentTermsLegacyRequest {
 
     @JsonProperty("version")
     @NotNull
-    private Integer version;
+    private BigInteger version;
 
     @JsonProperty("payment_terms")
     @NotNull

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/AddPaymentTermsLegacyResponse.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/AddPaymentTermsLegacyResponse.java
@@ -21,7 +21,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "response")
-public class AddDefendantAccountPaymentTermsLegacyResponse {
+public class AddPaymentTermsLegacyResponse {
 
     @XmlElement(name = "defendant_account_id")
     @NotBlank

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/AddPaymentTermsLegacyResponse.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/AddPaymentTermsLegacyResponse.java
@@ -13,6 +13,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.opal.util.LocalDateAdapter;
 
+import java.math.BigInteger;
 import java.time.LocalDate;
 
 @Data
@@ -29,7 +30,7 @@ public class AddPaymentTermsLegacyResponse {
 
     @XmlElement(name = "version")
     @NotNull
-    private Integer version;
+    private BigInteger version;
 
     @XmlElement(name = "payment_terms")
     @NotNull

--- a/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountPartyService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountPartyService.java
@@ -60,7 +60,7 @@ public class DefendantAccountPartyService {
                 defendantAccountPartyId, request, ifMatch, businessUnitId, postedBy,
                 getBusinessUnitUserIdForBusinessUnit(userState, buId));
         } else {
-            throw new PermissionNotAllowedException(FinesPermission.ACCOUNT_MAINTENANCE);
+            throw new PermissionNotAllowedException(buId, FinesPermission.ACCOUNT_MAINTENANCE);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountService.java
@@ -173,7 +173,7 @@ public class DefendantAccountService {
                 defendantAccountPartyId, request, ifMatch, businessUnitId, postedBy,
                 getBusinessUnitUserIdForBusinessUnit(userState, buId));
         } else {
-            throw new PermissionNotAllowedException(FinesPermission.ACCOUNT_MAINTENANCE);
+            throw new PermissionNotAllowedException(buId, FinesPermission.ACCOUNT_MAINTENANCE);
         }
     }
 
@@ -265,7 +265,7 @@ public class DefendantAccountService {
                 authHeaderValue,
                 addPaymentTermsRequest);
         } else {
-            throw new PermissionNotAllowedException(FinesPermission.AMEND_PAYMENT_TERMS);
+            throw new PermissionNotAllowedException(buId, FinesPermission.AMEND_PAYMENT_TERMS);
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/DraftAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DraftAccountService.java
@@ -180,7 +180,9 @@ public class DraftAccountService {
             return toGetResponseDto(entity);
 
         } else {
-            throw new PermissionNotAllowedException(FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS);
+            throw new PermissionNotAllowedException(
+                dto.getBusinessUnitId(),
+                FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS);
         }
 
     }
@@ -206,7 +208,9 @@ public class DraftAccountService {
 
             return toGetResponseDto(replacedEntity);
         } else {
-            throw new PermissionNotAllowedException(FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS);
+            throw new PermissionNotAllowedException(
+                dto.getBusinessUnitId(),
+                FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/opal/service/MinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/MinorCreditorService.java
@@ -102,7 +102,9 @@ public class MinorCreditorService {
         UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
         if (businessUnitId == null || !userState.hasBusinessUnitUserWithPermission(businessUnitId,
             FinesPermission.ADD_AND_REMOVE_PAYMENT_HOLD)) {
-            throw new PermissionNotAllowedException(FinesPermission.ADD_AND_REMOVE_PAYMENT_HOLD);
+            throw new PermissionNotAllowedException(
+                businessUnitId,
+                FinesPermission.ADD_AND_REMOVE_PAYMENT_HOLD);
         }
 
         String postedBy = userState.getBusinessUnitUserForBusinessUnit(businessUnitId)

--- a/src/main/java/uk/gov/hmcts/opal/service/NotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/NotesService.java
@@ -35,9 +35,10 @@ public class NotesService {
                     HttpStatus.NOT_FOUND, "Account %s not found".formatted(request.getActivityNote().getRecordId())
                 ));
 
+        Short businessUnitId = account.getBusinessUnit().getBusinessUnitId();
         if (!userState.hasBusinessUnitUserWithPermission(
-            account.getBusinessUnit().getBusinessUnitId(), FinesPermission.ACCOUNT_MAINTENANCE)) {
-            throw new PermissionNotAllowedException(FinesPermission.ACCOUNT_MAINTENANCE);
+            businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE)) {
+            throw new PermissionNotAllowedException(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE);
         }
 
         return notesProxy.addNote(request, ifMatch, userState, account);

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountEnforcementService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountEnforcementService.java
@@ -62,7 +62,7 @@ public class LegacyDefendantAccountEnforcementService implements DefendantAccoun
                 .defendantAccountId(String.valueOf(defendantAccountId))
                 .businessUnitId(businessUnitId)
                 .businessUnitUserId(businessUnitUserId)
-                .version(Integer.parseInt(VersionUtils.cleanVersion(ifMatch)))
+                .version(VersionUtils.extractBigInteger(ifMatch).intValue())
                 .resultId(request != null && request.getResultId() != null ? request.getResultId().value() : null)
                 .enforcementResultResponses(
                     mapResultResponses(request != null ? request.getEnforcementResultResponses() : null))

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountEnforcementService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountEnforcementService.java
@@ -31,6 +31,7 @@ import uk.gov.hmcts.opal.dto.legacy.common.CourtReference;
 import uk.gov.hmcts.opal.service.iface.DefendantAccountEnforcementServiceInterface;
 import uk.gov.hmcts.opal.service.legacy.GatewayService.Response;
 import uk.gov.hmcts.opal.service.opal.CourtService;
+import uk.gov.hmcts.opal.util.VersionUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -55,15 +56,13 @@ public class LegacyDefendantAccountEnforcementService implements DefendantAccoun
     public AddEnforcementResponse addEnforcement(Long defendantAccountId, String businessUnitId,
         String businessUnitUserId, String ifMatch, String authHeader, AddDefendantAccountEnforcementRequest request) {
 
-        String cleanVersion = ifMatch.replace("\"", "");
-
         // build legacy request object
         AddDefendantAccountEnforcementLegacyRequest legacyRequest =
             AddDefendantAccountEnforcementLegacyRequest.builder()
                 .defendantAccountId(String.valueOf(defendantAccountId))
                 .businessUnitId(businessUnitId)
                 .businessUnitUserId(businessUnitUserId)
-                .version(Integer.parseInt(cleanVersion))
+                .version(Integer.parseInt(VersionUtils.cleanVersion(ifMatch)))
                 .resultId(request != null && request.getResultId() != null ? request.getResultId().value() : null)
                 .enforcementResultResponses(
                     mapResultResponses(request != null ? request.getEnforcementResultResponses() : null))

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPartyService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPartyService.java
@@ -29,6 +29,7 @@ import uk.gov.hmcts.opal.dto.legacy.PartyDetailsLegacy;
 import uk.gov.hmcts.opal.dto.legacy.VehicleDetailsLegacy;
 import uk.gov.hmcts.opal.service.iface.DefendantAccountPartyServiceInterface;
 import uk.gov.hmcts.opal.service.legacy.GatewayService.Response;
+import uk.gov.hmcts.opal.util.VersionUtils;
 
 import java.math.BigInteger;
 import java.util.Collections;
@@ -274,7 +275,7 @@ public class LegacyDefendantAccountPartyService implements DefendantAccountParty
         String businessUnitUserId) {
 
         LegacyReplaceDefendantAccountPartyRequest req = LegacyReplaceDefendantAccountPartyRequest.builder()
-            .version(Long.parseLong(ifMatch.replace("\"", "").trim()))
+            .version(Long.parseLong(VersionUtils.cleanVersion(ifMatch)))
             .defendantAccountId(defendantAccountId)
             .businessUnitId(businessUnitId)
             .businessUnitUserId(businessUnitUserId)

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPartyService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPartyService.java
@@ -275,7 +275,7 @@ public class LegacyDefendantAccountPartyService implements DefendantAccountParty
         String businessUnitUserId) {
 
         LegacyReplaceDefendantAccountPartyRequest req = LegacyReplaceDefendantAccountPartyRequest.builder()
-            .version(Long.parseLong(VersionUtils.cleanVersion(ifMatch)))
+            .version(VersionUtils.extractBigInteger(ifMatch).longValue())
             .defendantAccountId(defendantAccountId)
             .businessUnitId(businessUnitId)
             .businessUnitUserId(businessUnitUserId)

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
@@ -51,8 +51,8 @@ import uk.gov.hmcts.opal.dto.common.PaymentTermsType;
 import uk.gov.hmcts.opal.dto.common.VehicleDetails;
 import uk.gov.hmcts.opal.dto.legacy.AddDefendantAccountEnforcementLegacyRequest;
 import uk.gov.hmcts.opal.dto.legacy.AddDefendantAccountEnforcementLegacyResponse;
-import uk.gov.hmcts.opal.dto.legacy.AddDefendantAccountPaymentTermsLegacyRequest;
-import uk.gov.hmcts.opal.dto.legacy.AddDefendantAccountPaymentTermsLegacyResponse;
+import uk.gov.hmcts.opal.dto.legacy.AddPaymentTermsLegacyRequest;
+import uk.gov.hmcts.opal.dto.legacy.AddPaymentTermsLegacyResponse;
 import uk.gov.hmcts.opal.dto.legacy.AddPaymentCardLegacyRequest;
 import uk.gov.hmcts.opal.dto.legacy.AddPaymentCardLegacyResponse;
 import uk.gov.hmcts.opal.dto.legacy.AddressDetailsLegacy;
@@ -341,7 +341,8 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
 
         return GetDefendantAccountPaymentTermsResponse.builder()
             .version(Optional.ofNullable(legacy.getVersion())
-                  .map(v -> BigInteger.valueOf(v.longValue())).orElse(BigInteger.ONE))
+                         .map(v -> BigInteger.valueOf(v.longValue()))
+                         .orElse(BigInteger.ONE))
             .paymentTerms(toPaymentTerms(legacy.getPaymentTerms()))
             .paymentCardLastRequested(legacy.getPaymentCardLastRequested())
             .lastEnforcement(legacy.getLastEnforcement())
@@ -985,7 +986,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
         String businessUnitUserId) {
 
         LegacyReplaceDefendantAccountPartyRequest req = LegacyReplaceDefendantAccountPartyRequest.builder()
-            .version(Long.parseLong(VersionUtils.cleanVersion(ifMatch)))
+            .version(VersionUtils.extractBigInteger(ifMatch).longValue())
             .defendantAccountId(defendantAccountId)
             .businessUnitId(businessUnitId)
             .businessUnitUserId(businessUnitUserId)
@@ -1158,7 +1159,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
                 .defendantAccountId(String.valueOf(defendantAccountId))
                 .businessUnitId(businessUnitId)
                 .businessUnitUserId(businessUnitUserId)
-                .version(Integer.parseInt(VersionUtils.cleanVersion(ifMatch)))
+                .version(VersionUtils.extractBigInteger(ifMatch).intValue())
                 .resultId(request != null && request.getResultId() != null ? request.getResultId().value() : null)
                 .enforcementResultResponses(
                     mapResultResponses(request != null ? request.getEnforcementResultResponses() : null))
@@ -1340,21 +1341,11 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
         String postedBy,
         AddDefendantAccountPaymentTermsRequest addPaymentTermsRequest) {
 
-        var legacyRequest = AddDefendantAccountPaymentTermsLegacyRequest.builder()
-            .defendantAccountId(String.valueOf(defendantAccountId))
-            .businessUnitId(businessUnitId)
-            .businessUnitUserId(businessUnitUserId)
-            .version(Integer.parseInt(VersionUtils.cleanVersion(ifMatch)))
-            .paymentTerms(mapPaymentTerms(addPaymentTermsRequest != null
-                                              ? addPaymentTermsRequest.getPaymentTerms() : null))
-            .requestPaymentCard(addPaymentTermsRequest != null ? addPaymentTermsRequest.getRequestPaymentCard() : null)
-            .generatePaymentTermsChangeLetter(addPaymentTermsRequest != null
-                                                  ? addPaymentTermsRequest.getGeneratePaymentTermsChangeLetter() : null)
-            .build();
+        var legacyRequest = buildAddPaymentTermsLegacyRequest(defendantAccountId, businessUnitId, businessUnitUserId,
+            ifMatch, addPaymentTermsRequest);
 
-        var response = gatewayService.postToGateway(ADD_PAYMENT_TERMS,
-                                                    AddDefendantAccountPaymentTermsLegacyResponse.class, legacyRequest,
-                                                    null);
+        var response = gatewayService.postToGateway(ADD_PAYMENT_TERMS, AddPaymentTermsLegacyResponse.class,
+                                                    legacyRequest, null);
 
         if (response.isError()) {
             log.error(":AddPaymentTerms: Legacy error HTTP {}", response.code);
@@ -1376,6 +1367,25 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             .paymentTerms(toPaymentTerms(addPaymentTermsResponse.getPaymentTerms()))
             .paymentCardLastRequested(addPaymentTermsResponse.getPaymentCardLastRequested())
             .lastEnforcement(addPaymentTermsResponse.getLastEnforcement())
+            .build();
+    }
+
+    private AddPaymentTermsLegacyRequest buildAddPaymentTermsLegacyRequest(Long defendantAccountId,
+        String businessUnitId,
+        String businessUnitUserId,
+        String ifMatch,
+        AddDefendantAccountPaymentTermsRequest addPaymentTermsRequest) {
+
+        return AddPaymentTermsLegacyRequest.builder()
+            .defendantAccountId(String.valueOf(defendantAccountId))
+            .businessUnitId(businessUnitId)
+            .businessUnitUserId(businessUnitUserId)
+            .version(VersionUtils.extractBigInteger(ifMatch).intValue())
+            .paymentTerms(mapPaymentTerms(addPaymentTermsRequest != null
+                                              ? addPaymentTermsRequest.getPaymentTerms() : null))
+            .requestPaymentCard(addPaymentTermsRequest != null ? addPaymentTermsRequest.getRequestPaymentCard() : null)
+            .generatePaymentTermsChangeLetter(addPaymentTermsRequest != null
+                                                  ? addPaymentTermsRequest.getGeneratePaymentTermsChangeLetter() : null)
             .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -50,6 +51,8 @@ import uk.gov.hmcts.opal.dto.common.PaymentTermsType;
 import uk.gov.hmcts.opal.dto.common.VehicleDetails;
 import uk.gov.hmcts.opal.dto.legacy.AddDefendantAccountEnforcementLegacyRequest;
 import uk.gov.hmcts.opal.dto.legacy.AddDefendantAccountEnforcementLegacyResponse;
+import uk.gov.hmcts.opal.dto.legacy.AddDefendantAccountPaymentTermsLegacyRequest;
+import uk.gov.hmcts.opal.dto.legacy.AddDefendantAccountPaymentTermsLegacyResponse;
 import uk.gov.hmcts.opal.dto.legacy.AddPaymentCardLegacyRequest;
 import uk.gov.hmcts.opal.dto.legacy.AddPaymentCardLegacyResponse;
 import uk.gov.hmcts.opal.dto.legacy.AddressDetailsLegacy;
@@ -104,9 +107,9 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
     public static final String GET_HEADER_SUMMARY = "LIBRA.get_header_summary";
     public static final String SEARCH_DEFENDANT_ACCOUNTS = "searchDefendantAccounts";
     public static final String GET_PAYMENT_TERMS = "LIBRA.get_payment_terms";
+    public static final String ADD_PAYMENT_TERMS = "LIBRA.get_payment_terms";
     public static final String GET_DEFENDANT_AT_A_GLANCE = "LIBRA.getDefendantAtAGlance";
     public static final String ADD_ENFORCEMENT = "LIBRA.addEnforcement";
-
 
     public static final String GET_DEFENDANT_ACCOUNT_PARTY = "LIBRA.get_defendant_account_party";
     public static final String REPLACE_DEFENDANT_ACCOUNT_PARTY = "LIBRA.replace_defendant_account_party";
@@ -114,7 +117,6 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
     public static final String GET_ENFORCEMENT_STATUS = "LIBRA.of_get_defendant_account_enf_status";
 
     public static final String ADD_PAYMENT_CARD_REQUEST = "LIBRA.of_add_defendant_account_pcr";
-
 
     private final GatewayService gatewayService;
     private final LegacyGatewayProperties legacyGatewayProperties;
@@ -467,7 +469,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
                 .organisationName(mapSafe(pd != null ? pd.getOrganisationDetails() : null,
                     OrganisationDetailsLegacy::getOrganisationName))
                 // arrays must not be null (schema expects an array)
-                .organisationAliases(java.util.Collections.emptyList())
+                .organisationAliases(Collections.emptyList())
                 .build();
         }
 
@@ -485,7 +487,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
                 .nationalInsuranceNumber(mapSafe(pd != null ? pd.getIndividualDetails() : null,
                     IndividualDetailsLegacy::getNationalInsuranceNumber))
                 // arrays must not be null (schema expects an array)
-                .individualAliases(java.util.Collections.emptyList())
+                .individualAliases(Collections.emptyList())
                 .build();
         }
 
@@ -635,7 +637,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
         return response;
     }
 
-    private static <T, R> R mapSafe(T obj, java.util.function.Function<T, R> f) {
+    private static <T, R> R mapSafe(T obj, Function<T, R> f) {
         return obj == null ? null : f.apply(obj);
     }
 
@@ -704,13 +706,13 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
         if (src == null) {
             return null;
         }
-        java.util.List<OrganisationAlias> aliases = java.util.Optional
+        List<OrganisationAlias> aliases = Optional
             .ofNullable(src.getOrganisationAliases())
-            .map(java.util.Arrays::asList)
-            .orElseGet(java.util.List::of)
+            .map(Arrays::asList)
+            .orElseGet(List::of)
             .stream()
             .map(this::toOrganisationAlias)
-            .filter(java.util.Objects::nonNull)
+            .filter(Objects::nonNull)
             .toList();
 
         return OrganisationDetails.builder()
@@ -737,13 +739,13 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             return null;
         }
 
-        java.util.List<IndividualAlias> aliases = java.util.Optional
+        List<IndividualAlias> aliases = Optional
             .ofNullable(src.getIndividualAliases())
-            .map(java.util.Arrays::asList)
-            .orElseGet(java.util.List::of)
+            .map(Arrays::asList)
+            .orElseGet(List::of)
             .stream()
             .map(this::toIndividualAlias)
-            .filter(java.util.Objects::nonNull)
+            .filter(Objects::nonNull)
             .toList();
 
         return IndividualDetails.builder()
@@ -791,12 +793,12 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             return null;
         }
 
-        String docCode = java.util.Optional.ofNullable(src.getDocumentLanguagePreference())
+        String docCode = Optional.ofNullable(src.getDocumentLanguagePreference())
             .map(uk.gov.hmcts.opal.dto.legacy.common.LanguagePreferences.DocumentLanguagePreference
                 ::getDocumentLanguageCode)
             .orElse(null);
 
-        String hearingCode = java.util.Optional.ofNullable(src.getHearingLanguagePreference())
+        String hearingCode = Optional.ofNullable(src.getHearingLanguagePreference())
             .map(uk.gov.hmcts.opal.dto.legacy.common.LanguagePreferences.HearingLanguagePreference
                 ::getHearingLanguageCode)
             .orElse(null);
@@ -810,13 +812,13 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             return null;
         }
 
-        String typeCode = java.util.Optional.ofNullable(src.getPaymentTermsType())
-            .map(uk.gov.hmcts.opal.dto.legacy.LegacyPaymentTermsType::getPaymentTermsTypeCode)
+        String typeCode = Optional.ofNullable(src.getPaymentTermsType())
+            .map(LegacyPaymentTermsType::getPaymentTermsTypeCode)
             .map(Enum::name)
             .orElse(null);
 
-        String instalmentCode = java.util.Optional.ofNullable(src.getInstalmentPeriod())
-            .map(uk.gov.hmcts.opal.dto.legacy.LegacyInstalmentPeriod::getInstalmentPeriodCode)
+        String instalmentCode = Optional.ofNullable(src.getInstalmentPeriod())
+            .map(LegacyInstalmentPeriod::getInstalmentPeriodCode)
             .map(Enum::name)
             .orElse(null);
 
@@ -1343,8 +1345,45 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
         String ifMatch,
         String postedBy,
         AddDefendantAccountPaymentTermsRequest addPaymentTermsRequest) {
-        throw new org.springframework.web.server.ResponseStatusException(
-            org.springframework.http.HttpStatus.NOT_IMPLEMENTED,
-            "Add Payment Terms is not implemented in legacy mode");
+
+        var cleanVersion = ifMatch.replace("\"", "");
+
+        var legacyRequest = AddDefendantAccountPaymentTermsLegacyRequest.builder()
+            .defendantAccountId(String.valueOf(defendantAccountId))
+            .businessUnitId(businessUnitId)
+            .businessUnitUserId(businessUnitUserId)
+            .version(Integer.parseInt(cleanVersion))
+            .paymentTerms(mapPaymentTerms(addPaymentTermsRequest != null
+                                              ? addPaymentTermsRequest.getPaymentTerms() : null))
+            .requestPaymentCard(addPaymentTermsRequest != null ? addPaymentTermsRequest.getRequestPaymentCard() : null)
+            .generatePaymentTermsChangeLetter(addPaymentTermsRequest != null
+                                                  ? addPaymentTermsRequest.getGeneratePaymentTermsChangeLetter() : null)
+            .build();
+
+        var response = gatewayService.postToGateway(ADD_PAYMENT_TERMS,
+                                                    AddDefendantAccountPaymentTermsLegacyResponse.class, legacyRequest,
+                                                    null);
+
+        if (response.isError()) {
+            log.error(":AddPaymentTerms: Legacy error HTTP {}", response.code);
+            if (response.isException()) {
+                log.error(":AddPaymentTerms: exception:", response.exception);
+            } else if (response.isLegacyFailure()) {
+                log.error(":AddPaymentTerms: legacy failure body:\n{}", response.body);
+            }
+        } else if (response.isSuccessful()) {
+            log.info(":AddPaymentTerms: Legacy success.");
+        }
+
+        var addPaymentTermsResponse = response.responseEntity;
+
+        return GetDefendantAccountPaymentTermsResponse.builder()
+            .version(Optional.ofNullable(addPaymentTermsResponse.getVersion())
+                         .map(v -> BigInteger.valueOf(v.longValue()))
+                         .orElse(BigInteger.ONE))
+            .paymentTerms(toPaymentTerms(addPaymentTermsResponse.getPaymentTerms()))
+            .paymentCardLastRequested(addPaymentTermsResponse.getPaymentCardLastRequested())
+            .lastEnforcement(addPaymentTermsResponse.getLastEnforcement())
+            .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
@@ -107,7 +107,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
     public static final String GET_HEADER_SUMMARY = "LIBRA.get_header_summary";
     public static final String SEARCH_DEFENDANT_ACCOUNTS = "searchDefendantAccounts";
     public static final String GET_PAYMENT_TERMS = "LIBRA.get_payment_terms";
-    public static final String ADD_PAYMENT_TERMS = "LIBRA.get_payment_terms";
+    public static final String ADD_PAYMENT_TERMS = "LIBRA.add_payment_terms";
     public static final String GET_DEFENDANT_AT_A_GLANCE = "LIBRA.getDefendantAtAGlance";
     public static final String ADD_ENFORCEMENT = "LIBRA.addEnforcement";
 

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
@@ -92,7 +92,6 @@ import uk.gov.hmcts.opal.dto.search.DefendantAccountSearchResultsDto;
 import uk.gov.hmcts.opal.mapper.legacy.LegacyUpdateDefendantAccountResponseMapper;
 import uk.gov.hmcts.opal.mapper.request.UpdateDefendantAccountRequestMapper;
 import uk.gov.hmcts.opal.repository.jpa.SpecificationUtils;
-import uk.gov.hmcts.opal.service.UserStateService;
 import uk.gov.hmcts.opal.service.iface.DefendantAccountServiceInterface;
 import uk.gov.hmcts.opal.service.legacy.GatewayService.Response;
 import uk.gov.hmcts.opal.service.opal.CourtService;
@@ -126,9 +125,6 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
     /* ---- Mappers ---- */
     private final UpdateDefendantAccountRequestMapper updateDefendantAccountRequestMapper;
     private final LegacyUpdateDefendantAccountResponseMapper legacyUpdateDefendantAccountResponseMapper;
-
-    private final UserStateService userStateService;
-
 
     public DefendantAccountHeaderSummary getHeaderSummary(Long defendantAccountId) {
         log.debug(":getHeaderSummary: id: {}", defendantAccountId);
@@ -989,7 +985,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
         String businessUnitUserId) {
 
         LegacyReplaceDefendantAccountPartyRequest req = LegacyReplaceDefendantAccountPartyRequest.builder()
-            .version(Long.parseLong(ifMatch.replace("\"", "").trim()))
+            .version(Long.parseLong(VersionUtils.cleanVersion(ifMatch)))
             .defendantAccountId(defendantAccountId)
             .businessUnitId(businessUnitId)
             .businessUnitUserId(businessUnitUserId)
@@ -1156,15 +1152,13 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
     public AddEnforcementResponse addEnforcement(Long defendantAccountId, String businessUnitId,
         String businessUnitUserId, String ifMatch, String authHeader, AddDefendantAccountEnforcementRequest request) {
 
-        String cleanVersion = ifMatch.replace("\"", "");
-
         // build legacy request object
         AddDefendantAccountEnforcementLegacyRequest legacyRequest =
             AddDefendantAccountEnforcementLegacyRequest.builder()
                 .defendantAccountId(String.valueOf(defendantAccountId))
                 .businessUnitId(businessUnitId)
                 .businessUnitUserId(businessUnitUserId)
-                .version(Integer.parseInt(cleanVersion))
+                .version(Integer.parseInt(VersionUtils.cleanVersion(ifMatch)))
                 .resultId(request != null && request.getResultId() != null ? request.getResultId().value() : null)
                 .enforcementResultResponses(
                     mapResultResponses(request != null ? request.getEnforcementResultResponses() : null))
@@ -1346,13 +1340,11 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
         String postedBy,
         AddDefendantAccountPaymentTermsRequest addPaymentTermsRequest) {
 
-        var cleanVersion = ifMatch.replace("\"", "");
-
         var legacyRequest = AddDefendantAccountPaymentTermsLegacyRequest.builder()
             .defendantAccountId(String.valueOf(defendantAccountId))
             .businessUnitId(businessUnitId)
             .businessUnitUserId(businessUnitUserId)
-            .version(Integer.parseInt(cleanVersion))
+            .version(Integer.parseInt(VersionUtils.cleanVersion(ifMatch)))
             .paymentTerms(mapPaymentTerms(addPaymentTermsRequest != null
                                               ? addPaymentTermsRequest.getPaymentTerms() : null))
             .requestPaymentCard(addPaymentTermsRequest != null ? addPaymentTermsRequest.getRequestPaymentCard() : null)

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
@@ -1341,33 +1341,28 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
         String postedBy,
         AddDefendantAccountPaymentTermsRequest addPaymentTermsRequest) {
 
-        try {
-            var legacyRequest = createAddPaymentTermsLegacyRequest(
-                defendantAccountId, businessUnitId, businessUnitUserId,
-                ifMatch, addPaymentTermsRequest
-            );
+        var legacyRequest = createAddPaymentTermsLegacyRequest(
+            defendantAccountId, businessUnitId, businessUnitUserId,
+            ifMatch, addPaymentTermsRequest
+        );
 
-            var response = gatewayService.postToGateway(
-                ADD_PAYMENT_TERMS, AddPaymentTermsLegacyResponse.class,
-                legacyRequest, null
-            );
+        var response = gatewayService.postToGateway(
+            ADD_PAYMENT_TERMS, AddPaymentTermsLegacyResponse.class,
+            legacyRequest, null
+        );
 
-            if (response.isError()) {
-                log.error(":addPaymentTerms: Legacy error HTTP {}", response.code);
-                if (response.isException()) {
-                    log.error(":addPaymentTerms: exception:", response.exception);
-                } else if (response.isLegacyFailure()) {
-                    log.error(":addPaymentTerms: legacy failure body:\n{}", response.body);
-                }
-            } else if (response.isSuccessful()) {
-                log.info(":addPaymentTerms: Legacy success.");
+        if (response.isError()) {
+            log.error(":addPaymentTerms: Legacy error HTTP {}", response.code);
+            if (response.isException()) {
+                log.error(":addPaymentTerms: exception:", response.exception);
+            } else if (response.isLegacyFailure()) {
+                log.error(":addPaymentTerms: legacy failure body:\n{}", response.body);
             }
-
-            return createGetDefendantAccountPaymentTermsResponse(response.responseEntity);
-        } catch (Exception e) {
-            log.error(":addPaymentTerms: problem with call to Legacy: {}", e.getClass().getName());
-            throw e;
+        } else if (response.isSuccessful()) {
+            log.info(":addPaymentTerms: Legacy success.");
         }
+
+        return createGetDefendantAccountPaymentTermsResponse(response.responseEntity);
     }
 
     private AddPaymentTermsLegacyRequest createAddPaymentTermsLegacyRequest(Long defendantAccountId,

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
@@ -1341,36 +1341,36 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
         String postedBy,
         AddDefendantAccountPaymentTermsRequest addPaymentTermsRequest) {
 
-        var legacyRequest = buildAddPaymentTermsLegacyRequest(defendantAccountId, businessUnitId, businessUnitUserId,
-            ifMatch, addPaymentTermsRequest);
+        try {
+            var legacyRequest = createAddPaymentTermsLegacyRequest(
+                defendantAccountId, businessUnitId, businessUnitUserId,
+                ifMatch, addPaymentTermsRequest
+            );
 
-        var response = gatewayService.postToGateway(ADD_PAYMENT_TERMS, AddPaymentTermsLegacyResponse.class,
-                                                    legacyRequest, null);
+            var response = gatewayService.postToGateway(
+                ADD_PAYMENT_TERMS, AddPaymentTermsLegacyResponse.class,
+                legacyRequest, null
+            );
 
-        if (response.isError()) {
-            log.error(":AddPaymentTerms: Legacy error HTTP {}", response.code);
-            if (response.isException()) {
-                log.error(":AddPaymentTerms: exception:", response.exception);
-            } else if (response.isLegacyFailure()) {
-                log.error(":AddPaymentTerms: legacy failure body:\n{}", response.body);
+            if (response.isError()) {
+                log.error(":addPaymentTerms: Legacy error HTTP {}", response.code);
+                if (response.isException()) {
+                    log.error(":addPaymentTerms: exception:", response.exception);
+                } else if (response.isLegacyFailure()) {
+                    log.error(":addPaymentTerms: legacy failure body:\n{}", response.body);
+                }
+            } else if (response.isSuccessful()) {
+                log.info(":addPaymentTerms: Legacy success.");
             }
-        } else if (response.isSuccessful()) {
-            log.info(":AddPaymentTerms: Legacy success.");
+
+            return createGetDefendantAccountPaymentTermsResponse(response.responseEntity);
+        } catch (RuntimeException e) {
+            log.error(":addPaymentTerms: problem with call to Legacy: {}", e.getClass().getName());
+            throw e;
         }
-
-        var addPaymentTermsResponse = response.responseEntity;
-
-        return GetDefendantAccountPaymentTermsResponse.builder()
-            .version(Optional.ofNullable(addPaymentTermsResponse.getVersion())
-                         .map(v -> BigInteger.valueOf(v.longValue()))
-                         .orElse(BigInteger.ONE))
-            .paymentTerms(toPaymentTerms(addPaymentTermsResponse.getPaymentTerms()))
-            .paymentCardLastRequested(addPaymentTermsResponse.getPaymentCardLastRequested())
-            .lastEnforcement(addPaymentTermsResponse.getLastEnforcement())
-            .build();
     }
 
-    private AddPaymentTermsLegacyRequest buildAddPaymentTermsLegacyRequest(Long defendantAccountId,
+    private AddPaymentTermsLegacyRequest createAddPaymentTermsLegacyRequest(Long defendantAccountId,
         String businessUnitId,
         String businessUnitUserId,
         String ifMatch,
@@ -1386,6 +1386,19 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             .requestPaymentCard(addPaymentTermsRequest != null ? addPaymentTermsRequest.getRequestPaymentCard() : null)
             .generatePaymentTermsChangeLetter(addPaymentTermsRequest != null
                                                   ? addPaymentTermsRequest.getGeneratePaymentTermsChangeLetter() : null)
+            .build();
+    }
+
+    private static GetDefendantAccountPaymentTermsResponse createGetDefendantAccountPaymentTermsResponse(
+        AddPaymentTermsLegacyResponse addPaymentTermsResponse) {
+
+        return GetDefendantAccountPaymentTermsResponse.builder()
+            .version(Optional.ofNullable(addPaymentTermsResponse.getVersion())
+                         .map(v -> BigInteger.valueOf(v.longValue()))
+                         .orElse(BigInteger.ONE))
+            .paymentTerms(toPaymentTerms(addPaymentTermsResponse.getPaymentTerms()))
+            .paymentCardLastRequested(addPaymentTermsResponse.getPaymentCardLastRequested())
+            .lastEnforcement(addPaymentTermsResponse.getLastEnforcement())
             .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
@@ -1364,7 +1364,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             }
 
             return createGetDefendantAccountPaymentTermsResponse(response.responseEntity);
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             log.error(":addPaymentTerms: problem with call to Legacy: {}", e.getClass().getName());
             throw e;
         }
@@ -1380,7 +1380,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             .defendantAccountId(String.valueOf(defendantAccountId))
             .businessUnitId(businessUnitId)
             .businessUnitUserId(businessUnitUserId)
-            .version(VersionUtils.extractBigInteger(ifMatch).intValue())
+            .version(VersionUtils.extractBigInteger(ifMatch))
             .paymentTerms(mapPaymentTerms(addPaymentTermsRequest != null
                                               ? addPaymentTermsRequest.getPaymentTerms() : null))
             .requestPaymentCard(addPaymentTermsRequest != null ? addPaymentTermsRequest.getRequestPaymentCard() : null)

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
@@ -135,18 +135,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
                 GET_HEADER_SUMMARY, LegacyGetDefendantAccountHeaderSummaryResponse.class,
                 createGetDefendantAccountRequest(defendantAccountId.toString()), null);
 
-            if (response.isError()) {
-                log.error(":getHeaderSummary: Legacy Gateway response: HTTP Response Code: {}", response.code);
-                if (response.isException()) {
-                    log.error(":getHeaderSummary:", response.exception);
-                } else if (response.isLegacyFailure()) {
-                    log.error(":getHeaderSummary: Legacy Gateway: body: \n{}", response.body);
-                    LegacyGetDefendantAccountHeaderSummaryResponse responseEntity = response.responseEntity;
-                    log.error(":getHeaderSummary: Legacy Gateway: entity: \n{}", responseEntity.toXml());
-                }
-            } else if (response.isSuccessful()) {
-                log.info(":getHeaderSummary: Legacy Gateway response: Success.");
-            }
+            checkResponseForError(response, "getHeaderSummary");
 
             return toHeaderSumaryDto(response.responseEntity);
 
@@ -177,18 +166,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             GET_PAYMENT_TERMS, LegacyGetDefendantAccountPaymentTermsResponse.class,
             createGetDefendantAccountRequest(defendantAccountId.toString()), null);
 
-        if (response.isError()) {
-            log.error(":getPaymentTerms: Legacy Gateway response: HTTP Response Code: {}", response.code);
-            if (response.isException()) {
-                log.error(":getPaymentTerms:", response.exception);
-            } else if (response.isLegacyFailure()) {
-                log.error(":getPaymentTerms: Legacy Gateway: body: \n{}", response.body);
-                LegacyGetDefendantAccountPaymentTermsResponse responseEntity = response.responseEntity;
-                log.error(":getPaymentTerms: Legacy Gateway: entity: \n{}", responseEntity.toXml());
-            }
-        } else if (response.isSuccessful()) {
-            log.info(":getPaymentTerms: Legacy Gateway response: Success.");
-        }
+        checkResponseForError(response, "getPaymentTerms");
 
         return toPaymentTermsResponse(response.responseEntity);
     }
@@ -432,16 +410,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             null
         );
 
-        if (response.isError()) {
-            log.error(":getDefendantAccountParty: Legacy error HTTP {}", response.code);
-            if (response.isException()) {
-                log.error(":getDefendantAccountParty: exception:", response.exception);
-            } else if (response.isLegacyFailure()) {
-                log.error(":getDefendantAccountParty: legacy failure body:\n{}", response.body);
-            }
-        } else if (response.isSuccessful()) {
-            log.info(":getDefendantAccountParty: Legacy success.");
-        }
+        checkResponseForError(response, "getDefendantAccountParty");
 
         return toDefendantAccountPartyResponse(response.responseEntity);
     }
@@ -646,18 +615,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             GET_DEFENDANT_AT_A_GLANCE, LegacyGetDefendantAccountAtAGlanceResponse.class,
             createGetDefendantAccountRequest(defendantAccountId.toString()), null);
 
-        if (response.isError()) {
-            log.error(":getAtAGlance: Legacy Gateway response: HTTP Response Code: {}", response.code);
-            if (response.isException()) {
-                log.error(":getAtAGlance:", response.exception);
-            } else if (response.isLegacyFailure()) {
-                log.error(":getAtAGlance: Legacy Gateway: body: \n{}", response.body);
-                LegacyGetDefendantAccountAtAGlanceResponse responseEntity = response.responseEntity;
-                log.error(":getAtAGlance: Legacy Gateway: entity: \n{}", responseEntity.toXml());
-            }
-        } else if (response.isSuccessful()) {
-            log.info(":getAtAGlance: Legacy Gateway response: Success.");
-        }
+        checkResponseForError(response, "getAtAGlance");
 
         return toDefendantAtAGlanceResponse(response.responseEntity);
 
@@ -889,18 +847,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             PATCH_DEFENDANT_ACCOUNT, LegacyUpdateDefendantAccountResponse.class,
             legacyRequest, null);
 
-        if (gwResponse.isError()) {
-            log.error(":updateDefendantAccount: Legacy Gateway response: HTTP Response Code: {}", gwResponse.code);
-            if (gwResponse.isException()) {
-                log.error(":updateDefendantAccount: Legacy Gateway response exception: {}", gwResponse.exception);
-            } else if (gwResponse.isLegacyFailure()) {
-                log.error(":updateDefendantAccount: Legacy Gateway: body: \n{}", gwResponse.body);
-                LegacyUpdateDefendantAccountResponse responseEntity = gwResponse.responseEntity;
-                log.error(":updateDefendantAccount: Legacy Gateway: entity: \n{}", responseEntity.toXml());
-            }
-        } else if (gwResponse.isSuccessful()) {
-            log.info(":updateDefendantAccount: Legacy Gateway response: Success.");
-        }
+        checkResponseForError(gwResponse, "updateDefendantAccount");
 
         return legacyUpdateDefendantAccountResponseMapper.toDefendantAccountResponse(gwResponse.responseEntity);
     }
@@ -1000,16 +947,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             null
         );
 
-        if (response.isError()) {
-            log.error(":replaceDefendantAccountParty: Legacy error HTTP {}", response.code);
-            if (response.isException()) {
-                log.error(":replaceDefendantAccountParty: exception:", response.exception);
-            } else if (response.isLegacyFailure()) {
-                log.error(":replaceDefendantAccountParty: legacy failure body:\n{}", response.body);
-            }
-        } else if (response.isSuccessful()) {
-            log.info(":replaceDefendantAccountParty: Legacy success.");
-        }
+        checkResponseForError(response, "replaceDefendantAccountParty");
 
         return fromReplaceDefendantAccountPartyLegacy(response.responseEntity);
     }
@@ -1170,16 +1108,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             ADD_ENFORCEMENT, AddDefendantAccountEnforcementLegacyResponse.class,
             legacyRequest, null);
 
-        if (response.isError()) {
-            log.error(":AddEnforcement: Legacy error HTTP {}", response.code);
-            if (response.isException()) {
-                log.error(":AddEnforcement: exception:", response.exception);
-            } else if (response.isLegacyFailure()) {
-                log.error(":AddEnforcement: legacy failure body:\n{}", response.body);
-            }
-        } else if (response.isSuccessful()) {
-            log.info(":AddEnforcement: Legacy success.");
-        }
+        checkResponseForError(response, "AddEnforcement");
 
         AddDefendantAccountEnforcementLegacyResponse enforcementResponse = response.responseEntity;
 
@@ -1288,18 +1217,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
                 GET_ENFORCEMENT_STATUS, LegacyGetDefendantAccountEnforcementStatusResponse.class,
                 createGetDefendantAccountRequest(defendantAccountId.toString()), null);
 
-            if (response.isError()) {
-                log.error(":getEnforcementStatus: Legacy Gateway response: HTTP Response Code: {}", response.code);
-                if (response.isException()) {
-                    log.error(":getEnforcementStatus:", response.exception);
-                } else if (response.isLegacyFailure()) {
-                    log.error(":getEnforcementStatus: Legacy Gateway: body: \n{}", response.body);
-                    LegacyGetDefendantAccountEnforcementStatusResponse responseEntity = response.responseEntity;
-                    log.error(":getEnforcementStatus: Legacy Gateway: entity: \n{}", responseEntity.toXml());
-                }
-            } else if (response.isSuccessful()) {
-                log.info(":getEnforcementStatus: Legacy Gateway response: Success.");
-            }
+            checkResponseForError(response, "getEnforcementStatus");
 
             LegacyGetDefendantAccountEnforcementStatusResponse enforcementStatus = response.responseEntity;
             populateCourtCode(enforcementStatus);
@@ -1351,16 +1269,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             legacyRequest, null
         );
 
-        if (response.isError()) {
-            log.error(":addPaymentTerms: Legacy error HTTP {}", response.code);
-            if (response.isException()) {
-                log.error(":addPaymentTerms: exception:", response.exception);
-            } else if (response.isLegacyFailure()) {
-                log.error(":addPaymentTerms: legacy failure body:\n{}", response.body);
-            }
-        } else if (response.isSuccessful()) {
-            log.info(":addPaymentTerms: Legacy success.");
-        }
+        checkResponseForError(response, "addPaymentTerms");
 
         return createGetDefendantAccountPaymentTermsResponse(response.responseEntity);
     }
@@ -1395,5 +1304,18 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             .paymentCardLastRequested(addPaymentTermsResponse.getPaymentCardLastRequested())
             .lastEnforcement(addPaymentTermsResponse.getLastEnforcement())
             .build();
+    }
+
+    private static <T> void checkResponseForError(Response<T> response, String method) {
+        if (response.isError()) {
+            log.error(":{}: legacy error HTTP {}", method, response.code);
+            if (response.isException()) {
+                log.error(":{}: exception:", method, response.exception);
+            } else if (response.isLegacyFailure()) {
+                log.error(":{}: legacy failure body:\n{}", method, response.body);
+            }
+        } else if (response.isSuccessful()) {
+            log.info(":{}: legacy success.", method);
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/util/VersionUtils.java
+++ b/src/main/java/uk/gov/hmcts/opal/util/VersionUtils.java
@@ -94,6 +94,10 @@ public class VersionUtils {
                   "Could not parse 'ifMatch': " + ifMatch + " in method: " + method, existingFromDB)), id, method);
     }
 
+    public static String cleanVersion(String ifMatch) {
+        return ifMatch.replace("\"", "").trim();
+    }
+
     // function to parse IfMatch value from header, removed.
     // At this stage we assume this will be a number.
     // If this is needed to it can be re-added later.

--- a/src/main/java/uk/gov/hmcts/opal/util/VersionUtils.java
+++ b/src/main/java/uk/gov/hmcts/opal/util/VersionUtils.java
@@ -80,7 +80,7 @@ public class VersionUtils {
 
     public static Optional<BigInteger> extractOptionalBigInteger(String ifMatch) {
         return Optional.ofNullable(ifMatch)
-            .map(s -> s.replace("\"", ""))
+            .map(s -> s.replace("\"", "").trim())
             .map(BigInteger::new);
     }
 
@@ -93,12 +93,4 @@ public class VersionUtils {
             .orElseThrow(() -> new ResourceConflictException(existingFromDB.getClass().getSimpleName(), id,
                   "Could not parse 'ifMatch': " + ifMatch + " in method: " + method, existingFromDB)), id, method);
     }
-
-    public static String cleanVersion(String ifMatch) {
-        return ifMatch.replace("\"", "").trim();
-    }
-
-    // function to parse IfMatch value from header, removed.
-    // At this stage we assume this will be a number.
-    // If this is needed to it can be re-added later.
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -174,6 +174,8 @@ opal:
   test-user:
     email: ${OPAL_TEST_USER_EMAIL:opal-test@HMCTS.NET}
     password: ${OPAL_TEST_USER_PASSWORD}
+  common:
+    domain: fines
 
 be-developer-config:
   user-role-permissions: ${BE_DEV_ROLE_PERMISSIONS:}

--- a/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
@@ -45,6 +45,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.TransactionSystemException;
@@ -57,7 +58,6 @@ import uk.gov.hmcts.opal.common.user.authentication.exception.AuthenticationErro
 import uk.gov.hmcts.opal.common.user.authentication.exception.MissingRequestHeaderException;
 import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
 import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
-import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountEntity;
 import uk.gov.hmcts.opal.exception.JsonSchemaValidationException;
 import uk.gov.hmcts.opal.common.exception.OpalApiException;
@@ -110,10 +110,10 @@ class GlobalExceptionHandlerTest {
 
     @Test
     void handleForbidden_false() {
-        PermissionNotAllowedException ex = new PermissionNotAllowedException(FinesPermission.ACCOUNT_ENQUIRY);
+        AccessDeniedException ex = new AccessDeniedException("acces denied");
         HttpServletRequest req = new MockHttpServletRequest();
 
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handlePermissionNotAllowedException(ex, req);
+        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleAccessDeniedException(ex, req);
         assertEquals(HttpStatus.FORBIDDEN, r.getStatusCode());
         ProblemDetail pd = r.getBody();
         assertEquals(HttpStatus.FORBIDDEN.value(), pd.getStatus());

--- a/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountEnforcementServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -113,6 +114,7 @@ class DefendantAccountEnforcementServiceTest {
             ex.getMessage() == null || ex.getMessage().contains(FinesPermission.ENTER_ENFORCEMENT.name()),
             "Exception should mention ENTER_ENFORCEMENT"
         );
+        assertThat(ex.getPermission()).containsExactly(FinesPermission.ENTER_ENFORCEMENT);
 
         verify(userStateService).checkForAuthorisedUser(authHeader);
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT);

--- a/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountPartyServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountPartyServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -86,6 +85,8 @@ class DefendantAccountPartyServiceTest {
             defendantAccountPartyService
                 .getDefendantAccountParty(defendantAccountId, defendantAccountPartyId, authHeader)
         );
+
+        assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
 
         verify(userStateService).checkForAuthorisedUser(authHeader);
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
@@ -200,22 +201,26 @@ class DefendantAccountPartyServiceTest {
         Long defendantAccountId = 100L;
         Long defendantAccountPartyId = 200L;
         String ifMatch = "W/\"X\"";
-        String businessUnitId = "3";
+        Short businessUnitId = 3;
+        String stringBusinessUnitId = String.valueOf(businessUnitId);
         DefendantAccountParty request = new DefendantAccountParty();
 
         when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
-        when(userState.hasBusinessUnitUserWithPermission(anyShort(), eq(FinesPermission.ACCOUNT_MAINTENANCE)))
+        when(userState.hasBusinessUnitUserWithPermission(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE))
             .thenReturn(false);
 
         // Act & Assert
-        assertThrows(PermissionNotAllowedException.class, () ->
-            defendantAccountPartyService.replaceDefendantAccountParty(
-                defendantAccountId, defendantAccountPartyId, authHeader, ifMatch, businessUnitId, request
-            )
+        PermissionNotAllowedException ex = assertThrows(
+            PermissionNotAllowedException.class,
+            () -> defendantAccountPartyService.replaceDefendantAccountParty(
+                defendantAccountId, defendantAccountPartyId, authHeader, ifMatch, stringBusinessUnitId, request)
         );
 
+        assertThat(ex.getPermission()).containsExactly(FinesPermission.ACCOUNT_MAINTENANCE);
+        assertThat(ex.getBusinessUnitId()).isEqualTo(businessUnitId);
+
         verify(userStateService).checkForAuthorisedUser(authHeader);
-        verify(userState).hasBusinessUnitUserWithPermission(anyShort(), eq(FinesPermission.ACCOUNT_MAINTENANCE));
+        verify(userState).hasBusinessUnitUserWithPermission(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE);
         verifyNoInteractions(defendantAccountPartyServiceProxy);
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -16,7 +17,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.math.BigInteger;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -126,6 +126,7 @@ class DefendantAccountServiceTest {
 
     @Test
     void testGetHeaderSummary_forbiddenWhenUserHasNoPermission() {
+        // Arrange
         UserState user = UserState.builder()
             .userId(456L)
             .userName("noperms")
@@ -133,9 +134,12 @@ class DefendantAccountServiceTest {
             .build();
         when(userStateService.checkForAuthorisedUser(any())).thenReturn(user);
 
-        Assertions.assertThrows(PermissionNotAllowedException.class, () -> {
-            defendantAccountService.getHeaderSummary(1L, "authHeaderValue");
-        });
+        // Act & Assert
+        PermissionNotAllowedException ex = assertThrows(
+            PermissionNotAllowedException.class,
+            () ->  defendantAccountService.getHeaderSummary(1L, "authHeaderValue")
+        );
+        assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
     }
 
     @Test
@@ -171,6 +175,8 @@ class DefendantAccountServiceTest {
 
     @Test
     void testSearchDefendantAccounts_forbiddenWhenUserHasNoPermission() {
+
+        //Arrange
         UserState user = UserState.builder()
             .userId(456L)
             .userName("noperms")
@@ -179,9 +185,14 @@ class DefendantAccountServiceTest {
         when(userStateService.checkForAuthorisedUser(any())).thenReturn(user);
 
         AccountSearchDto dto = AccountSearchDto.builder().build();
-        Assertions.assertThrows(PermissionNotAllowedException.class, () -> {
-            defendantAccountService.searchDefendantAccounts(dto, "authHeaderValue");
-        });
+
+        // Act & Assert
+        PermissionNotAllowedException ex = assertThrows(
+            PermissionNotAllowedException.class,
+            () -> defendantAccountService.searchDefendantAccounts(dto, "authHeaderValue")
+        );
+
+        assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
     }
 
     @Test
@@ -305,6 +316,7 @@ class DefendantAccountServiceTest {
             ex.getMessage() == null || ex.getMessage().contains(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS.name()),
             "Exception should mention the denied permission"
         );
+        assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
 
         // proxy must not be called
         verify(userStateService).checkForAuthorisedUser(authHeader);
@@ -374,11 +386,11 @@ class DefendantAccountServiceTest {
             PermissionNotAllowedException.class,
             () -> defendantAccountService.addEnforcement(defendantAccountId, businessUnitId, "\"3\"", authHeader, null)
         );
-
         assertTrue(
             ex.getMessage() == null || ex.getMessage().contains(FinesPermission.ENTER_ENFORCEMENT.name()),
             "Exception should mention ENTER_ENFORCEMENT"
         );
+        assertThat(ex.getPermission()).containsExactly(FinesPermission.ENTER_ENFORCEMENT);
 
         verify(userStateService).checkForAuthorisedUser(authHeader);
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT);

--- a/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -165,8 +166,9 @@ class DraftAccountServiceTest {
     @Test
     void testSubmitDraftAccounts_fail() {
         // Arrange
+        Short businessUnitId = (short)1;
         AddDraftAccountRequestDto addDraftAccountDto = AddDraftAccountRequestDto.builder()
-            .businessUnitId((short)1)
+            .businessUnitId(businessUnitId)
             .accountType("Fine")
             .account(createAccountString())
             .submittedBy("TestUser")
@@ -176,8 +178,13 @@ class DraftAccountServiceTest {
         when(userStateService.checkForAuthorisedUser(any())).thenReturn(UserStateUtil.noPermissionsUser());
 
         // Act & Assert
-        assertThrows(PermissionNotAllowedException.class, () ->
-            draftAccountService.submitDraftAccount(addDraftAccountDto, "authHeaderValue"));
+        PermissionNotAllowedException ex = assertThrows(
+            PermissionNotAllowedException.class,
+                () -> draftAccountService.submitDraftAccount(addDraftAccountDto, "authHeaderValue")
+        );
+
+        assertThat(ex.getPermission()).containsExactly(FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS);
+        assertThat(ex.getBusinessUnitId()).isEqualTo(businessUnitId);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -11,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import java.math.BigInteger;
 import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -99,10 +101,11 @@ class MinorCreditorServiceTest {
         when(userStateService.checkForAuthorisedUser(any())).thenReturn(noPermissionUser);
 
         // Act & Assert
-        assertThrows(
-            PermissionNotAllowedException.class, () ->
-                minorCreditorService.getMinorCreditorAccountHeaderSummary(123L, "authHeaderValue")
+        PermissionNotAllowedException ex = Assertions.assertThrows(
+            PermissionNotAllowedException.class,
+                () -> minorCreditorService.getMinorCreditorAccountHeaderSummary(123L, "authHeaderValue")
         );
+        assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
     }
 
     @Test
@@ -123,15 +126,18 @@ class MinorCreditorServiceTest {
 
     @Test
     void testGetMinorCreditorAccountAtAGlance_permissionNotAllowed() {
+        // Arrange
         UserState noPermissionUser = mock(UserState.class);
         when(noPermissionUser.anyBusinessUnitUserHasPermission(
             FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
         when(userStateService.checkForAuthorisedUser(any())).thenReturn(noPermissionUser);
 
-        assertThrows(
-            PermissionNotAllowedException.class, () ->
-                minorCreditorService.getMinorCreditorAtAGlance("123", "authHeaderValue")
+        // Act & Assert
+        PermissionNotAllowedException ex = Assertions.assertThrows(
+            PermissionNotAllowedException.class,
+            () -> minorCreditorService.getMinorCreditorAtAGlance("123", "authHeaderValue")
         );
+        assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
     }
 
     @Test
@@ -143,10 +149,11 @@ class MinorCreditorServiceTest {
         when(userStateService.checkForAuthorisedUser(any())).thenReturn(noPermissionUser);
 
         // Act & Assert
-        assertThrows(
-            PermissionNotAllowedException.class, () ->
-            minorCreditorService.searchMinorCreditors(MinorCreditorSearch.builder().build(), "authHeaderValue")
+        PermissionNotAllowedException ex = Assertions.assertThrows(
+            PermissionNotAllowedException.class,
+            () -> minorCreditorService.searchMinorCreditors(MinorCreditorSearch.builder().build(), "authHeaderValue")
         );
+        assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
     }
 
     @Test
@@ -277,10 +284,14 @@ class MinorCreditorServiceTest {
             .payment(new CreditorAccountPaymentDetailsCommon().holdPayment(true));
 
         // Act & Assert
-        assertThrows(
-            PermissionNotAllowedException.class, () ->
-                minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "authHeaderValue")
+        PermissionNotAllowedException ex = Assertions.assertThrows(
+            PermissionNotAllowedException.class,
+            () -> minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "authHeaderValue")
         );
+
+        assertThat(ex.getPermission()).containsExactly(FinesPermission.ADD_AND_REMOVE_PAYMENT_HOLD);
+        assertThat(ex.getBusinessUnitId()).isEqualTo(null);
+
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
@@ -51,6 +51,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpServerErrorException;
 import uk.gov.hmcts.opal.config.properties.LegacyGatewayProperties;
 import uk.gov.hmcts.opal.disco.legacy.LegacyTestsBase;
 import uk.gov.hmcts.opal.dto.AddDefendantAccountEnforcementRequest;
@@ -3350,21 +3351,27 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
         // When
         doReturn(gateWayResponse).when(gatewayService).postToGateway(any(), any(), any(), any());
 
-        var actualResponse = legacyDefendantAccountService.addPaymentTerms(defendantAccountId, businessUnitId,
-                                                                           businessUnitUserId, ifMatch,
-                                                                           "auth", null);
+        var actualResponse = legacyDefendantAccountService.addPaymentTerms(
+            defendantAccountId, businessUnitId,
+            businessUnitUserId, ifMatch,
+            "auth", null
+        );
 
         // Then
         var requestCaptor = ArgumentCaptor.forClass(AddPaymentTermsLegacyRequest.class);
 
         verify(gatewayService, times(1))
-            .postToGateway(eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
-                           eq(AddPaymentTermsLegacyResponse.class),
-                           requestCaptor.capture(),
-                           isNull());
+            .postToGateway(
+                eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
+                eq(AddPaymentTermsLegacyResponse.class),
+                requestCaptor.capture(),
+                isNull()
+            );
 
-        assertAddPaymentTermsLegacyRequest(requestCaptor.getValue(), defendantAccountId, businessUnitId,
-                                           businessUnitUserId, ifMatch);
+        assertAddPaymentTermsLegacyRequest(
+            requestCaptor.getValue(), defendantAccountId, businessUnitId,
+            businessUnitUserId, ifMatch
+        );
         assertGetDefendantAccountPaymentTermsResponse(actualResponse, legacyResponse);
 
         // Assert logs
@@ -3407,7 +3414,7 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
     }
 
     @Test
-    void addPaymentTerms_whenGatewayResponseWithException_thenHandleException() {
+    void addPaymentTerms_whenGatewayResponseWithException_thenDoNotReturnEntity() {
         // Given
         long defendantAccountId = 1L;
         String businessUnitId = "BU";
@@ -3415,32 +3422,42 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
         String ifMatch = "\"1\"";
 
         // When
-        doThrow(new RuntimeException("boom")).when(gatewayService).postToGateway(any(), any(), any(), any());
+        doThrow(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR))
+            .when(gatewayService).postToGateway(
+                any(),
+                any(),
+                any(),
+                any()
+            );
 
         // Then
-        assertThrows(RuntimeException.class, () ->
-            legacyDefendantAccountService.addPaymentTerms(defendantAccountId, businessUnitId,
-                                                          businessUnitUserId, ifMatch,
-                                                          "auth", null)
+        assertThrows(
+            HttpServerErrorException.class, () ->
+                legacyDefendantAccountService.addPaymentTerms(
+                    defendantAccountId, businessUnitId,
+                    businessUnitUserId, ifMatch,
+                    "auth", null
+                )
         );
 
         var requestCaptor = ArgumentCaptor.forClass(AddPaymentTermsLegacyRequest.class);
 
         verify(gatewayService, times(1))
-            .postToGateway(eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
-                           eq(AddPaymentTermsLegacyResponse.class),
-                           requestCaptor.capture(),
-                           isNull());
+            .postToGateway(
+                eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
+                eq(AddPaymentTermsLegacyResponse.class),
+                requestCaptor.capture(),
+                isNull()
+            );
 
-        assertAddPaymentTermsLegacyRequest(requestCaptor.getValue(), defendantAccountId, businessUnitId,
-                                           businessUnitUserId, ifMatch);
+        assertAddPaymentTermsLegacyRequest(
+            requestCaptor.getValue(), defendantAccountId, businessUnitId,
+            businessUnitUserId, ifMatch
+        );
 
         // Assert logs
         List<ILoggingEvent> logs = listAppender.list;
-        assertEquals(1, logs.size());
-        assertEquals(Level.ERROR, logs.getFirst().getLevel());
-        assertEquals(":addPaymentTerms: problem with call to Legacy: java.lang.RuntimeException",
-                     logs.getFirst().getFormattedMessage());
+        assertEquals(0, logs.size());
     }
 
     @Test
@@ -3452,37 +3469,49 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
         String ifMatch = "\"1\"";
 
         var legacyResponse = createAddPaymentTermsLegacyResponse(defendantAccountId, ifMatch);
-        var gateWayResponse = new GatewayService.Response<>(HttpStatus.SERVICE_UNAVAILABLE, legacyResponse,
-                                                 "<legacy-failure/>", null);
+        var gateWayResponse = new GatewayService.Response<>(
+            HttpStatus.SERVICE_UNAVAILABLE, legacyResponse,
+            "<legacy-failure/>", null
+        );
 
         // When
         doReturn(gateWayResponse).when(gatewayService).postToGateway(any(), any(), any(), any());
 
-        var actualResponse = legacyDefendantAccountService.addPaymentTerms(defendantAccountId, businessUnitId,
-                                                                           businessUnitUserId, ifMatch,
-                                                                           "auth", null);
+        var actualResponse = legacyDefendantAccountService.addPaymentTerms(
+            defendantAccountId, businessUnitId,
+            businessUnitUserId, ifMatch,
+            "auth", null
+        );
 
         // Then
         var requestCaptor = ArgumentCaptor.forClass(AddPaymentTermsLegacyRequest.class);
 
         verify(gatewayService, times(1))
-            .postToGateway(eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
-                           eq(AddPaymentTermsLegacyResponse.class),
-                           requestCaptor.capture(),
-                           isNull());
+            .postToGateway(
+                eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
+                eq(AddPaymentTermsLegacyResponse.class),
+                requestCaptor.capture(),
+                isNull()
+            );
 
-        assertAddPaymentTermsLegacyRequest(requestCaptor.getValue(), defendantAccountId, businessUnitId,
-                                           businessUnitUserId, ifMatch);
+        assertAddPaymentTermsLegacyRequest(
+            requestCaptor.getValue(), defendantAccountId, businessUnitId,
+            businessUnitUserId, ifMatch
+        );
         assertGetDefendantAccountPaymentTermsResponse(actualResponse, legacyResponse);
 
         // Assert logs
         List<ILoggingEvent> logs = listAppender.list;
         assertEquals(2, logs.size());
         assertEquals(Level.ERROR, logs.getFirst().getLevel());
-        assertEquals(":addPaymentTerms: Legacy error HTTP 503 SERVICE_UNAVAILABLE",
-                     logs.getFirst().getFormattedMessage());
+        assertEquals(
+            ":addPaymentTerms: Legacy error HTTP 503 SERVICE_UNAVAILABLE",
+            logs.getFirst().getFormattedMessage()
+        );
         assertEquals(Level.ERROR, logs.get(1).getLevel());
-        assertEquals(":addPaymentTerms: legacy failure body:\n"
-                         + "<legacy-failure/>", logs.get(1).getFormattedMessage());
+        assertEquals(
+            ":addPaymentTerms: legacy failure body:\n"
+                + "<legacy-failure/>", logs.get(1).getFormattedMessage()
+        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
@@ -132,8 +132,8 @@ import uk.gov.hmcts.opal.service.opal.LocalJusticeAreaService;
 @ExtendWith(MockitoExtension.class)
 class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
 
-    private Logger logger = (Logger) LoggerFactory.getLogger("opal.LegacyDefendantAccountService");
-    private ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+    private Logger logger;
+    private ListAppender<ILoggingEvent> listAppender;
 
     @Spy
     private MockRestClient restClient = spy(MockRestClient.class);
@@ -149,8 +149,11 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
 
     private GatewayService gatewayService;
 
-    @Mock private UpdateDefendantAccountRequestMapper updateDefendantAccountRequestMapper;
-    @Mock private LegacyUpdateDefendantAccountResponseMapper legacyUpdateDefendantAccountResponseMapper;
+    @Mock
+    private UpdateDefendantAccountRequestMapper updateDefendantAccountRequestMapper;
+
+    @Mock
+    private LegacyUpdateDefendantAccountResponseMapper legacyUpdateDefendantAccountResponseMapper;
 
     @InjectMocks
     private LegacyDefendantAccountService legacyDefendantAccountService;
@@ -159,6 +162,8 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
 
     @BeforeEach
     void setUp() throws Exception {
+        logger = (Logger) LoggerFactory.getLogger("opal.LegacyDefendantAccountService");
+        listAppender = new ListAppender<>();
         listAppender.start();
         logger.addAppender(listAppender);
 
@@ -180,8 +185,7 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
 
     @AfterEach
     void tearDown() {
-        logger.detachAppender(listAppender);
-        listAppender.stop();
+        logger.detachAndStopAllAppenders();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
@@ -25,19 +25,13 @@ import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 import static uk.gov.hmcts.opal.util.VersionUtils.extractBigInteger;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.read.ListAppender;
 import jakarta.persistence.EntityNotFoundException;
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,7 +41,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
+import static uk.gov.hmcts.opal.util.VersionUtils.extractBigInteger;
 
 import jakarta.persistence.EntityNotFoundException;
 import java.lang.reflect.Field;
@@ -64,8 +65,8 @@ import uk.gov.hmcts.opal.dto.common.PartyDetails;
 import uk.gov.hmcts.opal.dto.common.PaymentStateSummary;
 import uk.gov.hmcts.opal.dto.common.PaymentTermsType;
 import uk.gov.hmcts.opal.dto.legacy.AddDefendantAccountEnforcementLegacyResponse;
-import uk.gov.hmcts.opal.dto.legacy.AddDefendantAccountPaymentTermsLegacyRequest;
-import uk.gov.hmcts.opal.dto.legacy.AddDefendantAccountPaymentTermsLegacyResponse;
+import uk.gov.hmcts.opal.dto.legacy.AddPaymentTermsLegacyRequest;
+import uk.gov.hmcts.opal.dto.legacy.AddPaymentTermsLegacyResponse;
 import uk.gov.hmcts.opal.dto.legacy.AddPaymentCardLegacyRequest;
 import uk.gov.hmcts.opal.dto.legacy.AddPaymentCardLegacyResponse;
 import uk.gov.hmcts.opal.dto.legacy.AddressDetailsLegacy;
@@ -3313,92 +3314,146 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
     }
 
     @Test
-    void addPaymentTerms_whenGatewayResponseWithException_thenThrowNullPointerDueToMissingEntity() {
+    void addPaymentTerms_whenGatewayResponseWithSuccess_thenReturnMappedResponse() {
         // Given
-        var errResp = new GatewayService.Response<>(HttpStatus.INTERNAL_SERVER_ERROR, new RuntimeException("boom"),
-                                                    "<err/>");
+        long defendantAccountId = 1L;
+        String businessUnitId = "BU";
+        String businessUnitUserId = "U";
+        String ifMatch = "\"1\"";
+        var legacyResponse = getAddPaymentTermsLegacyResponse(defendantAccountId, ifMatch);
+        var gateWayResponse = new GatewayService.Response<>(HttpStatus.OK, legacyResponse, null, null);
 
         // When
-        doReturn(errResp).when(gatewayService).postToGateway(
+        doReturn(gateWayResponse).when(gatewayService).postToGateway(
             eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
-            eq(AddDefendantAccountPaymentTermsLegacyResponse.class),
-            any(AddDefendantAccountPaymentTermsLegacyRequest.class),
+            eq(AddPaymentTermsLegacyResponse.class),
+            any(),
+            Mockito.nullable(String.class)
+        );
+
+        var actualResponse = legacyDefendantAccountService.addPaymentTerms(defendantAccountId, businessUnitId,
+                                                                           businessUnitUserId, ifMatch,
+                                                                           "auth", null);
+
+        // Then
+        var requestCaptor = ArgumentCaptor.forClass(AddPaymentTermsLegacyRequest.class);
+
+        verify(gatewayService, times(1))
+            .postToGateway(eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
+                           eq(AddPaymentTermsLegacyResponse.class),
+                           requestCaptor.capture(),
+                           Mockito.nullable(String.class));
+
+        assertAddPaymentTermsLegacyRequest(requestCaptor.getValue(), defendantAccountId, businessUnitId,
+                                           businessUnitUserId, ifMatch);
+        assertGetDefendantAccountPaymentTermsResponse(actualResponse, legacyResponse);
+    }
+
+    private static AddPaymentTermsLegacyResponse getAddPaymentTermsLegacyResponse(long defendantAccountId,
+                                                                                  String ifMatch) {
+        return AddPaymentTermsLegacyResponse.builder()
+            .defendantAccountId(String.valueOf(defendantAccountId))
+            .version(extractBigInteger(ifMatch).intValue())
+            .paymentTerms(LegacyPaymentTerms.builder().build())
+            .paymentCardLastRequested(LocalDate.now().minusWeeks(1))
+            .lastEnforcement("12345")
+            .build();
+    }
+
+    private static void assertAddPaymentTermsLegacyRequest(AddPaymentTermsLegacyRequest legacyRequest,
+                                                           long defendantAccountId, String businessUnitId,
+                                                           String businessUnitUserId, String ifMatch) {
+        assertNotNull(legacyRequest);
+        assertThat(legacyRequest.getDefendantAccountId()).isEqualTo(String.valueOf(defendantAccountId));
+        assertThat(legacyRequest.getBusinessUnitId()).isEqualTo(businessUnitId);
+        assertThat(legacyRequest.getBusinessUnitUserId()).isEqualTo(businessUnitUserId);
+        assertThat(legacyRequest.getVersion()).isEqualTo(extractBigInteger(ifMatch).intValue());
+    }
+
+    private static void assertGetDefendantAccountPaymentTermsResponse(
+        GetDefendantAccountPaymentTermsResponse actualResponse, AddPaymentTermsLegacyResponse legacyResponse) {
+
+        assertNotNull(actualResponse);
+        assertThat(actualResponse.getVersion()).isEqualTo(BigInteger.valueOf(legacyResponse.getVersion()));
+        assertNotNull(actualResponse.getPaymentTerms());
+        assertThat(actualResponse.getPaymentCardLastRequested())
+            .isEqualTo(legacyResponse.getPaymentCardLastRequested());
+        assertThat(actualResponse.getLastEnforcement()).isEqualTo(legacyResponse.getLastEnforcement());
+    }
+
+    @Test
+    void addPaymentTerms_whenGatewayResponseWithException_thenThrowNullPointerDueToMissingEntity() {
+        // Given
+        long defendantAccountId = 1L;
+        String businessUnitId = "BU";
+        String businessUnitUserId = "U";
+        String ifMatch = "\"1\"";
+
+        var gateWayResponse = new GatewayService.Response<>(HttpStatus.INTERNAL_SERVER_ERROR,
+                                                            new RuntimeException("boom"), "<err/>");
+
+        // When
+        doReturn(gateWayResponse).when(gatewayService).postToGateway(
+            eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
+            eq(AddPaymentTermsLegacyResponse.class),
+            any(),
             Mockito.nullable(String.class)
         );
 
         // Then
         assertThrows(NullPointerException.class, () ->
-            legacyDefendantAccountService.addPaymentTerms(1L, "BU", "U",
-                                                          "\"1\"", "auth", null)
+            legacyDefendantAccountService.addPaymentTerms(defendantAccountId, businessUnitId,
+                                                          businessUnitUserId, ifMatch,
+                                                          "auth", null)
         );
+
+        var requestCaptor = ArgumentCaptor.forClass(AddPaymentTermsLegacyRequest.class);
+
+        verify(gatewayService, times(1))
+            .postToGateway(eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
+                           eq(AddPaymentTermsLegacyResponse.class),
+                           requestCaptor.capture(),
+                           Mockito.nullable(String.class));
+
+        assertAddPaymentTermsLegacyRequest(requestCaptor.getValue(), defendantAccountId, businessUnitId,
+                                           businessUnitUserId, ifMatch);
     }
 
     @Test
     void addPaymentTerms_whenGatewayResponseWithLegacyFailure_thenStillReturnMappedResponse() {
         // Given
-        var legacyResponse = AddDefendantAccountPaymentTermsLegacyResponse.builder()
-             .defendantAccountId("1")
-             .version(1)
-             .paymentTerms(LegacyPaymentTerms.builder().build())
-             .paymentCardLastRequested(LocalDate.now().minusWeeks(1))
-             .lastEnforcement("12345")
-             .build();
+        long defendantAccountId = 1L;
+        String businessUnitId = "BU";
+        String businessUnitUserId = "U";
+        String ifMatch = "\"1\"";
 
+        var legacyResponse = getAddPaymentTermsLegacyResponse(defendantAccountId, ifMatch);
         var gateWayResponse = new GatewayService.Response<>(HttpStatus.SERVICE_UNAVAILABLE, legacyResponse,
                                                  "<legacy-failure/>", null);
 
         // When
         doReturn(gateWayResponse).when(gatewayService).postToGateway(
             eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
-            eq(AddDefendantAccountPaymentTermsLegacyResponse.class),
+            eq(AddPaymentTermsLegacyResponse.class),
             any(),
             Mockito.nullable(String.class)
         );
 
-        var actualResponse = legacyDefendantAccountService.addPaymentTerms(1L, "BU",
-                                                                           "U", "\"1\"",
+        var actualResponse = legacyDefendantAccountService.addPaymentTerms(defendantAccountId, businessUnitId,
+                                                                           businessUnitUserId, ifMatch,
                                                                            "auth", null);
 
         // Then
-        assertNotNull(actualResponse);
-        assertThat(actualResponse.getVersion()).isEqualTo(BigInteger.valueOf(legacyResponse.getVersion()));
-        assertNotNull(actualResponse.getPaymentTerms());
-        assertThat(actualResponse.getPaymentCardLastRequested())
-            .isEqualTo(legacyResponse.getPaymentCardLastRequested());
-        assertThat(actualResponse.getLastEnforcement()).isEqualTo(legacyResponse.getLastEnforcement());
-    }
+        var requestCaptor = ArgumentCaptor.forClass(AddPaymentTermsLegacyRequest.class);
 
-    @Test
-    void addPaymentTerms_whenGatewayResponseWithSuccess_thenReturnMappedResponse() {
-        // Given
-        var legacyResponse = AddDefendantAccountPaymentTermsLegacyResponse.builder()
-            .defendantAccountId("1")
-            .version(1)
-            .paymentTerms(LegacyPaymentTerms.builder().build())
-            .paymentCardLastRequested(LocalDate.now().minusWeeks(1))
-            .lastEnforcement("12345")
-            .build();
+        verify(gatewayService, times(1))
+            .postToGateway(eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
+                           eq(AddPaymentTermsLegacyResponse.class),
+                           requestCaptor.capture(),
+                           Mockito.nullable(String.class));
 
-        var gateWayResponse = new GatewayService.Response<>(HttpStatus.OK, legacyResponse, null, null);
-
-        // When
-        doReturn(gateWayResponse).when(gatewayService).postToGateway(
-            eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
-            eq(AddDefendantAccountPaymentTermsLegacyResponse.class),
-            any(),
-            Mockito.nullable(String.class)
-        );
-
-        var actualResponse = legacyDefendantAccountService.addPaymentTerms(1L, "BU",
-                                                                           "U", "\"1\"",
-                                                                           "auth", null);
-
-        // Then
-        assertNotNull(actualResponse);
-        assertThat(actualResponse.getVersion()).isEqualTo(BigInteger.valueOf(legacyResponse.getVersion()));
-        assertNotNull(actualResponse.getPaymentTerms());
-        assertThat(actualResponse.getPaymentCardLastRequested())
-            .isEqualTo(legacyResponse.getPaymentCardLastRequested());
-        assertThat(actualResponse.getLastEnforcement()).isEqualTo(legacyResponse.getLastEnforcement());
+        assertAddPaymentTermsLegacyRequest(requestCaptor.getValue(), defendantAccountId, businessUnitId,
+                                           businessUnitUserId, ifMatch);
+        assertGetDefendantAccountPaymentTermsResponse(actualResponse, legacyResponse);
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
@@ -3378,7 +3378,7 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
         List<ILoggingEvent> logs = listAppender.list;
         assertEquals(1, logs.size());
         assertEquals(Level.INFO, logs.getFirst().getLevel());
-        assertEquals(":addPaymentTerms: Legacy success.", logs.getFirst().getFormattedMessage());
+        assertEquals(":addPaymentTerms: legacy success.", logs.getFirst().getFormattedMessage());
     }
 
     private static AddPaymentTermsLegacyResponse createAddPaymentTermsLegacyResponse(long defendantAccountId,
@@ -3505,7 +3505,7 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
         assertEquals(2, logs.size());
         assertEquals(Level.ERROR, logs.getFirst().getLevel());
         assertEquals(
-            ":addPaymentTerms: Legacy error HTTP 503 SERVICE_UNAVAILABLE",
+            ":addPaymentTerms: legacy error HTTP 503 SERVICE_UNAVAILABLE",
             logs.getFirst().getFormattedMessage()
         );
         assertEquals(Level.ERROR, logs.get(1).getLevel());

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
@@ -3378,7 +3378,7 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
                                                                                      String ifMatch) {
         return AddPaymentTermsLegacyResponse.builder()
             .defendantAccountId(String.valueOf(defendantAccountId))
-            .version(extractBigInteger(ifMatch).intValue())
+            .version(extractBigInteger(ifMatch))
             .paymentTerms(LegacyPaymentTerms.builder().build())
             .paymentCardLastRequested(LocalDate.now().minusWeeks(1))
             .lastEnforcement("12345")
@@ -3399,7 +3399,7 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
         GetDefendantAccountPaymentTermsResponse actualResponse, AddPaymentTermsLegacyResponse legacyResponse) {
 
         assertNotNull(actualResponse);
-        assertThat(actualResponse.getVersion()).isEqualTo(BigInteger.valueOf(legacyResponse.getVersion()));
+        assertThat(actualResponse.getVersion()).isEqualTo(legacyResponse.getVersion());
         assertNotNull(actualResponse.getPaymentTerms());
         assertThat(actualResponse.getPaymentCardLastRequested())
             .isEqualTo(legacyResponse.getPaymentCardLastRequested());
@@ -3407,7 +3407,7 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
     }
 
     @Test
-    void addPaymentTerms_whenGatewayResponseWithException() {
+    void addPaymentTerms_whenGatewayResponseWithException_thenHandleException() {
         // Given
         long defendantAccountId = 1L;
         String businessUnitId = "BU";

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
@@ -3320,16 +3320,11 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
         String businessUnitId = "BU";
         String businessUnitUserId = "U";
         String ifMatch = "\"1\"";
-        var legacyResponse = getAddPaymentTermsLegacyResponse(defendantAccountId, ifMatch);
+        var legacyResponse = createAddPaymentTermsLegacyResponse(defendantAccountId, ifMatch);
         var gateWayResponse = new GatewayService.Response<>(HttpStatus.OK, legacyResponse, null, null);
 
         // When
-        doReturn(gateWayResponse).when(gatewayService).postToGateway(
-            eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
-            eq(AddPaymentTermsLegacyResponse.class),
-            any(),
-            Mockito.nullable(String.class)
-        );
+        doReturn(gateWayResponse).when(gatewayService).postToGateway(any(), any(), any(), any());
 
         var actualResponse = legacyDefendantAccountService.addPaymentTerms(defendantAccountId, businessUnitId,
                                                                            businessUnitUserId, ifMatch,
@@ -3349,8 +3344,8 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
         assertGetDefendantAccountPaymentTermsResponse(actualResponse, legacyResponse);
     }
 
-    private static AddPaymentTermsLegacyResponse getAddPaymentTermsLegacyResponse(long defendantAccountId,
-                                                                                  String ifMatch) {
+    private static AddPaymentTermsLegacyResponse createAddPaymentTermsLegacyResponse(long defendantAccountId,
+                                                                                     String ifMatch) {
         return AddPaymentTermsLegacyResponse.builder()
             .defendantAccountId(String.valueOf(defendantAccountId))
             .version(extractBigInteger(ifMatch).intValue())
@@ -3382,26 +3377,18 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
     }
 
     @Test
-    void addPaymentTerms_whenGatewayResponseWithException_thenThrowNullPointerDueToMissingEntity() {
+    void addPaymentTerms_whenGatewayResponseWithException() {
         // Given
         long defendantAccountId = 1L;
         String businessUnitId = "BU";
         String businessUnitUserId = "U";
         String ifMatch = "\"1\"";
 
-        var gateWayResponse = new GatewayService.Response<>(HttpStatus.INTERNAL_SERVER_ERROR,
-                                                            new RuntimeException("boom"), "<err/>");
-
         // When
-        doReturn(gateWayResponse).when(gatewayService).postToGateway(
-            eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
-            eq(AddPaymentTermsLegacyResponse.class),
-            any(),
-            Mockito.nullable(String.class)
-        );
+        doThrow(new RuntimeException("boom")).when(gatewayService).postToGateway(any(), any(), any(), any());
 
         // Then
-        assertThrows(NullPointerException.class, () ->
+        assertThrows(RuntimeException.class, () ->
             legacyDefendantAccountService.addPaymentTerms(defendantAccountId, businessUnitId,
                                                           businessUnitUserId, ifMatch,
                                                           "auth", null)
@@ -3427,17 +3414,12 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
         String businessUnitUserId = "U";
         String ifMatch = "\"1\"";
 
-        var legacyResponse = getAddPaymentTermsLegacyResponse(defendantAccountId, ifMatch);
+        var legacyResponse = createAddPaymentTermsLegacyResponse(defendantAccountId, ifMatch);
         var gateWayResponse = new GatewayService.Response<>(HttpStatus.SERVICE_UNAVAILABLE, legacyResponse,
                                                  "<legacy-failure/>", null);
 
         // When
-        doReturn(gateWayResponse).when(gatewayService).postToGateway(
-            eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
-            eq(AddPaymentTermsLegacyResponse.class),
-            any(),
-            Mockito.nullable(String.class)
-        );
+        doReturn(gateWayResponse).when(gatewayService).postToGateway(any(), any(), any(), any());
 
         var actualResponse = legacyDefendantAccountService.addPaymentTerms(defendantAccountId, businessUnitId,
                                                                            businessUnitUserId, ifMatch,

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
@@ -25,12 +25,19 @@ import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 import static uk.gov.hmcts.opal.util.VersionUtils.extractBigInteger;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import jakarta.persistence.EntityNotFoundException;
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,6 +47,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -124,6 +132,9 @@ import uk.gov.hmcts.opal.service.opal.LocalJusticeAreaService;
 @ExtendWith(MockitoExtension.class)
 class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
 
+    private Logger logger = (Logger) LoggerFactory.getLogger("opal.LegacyDefendantAccountService");
+    private ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+
     @Spy
     private MockRestClient restClient = spy(MockRestClient.class);
 
@@ -147,7 +158,10 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
     private UpdateDefendantAccountRequest updateDefendantAccountRequest;
 
     @BeforeEach
-    void openMocks() throws Exception {
+    void setUp() throws Exception {
+        listAppender.start();
+        logger.addAppender(listAppender);
+
         gatewayService = Mockito.spy(new LegacyGatewayService(gatewayProperties, restClient));
         injectGatewayService(legacyDefendantAccountService, gatewayService);
 
@@ -162,6 +176,12 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
         field.setAccessible(true);
         field.set(legacyDefendantAccountService, gatewayService);
 
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(listAppender);
+        listAppender.stop();
     }
 
     @SuppressWarnings("unchecked")
@@ -3337,11 +3357,17 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
             .postToGateway(eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
                            eq(AddPaymentTermsLegacyResponse.class),
                            requestCaptor.capture(),
-                           Mockito.nullable(String.class));
+                           isNull());
 
         assertAddPaymentTermsLegacyRequest(requestCaptor.getValue(), defendantAccountId, businessUnitId,
                                            businessUnitUserId, ifMatch);
         assertGetDefendantAccountPaymentTermsResponse(actualResponse, legacyResponse);
+
+        // Assert logs
+        List<ILoggingEvent> logs = listAppender.list;
+        assertEquals(1, logs.size());
+        assertEquals(Level.INFO, logs.getFirst().getLevel());
+        assertEquals(":addPaymentTerms: Legacy success.", logs.getFirst().getFormattedMessage());
     }
 
     private static AddPaymentTermsLegacyResponse createAddPaymentTermsLegacyResponse(long defendantAccountId,
@@ -3400,10 +3426,17 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
             .postToGateway(eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
                            eq(AddPaymentTermsLegacyResponse.class),
                            requestCaptor.capture(),
-                           Mockito.nullable(String.class));
+                           isNull());
 
         assertAddPaymentTermsLegacyRequest(requestCaptor.getValue(), defendantAccountId, businessUnitId,
                                            businessUnitUserId, ifMatch);
+
+        // Assert logs
+        List<ILoggingEvent> logs = listAppender.list;
+        assertEquals(1, logs.size());
+        assertEquals(Level.ERROR, logs.getFirst().getLevel());
+        assertEquals(":addPaymentTerms: problem with call to Legacy: java.lang.RuntimeException",
+                     logs.getFirst().getFormattedMessage());
     }
 
     @Test
@@ -3432,10 +3465,20 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
             .postToGateway(eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
                            eq(AddPaymentTermsLegacyResponse.class),
                            requestCaptor.capture(),
-                           Mockito.nullable(String.class));
+                           isNull());
 
         assertAddPaymentTermsLegacyRequest(requestCaptor.getValue(), defendantAccountId, businessUnitId,
                                            businessUnitUserId, ifMatch);
         assertGetDefendantAccountPaymentTermsResponse(actualResponse, legacyResponse);
+
+        // Assert logs
+        List<ILoggingEvent> logs = listAppender.list;
+        assertEquals(2, logs.size());
+        assertEquals(Level.ERROR, logs.getFirst().getLevel());
+        assertEquals(":addPaymentTerms: Legacy error HTTP 503 SERVICE_UNAVAILABLE",
+                     logs.getFirst().getFormattedMessage());
+        assertEquals(Level.ERROR, logs.get(1).getLevel());
+        assertEquals(":addPaymentTerms: legacy failure body:\n"
+                         + "<legacy-failure/>", logs.get(1).getFormattedMessage());
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
@@ -64,6 +64,8 @@ import uk.gov.hmcts.opal.dto.common.PartyDetails;
 import uk.gov.hmcts.opal.dto.common.PaymentStateSummary;
 import uk.gov.hmcts.opal.dto.common.PaymentTermsType;
 import uk.gov.hmcts.opal.dto.legacy.AddDefendantAccountEnforcementLegacyResponse;
+import uk.gov.hmcts.opal.dto.legacy.AddDefendantAccountPaymentTermsLegacyRequest;
+import uk.gov.hmcts.opal.dto.legacy.AddDefendantAccountPaymentTermsLegacyResponse;
 import uk.gov.hmcts.opal.dto.legacy.AddPaymentCardLegacyRequest;
 import uk.gov.hmcts.opal.dto.legacy.AddPaymentCardLegacyResponse;
 import uk.gov.hmcts.opal.dto.legacy.AddressDetailsLegacy;
@@ -82,6 +84,7 @@ import uk.gov.hmcts.opal.dto.legacy.LegacyGetDefendantAccountEnforcementStatusRe
 import uk.gov.hmcts.opal.dto.legacy.LegacyGetDefendantAccountHeaderSummaryResponse;
 import uk.gov.hmcts.opal.dto.legacy.LegacyGetDefendantAccountPaymentTermsResponse;
 import uk.gov.hmcts.opal.dto.legacy.LegacyInstalmentPeriod;
+import uk.gov.hmcts.opal.dto.legacy.LegacyPaymentTerms;
 import uk.gov.hmcts.opal.dto.legacy.LegacyPaymentTermsType;
 import uk.gov.hmcts.opal.dto.legacy.LegacyPostedDetails;
 import uk.gov.hmcts.opal.dto.legacy.LegacyReplaceDefendantAccountPartyRequest;
@@ -3309,4 +3312,93 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
         assertNotNull(out.getPaymentTerms().getInstalmentPeriod());
     }
 
+    @Test
+    void addPaymentTerms_whenGatewayResponseWithException_thenThrowNullPointerDueToMissingEntity() {
+        // Given
+        var errResp = new GatewayService.Response<>(HttpStatus.INTERNAL_SERVER_ERROR, new RuntimeException("boom"),
+                                                    "<err/>");
+
+        // When
+        doReturn(errResp).when(gatewayService).postToGateway(
+            eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
+            eq(AddDefendantAccountPaymentTermsLegacyResponse.class),
+            any(AddDefendantAccountPaymentTermsLegacyRequest.class),
+            Mockito.nullable(String.class)
+        );
+
+        // Then
+        assertThrows(NullPointerException.class, () ->
+            legacyDefendantAccountService.addPaymentTerms(1L, "BU", "U",
+                                                          "\"1\"", "auth", null)
+        );
+    }
+
+    @Test
+    void addPaymentTerms_whenGatewayResponseWithLegacyFailure_thenStillReturnMappedResponse() {
+        // Given
+        var legacyResponse = AddDefendantAccountPaymentTermsLegacyResponse.builder()
+             .defendantAccountId("1")
+             .version(1)
+             .paymentTerms(LegacyPaymentTerms.builder().build())
+             .paymentCardLastRequested(LocalDate.now().minusWeeks(1))
+             .lastEnforcement("12345")
+             .build();
+
+        var gateWayResponse = new GatewayService.Response<>(HttpStatus.SERVICE_UNAVAILABLE, legacyResponse,
+                                                 "<legacy-failure/>", null);
+
+        // When
+        doReturn(gateWayResponse).when(gatewayService).postToGateway(
+            eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
+            eq(AddDefendantAccountPaymentTermsLegacyResponse.class),
+            any(),
+            Mockito.nullable(String.class)
+        );
+
+        var actualResponse = legacyDefendantAccountService.addPaymentTerms(1L, "BU",
+                                                                           "U", "\"1\"",
+                                                                           "auth", null);
+
+        // Then
+        assertNotNull(actualResponse);
+        assertThat(actualResponse.getVersion()).isEqualTo(BigInteger.valueOf(legacyResponse.getVersion()));
+        assertNotNull(actualResponse.getPaymentTerms());
+        assertThat(actualResponse.getPaymentCardLastRequested())
+            .isEqualTo(legacyResponse.getPaymentCardLastRequested());
+        assertThat(actualResponse.getLastEnforcement()).isEqualTo(legacyResponse.getLastEnforcement());
+    }
+
+    @Test
+    void addPaymentTerms_whenGatewayResponseWithSuccess_thenReturnMappedResponse() {
+        // Given
+        var legacyResponse = AddDefendantAccountPaymentTermsLegacyResponse.builder()
+            .defendantAccountId("1")
+            .version(1)
+            .paymentTerms(LegacyPaymentTerms.builder().build())
+            .paymentCardLastRequested(LocalDate.now().minusWeeks(1))
+            .lastEnforcement("12345")
+            .build();
+
+        var gateWayResponse = new GatewayService.Response<>(HttpStatus.OK, legacyResponse, null, null);
+
+        // When
+        doReturn(gateWayResponse).when(gatewayService).postToGateway(
+            eq(LegacyDefendantAccountService.ADD_PAYMENT_TERMS),
+            eq(AddDefendantAccountPaymentTermsLegacyResponse.class),
+            any(),
+            Mockito.nullable(String.class)
+        );
+
+        var actualResponse = legacyDefendantAccountService.addPaymentTerms(1L, "BU",
+                                                                           "U", "\"1\"",
+                                                                           "auth", null);
+
+        // Then
+        assertNotNull(actualResponse);
+        assertThat(actualResponse.getVersion()).isEqualTo(BigInteger.valueOf(legacyResponse.getVersion()));
+        assertNotNull(actualResponse.getPaymentTerms());
+        assertThat(actualResponse.getPaymentCardLastRequested())
+            .isEqualTo(legacyResponse.getPaymentCardLastRequested());
+        assertThat(actualResponse.getLastEnforcement()).isEqualTo(legacyResponse.getLastEnforcement());
+    }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountServiceTest.java
@@ -133,9 +133,6 @@ import uk.gov.hmcts.opal.service.opal.LocalJusticeAreaService;
 @ExtendWith(MockitoExtension.class)
 class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
 
-    private Logger logger;
-    private ListAppender<ILoggingEvent> listAppender;
-
     @Spy
     private MockRestClient restClient = spy(MockRestClient.class);
 
@@ -163,11 +160,6 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
 
     @BeforeEach
     void setUp() throws Exception {
-        logger = (Logger) LoggerFactory.getLogger("opal.LegacyDefendantAccountService");
-        listAppender = new ListAppender<>();
-        listAppender.start();
-        logger.addAppender(listAppender);
-
         gatewayService = Mockito.spy(new LegacyGatewayService(gatewayProperties, restClient));
         injectGatewayService(legacyDefendantAccountService, gatewayService);
 
@@ -182,11 +174,6 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
         field.setAccessible(true);
         field.set(legacyDefendantAccountService, gatewayService);
 
-    }
-
-    @AfterEach
-    void tearDown() {
-        logger.detachAndStopAllAppenders();
     }
 
     @SuppressWarnings("unchecked")
@@ -3373,12 +3360,6 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
             businessUnitUserId, ifMatch
         );
         assertGetDefendantAccountPaymentTermsResponse(actualResponse, legacyResponse);
-
-        // Assert logs
-        List<ILoggingEvent> logs = listAppender.list;
-        assertEquals(1, logs.size());
-        assertEquals(Level.INFO, logs.getFirst().getLevel());
-        assertEquals(":addPaymentTerms: legacy success.", logs.getFirst().getFormattedMessage());
     }
 
     private static AddPaymentTermsLegacyResponse createAddPaymentTermsLegacyResponse(long defendantAccountId,
@@ -3454,10 +3435,6 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
             requestCaptor.getValue(), defendantAccountId, businessUnitId,
             businessUnitUserId, ifMatch
         );
-
-        // Assert logs
-        List<ILoggingEvent> logs = listAppender.list;
-        assertEquals(0, logs.size());
     }
 
     @Test
@@ -3499,19 +3476,5 @@ class LegacyDefendantAccountServiceTest extends LegacyTestsBase {
             businessUnitUserId, ifMatch
         );
         assertGetDefendantAccountPaymentTermsResponse(actualResponse, legacyResponse);
-
-        // Assert logs
-        List<ILoggingEvent> logs = listAppender.list;
-        assertEquals(2, logs.size());
-        assertEquals(Level.ERROR, logs.getFirst().getLevel());
-        assertEquals(
-            ":addPaymentTerms: legacy error HTTP 503 SERVICE_UNAVAILABLE",
-            logs.getFirst().getFormattedMessage()
-        );
-        assertEquals(Level.ERROR, logs.get(1).getLevel());
-        assertEquals(
-            ":addPaymentTerms: legacy failure body:\n"
-                + "<legacy-failure/>", logs.get(1).getFormattedMessage()
-        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServicePaymentCardTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServicePaymentCardTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service.opal;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -209,9 +210,11 @@ class OpalDefendantAccountServicePaymentCardTest {
 
         var svc = new DefendantAccountPaymentTermsService(proxy, userStateService);
 
-        assertThrows(PermissionNotAllowedException.class,
+        PermissionNotAllowedException ex = assertThrows(
+            PermissionNotAllowedException.class,
             () -> svc.addPaymentCardRequest(1L, "10", "USR", "\"1\"", "AUTH")
         );
+        assertThat(ex.getPermission()).containsExactly(FinesPermission.AMEND_PAYMENT_TERMS);
 
         verifyNoInteractions(proxy);
     }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/PO-2813

We want to record authentication and authorization errors using the new security logger.

The two two types of errors are covered as follows

### 1. Authorization : Servicer layer code throwing PermissionNotAllowedException

Handled by a new common lib class: `CommonGlobalExceptionHandler`

We already have ITs covering this e.g. `DraftAccountControllerIntegrationTest#testPatchDraftAccount_withCreateManagePermission_shouldFail403`

### 2. Authentication : exceptions such as InvalidBearerTokenException (invalid access token), 

Handled by a new common lib class: `CustomOauth2AuthenticationEntryPoint`

Various AuthenticationExceptions will be handled, e.g. InvalidBearerTokenException, InsufficientAuthenticationException - all extend AuthenticationException.

We cannot write an IT for this as Spring Security is turned off. So only manual testing was possible.

### Changes to SecurityConfig.java

We are wiring in the new CustomOauth2AuthenticationEntryPoint with oauth2.authenticationEntryPoint.
The other changes are just to allow Spring to differentiate between different beans now we have two AuthenticationEntryPoint implementations.

Associated PR: https://github.com/hmcts/opal-common-lib/pull/72

### Does this PR introduce a breaking change?

```
[ ] Yes
[X ] No
```


# Test Evidence:

### Permission exception

`curl http://localhost:4550/draft-accounts/100001  -H "Accept: application/json" -H "Authorization: Bearer $ACCESS_TOKEN" -v      `

```
2026-03-06T12:02:14.395 WARN  [http-nio-4550-exec-4] opal.LoggingExceptionResolver :resolveException: PermissionNotAllowedException: '[CREATE_MANAGE_DRAFT_ACCOUNTS, CHECK_VALIDATE_DRAFT_ACCOUNTS] permission(s) are not enabled for the user.'
2026-03-06T12:02:14.396 INFO  [http-nio-4550-exec-4] opal.UserStateClientService :getUserState: Fetching user state for specific userId: 0
2026-03-06T12:02:14.396 INFO  [http-nio-4550-exec-4] opal.UserStateClientService :getUserState: Fetching user state for userId: 0
2026-03-06T12:02:14.416 INFO  [http-nio-4550-exec-4] opal.EventLoggingService Authorisation Access Control,Failure,2026-03-06T12:02:14.415591209,fines,,3c35e56ff9814988bd9a86942f117e46,Authentication,2026-03-06T12:02:08.728632262,Permission=CREATE_MANAGE_DRAFT_ACCOUNTS:CHECK_VALIDATE_DRAFT_ACCOUNTS,UserIdentifier=500000000,Resource='Unknown'
```


### Invalid token

`curl http://localhost:4550/business-units/5  -H "Accept: application/json" -verbose -H "Authorization: Bearer xxx"
`

```
2026-03-06T12:40:31.035 ERROR [http-nio-4550-exec-10] opal.AccessTokenService :extractClaim: Unable to extract claims from JWT Token: Invalid JWT serialization: Missing dot delimiter(s)
2026-03-06T12:40:31.043 INFO  [http-nio-4550-exec-10] opal.EventLoggingService Authorisation Access Control,Failure,2026-03-06T12:40:31.042537508,fines,,1392d989c66644058c2fb83a1d421792,Authentication,2026-03-06T12:40:31.041072674,Details=Invalid JWT serialization: Missing dot delimiter(s),UserIdentifier=192.168.65.1,Resource=/business-units/5
```


### Expired token

`curl http://localhost:4550/business-units/5  —VERBOSE -H "Accept: application/json" -verbose -H "Authorization: Bearer <EXPIRED_TOKEN>"`

`2026-03-06T12:39:03.399 INFO  [http-nio-4550-exec-9] opal.EventLoggingService Authorisation Access Control,Failure,2026-03-06T12:39:03.398260342,fines,,5afd8f90a26147f49485ca42232f54be,Authentication,2026-03-06T12:39:03.394426259,Details=An error occurred while attempting to decode the Jwt: Jwt expired at 2026-03-04T17:06:23Z,UserIdentifier=4d432627-dd62-41bd-b6c2-08e61eb836d9,Resource=/business-units/5%c2%a0
`