### PR TITLE
Po 2257 add report queue consumer service

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ This is already bundled with the docker-compose setup.
 To view any messages sent to the queues/topics you can use a tool like 'Azure Service Bus Explorer'.
 Or you can use the PeekSbEmulator class that is setup in test/java/uk/gov/hmcts/opal/support/PeekSbEmulator.java to do this simply call the main method of this class you can add a argument to specify which queue/topic you want to peek messages from.
 
+## Azurite emulator (for Azure Blob Storage)
+This is already bundled with the docker-compose setup.
+To view blobs stored in Azurite use 'Azure Service Bus Explorer'
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details

--- a/build.gradle
+++ b/build.gradle
@@ -315,7 +315,7 @@ sonarqube {
     property "sonar.projectKey", "uk.gov.hmcts:opal-fines-service"
     property "sonar.gradle.skipCompile", "true"
     property "sonar.exclusions", coverageExclusions.join(', ')
-    property 'sonar.coverage.exclusions', "**/entity/*,**/model/*,**/exception/*,**/config/**,**/repository/jpa/*,**/opal/dto/*,**/service/report/ReportMetaData.java"
+    property 'sonar.coverage.exclusions', "**/entity/*,**/model/*,**/exception/*,**/config/**,**/repository/jpa/*,**/opal/dto/*"
     property 'sonar.cpd.exclusions', "**/entity/*,**/opal/dto/**,**/service/DefendantAccountService.java,**/service/legacy/LegacyDefendantAccountService.java,**/service/opal/OpalDefendantAccountService.java"
   }
 }
@@ -379,6 +379,7 @@ dependencies {
   openapiImplementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.20.1"
 
   implementation 'com.microsoft.azure:applicationinsights-spring-boot-starter:2.6.4'
+  implementation("com.azure:azure-storage-blob:12.33.2")
   implementation "org.springframework.boot:spring-boot-starter-web:${springVersion}"
   implementation "org.springframework.boot:spring-boot-starter-actuator:${springVersion}"
   implementation "org.springframework.boot:spring-boot-starter-aop:${springVersion}"
@@ -397,6 +398,7 @@ dependencies {
   implementation 'org.springframework.security:spring-security-oauth2-authorization-server:1.5.5'
 
   implementation 'org.springframework:spring-aspects'
+  implementation 'org.springframework:spring-jms'
   implementation 'commons-fileupload:commons-fileupload:1.6.0'
   implementation 'org.springframework.cloud:spring-cloud-starter-openfeign', {
     exclude group: 'commons-fileupload', module: 'commons-fileupload'
@@ -408,6 +410,7 @@ dependencies {
 
   implementation "org.apache.logging.log4j:log4j-api:${log4JVersion}"
   implementation "org.apache.logging.log4j:log4j-to-slf4j:${log4JVersion}"
+  implementation 'org.apache.qpid:qpid-jms-client:2.10.0'
   implementation 'com.google.guava:guava:33.5.0-jre'
 
   implementation 'com.launchdarkly:launchdarkly-java-server-sdk:7.12.0'

--- a/build.gradle
+++ b/build.gradle
@@ -378,8 +378,7 @@ dependencies {
   openapiImplementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.20.1"
 
   implementation 'com.microsoft.azure:applicationinsights-spring-boot-starter:2.6.4'
-
-  implementation("com.azure:azure-storage-blob:12.33.2")
+  implementation 'com.azure:azure-storage-blob:12.33.2'
   implementation "org.springframework.boot:spring-boot-starter-web"
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.springframework.boot:spring-boot-starter-aop"

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -1,6 +1,8 @@
 include:
   - path: ../opal-shared-infrastructure/docker-compose.yml
   - path: ../opal-shared-infrastructure/docker-compose-service-bus.yml
+  - path: ../opal-shared-infrastructure/docker-compose-blob-storage.yml
+
 
 services:
   opal-fines-service:
@@ -27,12 +29,18 @@ services:
       - TESTING_SUPPORT_ENDPOINTS_ENABLED=true
       - OPAL_REDIS_ENABLED=false
       - SERVICEBUS_CONNECTION_STRING=Endpoint=sb://sb-emulator/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=local;UseDevelopmentEmulator=true
+      - AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1+...;BlobEndpoint=http://azurite:10000/devstoreaccount1;
+      - AZURE_STORAGE_CONTAINER=test-container
+
+
     ports:
       - "${FINES_PORT:-4550}:4550"
     depends_on:
       - opal-db
       - redis
       - azure-sb-emulator
+      - azurite
     networks:
       - default
       - sb-emulator
+      - storage-emulator

--- a/src/integrationTest/java/uk/gov/hmcts/opal/config/ReportQueueConnectivityIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/config/ReportQueueConnectivityIntegrationTest.java
@@ -14,6 +14,7 @@ import java.util.Enumeration;
 import org.apache.qpid.jms.JmsConnectionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.opal.service.messaging.ReportQueueMessage;
@@ -27,7 +28,7 @@ import uk.gov.hmcts.opal.service.messaging.ReportQueueMessage;
  * Storage Explorer and connect it to your local running Azurite instance. - To view messages on the queue use
  * peekAtQueue()</p>
  */
-//@EnabledIfEnvironmentVariable(named = "REPORT_QUEUE_ASB_TEST_ENABLED", matches = "true")
+@EnabledIfEnvironmentVariable(named = "REPORT_QUEUE_ASB_TEST_ENABLED", matches = "true")
 class ReportQueueConnectivityIntegrationTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ReportQueueConnectivityIntegrationTest.class);

--- a/src/integrationTest/java/uk/gov/hmcts/opal/config/ReportQueueConnectivityIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/config/ReportQueueConnectivityIntegrationTest.java
@@ -33,21 +33,17 @@ class ReportQueueConnectivityIntegrationTest {
 
     private final ObjectMapper objectMapper = JsonMapper.builder().build();
 
-    private String connectionString;
-
     private String queueName;
-
-    private String protocol;
 
     private JmsConnectionFactory connectionFactory;
 
     @BeforeEach
     void setUp() {
-        connectionString = optionalEnv("SERVICEBUS_CONNECTION_STRING",
+        String connectionString = optionalEnv("SERVICEBUS_CONNECTION_STRING",
             "Endpoint=sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=local;"
                 + "UseDevelopmentEmulator=true");
         queueName = optionalEnv("SERVICEBUS_REPORT_QUEUE_NAME", "report");
-        protocol = optionalEnv("SERVICEBUS_REPORT_PROTOCOL", "amqp");
+        String protocol = optionalEnv("SERVICEBUS_REPORT_PROTOCOL", "amqp");
 
         ServiceBusConnectionStringParser.ConnectionDetails details =
             ServiceBusConnectionStringParser.parse(connectionString);

--- a/src/integrationTest/java/uk/gov/hmcts/opal/config/ReportQueueConnectivityIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/config/ReportQueueConnectivityIntegrationTest.java
@@ -1,0 +1,99 @@
+package uk.gov.hmcts.opal.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import jakarta.jms.JMSContext;
+import jakarta.jms.Message;
+import jakarta.jms.Queue;
+import jakarta.jms.QueueBrowser;
+import jakarta.jms.TextMessage;
+import java.util.Enumeration;
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.hmcts.opal.service.messaging.ReportQueueMessage;
+
+/**
+ * Manual helper that publishes a report message to a queue for developer testing.
+ *
+ * - Before using this test, set the environment variable REPORT_QUEUE_ASB_TEST_ENABLED=true
+ * - Ensure that you have run the docker scripts in `opal-shared-infrastructure and that Azure Service Bus and
+ *   Azurite are running in docker
+ * - To check that Blob files have been saved to Blob storage you can install Microsoft Azure Storage Explorer and
+ *   connect it to your local running Azurite instance.
+ * - To view messages on the queue use peekAtQueue()
+ */
+@EnabledIfEnvironmentVariable(named = "REPORT_QUEUE_ASB_TEST_ENABLED", matches = "true")
+class ReportQueueConnectivityIntegrationTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReportQueueConnectivityIntegrationTest.class);
+
+    private final ObjectMapper objectMapper = JsonMapper.builder().build();
+
+    private String connectionString;
+
+    private String queueName;
+
+    private String protocol;
+
+    private JmsConnectionFactory connectionFactory;
+
+    @BeforeEach
+    void setUp() {
+        connectionString = optionalEnv("SERVICEBUS_CONNECTION_STRING",
+            "Endpoint=sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=local;"
+                + "UseDevelopmentEmulator=true");
+        queueName = optionalEnv("SERVICEBUS_REPORT_QUEUE_NAME", "report");
+        protocol = optionalEnv("SERVICEBUS_REPORT_PROTOCOL", "amqp");
+
+        ServiceBusConnectionStringParser.ConnectionDetails details =
+            ServiceBusConnectionStringParser.parse(connectionString);
+
+        String remoteUri = "%s://%s".formatted(protocol, details.fullyQualifiedNamespace());
+        connectionFactory = new JmsConnectionFactory(remoteUri);
+        connectionFactory.setUsername(details.sharedAccessKeyName());
+        connectionFactory.setPassword(details.sharedAccessKey());
+    }
+
+    @Test
+    void sendsReportMessageToQueue() throws Exception {
+        long instanceId = 99000000008000L;
+
+        try (JMSContext context = connectionFactory.createContext(JMSContext.AUTO_ACKNOWLEDGE)) {
+            Queue queue = context.createQueue(queueName);
+            context.createProducer().send(queue, objectMapper.writeValueAsString(new ReportQueueMessage(instanceId)));
+
+            LOGGER.info("Sent Report test message with instanceId={}", instanceId);
+        }
+    }
+
+    @Test
+    void peekAtQueue() throws Exception {
+        try (JMSContext context = connectionFactory.createContext(JMSContext.AUTO_ACKNOWLEDGE)) {
+            Queue queue = context.createQueue(queueName);
+            QueueBrowser browser = context.createBrowser(queue);
+            Enumeration<?> messages = browser.getEnumeration();
+
+            if (messages.hasMoreElements()) {
+                Message message = (Message) messages.nextElement();
+
+                if (message instanceof TextMessage textMessage) {
+                    System.out.println("Peeked message: " + textMessage.getText());
+                }
+            } else {
+                System.out.println("Queue is empty");
+            }
+        }
+    }
+
+    private static String optionalEnv(String name, String defaultValue) {
+        String value = System.getenv(name);
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        return value;
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/opal/config/ReportQueueConnectivityIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/config/ReportQueueConnectivityIntegrationTest.java
@@ -19,12 +19,12 @@ import uk.gov.hmcts.opal.service.messaging.ReportQueueMessage;
 /**
  * Manual helper that publishes a report message to a queue for developer testing.
  *
- * - Before using this test, set the environment variable REPORT_QUEUE_ASB_TEST_ENABLED=true
+ *<p>Before using this test, set the environment variable REPORT_QUEUE_ASB_TEST_ENABLED=true
  * - Ensure that you have run the docker scripts in `opal-shared-infrastructure and that Azure Service Bus and
  *   Azurite are running in docker
  * - To check that Blob files have been saved to Blob storage you can install Microsoft Azure Storage Explorer and
  *   connect it to your local running Azurite instance.
- * - To view messages on the queue use peekAtQueue()
+ * - To view messages on the queue use peekAtQueue()</p>
  */
 @EnabledIfEnvironmentVariable(named = "REPORT_QUEUE_ASB_TEST_ENABLED", matches = "true")
 class ReportQueueConnectivityIntegrationTest {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/config/ReportQueueConnectivityIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/config/ReportQueueConnectivityIntegrationTest.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.opal.config;
 
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import jakarta.jms.JMSContext;
@@ -11,7 +14,6 @@ import java.util.Enumeration;
 import org.apache.qpid.jms.JmsConnectionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.opal.service.messaging.ReportQueueMessage;
@@ -19,14 +21,13 @@ import uk.gov.hmcts.opal.service.messaging.ReportQueueMessage;
 /**
  * Manual helper that publishes a report message to a queue for developer testing.
  *
- *<p>Before using this test, set the environment variable REPORT_QUEUE_ASB_TEST_ENABLED=true
- * - Ensure that you have run the docker scripts in `opal-shared-infrastructure and that Azure Service Bus and
- *   Azurite are running in docker
- * - To check that Blob files have been saved to Blob storage you can install Microsoft Azure Storage Explorer and
- *   connect it to your local running Azurite instance.
- * - To view messages on the queue use peekAtQueue()</p>
+ * <p>Before using this test, set the environment variable REPORT_QUEUE_ASB_TEST_ENABLED=true
+ * - Ensure that you have run the docker scripts in `opal-shared-infrastructure and that Azure Service Bus and Azurite
+ * are running in docker - To check that Blob files have been saved to Blob storage you can install Microsoft Azure
+ * Storage Explorer and connect it to your local running Azurite instance. - To view messages on the queue use
+ * peekAtQueue()</p>
  */
-@EnabledIfEnvironmentVariable(named = "REPORT_QUEUE_ASB_TEST_ENABLED", matches = "true")
+//@EnabledIfEnvironmentVariable(named = "REPORT_QUEUE_ASB_TEST_ENABLED", matches = "true")
 class ReportQueueConnectivityIntegrationTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ReportQueueConnectivityIntegrationTest.class);
@@ -56,6 +57,16 @@ class ReportQueueConnectivityIntegrationTest {
 
     @Test
     void sendsReportMessageToQueue() throws Exception {
+
+        BlobServiceClient blobService = new BlobServiceClientBuilder()
+            .connectionString("UseDevelopmentStorage=true")
+            .buildClient();
+        String containerName = "reports";
+        BlobContainerClient container = blobService.getBlobContainerClient(containerName);
+        if (!container.exists()) {
+            container.create();
+        }
+
         long instanceId = 99000000008000L;
 
         try (JMSContext context = connectionFactory.createContext(JMSContext.AUTO_ACKNOWLEDGE)) {

--- a/src/main/java/uk/gov/hmcts/opal/config/QueueConsumerJmsConfig.java
+++ b/src/main/java/uk/gov/hmcts/opal/config/QueueConsumerJmsConfig.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.opal.config;
+
+import jakarta.jms.ConnectionFactory;
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jms.annotation.EnableJms;
+import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
+import org.springframework.jms.connection.CachingConnectionFactory;
+
+@EnableJms
+@Configuration
+@EnableConfigurationProperties(QueueConsumerProperties.class)
+@ConditionalOnProperty(prefix = "opal.report.consumer", name = "enabled", havingValue = "true")
+public class QueueConsumerJmsConfig {
+
+    @Bean
+    public ConnectionFactory reportConsumerConnectionFactory(QueueConsumerProperties properties) {
+        ServiceBusConnectionStringParser.ConnectionDetails details =
+            ServiceBusConnectionStringParser.parse(properties.getConnectionString());
+
+        String remoteUri = "%s://%s?amqp.idleTimeout=%d".formatted(
+            properties.getProtocol(),
+            details.fullyQualifiedNamespace(),
+            properties.getIdleTimeoutMs()
+        );
+
+        JmsConnectionFactory qpidFactory = new JmsConnectionFactory(remoteUri);
+        qpidFactory.setUsername(details.sharedAccessKeyName());
+        qpidFactory.setPassword(details.sharedAccessKey());
+        return new CachingConnectionFactory(qpidFactory);
+    }
+
+    @Bean
+    public DefaultJmsListenerContainerFactory reportListenerContainerFactory(
+        ConnectionFactory reportConsumerConnectionFactory) {
+        DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
+        factory.setConnectionFactory(reportConsumerConnectionFactory);
+        factory.setSessionTransacted(true);
+        return factory;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/opal/config/QueueConsumerProperties.java
+++ b/src/main/java/uk/gov/hmcts/opal/config/QueueConsumerProperties.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.opal.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "opal.report.consumer")
+@Data
+public class QueueConsumerProperties {
+
+    private boolean enabled;
+    private String connectionString;
+    private String queueName;
+    private String protocol = "amqp";
+    private long idleTimeoutMs;
+
+}

--- a/src/main/java/uk/gov/hmcts/opal/config/ServiceBusConnectionStringParser.java
+++ b/src/main/java/uk/gov/hmcts/opal/config/ServiceBusConnectionStringParser.java
@@ -1,0 +1,61 @@
+package uk.gov.hmcts.opal.config;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+final class ServiceBusConnectionStringParser {
+
+    private ServiceBusConnectionStringParser() {
+        // Utility class
+    }
+
+    static ConnectionDetails parse(String connectionString) {
+        if (connectionString == null || connectionString.isBlank()) {
+            throw new IllegalArgumentException("Connection string must not be blank");
+        }
+
+        Map<String, String> parts = Arrays.stream(connectionString.split(";"))
+            .map(String::trim)
+            .filter(part -> !part.isEmpty())
+            .map(part -> part.split("=", 2))
+            .collect(Collectors.toMap(
+                entry -> entry[0],
+                entry -> entry.length > 1 ? entry[1] : ""
+            ));
+
+        String endpoint = parts.get("Endpoint");
+        if (endpoint == null || endpoint.isBlank()) {
+            throw new IllegalArgumentException("Connection string missing endpoint segment");
+        }
+
+        URI endpointUri;
+        try {
+            endpointUri = URI.create(endpoint);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Endpoint segment invalid uri", ex);
+        }
+        String host = endpointUri.getHost();
+        if (host == null || host.isBlank()) {
+            throw new IllegalArgumentException("Endpoint segment missing host");
+        }
+
+        String keyName = parts.get("SharedAccessKeyName");
+        if (keyName == null || keyName.isBlank()) {
+            throw new IllegalArgumentException("Connection string missing SharedAccessKeyName");
+        }
+
+        String key = parts.get("SharedAccessKey");
+        if (key == null || key.isBlank()) {
+            throw new IllegalArgumentException("Connection string missing SharedAccessKey");
+        }
+
+        return new ConnectionDetails(host, keyName, key);
+    }
+
+    record ConnectionDetails(String fullyQualifiedNamespace,
+                             String sharedAccessKeyName,
+                             String sharedAccessKey) {
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/entity/ReportEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/ReportEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.Duration;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -34,5 +35,8 @@ public class ReportEntity {
 
     @Column(name = "audited_report", nullable = false)
     private String auditedReport;
+
+    @Column(name = "retention_period", length = 30)
+    private Duration retentionPeriod;
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/entity/ReportInstanceEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/ReportInstanceEntity.java
@@ -64,7 +64,7 @@ public class ReportInstanceEntity {
     @Enumerated(EnumType.STRING)
     private ReportInstanceGenerationStatus generationStatus;
 
-    @Column(name = "location", length = 30)
+    @Column(name = "location", length = 36)
     private String location;
 
     @Column(name = "created_timestamp")

--- a/src/main/java/uk/gov/hmcts/opal/entity/ReportInstanceEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/ReportInstanceEntity.java
@@ -2,25 +2,32 @@ package uk.gov.hmcts.opal.entity;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators.PropertyGenerator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitFullEntity;
-
-import java.time.LocalDate;
+import org.hibernate.annotations.JdbcType;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.dialect.PostgreSQLEnumJdbcType;
+import org.hibernate.type.SqlTypes;
+import uk.gov.hmcts.opal.service.report.ReportError;
+import uk.gov.hmcts.opal.service.report.ReportInstanceGenerationStatus;
+import uk.gov.hmcts.opal.util.LocalDateTimeAdapter;
 
 @Entity
 @Table(name = "report_instances")
@@ -29,7 +36,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @Builder
 @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
-@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "reportInstanceId")
+@JsonIdentityInfo(generator = PropertyGenerator.class, property = "reportInstanceId")
 public class ReportInstanceEntity {
 
     @Id
@@ -40,26 +47,40 @@ public class ReportInstanceEntity {
     private Long reportInstanceId;
 
     @Column(name = "report_id", nullable = false)
-    private Long reportId;
+    private String reportId;
 
-    @ManyToOne
-    @JoinColumn(name = "business_unit_id", nullable = false)
-    private BusinessUnitFullEntity businessUnit;
+    @Column(name = "business_unit_id")
+    private List<Long> businessUnit;
 
     @Column(name = "audit_sequence", nullable = false)
     private Long auditSequence;
 
-    @Column(name = "generated_date", nullable = false)
-    @Temporal(TemporalType.DATE)
-    private LocalDate generatedDate;
-
-    @Column(name = "generated_by", length = 20, nullable = false)
-    private String generatedBy;
-
-    @Column(name = "report_parameters", nullable = false)
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "report_parameters", columnDefinition = "json", nullable = false)
     private String reportParameters;
 
-    @Column(name = "content", nullable = false)
-    private String content;
+    @JdbcType(PostgreSQLEnumJdbcType.class)
+    @Column(name = "generation_status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ReportInstanceGenerationStatus generationStatus;
 
+    @Column(name = "location", length = 30)
+    private String location;
+
+    @Column(name = "created_timestamp")
+    @Temporal(TemporalType.TIMESTAMP)
+    @XmlJavaTypeAdapter(LocalDateTimeAdapter.class)
+    private LocalDateTime createdTimestamp;
+
+    @Column(name = "scheduled_deletion_timestamp")
+    @Temporal(TemporalType.TIMESTAMP)
+    @XmlJavaTypeAdapter(LocalDateTimeAdapter.class)
+    private LocalDateTime scheduledDeletionTimestamp;
+
+    @Column(name = "no_of_records")
+    private Short noOfRecords;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "errors", columnDefinition = "json")
+    private ReportError errors;
 }

--- a/src/main/java/uk/gov/hmcts/opal/exception/EntityNotSavedException.java
+++ b/src/main/java/uk/gov/hmcts/opal/exception/EntityNotSavedException.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.opal.exception;
+
+public class EntityNotSavedException extends RuntimeException {
+
+
+    public EntityNotSavedException(String message) {
+        super(message);
+    }
+
+    public EntityNotSavedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/opal/exception/EntityNotSavedException.java
+++ b/src/main/java/uk/gov/hmcts/opal/exception/EntityNotSavedException.java
@@ -2,11 +2,6 @@ package uk.gov.hmcts.opal.exception;
 
 public class EntityNotSavedException extends RuntimeException {
 
-
-    public EntityNotSavedException(String message) {
-        super(message);
-    }
-
     public EntityNotSavedException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/uk/gov/hmcts/opal/exception/ReportGenerationException.java
+++ b/src/main/java/uk/gov/hmcts/opal/exception/ReportGenerationException.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.opal.exception;
+
+public class ReportGenerationException extends RuntimeException {
+
+
+    public ReportGenerationException(String message) {
+        super(message);
+    }
+
+    public ReportGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/opal/exception/ReportGenerationException.java
+++ b/src/main/java/uk/gov/hmcts/opal/exception/ReportGenerationException.java
@@ -2,11 +2,6 @@ package uk.gov.hmcts.opal.exception;
 
 public class ReportGenerationException extends RuntimeException {
 
-
-    public ReportGenerationException(String message) {
-        super(message);
-    }
-
     public ReportGenerationException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/main/java/uk/gov/hmcts/opal/exception/ReportNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/opal/exception/ReportNotFoundException.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.opal.exception;
+
+public class ReportNotFoundException extends RuntimeException {
+
+
+    public ReportNotFoundException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/opal/exception/ReportNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/opal/exception/ReportNotFoundException.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.opal.exception;
 
 public class ReportNotFoundException extends RuntimeException {
 
-
     public ReportNotFoundException(String message) {
         super(message);
     }

--- a/src/main/java/uk/gov/hmcts/opal/repository/ReportInstanceRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/ReportInstanceRepository.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.opal.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.hmcts.opal.entity.ReportInstanceEntity;
+
+@Repository
+public interface ReportInstanceRepository extends JpaRepository<ReportInstanceEntity, Long> {
+
+}

--- a/src/main/java/uk/gov/hmcts/opal/repository/ReportRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/ReportRepository.java
@@ -7,5 +7,5 @@ import uk.gov.hmcts.opal.entity.ReportEntity;
 @Repository
 public interface ReportRepository extends JpaRepository<ReportEntity, String> {
 
-    void deleteByReportId(String reportId);
+    ReportEntity getByReportId(String reportId);
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/blobstore/AzureStorageConfig.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/blobstore/AzureStorageConfig.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.opal.service.blobstore;
+
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AzureStorageConfig {
+
+    @Value("${opal.report.storage.connection-string}")
+    private String connectionString;
+
+    @Bean
+    public BlobServiceClient blobServiceClient() {
+        return new BlobServiceClientBuilder()
+            .connectionString(connectionString)
+            .buildClient();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/blobstore/ReportBlobStore.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/blobstore/ReportBlobStore.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.opal.service.blobstore;
+
+public interface ReportBlobStore {
+
+    String storeReport(String jsonReport);
+
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/blobstore/ReportBlobStoreService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/blobstore/ReportBlobStoreService.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.opal.service.blobstore;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
-import com.azure.storage.blob.models.BlobStorageException;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/uk/gov/hmcts/opal/service/blobstore/ReportBlobStoreService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/blobstore/ReportBlobStoreService.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.opal.service.blobstore;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.BlobStorageException;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
@@ -28,7 +29,7 @@ public class ReportBlobStoreService implements ReportBlobStore {
     public String storeReport(String report) {
         BlobContainerClient container = blobServiceClient.getBlobContainerClient(containerName);
         if (!container.exists()) {
-            container.create();
+            throw new IllegalArgumentException("Blob container does not exist");
         }
         String location = String.valueOf(uuidProvider.getUuid());
         BlobClient blob = container.getBlobClient(location);

--- a/src/main/java/uk/gov/hmcts/opal/service/blobstore/ReportBlobStoreService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/blobstore/ReportBlobStoreService.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.opal.service.blobstore;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.opal.util.UuidProvider;
+
+@Service
+@Slf4j(topic = "opal.ReportBlobStoreService")
+public class ReportBlobStoreService implements ReportBlobStore {
+
+    private final BlobServiceClient blobServiceClient;
+    private final UuidProvider uuidProvider;
+    private final String containerName;
+
+    public ReportBlobStoreService(BlobServiceClient blobServiceClient, UuidProvider uuidProvider,
+        @Value("${opal.report.storage.container}") String containerName) {
+        this.blobServiceClient = blobServiceClient;
+        this.containerName = containerName;
+        this.uuidProvider = uuidProvider;
+    }
+
+    public String storeReport(String report) {
+        BlobContainerClient container = blobServiceClient.getBlobContainerClient(containerName);
+        if (!container.exists()) {
+            container.create();
+        }
+        String location = String.valueOf(uuidProvider.getUuid());
+        BlobClient blob = container.getBlobClient(location);
+        if (!blob.exists()) {
+            byte[] bytes = report.getBytes(StandardCharsets.UTF_8);
+            blob.upload(new ByteArrayInputStream(bytes), bytes.length);
+            log.info("Stored report at location: {}", location);
+            return location;
+        } else {
+            return storeReport(report);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/messaging/QueueConsumerInterface.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/messaging/QueueConsumerInterface.java
@@ -1,0 +1,11 @@
+package uk.gov.hmcts.opal.service.messaging;
+
+public interface QueueConsumerInterface {
+
+    /**
+     * Handles queue messages once they are received from Azure Service Bus.
+     */
+
+    void consume(String messagePayload);
+
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/messaging/ReportQueueConsumerService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/messaging/ReportQueueConsumerService.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.opal.service.messaging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.opal.service.report.GenericReportService;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j(topic = "opal.ReportQueueConsumer")
+public class ReportQueueConsumerService implements QueueConsumerInterface {
+
+    private final ObjectMapper objectMapper;
+    private final GenericReportService genericReportService;
+
+    @Override
+    public void consume(String messagePayload) {
+        ReportQueueMessage message = parse(messagePayload);
+        genericReportService.generateReportInstanceContent(message.instanceId());
+        log.info("Report queue message received: {}", message);
+    }
+
+    private ReportQueueMessage parse(String messagePayload) {
+        if (messagePayload == null || messagePayload.isBlank()) {
+            throw new IllegalArgumentException("Report message payload is blank");
+        }
+        try {
+            return objectMapper.readValue(messagePayload, ReportQueueMessage.class);
+        } catch (IOException ex) {
+            log.error("Report queue message parse failed", ex);
+            throw new IllegalArgumentException("Unable to parse Report message payload", ex);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/messaging/ReportQueueListener.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/messaging/ReportQueueListener.java
@@ -24,7 +24,6 @@ public class ReportQueueListener {
     public void onMessage(Message message) throws JMSException {
         if (message instanceof TextMessage textMessage) {
             String payload = textMessage.getText();
-            log.debug("Report queue message received payload={}", payload);
             consumer.consume(payload);
         } else {
             throw new IllegalArgumentException("Message must be of type TextMessage");

--- a/src/main/java/uk/gov/hmcts/opal/service/messaging/ReportQueueListener.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/messaging/ReportQueueListener.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.opal.service.messaging;
+
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.TextMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.jms.annotation.JmsListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j(topic = "opal.ReportQueueListener")
+@ConditionalOnProperty(prefix = "opal.report.consumer", name = "enabled", havingValue = "true")
+public class ReportQueueListener {
+
+    private final ReportQueueConsumerService consumer;
+
+    @JmsListener(
+        destination = "${opal.report.consumer.queue-name}",
+        containerFactory = "reportListenerContainerFactory"
+    )
+    public void onMessage(Message message) throws JMSException {
+        if (message instanceof TextMessage textMessage) {
+            String payload = textMessage.getText();
+            log.debug("Report queue message received payload={}", payload);
+            consumer.consume(payload);
+        } else {
+            throw new IllegalArgumentException("Message must be of type TextMessage");
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/messaging/ReportQueueMessage.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/messaging/ReportQueueMessage.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.opal.service.messaging;
+
+public record ReportQueueMessage(
+    Long instanceId
+) {
+
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/report/GenericReportService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/GenericReportService.java
@@ -1,0 +1,100 @@
+package uk.gov.hmcts.opal.service.report;
+
+import static uk.gov.hmcts.opal.service.report.ReportInstanceGenerationStatus.IN_PROGRESS;
+import static uk.gov.hmcts.opal.service.report.ReportInstanceGenerationStatus.READY;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.opal.entity.ReportEntity;
+import uk.gov.hmcts.opal.entity.ReportInstanceEntity;
+import uk.gov.hmcts.opal.exception.EntityNotSavedException;
+import uk.gov.hmcts.opal.exception.ReportGenerationException;
+import uk.gov.hmcts.opal.repository.ReportInstanceRepository;
+import uk.gov.hmcts.opal.repository.ReportRepository;
+import uk.gov.hmcts.opal.service.blobstore.ReportBlobStore;
+import uk.gov.hmcts.opal.util.LogUtil;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j(topic = "opal.ReportService")
+public class GenericReportService implements GenericReportServiceInterface {
+
+    private final ReportInstanceRepository reportInstanceRepository;
+    private final ReportRepository reportRepository;
+    private final ReportRegistry reportRegistry;
+    private final ReportBlobStore blobStore;
+    private final Clock clock;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public void generateReportInstanceContent(Long id) {
+        final LocalDateTime currentTimestamp = LocalDateTime.now(clock);
+        ReportInstanceEntity instance =
+            reportInstanceRepository.findById(id).orElseThrow(EntityNotFoundException::new);
+        try {
+            String templateId = instance.getReportId();
+            final ReportInterface<?> reportTemplate = reportRegistry.get(templateId);
+            instance.setGenerationStatus(IN_PROGRESS);
+            instance.setErrors(null);
+            saveReportInstance(instance);
+            ReportDataInterface data = reportTemplate.generateReportData(instance);
+            final String location = blobStore.storeReport(getDataAsJson(data));
+            instance.setLocation(location);
+            instance.setGenerationStatus(READY);
+            instance.setCreatedTimestamp(currentTimestamp);
+            instance.setNoOfRecords(data.getNumberOfRecords());
+            ReportEntity reportEntity = reportRepository.getByReportId(templateId);
+            var retentionPeriod = reportEntity.getRetentionPeriod();
+            if (retentionPeriod != null) {
+                instance.setScheduledDeletionTimestamp(currentTimestamp.plus(retentionPeriod));
+            }
+            saveReportInstance(instance);
+        } catch (EntityNotSavedException e) {
+            throw new ReportGenerationException("Unable to save report instance", e);
+        } catch (Exception e) {
+            processError(instance, e);
+            saveReportInstance(instance);
+            throw new ReportGenerationException("Error generating report instance", e);
+        }
+    }
+
+    private void saveReportInstance(ReportInstanceEntity instance) {
+        try {
+            reportInstanceRepository.saveAndFlush(instance);
+        } catch (Exception e) {
+            throw new EntityNotSavedException("Unable to save report instance", e);
+        }
+    }
+
+    private String getDataAsJson(ReportDataInterface data) throws JsonProcessingException {
+        return mapper.writeValueAsString(
+            Data.builder()
+                .reportData(data)
+                .reportMetaData(data.getReportMetaData())
+                .build()
+        );
+    }
+
+    private static void processError(ReportInstanceEntity instance, Exception exception) {
+        instance.setGenerationStatus(ReportInstanceGenerationStatus.ERROR);
+        instance.setErrors(ReportError.builder()
+            .operationId(LogUtil.getOrCreateOpalOperationId())
+            .error(String.format("%s: %s", exception.getClass().getName(), exception.getMessage())).build());
+    }
+
+    @Builder
+    @lombok.Data
+    static class Data<T> {
+
+        private T reportData;
+        private ReportMetaData reportMetaData;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/report/GenericReportService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/GenericReportService.java
@@ -73,6 +73,13 @@ public class GenericReportService implements GenericReportServiceInterface {
         }
     }
 
+    private static void processError(ReportInstanceEntity instance, Exception exception) {
+        instance.setGenerationStatus(ReportInstanceGenerationStatus.ERROR);
+        instance.setErrors(ReportError.builder()
+            .operationId(LogUtil.getOrCreateOpalOperationId())
+            .error(String.format("%s: %s", exception.getClass().getName(), exception.getMessage())).build());
+    }
+
     private String getDataAsJson(ReportDataInterface data) throws JsonProcessingException {
         return mapper.writeValueAsString(
             Data.builder()
@@ -82,17 +89,9 @@ public class GenericReportService implements GenericReportServiceInterface {
         );
     }
 
-    private static void processError(ReportInstanceEntity instance, Exception exception) {
-        instance.setGenerationStatus(ReportInstanceGenerationStatus.ERROR);
-        instance.setErrors(ReportError.builder()
-            .operationId(LogUtil.getOrCreateOpalOperationId())
-            .error(String.format("%s: %s", exception.getClass().getName(), exception.getMessage())).build());
-    }
-
     @Builder
     @lombok.Data
     static class Data<T> {
-
         private T reportData;
         private ReportMetaData reportMetaData;
     }

--- a/src/main/java/uk/gov/hmcts/opal/service/report/GenericReportServiceInterface.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/GenericReportServiceInterface.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.opal.service.report;
+
+public interface GenericReportServiceInterface {
+
+    void generateReportInstanceContent(Long id);
+
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/report/ReportDataInterface.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/ReportDataInterface.java
@@ -2,7 +2,7 @@ package uk.gov.hmcts.opal.service.report;
 
 public interface ReportDataInterface {
 
-    long getNumberOfRecords();
+    short getNumberOfRecords();
 
     ReportMetaData getReportMetaData();
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/report/ReportError.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/ReportError.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.opal.service.report;
+
+import lombok.Builder;
+
+@Builder
+public record ReportError(String operationId, String error) {
+
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/report/ReportInstanceGenerationStatus.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/ReportInstanceGenerationStatus.java
@@ -1,0 +1,11 @@
+package uk.gov.hmcts.opal.service.report;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public enum ReportInstanceGenerationStatus {
+    REQUESTED,
+    IN_PROGRESS,
+    READY,
+    ERROR
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/report/ReportInterface.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/ReportInterface.java
@@ -5,6 +5,8 @@ import uk.gov.hmcts.opal.entity.ReportInstanceEntity;
 
 public interface ReportInterface<T extends ReportDataInterface> {
 
+    ReportType getType();
+
     T generateReportData(ReportInstanceEntity reportInstance);
 
     byte[] convertReportDataToFileType(ReportInstanceEntity reportInstance, T reportData, FileType fileType);

--- a/src/main/java/uk/gov/hmcts/opal/service/report/ReportMetaData.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/ReportMetaData.java
@@ -3,10 +3,11 @@ package uk.gov.hmcts.opal.service.report;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import uk.gov.hmcts.opal.logging.integration.dto.ParticipantIdentifier;
 
 @Data
 @AllArgsConstructor
 public class ReportMetaData {
-    private List<Integer> pdpoPartyIds;
+    private List<ParticipantIdentifier> pdpoPartyIds;
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/report/ReportMetaData.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/ReportMetaData.java
@@ -1,9 +1,11 @@
 package uk.gov.hmcts.opal.service.report;
 
 import java.util.List;
-import lombok.Getter;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
-@Getter
+@Data
+@AllArgsConstructor
 public class ReportMetaData {
     private List<Integer> pdpoPartyIds;
 

--- a/src/main/java/uk/gov/hmcts/opal/service/report/ReportRegistry.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/ReportRegistry.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.opal.service.report;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.opal.exception.ReportNotFoundException;
+
+@Component
+public class ReportRegistry {
+
+    private final Map<ReportType, ReportInterface<?>> reports;
+
+    public ReportRegistry(List<ReportInterface<?>> reports) {
+        this.reports = reports.stream()
+            .collect(Collectors.toMap(
+                ReportInterface::getType,
+                Function.identity()
+            ));
+    }
+
+    public ReportInterface<?> get(String reportId) {
+        return Optional.ofNullable(reports.get(ReportType.fromReportId(reportId)))
+            .orElseThrow(() -> new ReportNotFoundException("No implementation found for reportId: " + reportId));
+
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/report/ReportType.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/ReportType.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.opal.service.report;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.Getter;
+import uk.gov.hmcts.opal.exception.ReportNotFoundException;
+
+@Getter
+public enum ReportType {
+
+    FP_REGISTER("fp_register");
+
+    public final String reportId;
+
+    ReportType(String reportId) {
+        this.reportId = reportId;
+    }
+
+    private static final Map<String, ReportType> BY_REPORT_ID =
+        Stream.of(values())
+            .collect(Collectors.toMap(ReportType::getReportId, reportType -> reportType));
+
+    public static ReportType fromReportId(String reportId) {
+        ReportType type = BY_REPORT_ID.get(reportId);
+        if (type == null) {
+            throw new ReportNotFoundException("Report id is not a valid report type: " + reportId);
+        }
+        return type;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/util/UuidProvider.java
+++ b/src/main/java/uk/gov/hmcts/opal/util/UuidProvider.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.opal.util;
+
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UuidProvider {
+    public UUID getUuid() {
+        return UUID.randomUUID();
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -178,7 +178,7 @@ opal:
   report:
     storage:
       connection-string: ${AZURE_STORAGE_CONNECTION_STRING:UseDevelopmentStorage=true}
-      container: ${AZURE_STORAGE_CONTAINER:test-container}
+      container: ${AZURE_STORAGE_CONTAINER:reports}
     consumer:
       enabled: ${REPORT_CONSUMER_ENABLED:true}
       connection-string: ${SERVICEBUS_CONNECTION_STRING:Endpoint=sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=local;UseDevelopmentEmulator=true}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -175,6 +175,17 @@ opal:
     email: ${OPAL_TEST_USER_EMAIL:opal-test@HMCTS.NET}
     password: ${OPAL_TEST_USER_PASSWORD}
 
+  report:
+    storage:
+      connection-string: ${AZURE_STORAGE_CONNECTION_STRING:UseDevelopmentStorage=true}
+      container: ${AZURE_STORAGE_CONTAINER:test-container}
+    consumer:
+      enabled: ${REPORT_CONSUMER_ENABLED:true}
+      connection-string: ${SERVICEBUS_CONNECTION_STRING:Endpoint=sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=local;UseDevelopmentEmulator=true}
+      queue-name: ${SERVICEBUS_REPORT_QUEUE_NAME:report}
+      protocol: ${SERVICEBUS_REPORT_PROTOCOL:amqp}
+      idle-timeout-ms: ${SERVICEBUS_IDLE_TIMEOUT_MS:30000}
+
 be-developer-config:
   user-role-permissions: ${BE_DEV_ROLE_PERMISSIONS:}
 
@@ -198,7 +209,6 @@ logging:
         orm:
           jdbc:
             bind: INFO
-
 
 user:
   service:

--- a/src/test/java/uk/gov/hmcts/opal/config/QueueConsumerJmsConfigTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/config/QueueConsumerJmsConfigTest.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.opal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.jms.ConnectionFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
+
+class QueueConsumerJmsConfigTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withUserConfiguration(QueueConsumerJmsConfig.class);
+
+    @Test
+    void loadsJmsBeansWhenEnabled() {
+        contextRunner
+            .withPropertyValues(
+                "opal.report.consumer.enabled=true",
+                "opal.report.consumer.connection-string=Endpoint=sb://example.servicebus.windows.net/;"
+                    + "SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=key",
+                "opal.report.consumer.queue-name=report"
+            )
+            .run(context -> {
+                assertThat(context).hasSingleBean(QueueConsumerJmsConfig.class);
+                assertThat(context).hasSingleBean(ConnectionFactory.class);
+                assertThat(context).hasSingleBean(DefaultJmsListenerContainerFactory.class);
+            });
+    }
+
+    @Test
+    void skipsJmsBeansWhenDisabled() {
+        contextRunner
+            .withPropertyValues("opal.report.consumer.enabled=false")
+            .run(context -> assertThat(context).doesNotHaveBean(ConnectionFactory.class));
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/opal/config/ServiceBusConnectionStringParserTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/config/ServiceBusConnectionStringParserTest.java
@@ -1,0 +1,122 @@
+package uk.gov.hmcts.opal.config;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.stream.Stream;
+import joptsimple.internal.Strings;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import uk.gov.hmcts.opal.config.ServiceBusConnectionStringParser.ConnectionDetails;
+
+public class ServiceBusConnectionStringParserTest {
+
+    public static final String BASE_CONNECTION_STRING = "%s=%s;%s=%s;%s=%s";
+    public static final String ENDPOINT_KEY = "Endpoint";
+    public static final String KEY_VALUE_KEY = "SharedAccessKey";
+    public static final String KEY_NAME_KEY = "SharedAccessKeyName";
+    public static final String VALID_ENDPOINT = "sb://localhost/;";
+    public static final String VALID_SHARED_ACCESS_KEY_NAME = "AccessKey";
+    public static final String VALID_SHARED_ACCESS_KEY_VALUE = "keyValue";
+
+    static Stream<Arguments> provideBlankEndpoint() {
+        return Stream.of(Arguments.of(Strings.EMPTY, VALID_ENDPOINT),
+            Arguments.of(ENDPOINT_KEY, Strings.EMPTY));
+    }
+
+    static Stream<Arguments> provideBlankSharedAccessKeyName() {
+        return Stream.of(Arguments.of(Strings.EMPTY, VALID_SHARED_ACCESS_KEY_NAME),
+            Arguments.of(KEY_NAME_KEY, Strings.EMPTY));
+    }
+
+    static Stream<Arguments> provideBlankSharedAccessKeyValue() {
+        return Stream.of(Arguments.of(Strings.EMPTY, VALID_SHARED_ACCESS_KEY_VALUE),
+            Arguments.of(KEY_VALUE_KEY, Strings.EMPTY));
+    }
+
+    @Test
+    public void parse_validConnectionString_returnsConnectionDetails() {
+        ConnectionDetails parsed = ServiceBusConnectionStringParser.parse(
+            String.format(BASE_CONNECTION_STRING,
+                ENDPOINT_KEY, VALID_ENDPOINT,
+                KEY_NAME_KEY, VALID_SHARED_ACCESS_KEY_NAME,
+                KEY_VALUE_KEY, VALID_SHARED_ACCESS_KEY_VALUE));
+        assertThat(parsed).hasNoNullFieldsOrProperties();
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void parse_noConnectionStringPassed_throwsIllegalArgumentException(String connectionString) {
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> ServiceBusConnectionStringParser.parse(connectionString));
+        assertThat(ex).hasMessageContaining("must not be blank");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideBlankEndpoint")
+    public void parse_endpointIsBlank_throwsIllegalArgumentException(String key, String value) {
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> ServiceBusConnectionStringParser.parse(
+                String.format(BASE_CONNECTION_STRING,
+                    key, value,
+                    KEY_NAME_KEY, VALID_SHARED_ACCESS_KEY_NAME,
+                    KEY_VALUE_KEY, VALID_SHARED_ACCESS_KEY_VALUE)));
+        assertThat(ex).hasMessageContaining("missing endpoint segment");
+    }
+
+    @Test
+    public void parse_invalidUriInEndpoint_throwsIllegalArgumentException() {
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> ServiceBusConnectionStringParser.parse(
+                String.format(BASE_CONNECTION_STRING,
+                    ENDPOINT_KEY, "invalid uri",
+                    KEY_NAME_KEY, VALID_SHARED_ACCESS_KEY_NAME,
+                    KEY_VALUE_KEY, VALID_SHARED_ACCESS_KEY_VALUE)));
+        assertThat(ex).hasMessageContaining("invalid uri");
+    }
+
+    @Test
+    public void parse_noHostInEndpoint_throwsIllegalArgumentException() {
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> ServiceBusConnectionStringParser.parse(
+                String.format(BASE_CONNECTION_STRING,
+                    ENDPOINT_KEY, "missingHost",
+                    KEY_NAME_KEY, VALID_SHARED_ACCESS_KEY_NAME,
+                    KEY_VALUE_KEY, VALID_SHARED_ACCESS_KEY_VALUE)));
+        assertThat(ex).hasMessageContaining("missing host");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideBlankSharedAccessKeyName")
+    public void parse_noSharedAccessKeyName_throwsIllegalArgumentException(String key, String value) {
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> ServiceBusConnectionStringParser.parse(
+                String.format(BASE_CONNECTION_STRING,
+                    ENDPOINT_KEY, VALID_ENDPOINT,
+                    key, value,
+                    KEY_VALUE_KEY, VALID_SHARED_ACCESS_KEY_VALUE)));
+        assertThat(ex).hasMessageContaining("missing " + KEY_NAME_KEY);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideBlankSharedAccessKeyValue")
+    public void parse_noSharedAccessKey_throwsIllegalArgumentException(String key, String value) {
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> ServiceBusConnectionStringParser.parse(
+                String.format(BASE_CONNECTION_STRING,
+                    ENDPOINT_KEY, VALID_ENDPOINT,
+                    KEY_NAME_KEY, VALID_SHARED_ACCESS_KEY_NAME,
+                    key, value)));
+        assertThat(ex).hasMessageContaining("missing " + KEY_VALUE_KEY);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/blobstore/ReportBlobStoreServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/blobstore/ReportBlobStoreServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service.blobstore;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -23,6 +24,7 @@ import uk.gov.hmcts.opal.util.UuidProvider;
 @ExtendWith(MockitoExtension.class)
 public class ReportBlobStoreServiceTest {
 
+    public static final String CONTAINER = "container";
     private final String message = "I am a report";
 
     @Mock
@@ -43,16 +45,15 @@ public class ReportBlobStoreServiceTest {
 
     @BeforeEach
     public void setUp() {
-        String containerName = "container";
-        reportBlobStoreService = new ReportBlobStoreService(blobServiceClient, uuidProvider, containerName);
+        reportBlobStoreService = new ReportBlobStoreService(blobServiceClient, uuidProvider, CONTAINER);
+        when(blobServiceClient.getBlobContainerClient(CONTAINER)).thenReturn(container);
         uuid = UUID.randomUUID();
-        when(blobServiceClient.getBlobContainerClient("container")).thenReturn(container);
-        when(container.getBlobClient(anyString())).thenReturn(blob);
     }
 
     @Test
     public void storeReport() {
         //Arrange
+        when(container.getBlobClient(anyString())).thenReturn(blob);
         when(uuidProvider.getUuid()).thenReturn(uuid);
         when(container.exists()).thenReturn(true);
         when(blob.exists()).thenReturn(false);
@@ -67,8 +68,15 @@ public class ReportBlobStoreServiceTest {
     }
 
     @Test
+    public void storeReport_containerDoesNotExist_throwError() {
+        when(container.exists()).thenReturn(false);
+        assertThrows(IllegalArgumentException.class, () -> reportBlobStoreService.storeReport(message));
+    }
+
+    @Test
     public void storeReport_locationExists_generateNewLocation() {
         //Arrange
+        when(container.getBlobClient(anyString())).thenReturn(blob);
         UUID uuid2 = UUID.randomUUID();
         when(uuidProvider.getUuid()).thenReturn(uuid, uuid2);
         when(container.exists()).thenReturn(true);

--- a/src/test/java/uk/gov/hmcts/opal/service/blobstore/ReportBlobStoreServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/blobstore/ReportBlobStoreServiceTest.java
@@ -23,7 +23,7 @@ import uk.gov.hmcts.opal.util.UuidProvider;
 @ExtendWith(MockitoExtension.class)
 public class ReportBlobStoreServiceTest {
 
-    private final String MESSAGE = "I am a report";
+    private final String message = "I am a report";
 
     @Mock
     private BlobServiceClient blobServiceClient;
@@ -43,8 +43,8 @@ public class ReportBlobStoreServiceTest {
 
     @BeforeEach
     public void setUp() {
-        String CONTAINER_NAME = "container";
-        reportBlobStoreService = new ReportBlobStoreService(blobServiceClient, uuidProvider, CONTAINER_NAME);
+        String containerName = "container";
+        reportBlobStoreService = new ReportBlobStoreService(blobServiceClient, uuidProvider, containerName);
         uuid = UUID.randomUUID();
         when(blobServiceClient.getBlobContainerClient("container")).thenReturn(container);
         when(container.getBlobClient(anyString())).thenReturn(blob);
@@ -57,12 +57,12 @@ public class ReportBlobStoreServiceTest {
         when(container.exists()).thenReturn(true);
         when(blob.exists()).thenReturn(false);
         //Act
-        String savedAt = reportBlobStoreService.storeReport(MESSAGE);
+        String savedAt = reportBlobStoreService.storeReport(message);
         //Assert
         ArgumentCaptor<ByteArrayInputStream> argument = ArgumentCaptor.forClass(ByteArrayInputStream.class);
         verify(blob).upload(argument.capture(), anyLong());
         String saved = new String(argument.getValue().readAllBytes(), StandardCharsets.UTF_8);
-        assertEquals(MESSAGE, saved);
+        assertEquals(message, saved);
         assertEquals(savedAt, uuid.toString());
     }
 
@@ -74,12 +74,12 @@ public class ReportBlobStoreServiceTest {
         when(container.exists()).thenReturn(true);
         when(blob.exists()).thenReturn(true, false);
         //Act
-        String savedAt = reportBlobStoreService.storeReport(MESSAGE);
+        String savedAt = reportBlobStoreService.storeReport(message);
         //Assert
         ArgumentCaptor<ByteArrayInputStream> argument = ArgumentCaptor.forClass(ByteArrayInputStream.class);
         verify(blob).upload(argument.capture(), anyLong());
         String saved = new String(argument.getValue().readAllBytes(), StandardCharsets.UTF_8);
-        assertEquals(MESSAGE, saved);
+        assertEquals(message, saved);
         assertEquals(savedAt, uuid2.toString());
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/service/blobstore/ReportBlobStoreServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/blobstore/ReportBlobStoreServiceTest.java
@@ -1,0 +1,86 @@
+package uk.gov.hmcts.opal.service.blobstore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.opal.util.UuidProvider;
+
+@ExtendWith(MockitoExtension.class)
+public class ReportBlobStoreServiceTest {
+
+    private final String MESSAGE = "I am a report";
+    private final String CONTAINER_NAME = "container";
+
+    @Mock
+    private BlobServiceClient blobServiceClient;
+
+    @Mock
+    private BlobContainerClient container;
+
+    @Mock
+    private BlobClient blob;
+
+    @Mock
+    private UuidProvider uuidProvider;
+
+    private ReportBlobStoreService reportBlobStoreService;
+
+    private UUID uuid;
+
+    @BeforeEach
+    public void setUp() {
+        reportBlobStoreService = new ReportBlobStoreService(blobServiceClient, uuidProvider, CONTAINER_NAME);
+        uuid = UUID.randomUUID();
+        when(blobServiceClient.getBlobContainerClient(CONTAINER_NAME)).thenReturn(container);
+        when(container.getBlobClient(anyString())).thenReturn(blob);
+    }
+
+    @Test
+    public void storeReport() {
+        //Arrange
+        when(uuidProvider.getUuid()).thenReturn(uuid);
+        when(container.exists()).thenReturn(true);
+        when(blob.exists()).thenReturn(false);
+        //Act
+        String savedAt = reportBlobStoreService.storeReport(MESSAGE);
+        //Assert
+        ArgumentCaptor<ByteArrayInputStream> argument = ArgumentCaptor.forClass(ByteArrayInputStream.class);
+        verify(blob).upload(argument.capture(), anyLong());
+        String saved = new String(argument.getValue().readAllBytes(), StandardCharsets.UTF_8);
+        assertEquals(MESSAGE, saved);
+        assertEquals(savedAt, uuid.toString());
+    }
+
+    @Test
+    public void storeReport_locationExists_generateNewLocation() {
+        //Arrange
+        UUID uuid2 = UUID.randomUUID();
+        when(uuidProvider.getUuid()).thenReturn(uuid, uuid2);
+        when(container.exists()).thenReturn(true);
+        when(blob.exists()).thenReturn(true, false);
+        //Act
+        String savedAt = reportBlobStoreService.storeReport(MESSAGE);
+        //Assert
+        ArgumentCaptor<ByteArrayInputStream> argument = ArgumentCaptor.forClass(ByteArrayInputStream.class);
+        verify(blob).upload(argument.capture(), anyLong());
+        String saved = new String(argument.getValue().readAllBytes(), StandardCharsets.UTF_8);
+        assertEquals(MESSAGE, saved);
+        assertEquals(savedAt, uuid2.toString());
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/blobstore/ReportBlobStoreServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/blobstore/ReportBlobStoreServiceTest.java
@@ -24,7 +24,6 @@ import uk.gov.hmcts.opal.util.UuidProvider;
 public class ReportBlobStoreServiceTest {
 
     private final String MESSAGE = "I am a report";
-    private final String CONTAINER_NAME = "container";
 
     @Mock
     private BlobServiceClient blobServiceClient;
@@ -44,9 +43,10 @@ public class ReportBlobStoreServiceTest {
 
     @BeforeEach
     public void setUp() {
+        String CONTAINER_NAME = "container";
         reportBlobStoreService = new ReportBlobStoreService(blobServiceClient, uuidProvider, CONTAINER_NAME);
         uuid = UUID.randomUUID();
-        when(blobServiceClient.getBlobContainerClient(CONTAINER_NAME)).thenReturn(container);
+        when(blobServiceClient.getBlobContainerClient("container")).thenReturn(container);
         when(container.getBlobClient(anyString())).thenReturn(blob);
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/service/messaging/ReportQueueListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/messaging/ReportQueueListenerTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/uk/gov/hmcts/opal/service/messaging/ReportQueueListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/messaging/ReportQueueListenerTest.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.opal.service.messaging;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.TextMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReportQueueListenerTest {
+
+    public static final String MESSAGE_PAYLOAD = "payload";
+
+    @Mock
+    TextMessage textMessage;
+
+    @Mock
+    Message message;
+
+    @Mock
+    ReportQueueConsumerService consumer;
+
+    ReportQueueListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new ReportQueueListener(consumer);
+    }
+
+    @Test
+    void onMessage_delegatesMessageToConsumer() throws JMSException {
+        when(textMessage.getText()).thenReturn(MESSAGE_PAYLOAD);
+        listener.onMessage(textMessage);
+        verify(consumer).consume(MESSAGE_PAYLOAD);
+    }
+
+    @Test
+    void onMessage_messageIsNotText_throwException() {
+        assertThrows((IllegalArgumentException.class), () -> listener.onMessage(message));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/report/GenericReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/GenericReportServiceTest.java
@@ -1,0 +1,207 @@
+package uk.gov.hmcts.opal.service.report;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.opal.service.report.ReportInstanceGenerationStatus.ERROR;
+import static uk.gov.hmcts.opal.service.report.ReportInstanceGenerationStatus.READY;
+
+import jakarta.persistence.EntityNotFoundException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.opal.entity.ReportEntity;
+import uk.gov.hmcts.opal.entity.ReportInstanceEntity;
+import uk.gov.hmcts.opal.exception.ReportGenerationException;
+import uk.gov.hmcts.opal.exception.ReportNotFoundException;
+import uk.gov.hmcts.opal.repository.ReportInstanceRepository;
+import uk.gov.hmcts.opal.repository.ReportRepository;
+import uk.gov.hmcts.opal.service.blobstore.ReportBlobStore;
+
+@ExtendWith(MockitoExtension.class)
+class GenericReportServiceTest {
+
+    public static final String LOCATION = "location";
+
+    @InjectMocks
+    private GenericReportService genericReportService;
+
+    @Mock
+    ReportInstanceRepository reportInstanceRepository;
+
+    @Mock
+    ReportRepository reportRepository;
+
+    @Mock
+    ReportBlobStore reportBlobStore;
+
+    @Mock
+    ReportRegistry reportRegistry;
+
+    @SuppressWarnings("rawtypes")
+    @Mock
+    ReportInterface reportInterfaceImplementation;
+
+    @Mock
+    Clock clock;
+
+    ReportInstanceEntity reportInstance;
+
+    @Mock
+    ReportEntity reportEntity;
+
+    @Mock
+    TestData reportData;
+
+    String reportId;
+
+    Instant now;
+
+    @BeforeEach
+    void setUp() {
+        reportInstance = new ReportInstanceEntity();
+        reportId = String.valueOf(UUID.randomUUID());
+        reportInstance.setReportId(reportId);
+
+        now = Instant.parse("2026-01-01T10:00:00Z");
+        when(clock.instant()).thenReturn(now);
+        when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+    }
+
+    @Test
+    void generateReportInstanceContent_happyPath() {
+        reportInstance.setReportId(reportId);
+        when(reportInstanceRepository.findById(any())).thenReturn(Optional.of(reportInstance));
+        //noinspection rawtypes
+        when((ReportInterface) reportRegistry.get(reportId)).thenReturn(reportInterfaceImplementation);
+        when(reportInterfaceImplementation.generateReportData(reportInstance)).thenReturn(reportData);
+        when(reportData.getNumberOfRecords()).thenReturn((short) 2);
+        when(reportBlobStore.storeReport(any())).thenReturn(LOCATION);
+        when(reportRepository.getByReportId(reportId)).thenReturn(reportEntity);
+        when(reportEntity.getRetentionPeriod()).thenReturn(Duration.ofDays(1));
+        //Act
+        genericReportService.generateReportInstanceContent(1L);
+        //Assert
+        ArgumentCaptor<String> toSaveInBlobStore = ArgumentCaptor.forClass(String.class);
+        verify(reportBlobStore).storeReport(toSaveInBlobStore.capture());
+        ArgumentCaptor<ReportInstanceEntity> entities = ArgumentCaptor.forClass(ReportInstanceEntity.class);
+        verify(reportInstanceRepository, times(2)).saveAndFlush(entities.capture());
+
+        String dataToSave = toSaveInBlobStore.getAllValues().getFirst();
+        assertThat(dataToSave)
+            .isEqualTo("{\"reportData\":{\"numberOfRecords\":2,\"reportMetaData\":null},\"reportMetaData\":null}");
+
+        ReportInstanceEntity lastEntity = entities.getAllValues().getLast();
+        assertThat(lastEntity.getReportId()).isEqualTo(reportId);
+        assertThat(lastEntity.getGenerationStatus()).isEqualTo(READY);
+        assertThat(lastEntity.getLocation()).isEqualTo(LOCATION);
+        assertThat(lastEntity.getErrors()).isNull();
+        assertThat(lastEntity.getNoOfRecords()).isEqualTo((short) 2);
+        assertThat(lastEntity.getCreatedTimestamp()).isEqualTo(LocalDateTime.now(clock));
+        assertThat(lastEntity.getScheduledDeletionTimestamp()).isEqualTo(LocalDateTime.now(clock).plusDays(1));
+    }
+
+    @Test
+    void generateReportInstanceContent_retentionPeriodIsNull_doNotSetDeletionTimestamp() {
+        reportInstance.setReportId(reportId);
+        when(reportInstanceRepository.findById(any())).thenReturn(Optional.of(reportInstance));
+        //noinspection rawtypes
+        when((ReportInterface) reportRegistry.get(reportId)).thenReturn(reportInterfaceImplementation);
+        when(reportInterfaceImplementation.generateReportData(reportInstance)).thenReturn(reportData);
+        when(reportData.getNumberOfRecords()).thenReturn((short) 2);
+        when(reportBlobStore.storeReport(any())).thenReturn(LOCATION);
+        when(reportRepository.getByReportId(reportId)).thenReturn(reportEntity);
+        when(reportEntity.getRetentionPeriod()).thenReturn(null);
+        //Act
+        genericReportService.generateReportInstanceContent(1L);
+        //Assert
+        ArgumentCaptor<ReportInstanceEntity> entities = ArgumentCaptor.forClass(ReportInstanceEntity.class);
+        verify(reportInstanceRepository, times(2)).saveAndFlush(entities.capture());
+        ReportInstanceEntity lastEntity = entities.getAllValues().getLast();
+        assertNull(lastEntity.getScheduledDeletionTimestamp());
+    }
+
+    @Test
+    void generateReportInstanceContent_reportIdNotFound_throwsExceptionAndDoesNotSaveAnEmptyEntity() {
+        //Arrange
+        when(reportInstanceRepository.findById(any())).thenThrow(EntityNotFoundException.class);
+        //Act
+        assertThrows(EntityNotFoundException.class, () -> genericReportService.generateReportInstanceContent(1L));
+        //Assert
+        verify(reportInstanceRepository, times(0)).saveAndFlush(reportInstance);
+    }
+
+    @Test
+    void generateReportInstanceContent_unableToSaveToBlobStore_throwsException() {
+        //Arrange
+        when(reportInstanceRepository.findById(any())).thenReturn(Optional.of(reportInstance));
+        //noinspection rawtypes
+        when((ReportInterface) reportRegistry.get(reportId)).thenReturn(reportInterfaceImplementation);
+        when(reportInterfaceImplementation.generateReportData(reportInstance)).thenReturn(reportData);
+        when(reportBlobStore.storeReport(any())).thenThrow(RuntimeException.class);
+        //Act
+        assertThrows(ReportGenerationException.class, () -> genericReportService.generateReportInstanceContent(1L));
+        //Assert
+        ArgumentCaptor<ReportInstanceEntity> entities = ArgumentCaptor.forClass(ReportInstanceEntity.class);
+        verify(reportInstanceRepository, times(2)).saveAndFlush(entities.capture());
+        ReportInstanceEntity savedEntity = entities.getAllValues().getLast();
+        assertThat(savedEntity.getGenerationStatus()).isEqualTo(ERROR);
+        assertThat(savedEntity.getErrors()).isInstanceOf(ReportError.class);
+    }
+
+    @Test
+    void generateReportInstanceContent_noImplementationForReportIdFound_throwsException() {
+        //Arrange
+        when(reportInstanceRepository.findById(any())).thenReturn(Optional.of(reportInstance));
+        //noinspection rawtypes
+        when((ReportInterface) reportRegistry.get(reportId)).thenThrow(ReportNotFoundException.class);
+        //Act
+        assertThrows(ReportGenerationException.class, () -> genericReportService.generateReportInstanceContent(1L));
+        //Assert
+        ArgumentCaptor<ReportInstanceEntity> entities = ArgumentCaptor.forClass(ReportInstanceEntity.class);
+        verify(reportInstanceRepository, times(1)).saveAndFlush(entities.capture());
+        ReportInstanceEntity savedEntity = entities.getAllValues().getFirst();
+        assertThat(savedEntity.getGenerationStatus()).isEqualTo(ERROR);
+        assertThat(savedEntity.getErrors()).isInstanceOf(ReportError.class);
+    }
+
+    @Test
+    void generateReportInstanceContent_unableToSaveToDb_throwsException() {
+        //Arrange
+        when(reportInstanceRepository.findById(any())).thenReturn(Optional.of(reportInstance));
+        //noinspection rawtypes
+        when((ReportInterface) reportRegistry.get(reportId)).thenReturn(reportInterfaceImplementation);
+        when(reportInstanceRepository.saveAndFlush(any())).thenThrow(RuntimeException.class);
+        //Act + Assert
+        assertThrows(ReportGenerationException.class, () -> genericReportService.generateReportInstanceContent(1L));
+    }
+
+    static class TestData implements ReportDataInterface {
+
+        @Override
+        public short getNumberOfRecords() {
+            return 0;
+        }
+
+        @Override
+        public ReportMetaData getReportMetaData() {
+            return null;
+        }
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/report/ReportQueueConsumerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/ReportQueueConsumerServiceTest.java
@@ -1,0 +1,66 @@
+package uk.gov.hmcts.opal.service.report;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.opal.service.messaging.ReportQueueConsumerService;
+import uk.gov.hmcts.opal.service.messaging.ReportQueueMessage;
+
+@ExtendWith(MockitoExtension.class)
+class ReportQueueConsumerServiceTest {
+
+    @Mock
+    GenericReportService genericReportService;
+    static ReportQueueConsumerService consumer;
+
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+        .findAndAddModules()
+        .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+        .build();
+
+    @BeforeEach
+    public void setUp() {
+        consumer = new ReportQueueConsumerService(objectMapper, genericReportService);
+    }
+
+    @Test
+    void consume_validPayload_parsesMessageAndSendsToService() throws Exception {
+        ReportQueueMessage details = new ReportQueueMessage(1L);
+        String payload = objectMapper.writeValueAsString(details);
+        consumer.consume(payload);
+        verify(genericReportService, times(1))
+            .generateReportInstanceContent(details.instanceId());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"     "})
+    void consume_blankPayload_throwsIllegalArgumentException(String payload) {
+        assertThatThrownBy(() -> consumer.consume(payload))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("payload is blank");
+        verify(genericReportService, never()).generateReportInstanceContent(Mockito.any());
+    }
+
+    @Test
+    void consume_invalidJson_throwsIllegalArgumentException() {
+        assertThatThrownBy(() -> consumer.consume("{invalid"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("Unable to parse");
+        verify(genericReportService, never()).generateReportInstanceContent(Mockito.any());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/report/ReportRegistryTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/ReportRegistryTest.java
@@ -26,7 +26,7 @@ class ReportRegistryTest {
     void constructor_buildsMapAccessibleWithReportId() {
         when(report1.getType()).thenReturn(ReportType.FP_REGISTER);
 
-        @SuppressWarnings("unchecked") ReportRegistry registry =
+        ReportRegistry registry =
             new ReportRegistry(List.of(report1));
 
         assertSame(report1, registry.get(ReportType.FP_REGISTER.reportId));
@@ -37,7 +37,6 @@ class ReportRegistryTest {
         when(report1.getType()).thenReturn(ReportType.FP_REGISTER);
         when(report2.getType()).thenReturn(ReportType.FP_REGISTER);
 
-        //noinspection unchecked
         assertThrows(IllegalStateException.class, () -> new ReportRegistry(List.of(report1, report2)));
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/report/ReportRegistryTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/ReportRegistryTest.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.opal.service.report;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReportRegistryTest {
+
+    @SuppressWarnings("rawtypes")
+    @Mock
+    ReportInterface report1;
+
+    @SuppressWarnings("rawtypes")
+    @Mock
+    ReportInterface report2;
+
+
+    @Test
+    void constructor_buildsMapAccessibleWithReportId() {
+        when(report1.getType()).thenReturn(ReportType.FP_REGISTER);
+
+        @SuppressWarnings("unchecked") ReportRegistry registry =
+            new ReportRegistry(List.of(report1));
+
+        assertSame(report1, registry.get(ReportType.FP_REGISTER.reportId));
+    }
+
+    @Test
+    void constructor_throwsOnDuplicateTypes() {
+        when(report1.getType()).thenReturn(ReportType.FP_REGISTER);
+        when(report2.getType()).thenReturn(ReportType.FP_REGISTER);
+
+        //noinspection unchecked
+        assertThrows(IllegalStateException.class, () -> new ReportRegistry(List.of(report1, report2)));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/report/ReportTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/ReportTypeTest.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.opal.service.report;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static uk.gov.hmcts.opal.service.report.ReportType.FP_REGISTER;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.hmcts.opal.exception.ReportNotFoundException;
+
+class ReportTypeTest {
+
+    @Test
+    void getReportId_reportTypeExists_returnReportType() {
+        ReportType type = ReportType.fromReportId("fp_register");
+        assertEquals(FP_REGISTER, type);
+    }
+
+    @Test
+    void getReportId_reportTypeDoesNotExist_throwException() {
+        assertThrows(
+            ReportNotFoundException.class,
+            () -> ReportType.fromReportId("fake_report_type")
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/report/ReportTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/ReportTypeTest.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.opal.service.report;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.hmcts.opal.service.report.ReportType.FP_REGISTER;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.web.server.ResponseStatusException;
 import uk.gov.hmcts.opal.exception.ReportNotFoundException;
 
 class ReportTypeTest {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-2257 


### Change description ###
Creates a generic service to: 
- consume reportInstanceId messages from the azure service bus queue
- retrieve associated data and store to Azure blob store
- persist the location of the blob data in the db

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
