### PR TITLE
PO-3444 : submitter cannot delete draft account

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPatchIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPatchIntegrationTest.java
@@ -209,7 +209,7 @@ class DraftAccountControllerPatchIntegrationTest extends CommonDraftAccountContr
             .build();
         UserState userState = UserState.builder()
             .userId(1L)
-            .userName("normal@users.com")
+            .userName("user_003")
             .businessUnitUser(Set.of(buUser))
             .build();
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPatchIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPatchIntegrationTest.java
@@ -194,6 +194,41 @@ class DraftAccountControllerPatchIntegrationTest extends CommonDraftAccountContr
         );
     }
 
+    @Test
+    @DisplayName("Patch draft account - submitter cannot delete their own submission")
+    void testPatchDraftAccount_submitterCannotDelete_returns403() throws Exception {
+        Long draftAccountId = 7L; // submitted_by = user_003 in seed data
+
+        BusinessUnitUser buUser = BusinessUnitUser.builder()
+            .businessUnitUserId("user_003")
+            .businessUnitId((short)78)
+            .permissions(Set.of(Permission.builder()
+                .permissionId(FinesPermission.CHECK_VALIDATE_DRAFT_ACCOUNTS.getId())
+                .permissionName(FinesPermission.CHECK_VALIDATE_DRAFT_ACCOUNTS.getDescription())
+                .build()))
+            .build();
+        UserState userState = UserState.builder()
+            .userId(1L)
+            .userName("normal@users.com")
+            .businessUnitUser(Set.of(buUser))
+            .build();
+
+        when(userStateService.checkForAuthorisedUser(any())).thenReturn(userState);
+
+        ResultActions resultActions = mockMvc.perform(patch(URL_BASE + "/" + draftAccountId)
+            .header("authorization", "Bearer some_value")
+            .header("If-Match", "0")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(validUpdateRequestBody("78", "Deleted","A")));
+
+        resultActions.andExpect(status().isForbidden())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/submitter-cannot-delete"))
+            .andExpect(jsonPath("$.title").value("Submitter cannot delete"))
+            .andExpect(jsonPath("$.detail")
+                .value("A single user cannot submit and delete the same Draft Account"));
+    }
+
 
     @Test
     @DisplayName("Patch draft account - user with CREATE_MANAGE permission should be forbidden [@PO-1820]")

--- a/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
@@ -46,6 +46,7 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 import uk.gov.hmcts.opal.common.logging.LogUtil;
 import uk.gov.hmcts.opal.common.user.authentication.exception.MissingRequestHeaderException;
 import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
+import uk.gov.hmcts.opal.exception.SubmitterCannotDeleteException;
 import uk.gov.hmcts.opal.exception.JsonSchemaValidationException;
 import uk.gov.hmcts.opal.common.exception.OpalApiException;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
@@ -501,6 +502,19 @@ public class GlobalExceptionHandler {
             "Submitter cannot validate",
             "A single user cannot submit and validate the same Draft Account",
             "submitter-cannot-validate",
+            false,
+            e
+        );
+        return responseWithProblemDetail(HttpStatus.FORBIDDEN, problemDetail);
+    }
+
+    @ExceptionHandler(SubmitterCannotDeleteException.class)
+    public ResponseEntity<ProblemDetail> handleSubmitterCannotValidateException(SubmitterCannotDeleteException e) {
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.FORBIDDEN,
+            "Submitter cannot delete",
+            "A single user cannot submit and delete the same Draft Account",
+            "submitter-cannot-delete",
             false,
             e
         );

--- a/src/main/java/uk/gov/hmcts/opal/entity/draft/DraftAccountStatus.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/draft/DraftAccountStatus.java
@@ -38,4 +38,8 @@ public enum DraftAccountStatus {
     public boolean isPublishingPending() {
         return this == PUBLISHING_PENDING;
     }
+
+    public boolean isDeleted() {
+        return this == DELETED;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/opal/exception/SubmitterCannotDeleteException.java
+++ b/src/main/java/uk/gov/hmcts/opal/exception/SubmitterCannotDeleteException.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.opal.exception;
+
+public class SubmitterCannotDeleteException extends RuntimeException {
+
+    public SubmitterCannotDeleteException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/exception/SubmitterCannotDeleteException.java
+++ b/src/main/java/uk/gov/hmcts/opal/exception/SubmitterCannotDeleteException.java
@@ -1,8 +1,16 @@
 package uk.gov.hmcts.opal.exception;
 
+import lombok.Getter;
+
+@Getter
 public class SubmitterCannotDeleteException extends RuntimeException {
 
-    public SubmitterCannotDeleteException(String message) {
+    private final String submittedBy;
+    private final String deletedBy;
+
+    public SubmitterCannotDeleteException(String message, String submittedBy, String deletedBy) {
         super(message);
+        this.submittedBy = submittedBy;
+        this.deletedBy = deletedBy;
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/DraftAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DraftAccountService.java
@@ -239,7 +239,7 @@ public class DraftAccountService {
 
             try {
                 DraftAccountEntity updatedEntity = draftAccountTransactional
-                    .updateDraftAccount(draftAccountId, dto, draftAccountTransactional, updateVersion);
+                    .updateDraftAccount(draftAccountId, dto, draftAccountTransactional, updateVersion, userState);
                 verifyUpdated(updatedEntity, updateVersion, draftAccountId, "updateDraftAccount");
 
                 loggingService.pdplForDraftAccount(updatedEntity, Action.RESUBMIT, userState);

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactional.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactional.java
@@ -27,6 +27,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddDraftAccountRequestDto;
 import uk.gov.hmcts.opal.dto.DraftAccountRequestDto;
 import uk.gov.hmcts.opal.dto.ReplaceDraftAccountRequestDto;
@@ -147,7 +148,8 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
 
     @Transactional
     public DraftAccountEntity updateDraftAccount(Long draftAccountId, UpdateDraftAccountRequestDto dto,
-                                                 DraftAccountTransactionalProxy proxy, BigInteger updateVersion) {
+                                                 DraftAccountTransactionalProxy proxy, BigInteger updateVersion,
+                                                 UserState userState) {
         DraftAccountEntity existingAccount = proxy.getDraftAccount(draftAccountId);
         verifyIfMatch(existingAccount, updateVersion, draftAccountId, "updateDraftAccount");
 
@@ -188,9 +190,10 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
 
         if (newStatus.isDeleted()) {
             if (existingAccount.getSubmittedBy() != null
-                && existingAccount.getSubmittedBy().equals(dto.getValidatedBy())) {
+                && existingAccount.getSubmittedBy().equals(userState.getUserName())) {
                 throw new SubmitterCannotDeleteException(
-                    "A single user cannot submit and delete the same Draft Account");
+                    "A single user cannot submit and delete the same Draft Account",
+                    existingAccount.getSubmittedBy(), userState.getUserName());
             }
         }
 

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactional.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactional.java
@@ -37,6 +37,7 @@ import uk.gov.hmcts.opal.entity.draft.DraftAccountEntity;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountEntity_;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountSnapshots;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountStatus;
+import uk.gov.hmcts.opal.exception.SubmitterCannotDeleteException;
 import uk.gov.hmcts.opal.exception.SubmitterCannotValidateException;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.opal.repository.BusinessUnitRepository;
@@ -184,6 +185,15 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
             existingAccount.setAccountSnapshot(addSnapshotApprovedDate(existingAccount));
             existingAccount.setAccountStatusDate(LocalDateTime.now());
         }
+
+        if (newStatus.isDeleted()) {
+            if (existingAccount.getSubmittedBy() != null
+                && existingAccount.getSubmittedBy().equals(dto.getValidatedBy())) {
+                throw new SubmitterCannotDeleteException(
+                    "A single user cannot submit and delete the same Draft Account");
+            }
+        }
+
         // Set the timeline data as received from the front end
         existingAccount.setTimelineData(dto.getTimelineData());
 

--- a/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
@@ -62,6 +62,7 @@ import uk.gov.hmcts.opal.entity.draft.DraftAccountEntity;
 import uk.gov.hmcts.opal.exception.JsonSchemaValidationException;
 import uk.gov.hmcts.opal.common.exception.OpalApiException;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
+import uk.gov.hmcts.opal.exception.SubmitterCannotDeleteException;
 import uk.gov.hmcts.opal.exception.UnprocessableException;
 import uk.gov.hmcts.opal.exception.SubmitterCannotValidateException;
 import uk.gov.hmcts.opal.launchdarkly.FeatureDisabledException;
@@ -446,6 +447,21 @@ class GlobalExceptionHandlerTest {
         assertEquals("Submitter cannot validate", pd.getTitle());
         assertEquals("A single user cannot submit and validate the same Draft Account", pd.getDetail());
         assertEquals(URI.create("https://hmcts.gov.uk/problems/submitter-cannot-validate"), pd.getType());
+        assertEquals(false, pd.getProperties().get("retriable"));
+    }
+
+    @Test
+    void handleSubmitterCannotDelete_forbidden() {
+        SubmitterCannotDeleteException ex =
+            new SubmitterCannotDeleteException("A single user cannot submit and delete the same Draft Account");
+        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleSubmitterCannotValidateException(ex);
+
+        assertEquals(HttpStatus.FORBIDDEN, r.getStatusCode());
+        ProblemDetail pd = r.getBody();
+        assertEquals(HttpStatus.FORBIDDEN.value(), pd.getStatus());
+        assertEquals("Submitter cannot delete", pd.getTitle());
+        assertEquals("A single user cannot submit and delete the same Draft Account", pd.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/submitter-cannot-delete"), pd.getType());
         assertEquals(false, pd.getProperties().get("retriable"));
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
@@ -453,7 +453,8 @@ class GlobalExceptionHandlerTest {
     @Test
     void handleSubmitterCannotDelete_forbidden() {
         SubmitterCannotDeleteException ex =
-            new SubmitterCannotDeleteException("A single user cannot submit and delete the same Draft Account");
+            new SubmitterCannotDeleteException("A single user cannot submit and delete the same Draft Account",
+                "Pablo", "Pablo");
         ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleSubmitterCannotValidateException(ex);
 
         assertEquals(HttpStatus.FORBIDDEN, r.getStatusCode());

--- a/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
@@ -340,7 +340,8 @@ class DraftAccountServiceTest {
             .businessUnit(BusinessUnitFullEntity.builder().businessUnitId((short) 3).build())
             .versionNumber(0L)
             .build();
-        when(draftAccountTransactional.updateDraftAccount(any(), any(), any(), any())).thenReturn(existingAccount);
+        when(draftAccountTransactional.updateDraftAccount(any(), any(), any(), any(), any()))
+            .thenReturn(existingAccount);
         when(userStateService.checkForAuthorisedUser(any()))
             .thenReturn(UserStateUtil.permissionUser((short) 2, FinesPermission.CHECK_VALIDATE_DRAFT_ACCOUNTS));
 
@@ -375,7 +376,8 @@ class DraftAccountServiceTest {
             .timelineData(createTimelineDataString())
             .versionNumber(1L)
             .build();
-        when(draftAccountTransactional.updateDraftAccount(any(), any(), any(), any())).thenReturn(updatedAccount);
+        when(draftAccountTransactional.updateDraftAccount(any(), any(), any(), any(), any()))
+            .thenReturn(updatedAccount);
         var userState = UserStateUtil.permissionUser((short) 2, FinesPermission.CHECK_VALIDATE_DRAFT_ACCOUNTS);
         when(userStateService.checkForAuthorisedUser(any())).thenReturn(userState);
 
@@ -388,7 +390,7 @@ class DraftAccountServiceTest {
         // More Assert
         ArgumentCaptor<UpdateDraftAccountRequestDto> captor =
             ArgumentCaptor.forClass(UpdateDraftAccountRequestDto.class);
-        verify(draftAccountTransactional).updateDraftAccount(any(), captor.capture(), any(), any());
+        verify(draftAccountTransactional).updateDraftAccount(any(), captor.capture(), any(), any(), any());
         assertEquals("USER01", captor.getValue().getValidatedBy());
         assertEquals("normal@users.com", captor.getValue().getValidatedByName());
 

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
@@ -38,6 +38,7 @@ import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitFullEntity;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountEntity;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountStatus;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
+import uk.gov.hmcts.opal.exception.SubmitterCannotDeleteException;
 import uk.gov.hmcts.opal.exception.SubmitterCannotValidateException;
 import uk.gov.hmcts.opal.repository.BusinessUnitRepository;
 import uk.gov.hmcts.opal.repository.DraftAccountRepository;
@@ -419,6 +420,34 @@ class DraftAccountTransactionalTest {
         when(draftAccountRepository.findById(draftAccountId)).thenReturn(Optional.of(existingAccount));
 
         assertThrows(SubmitterCannotValidateException.class, () ->
+            draftAccountTransactional.updateDraftAccount(draftAccountId, updateDto, draftAccountTransactional,
+                BigInteger.ZERO)
+        );
+    }
+
+    @Test
+    void testUpdateDraftAccount_submitterCannotDelete() {
+        Long draftAccountId = 1L;
+        UpdateDraftAccountRequestDto updateDto = UpdateDraftAccountRequestDto.builder()
+            .accountStatus(DraftAccountStatus.DELETED.getLabel())
+            .validatedBy("BUUID1")
+            .validatedByName("User One")
+            .timelineData(createTimelineDataString())
+            .businessUnitId((short) 2)
+            .build();
+
+        DraftAccountEntity existingAccount = DraftAccountEntity.builder()
+            .draftAccountId(draftAccountId)
+            .submittedBy("BUUID1")
+            .accountStatus(DraftAccountStatus.SUBMITTED)
+            .businessUnit(BusinessUnitFullEntity.builder().businessUnitId((short) 2).build())
+            .timelineData(createTimelineDataString())
+            .versionNumber(0L)
+            .build();
+
+        when(draftAccountRepository.findById(draftAccountId)).thenReturn(Optional.of(existingAccount));
+
+        assertThrows(SubmitterCannotDeleteException.class, () ->
             draftAccountTransactional.updateDraftAccount(draftAccountId, updateDto, draftAccountTransactional,
                 BigInteger.ZERO)
         );

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
@@ -30,6 +30,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor.SpecificationFluentQuery;
+import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddDraftAccountRequestDto;
 import uk.gov.hmcts.opal.dto.ReplaceDraftAccountRequestDto;
 import uk.gov.hmcts.opal.dto.UpdateDraftAccountRequestDto;
@@ -337,11 +338,12 @@ class DraftAccountTransactionalTest {
             .build();
 
         when(draftAccountRepository.findById(draftAccountId)).thenReturn(Optional.of(existingAccount));
+        UserState userState = UserState.builder().userName("USER_NAME_1").build();
 
         // Act & Assert
         assertThrows(ResourceConflictException.class, () ->
             draftAccountTransactional.updateDraftAccount(draftAccountId, updateDto, draftAccountTransactional,
-                BigInteger.ZERO)
+                BigInteger.ZERO, userState)
         );
     }
 
@@ -379,9 +381,11 @@ class DraftAccountTransactionalTest {
         when(draftAccountRepository.findById(draftAccountId)).thenReturn(Optional.of(existingAccount));
         when(draftAccountRepository.save(any(DraftAccountEntity.class))).thenReturn(updatedAccount);
 
+        UserState userState = UserState.builder().userName("USER_NAME_1").build();
+
         // Act
         DraftAccountEntity result = draftAccountTransactional
-            .updateDraftAccount(draftAccountId, updateDto, draftAccountTransactional, BigInteger.ZERO);
+            .updateDraftAccount(draftAccountId, updateDto, draftAccountTransactional, BigInteger.ZERO, userState);
 
         // Assert
         assertNotNull(result);
@@ -419,9 +423,11 @@ class DraftAccountTransactionalTest {
 
         when(draftAccountRepository.findById(draftAccountId)).thenReturn(Optional.of(existingAccount));
 
+        UserState userState = UserState.builder().userName("USER_NAME_1").build();
+
         assertThrows(SubmitterCannotValidateException.class, () ->
             draftAccountTransactional.updateDraftAccount(draftAccountId, updateDto, draftAccountTransactional,
-                BigInteger.ZERO)
+                BigInteger.ZERO, userState)
         );
     }
 
@@ -447,10 +453,14 @@ class DraftAccountTransactionalTest {
 
         when(draftAccountRepository.findById(draftAccountId)).thenReturn(Optional.of(existingAccount));
 
-        assertThrows(SubmitterCannotDeleteException.class, () ->
+        UserState userState = UserState.builder().userName("BUUID1").build();
+
+        SubmitterCannotDeleteException exception = assertThrows(SubmitterCannotDeleteException.class, () -> {
             draftAccountTransactional.updateDraftAccount(draftAccountId, updateDto, draftAccountTransactional,
-                BigInteger.ZERO)
-        );
+                BigInteger.ZERO, userState);
+        });
+        assertEquals("BUUID1", exception.getSubmittedBy());
+        assertEquals("BUUID1", exception.getDeletedBy());
     }
 
     @Test
@@ -473,10 +483,12 @@ class DraftAccountTransactionalTest {
 
         when(draftAccountRepository.findById(draftAccountId)).thenReturn(Optional.of(existingAccount));
 
+        UserState userState = UserState.builder().userName("BUUID1").build();
+
         // Act & Assert
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
             draftAccountTransactional.updateDraftAccount(draftAccountId, updateDto, draftAccountTransactional,
-                BigInteger.ZERO)
+                BigInteger.ZERO, userState)
         );
         assertEquals("'SUBMITTED' is not a valid Draft Account Status.", exception.getMessage());
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/PO-3444
"BE - delete draft account missing authorisation"

### Details

Draft accounts should not be deleted by the user who submitted them.
New exception thrown in this scenario: SubmitterCannotDeleteException

### Does this PR introduce a breaking change?** (check one with "x")

```
[  ] Yes
[X ] No
```
