### PR TITLE
Po 2281 add exception to global handler

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantsCommentNotesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantsCommentNotesIntegrationTest.java
@@ -76,8 +76,8 @@ class LegacyDefendantsCommentNotesIntegrationTest extends AbstractLegacyDefendan
     }
 
     @Test
-    @DisplayName("LEGACY: PATCH Update Defendant Account - Update Comment Notes - 500 Error [@PO-1908]")
-    void testUpdateDefAcc_CommentNotes_500Error() throws Exception {
+    @DisplayName("LEGACY: PATCH Update Defendant Account - Update Comment Notes - 400 Error [@PO-1908]")
+    void testUpdateDefAcc_CommentNotes_400ErrorForMissingRequiredHeader() throws Exception {
         when(userStateService.checkForAuthorisedUser(any())).thenReturn(allPermissionsUser());
 
         String requestJson = commentAndNotesPayload(
@@ -88,16 +88,16 @@ class LegacyDefendantsCommentNotesIntegrationTest extends AbstractLegacyDefendan
         );
 
         ResultActions actions = mockMvc.perform(
-            patch(URL_BASE + "/500")
+            patch(URL_BASE + "/400")
                 .header("authorization", "Bearer some_value")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestJson)
         );
 
         String body = actions.andReturn().getResponse().getContentAsString();
-        log.info(":Legacy_UpdateDefendantAccount_CommentNotes_500Error body:\n{}", ToJsonString.toPrettyJson(body));
+        log.info(":Legacy_UpdateDefendantAccount_CommentNotes_400Error body:\n{}", ToJsonString.toPrettyJson(body));
 
-        actions.andExpect(status().is5xxServerError())
+        actions.andExpect(status().isBadRequest())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE))
             .andExpect(header().doesNotExist("ETag"));
     }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsPatchIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsPatchIntegrationTest.java
@@ -18,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
@@ -383,6 +384,12 @@ class OpalDefendantsPatchIntegrationTest extends AbstractOpalDefendantsIntegrati
                 .headers(headers)
                 .contentType(MediaType.APPLICATION_JSON).content("")
             ).andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/missing-header"));
+            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/missing-header"))
+            .andExpect(jsonPath("$.title").value("Missing Required Header"))
+            .andExpect(jsonPath("$.detail").isNotEmpty())
+            .andExpect(jsonPath("$.instance").isNotEmpty())
+            .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+            .andExpect(jsonPath("$.operation_id").isNotEmpty())
+            .andExpect(jsonPath("$.retriable").value(false));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsPatchIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsPatchIntegrationTest.java
@@ -373,4 +373,16 @@ class OpalDefendantsPatchIntegrationTest extends AbstractOpalDefendantsIntegrati
         assertNotNull(etag, "ETag must be present");
         assertTrue(etag.matches("^\"\\d+\"$"), "ETag should be a quoted number");
     }
+
+    @Test
+    @DisplayName("OPAL: PATCH Update Defendant Account - Missing required headers [@PO-2281]")
+    void patch_badRequest_whenMissingRequiredHeader() throws Exception {
+        authoriseAllPermissions();
+        HttpHeaders headers = new HttpHeaders();
+        mockMvc.perform(patch(URL_BASE + "/77")
+                .headers(headers)
+                .contentType(MediaType.APPLICATION_JSON).content("")
+            ).andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/missing-header"));
+    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsPatchIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsPatchIntegrationTest.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.opal.controllers;
 
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -386,10 +386,9 @@ class OpalDefendantsPatchIntegrationTest extends AbstractOpalDefendantsIntegrati
             ).andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/missing-header"))
             .andExpect(jsonPath("$.title").value("Missing Required Header"))
-            .andExpect(jsonPath("$.detail").isNotEmpty())
+            .andExpect(jsonPath("$.detail").value("Required request header \"Authorization\" is missing"))
             .andExpect(jsonPath("$.instance").isNotEmpty())
             .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-            .andExpect(jsonPath("$.operation_id").isNotEmpty())
             .andExpect(jsonPath("$.retriable").value(false));
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
@@ -69,7 +69,7 @@ public class GlobalExceptionHandler {
         ProblemDetail problemDetail = createProblemDetail(
             HttpStatus.BAD_REQUEST,
             "Missing Required Header",
-            "A required request header is missing",
+            String.format("Required request header \"%s\" is missing", ex.getHeaderName()),
             "missing-header",
             false,
             ex

--- a/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
@@ -37,6 +37,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.transaction.TransactionSystemException;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.client.HttpServerErrorException;
@@ -44,7 +45,6 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 import uk.gov.hmcts.opal.common.exception.OpalApiException;
 import uk.gov.hmcts.opal.common.logging.LogUtil;
-import uk.gov.hmcts.opal.common.user.authentication.exception.MissingRequestHeaderException;
 import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
 import uk.gov.hmcts.opal.exception.JsonSchemaValidationException;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;

--- a/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
@@ -81,7 +81,7 @@ class GlobalExceptionHandlerTest {
 
     @Test
     void handleMissingHeader_false() throws NoSuchMethodException {
-        Method method = TestMissingHeaderClass.class.getMethod("testMethod");
+        Method method = TestMissingHeaderClass.class.getMethod("testMethod", String.class);
         MethodParameter param = new MethodParameter(method, 0);
         MissingRequestHeaderException ex = new MissingRequestHeaderException("TYPE", param);
         ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleMissingRequestHeaderException(ex);
@@ -95,7 +95,8 @@ class GlobalExceptionHandlerTest {
     }
 
     static class TestMissingHeaderClass {
-        public void testMethod() {}
+        public void testMethod(String type) {
+        }
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
@@ -52,12 +52,12 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.TransactionSystemException;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 import uk.gov.hmcts.opal.common.exception.OpalApiException;
 import uk.gov.hmcts.opal.common.user.authentication.exception.AuthenticationError;
-import uk.gov.hmcts.opal.common.user.authentication.exception.MissingRequestHeaderException;
 import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
 import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountEntity;
@@ -80,8 +80,10 @@ class GlobalExceptionHandlerTest {
     // ---------- Simple false (non-retriable) buckets ----------
 
     @Test
-    void handleMissingHeader_false() {
-        MissingRequestHeaderException ex = new MissingRequestHeaderException("TYPE");
+    void handleMissingHeader_false() throws NoSuchMethodException {
+        Method method = TestMissingHeaderClass.class.getMethod("testMethod");
+        MethodParameter param = new MethodParameter(method, 0);
+        MissingRequestHeaderException ex = new MissingRequestHeaderException("TYPE", param);
         ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleMissingRequestHeaderException(ex);
 
         assertEquals(HttpStatus.BAD_REQUEST, r.getStatusCode());
@@ -90,6 +92,10 @@ class GlobalExceptionHandlerTest {
         assertEquals("Missing Required Header", pd.getTitle());
         assertEquals(URI.create("https://hmcts.gov.uk/problems/missing-header"), pd.getType());
         assertEquals(false, pd.getProperties().get("retriable"));
+    }
+
+    static class TestMissingHeaderClass {
+        public void testMethod() {}
     }
 
     @Test


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/PO-2281 

Fix issue of GlobalExceptionHandler not handling MissingRequestHeaderException. 

This issue was that the handler was catching the wrong MissingRequestHeaderException and the import statement needed updating to catch the correct exception.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
