### PR TITLE
PO-2897 Refactor Creditor Account Type to Enum

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/dto/GetMinorCreditorAccountHeaderSummaryResponse.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/GetMinorCreditorAccountHeaderSummaryResponse.java
@@ -11,11 +11,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.opal.dto.common.BusinessUnitSummary;
 import uk.gov.hmcts.opal.dto.common.CreditorAccountTypeReference;
-import uk.gov.hmcts.opal.dto.common.IndividualDetails;
-import uk.gov.hmcts.opal.dto.common.OrganisationDetails;
 import uk.gov.hmcts.opal.dto.common.PartyDetails;
-import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountType;
-import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorAccountHeaderEntity;
 import uk.gov.hmcts.opal.util.Versioned;
 
 @Data
@@ -58,55 +54,4 @@ public class GetMinorCreditorAccountHeaderSummaryResponse implements ToJsonStrin
     @JsonProperty("has_associated_defendant")
     private Boolean hasAssociatedDefendant;
 
-    public static GetMinorCreditorAccountHeaderSummaryResponse fromEntity(MinorCreditorAccountHeaderEntity entity) {
-        return GetMinorCreditorAccountHeaderSummaryResponse.builder()
-            .creditorAccountId(String.valueOf(entity.getCreditorAccountId()))
-            .accountNumber(entity.getCreditorAccountNumber())
-            .creditorAccountType(toCreditorAccountTypeReference(entity.getCreditorAccountType()))
-            .version(entity.getVersionNumber() == null ? null : BigInteger.valueOf(entity.getVersionNumber()))
-            .businessUnitSummary(toBusinessUnitSummary(entity))
-            .partyDetails(toPartyDetails(entity))
-            .awardedAmount(entity.getAwarded())
-            .paidOutAmount(entity.getPaidOut())
-            .awaitingPayoutAmount(entity.getAwaitingPayment())
-            .outstandingAmount(entity.getOutstanding())
-            .hasAssociatedDefendant(hasAssociatedDefendant(entity))
-            .build();
-    }
-
-    private static CreditorAccountTypeReference toCreditorAccountTypeReference(String typeCode) {
-        return CreditorAccountTypeReference.builder()
-            .type(typeCode)
-            .displayName(CreditorAccountType.getDisplayName(typeCode))
-            .build();
-    }
-
-    private static BusinessUnitSummary toBusinessUnitSummary(MinorCreditorAccountHeaderEntity entity) {
-        return BusinessUnitSummary.builder()
-            .businessUnitId(String.valueOf(entity.getBusinessUnitId()))
-            .businessUnitName(entity.getBusinessUnitName())
-            .welshSpeaking(entity.isWelshLanguage() ? "Y" : "N")
-            .build();
-    }
-
-    private static PartyDetails toPartyDetails(MinorCreditorAccountHeaderEntity entity) {
-        boolean isOrg = entity.isOrganisation();
-        return PartyDetails.builder()
-            .partyId(String.valueOf(entity.getPartyId()))
-            .organisationFlag(isOrg)
-            .organisationDetails(isOrg ? OrganisationDetails.builder()
-                .organisationName(entity.getOrganisationName())
-                .build() : null)
-            .individualDetails(!isOrg ? IndividualDetails.builder()
-                .title(entity.getTitle())
-                .forenames(entity.getForenames())
-                .surname(entity.getSurname())
-                .build() : null)
-            .build();
-    }
-
-    private static boolean hasAssociatedDefendant(MinorCreditorAccountHeaderEntity entity) {
-        return (entity.getAwarded() != null && entity.getAwarded().signum() > 0)
-            || (entity.getOutstanding() != null && entity.getOutstanding().signum() > 0);
-    }
 }

--- a/src/main/java/uk/gov/hmcts/opal/entity/creditoraccount/CreditorAccountEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/creditoraccount/CreditorAccountEntity.java
@@ -26,6 +26,8 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import uk.gov.hmcts.opal.util.LocalDateTimeAdapter;
 import uk.gov.hmcts.opal.util.Versioned;
 
@@ -59,6 +61,7 @@ public abstract class CreditorAccountEntity implements Versioned {
 
     @Column(name = "creditor_account_type", length = 2, nullable = false)
     @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
     private CreditorAccountType creditorAccountType;
 
     @Column(name = "prosecution_service", nullable = false)

--- a/src/main/java/uk/gov/hmcts/opal/entity/minorcreditor/MinorCreditorAccountHeaderEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/minorcreditor/MinorCreditorAccountHeaderEntity.java
@@ -2,14 +2,19 @@ package uk.gov.hmcts.opal.entity.minorcreditor;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.Immutable;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.math.BigDecimal;
+import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountType;
 
 @Getter
 @Entity
@@ -27,7 +32,9 @@ public class MinorCreditorAccountHeaderEntity {
     private String creditorAccountNumber;
 
     @Column(name = "creditor_account_type")
-    private String creditorAccountType;
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    private CreditorAccountType creditorAccountType;
 
     @Column(name = "version_number")
     private Long versionNumber;

--- a/src/main/java/uk/gov/hmcts/opal/mapper/MinorCreditorAccountHeaderSummaryMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/mapper/MinorCreditorAccountHeaderSummaryMapper.java
@@ -1,0 +1,75 @@
+package uk.gov.hmcts.opal.mapper;
+
+import java.math.BigInteger;
+import org.mapstruct.Builder;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import uk.gov.hmcts.opal.dto.GetMinorCreditorAccountHeaderSummaryResponse;
+import uk.gov.hmcts.opal.dto.common.BusinessUnitSummary;
+import uk.gov.hmcts.opal.dto.common.CreditorAccountTypeReference;
+import uk.gov.hmcts.opal.dto.common.IndividualDetails;
+import uk.gov.hmcts.opal.dto.common.OrganisationDetails;
+import uk.gov.hmcts.opal.dto.common.PartyDetails;
+import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountType;
+import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorAccountHeaderEntity;
+
+@Mapper(componentModel = "spring",
+    builder = @Builder(disableBuilder = true))
+public interface MinorCreditorAccountHeaderSummaryMapper {
+
+    @Mapping(target = "creditorAccountId", expression = "java(String.valueOf(entity.getCreditorAccountId()))")
+    @Mapping(target = "accountNumber", source = "creditorAccountNumber")
+    @Mapping(target = "creditorAccountType", source = "creditorAccountType")
+    @Mapping(target = "version", expression = "java(toVersion(entity.getVersionNumber()))")
+    @Mapping(target = "businessUnitSummary", expression = "java(toBusinessUnitSummary(entity))")
+    @Mapping(target = "partyDetails", expression = "java(toPartyDetails(entity))")
+    @Mapping(target = "awardedAmount", source = "awarded")
+    @Mapping(target = "paidOutAmount", source = "paidOut")
+    @Mapping(target = "awaitingPayoutAmount", source = "awaitingPayment")
+    @Mapping(target = "outstandingAmount", source = "outstanding")
+    @Mapping(target = "hasAssociatedDefendant", expression = "java(hasAssociatedDefendant(entity))")
+    GetMinorCreditorAccountHeaderSummaryResponse toResponse(MinorCreditorAccountHeaderEntity entity);
+
+    default CreditorAccountTypeReference toCreditorAccountTypeReference(CreditorAccountType type) {
+        if (type == null) {
+            return null;
+        }
+        return CreditorAccountTypeReference.builder()
+            .type(type.name())
+            .displayName(type.getLabel())
+            .build();
+    }
+
+    default BigInteger toVersion(Long versionNumber) {
+        return versionNumber == null ? null : BigInteger.valueOf(versionNumber);
+    }
+
+    default BusinessUnitSummary toBusinessUnitSummary(MinorCreditorAccountHeaderEntity entity) {
+        return BusinessUnitSummary.builder()
+            .businessUnitId(String.valueOf(entity.getBusinessUnitId()))
+            .businessUnitName(entity.getBusinessUnitName())
+            .welshSpeaking(entity.isWelshLanguage() ? "Y" : "N")
+            .build();
+    }
+
+    default PartyDetails toPartyDetails(MinorCreditorAccountHeaderEntity entity) {
+        boolean isOrg = entity.isOrganisation();
+        return PartyDetails.builder()
+            .partyId(String.valueOf(entity.getPartyId()))
+            .organisationFlag(isOrg)
+            .organisationDetails(isOrg ? OrganisationDetails.builder()
+                .organisationName(entity.getOrganisationName())
+                .build() : null)
+            .individualDetails(!isOrg ? IndividualDetails.builder()
+                .title(entity.getTitle())
+                .forenames(entity.getForenames())
+                .surname(entity.getSurname())
+                .build() : null)
+            .build();
+    }
+
+    default boolean hasAssociatedDefendant(MinorCreditorAccountHeaderEntity entity) {
+        return (entity.getAwarded() != null && entity.getAwarded().signum() > 0)
+            || (entity.getOutstanding() != null && entity.getOutstanding().signum() > 0);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorService.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
 import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorAccountHeaderEntity;
 import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorEntity;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
+import uk.gov.hmcts.opal.mapper.MinorCreditorAccountHeaderSummaryMapper;
 import uk.gov.hmcts.opal.mapper.MinorCreditorAccountUpdateMapper;
 import uk.gov.hmcts.opal.mapper.MinorCreditorAccountResponseMapper;
 import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
@@ -43,6 +44,7 @@ public class OpalMinorCreditorService implements MinorCreditorServiceInterface {
     private final CreditorAccountRepository creditorAccountRepository;
     private final PartyRepository partyRepository;
     private final AmendmentService amendmentService;
+    private final MinorCreditorAccountHeaderSummaryMapper headerSummaryMapper;
     private final MinorCreditorAccountUpdateMapper updateMapper;
     private final MinorCreditorAccountResponseMapper responseMapper;
 
@@ -72,7 +74,7 @@ public class OpalMinorCreditorService implements MinorCreditorServiceInterface {
                     "Minor creditor account not found: " + minorCreditorAccountId
                 ));
 
-        return GetMinorCreditorAccountHeaderSummaryResponse.fromEntity(entity);
+        return headerSummaryMapper.toResponse(entity);
     }
 
     @Override

--- a/src/test/java/uk/gov/hmcts/opal/mapper/MinorCreditorAccountHeaderSummaryMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/mapper/MinorCreditorAccountHeaderSummaryMapperTest.java
@@ -1,0 +1,156 @@
+package uk.gov.hmcts.opal.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import uk.gov.hmcts.opal.dto.GetMinorCreditorAccountHeaderSummaryResponse;
+import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountType;
+import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorAccountHeaderEntity;
+
+@SpringJUnitConfig
+@ContextConfiguration(classes = {
+    MinorCreditorAccountHeaderSummaryMapperImpl.class
+})
+class MinorCreditorAccountHeaderSummaryMapperTest {
+
+    @Autowired
+    private MinorCreditorAccountHeaderSummaryMapper mapper;
+
+    @Test
+    void givenIndividualEntity_whenToResponse_thenMapsExpectedFields() {
+        // Arrange
+        MinorCreditorAccountHeaderEntity entity = MinorCreditorAccountHeaderEntity.builder()
+            .creditorAccountId(101L)
+            .creditorAccountNumber("123")
+            .creditorAccountType(CreditorAccountType.MN)
+            .versionNumber(8L)
+            .partyId(999L)
+            .title("Ms")
+            .forenames("Jane")
+            .surname("Doe")
+            .organisation(false)
+            .businessUnitId((short) 12)
+            .businessUnitName("BU Name")
+            .welshLanguage(true)
+            .awarded(new BigDecimal("10.00"))
+            .paidOut(new BigDecimal("2.00"))
+            .awaitingPayment(new BigDecimal("1.00"))
+            .outstanding(BigDecimal.ZERO)
+            .build();
+
+        // Act
+        GetMinorCreditorAccountHeaderSummaryResponse mapped = mapper.toResponse(entity);
+
+        // Assert
+        assertNotNull(mapped);
+        assertEquals("101", mapped.getCreditorAccountId());
+        assertEquals("123", mapped.getAccountNumber());
+        assertEquals(BigInteger.valueOf(8L), mapped.getVersion());
+        assertNotNull(mapped.getCreditorAccountType());
+        assertEquals("MN", mapped.getCreditorAccountType().getType());
+        assertEquals("Minor Creditor", mapped.getCreditorAccountType().getDisplayName());
+        assertNotNull(mapped.getBusinessUnitSummary());
+        assertEquals("12", mapped.getBusinessUnitSummary().getBusinessUnitId());
+        assertEquals("BU Name", mapped.getBusinessUnitSummary().getBusinessUnitName());
+        assertEquals("Y", mapped.getBusinessUnitSummary().getWelshSpeaking());
+        assertNotNull(mapped.getPartyDetails());
+        assertEquals("999", mapped.getPartyDetails().getPartyId());
+        assertFalse(mapped.getPartyDetails().getOrganisationFlag());
+        assertNotNull(mapped.getPartyDetails().getIndividualDetails());
+        assertEquals("Ms", mapped.getPartyDetails().getIndividualDetails().getTitle());
+        assertEquals("Jane", mapped.getPartyDetails().getIndividualDetails().getForenames());
+        assertEquals("Doe", mapped.getPartyDetails().getIndividualDetails().getSurname());
+        assertNull(mapped.getPartyDetails().getOrganisationDetails());
+        assertTrue(mapped.getHasAssociatedDefendant());
+    }
+
+    @Test
+    void givenOrganisationEntityWithoutBalances_whenToResponse_thenMapsOrganisationAndFalseAssociation() {
+        // Arrange
+        MinorCreditorAccountHeaderEntity entity = MinorCreditorAccountHeaderEntity.builder()
+            .creditorAccountId(202L)
+            .creditorAccountNumber("101")
+            .creditorAccountType(CreditorAccountType.CF)
+            .partyId(303L)
+            .organisation(true)
+            .organisationName("Some Org Ltd")
+            .businessUnitId((short) 44)
+            .businessUnitName("Some BU Name")
+            .welshLanguage(false)
+            .build();
+
+        // Act
+        GetMinorCreditorAccountHeaderSummaryResponse mapped = mapper.toResponse(entity);
+
+        // Assert
+        assertNotNull(mapped.getCreditorAccountType());
+        assertEquals("CF", mapped.getCreditorAccountType().getType());
+        assertEquals("Central Fund", mapped.getCreditorAccountType().getDisplayName());
+        assertNotNull(mapped.getPartyDetails().getOrganisationDetails());
+        assertEquals("Some Org Ltd", mapped.getPartyDetails().getOrganisationDetails().getOrganisationName());
+        assertNull(mapped.getPartyDetails().getIndividualDetails());
+        assertEquals("N", mapped.getBusinessUnitSummary().getWelshSpeaking());
+        assertFalse(mapped.getHasAssociatedDefendant());
+    }
+
+    @Test
+    void givenMajorCreditorType_whenToResponse_thenMapsMajorCreditorDisplayName() {
+        // Arrange
+        MinorCreditorAccountHeaderEntity entity = MinorCreditorAccountHeaderEntity.builder()
+            .creditorAccountId(303L)
+            .creditorAccountNumber("202")
+            .creditorAccountType(CreditorAccountType.MJ)
+            .partyId(404L)
+            .organisation(true)
+            .organisationName("Major Creditor Ltd")
+            .businessUnitId((short) 55)
+            .businessUnitName("Major BU Name")
+            .welshLanguage(false)
+            .build();
+
+        // Act
+        GetMinorCreditorAccountHeaderSummaryResponse mapped = mapper.toResponse(entity);
+
+        // Assert
+        assertNotNull(mapped.getCreditorAccountType());
+        assertEquals("MJ", mapped.getCreditorAccountType().getType());
+        assertEquals("Major Creditor", mapped.getCreditorAccountType().getDisplayName());
+    }
+
+    @Test
+    void givenOutstandingPositiveAndAwardedNull_whenToResponse_thenHasAssociatedDefendantTrue() {
+        // Arrange
+        MinorCreditorAccountHeaderEntity entity = MinorCreditorAccountHeaderEntity.builder()
+            .creditorAccountId(404L)
+            .creditorAccountNumber("303")
+            .creditorAccountType(CreditorAccountType.MN)
+            .partyId(505L)
+            .organisation(false)
+            .title("Mr")
+            .forenames("John")
+            .surname("Smith")
+            .businessUnitId((short) 66)
+            .businessUnitName("Another BU Name")
+            .welshLanguage(false)
+            .awarded(null)
+            .paidOut(BigDecimal.ZERO)
+            .awaitingPayment(BigDecimal.ZERO)
+            .outstanding(new BigDecimal("1.00"))
+            .build();
+
+        // Act
+        GetMinorCreditorAccountHeaderSummaryResponse mapped = mapper.toResponse(entity);
+
+        // Assert
+        assertTrue(mapped.getHasAssociatedDefendant());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.jpa.domain.Specification;
 import jakarta.persistence.EntityNotFoundException;
@@ -23,8 +24,11 @@ import uk.gov.hmcts.opal.dto.common.CreditorAccountTypeReference;
 import uk.gov.hmcts.opal.dto.common.IndividualDetails;
 import uk.gov.hmcts.opal.dto.common.OrganisationDetails;
 import uk.gov.hmcts.opal.dto.common.PartyDetails;
+import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountType;
 import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorAccountHeaderEntity;
 import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorEntity;
+import uk.gov.hmcts.opal.mapper.MinorCreditorAccountHeaderSummaryMapper;
+import uk.gov.hmcts.opal.mapper.MinorCreditorAccountHeaderSummaryMapperImpl;
 import uk.gov.hmcts.opal.repository.MinorCreditorAccountHeaderRepository;
 import uk.gov.hmcts.opal.repository.MinorCreditorRepository;
 
@@ -52,6 +56,9 @@ class OpalMinorCreditorServiceTest {
     @Mock
     private MinorCreditorAccountHeaderRepository minorCreditorAccountHeaderRepository;
 
+    @Spy
+    private MinorCreditorAccountHeaderSummaryMapper headerSummaryMapper =
+        new MinorCreditorAccountHeaderSummaryMapperImpl();
 
     @InjectMocks
     private OpalMinorCreditorService service;
@@ -225,7 +232,7 @@ class OpalMinorCreditorServiceTest {
         MinorCreditorAccountHeaderEntity entity = MinorCreditorAccountHeaderEntity.builder()
             .creditorAccountId(id)
             .creditorAccountNumber("87654321")
-            .creditorAccountType("MN")
+            .creditorAccountType(CreditorAccountType.MN)
             .versionNumber(5L)
             .partyId(99000000000900L)
             .title(null)
@@ -289,7 +296,7 @@ class OpalMinorCreditorServiceTest {
         MinorCreditorAccountHeaderEntity entity = MinorCreditorAccountHeaderEntity.builder()
             .creditorAccountId(id)
             .creditorAccountNumber("87654322")
-            .creditorAccountType("MN")
+            .creditorAccountType(CreditorAccountType.MN)
             .versionNumber(null) // verify null -> null
             .partyId(99000000000901L)
             .title("Mr")
@@ -367,7 +374,7 @@ class OpalMinorCreditorServiceTest {
         MinorCreditorAccountHeaderEntity entity = MinorCreditorAccountHeaderEntity.builder()
             .creditorAccountId(id)
             .creditorAccountNumber("X")
-            .creditorAccountType("MN")
+            .creditorAccountType(CreditorAccountType.MN)
             .versionNumber(null)
             .partyId(333L)
             .organisation(true)
@@ -398,7 +405,7 @@ class OpalMinorCreditorServiceTest {
         MinorCreditorAccountHeaderEntity entity = MinorCreditorAccountHeaderEntity.builder()
             .creditorAccountId(id)
             .creditorAccountNumber("87654321")
-            .creditorAccountType("MN")
+            .creditorAccountType(CreditorAccountType.MN)
             .versionNumber(null) // covers version null branch
             .partyId(99000000000900L)
             .organisation(true)
@@ -460,7 +467,7 @@ class OpalMinorCreditorServiceTest {
         MinorCreditorAccountHeaderEntity entity = MinorCreditorAccountHeaderEntity.builder()
             .creditorAccountId(id)
             .creditorAccountNumber("ACC123")
-            .creditorAccountType("MN")
+            .creditorAccountType(CreditorAccountType.MN)
             .versionNumber(5L) // covers version non-null branch
             .partyId(456L)
             .organisation(false)
@@ -514,7 +521,7 @@ class OpalMinorCreditorServiceTest {
         MinorCreditorAccountHeaderEntity entity = MinorCreditorAccountHeaderEntity.builder()
             .creditorAccountId(id)
             .creditorAccountNumber("ACC200")
-            .creditorAccountType("MN")
+            .creditorAccountType(CreditorAccountType.MN)
             .versionNumber(null)
             .partyId(300L)
             .organisation(true)
@@ -545,7 +552,7 @@ class OpalMinorCreditorServiceTest {
         MinorCreditorAccountHeaderEntity entity = MinorCreditorAccountHeaderEntity.builder()
             .creditorAccountId(id)
             .creditorAccountNumber("ACC201")
-            .creditorAccountType("MN")
+            .creditorAccountType(CreditorAccountType.MN)
             .versionNumber(null)
             .partyId(301L)
             .organisation(false)


### PR DESCRIPTION
### JIRA link (if applicable) ###
BE - Database enum alignment - Creditor Accounts
https://tools.hmcts.net/jira/browse/PO-2897

### Change description ###
Refactored minor creditor account entity to  align `creditor_account_type` with the Java enum:
- Replaced `String` usage with `CreditorAccountType` in the entity
- Moved the touched header summary entity-to-DTO mapping to use MapStruct
- Updated tests to cover enum mapping behaviour  


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
