### PR TITLE
PO-2124: Updated account.json and the matching legacy schema accountL…

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerIntegrationTest.java
@@ -307,6 +307,7 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
                 FinesPermission.ADD_AND_REMOVE_PAYMENT_HOLD,
                 FinesPermission.ACCOUNT_MAINTENANCE));
 
+        final boolean initialHoldPayout = getCurrentCreditorAccountHoldPayout();
         Integer currentVersion = getCurrentCreditorAccountVersion();
 
         String requestJson = patchMinorCreditorPayoutHoldRequestJson();
@@ -333,8 +334,9 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
             .andExpect(jsonPath("$.payment.hold_payment").value(true))
             .andExpect(jsonPath("$.payment.pay_by_bacs").value(true));
 
+        assertEquals(true, getCurrentCreditorAccountHoldPayout());
         Integer updatedVersion = getCurrentCreditorAccountVersion();
-        assertEquals(currentVersion + 1, updatedVersion);
+        assertEquals(initialHoldPayout ? currentVersion : currentVersion + 1, updatedVersion);
     }
 
     void patchMinorCreditor_withoutPermission_returns403() throws Exception {
@@ -458,6 +460,15 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
             Integer.class,
             PATCH_MINOR_CREDITOR_ACCOUNT_ID
         );
+    }
+
+    private boolean getCurrentCreditorAccountHoldPayout() {
+        Boolean holdPayout = jdbcTemplate.queryForObject(
+            "SELECT hold_payout FROM creditor_accounts WHERE creditor_account_id = ?",
+            Boolean.class,
+            PATCH_MINOR_CREDITOR_ACCOUNT_ID
+        );
+        return Boolean.TRUE.equals(holdPayout);
     }
 
     // AC1b: Test that both active and inactive accounts are returned regardless of activeAccountsOnly value

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerIntegrationTest.java
@@ -47,6 +47,9 @@ import static uk.gov.hmcts.opal.controllers.util.UserStateUtil.permissionUser;
 abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegrationTest {
 
     protected static final String URL_BASE = "/minor-creditor-accounts";
+    private static final String AUTH_HEADER = "Bearer some_value";
+    private static final long PATCH_MINOR_CREDITOR_ACCOUNT_ID = 607L;
+    private static final short PATCH_MINOR_CREDITOR_BUSINESS_UNIT_ID = 10;
 
     private static final String MINOR_CREDITOR_RESPONSE =
         "opal/minor-creditor/postMinorCreditorAccountSearchResponse.json";
@@ -299,19 +302,21 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
     }
 
     void patchMinorCreditor_payoutHold_success(Logger log) throws Exception {
-        when(userStateService.checkForAuthorisedUser(any()))
-            .thenReturn(permissionUser((short)10, FinesPermission.ADD_AND_REMOVE_PAYMENT_HOLD));
+        when(userStateService.checkForAuthorisedUser(AUTH_HEADER))
+            .thenReturn(permissionUser(PATCH_MINOR_CREDITOR_BUSINESS_UNIT_ID,
+                FinesPermission.ADD_AND_REMOVE_PAYMENT_HOLD,
+                FinesPermission.ACCOUNT_MAINTENANCE));
 
-        Integer currentVersion = getCurrentCreditorAccountVersion(607L);
+        Integer currentVersion = getCurrentCreditorAccountVersion();
 
         String requestJson = patchMinorCreditorPayoutHoldRequestJson();
 
         ResultActions a = mockMvc.perform(
-            patch(URL_BASE + "/607")
+            patch(URL_BASE + "/" + PATCH_MINOR_CREDITOR_ACCOUNT_ID)
                 .contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", "Bearer some_value")
+                .header("Authorization", AUTH_HEADER)
                 .header("If-Match", currentVersion)
-                .header("Business-Unit-Id", "10")
+                .header("Business-Unit-Id", String.valueOf(PATCH_MINOR_CREDITOR_BUSINESS_UNIT_ID))
                 .content(requestJson));
 
         String body = a.andReturn().getResponse().getContentAsString();
@@ -321,14 +326,14 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
         a.andExpect(status().isOk())
             .andExpect(header().exists("ETag"))
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.creditor_account_id").value(607))
+            .andExpect(jsonPath("$.creditor_account_id").value(PATCH_MINOR_CREDITOR_ACCOUNT_ID))
             .andExpect(jsonPath("$.party_details.individual_details.surname").value("Updated"))
             .andExpect(jsonPath("$.party_details.individual_details.forenames").value("Creditor"))
             .andExpect(jsonPath("$.address.postcode").value("NW1 1AA"))
             .andExpect(jsonPath("$.payment.hold_payment").value(true))
             .andExpect(jsonPath("$.payment.pay_by_bacs").value(true));
 
-        Integer updatedVersion = getCurrentCreditorAccountVersion(607L);
+        Integer updatedVersion = getCurrentCreditorAccountVersion();
         assertEquals(currentVersion + 1, updatedVersion);
     }
 
@@ -339,7 +344,7 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
         UserState userState = UserState.builder().userId(123L).build();
         when(userStateClientService.getUserStateByAuthenticatedUser()).thenReturn(Optional.of(userState));
 
-        Integer currentVersion = getCurrentCreditorAccountVersion(607L);
+        Integer currentVersion = getCurrentCreditorAccountVersion();
 
         mockMvc.perform(patch(URL_BASE + "/606")
                             .contentType(MediaType.APPLICATION_JSON)
@@ -351,17 +356,52 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
     }
 
-    void patchMinorCreditor_missingPayload_returns400() throws Exception {
-        when(userStateService.checkForAuthorisedUser(any()))
-            .thenReturn(permissionUser((short)10, FinesPermission.ADD_AND_REMOVE_PAYMENT_HOLD));
+    void patchMinorCreditor_withoutHoldPermission_returns403() throws Exception {
+        when(userStateService.checkForAuthorisedUser(AUTH_HEADER))
+            .thenReturn(permissionUser(PATCH_MINOR_CREDITOR_BUSINESS_UNIT_ID, FinesPermission.ACCOUNT_MAINTENANCE));
 
-        Integer currentVersion = getCurrentCreditorAccountVersion(607L);
+        Integer currentVersion = getCurrentCreditorAccountVersion();
 
-        mockMvc.perform(patch(URL_BASE + "/607")
+        mockMvc.perform(patch(URL_BASE + "/" + PATCH_MINOR_CREDITOR_ACCOUNT_ID)
                             .contentType(MediaType.APPLICATION_JSON)
-                            .header("Authorization", "Bearer some_value")
+                            .header("Authorization", AUTH_HEADER)
                             .header("If-Match", currentVersion)
-                            .header("Business-Unit-Id", "10")
+                            .header("Business-Unit-Id", String.valueOf(PATCH_MINOR_CREDITOR_BUSINESS_UNIT_ID))
+                            .content(patchMinorCreditorPayoutHoldRequestJson()))
+            .andExpect(status().isForbidden())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    void patchMinorCreditor_withoutAccountMaintenancePermission_returns403() throws Exception {
+        when(userStateService.checkForAuthorisedUser(AUTH_HEADER))
+            .thenReturn(permissionUser(PATCH_MINOR_CREDITOR_BUSINESS_UNIT_ID,
+                FinesPermission.ADD_AND_REMOVE_PAYMENT_HOLD));
+
+        Integer currentVersion = getCurrentCreditorAccountVersion();
+
+        mockMvc.perform(patch(URL_BASE + "/" + PATCH_MINOR_CREDITOR_ACCOUNT_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header("Authorization", AUTH_HEADER)
+                            .header("If-Match", currentVersion)
+                            .header("Business-Unit-Id", String.valueOf(PATCH_MINOR_CREDITOR_BUSINESS_UNIT_ID))
+                            .content(patchMinorCreditorPayoutHoldRequestJson()))
+            .andExpect(status().isForbidden())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
+    }
+
+    void patchMinorCreditor_missingPayload_returns400() throws Exception {
+        when(userStateService.checkForAuthorisedUser(AUTH_HEADER))
+            .thenReturn(permissionUser(PATCH_MINOR_CREDITOR_BUSINESS_UNIT_ID,
+                FinesPermission.ADD_AND_REMOVE_PAYMENT_HOLD,
+                FinesPermission.ACCOUNT_MAINTENANCE));
+
+        Integer currentVersion = getCurrentCreditorAccountVersion();
+
+        mockMvc.perform(patch(URL_BASE + "/" + PATCH_MINOR_CREDITOR_ACCOUNT_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .header("Authorization", AUTH_HEADER)
+                            .header("If-Match", currentVersion)
+                            .header("Business-Unit-Id", String.valueOf(PATCH_MINOR_CREDITOR_BUSINESS_UNIT_ID))
                             .content("{}"))
             .andExpect(status().isBadRequest())
             .andExpect(content().string(org.hamcrest.Matchers.anything()));
@@ -412,11 +452,11 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
             """;
     }
 
-    private Integer getCurrentCreditorAccountVersion(Long creditorAccountId) {
+    private Integer getCurrentCreditorAccountVersion() {
         return jdbcTemplate.queryForObject(
             "SELECT version_number FROM creditor_accounts WHERE creditor_account_id = ?",
             Integer.class,
-            creditorAccountId
+            PATCH_MINOR_CREDITOR_ACCOUNT_ID
         );
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMinorCreditorIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMinorCreditorIntegrationTest.java
@@ -208,6 +208,16 @@ public class OpalMinorCreditorIntegrationTest extends MinorCreditorControllerInt
     }
 
     @Test
+    void patchMinorCreditor_withoutHoldPermission_returns403() throws Exception {
+        super.patchMinorCreditor_withoutHoldPermission_returns403();
+    }
+
+    @Test
+    void patchMinorCreditor_withoutAccountMaintenancePermission_returns403() throws Exception {
+        super.patchMinorCreditor_withoutAccountMaintenancePermission_returns403();
+    }
+
+    @Test
     void patchMinorCreditor_missingPayload_returns400() throws Exception {
         super.patchMinorCreditor_missingPayload_returns400();
     }

--- a/src/main/java/uk/gov/hmcts/opal/service/MinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/MinorCreditorService.java
@@ -99,6 +99,11 @@ public class MinorCreditorService {
                 businessUnitIdShort,
                 FinesPermission.ADD_AND_REMOVE_PAYMENT_HOLD);
         }
+        if (!userState.hasBusinessUnitUserWithPermission(businessUnitIdShort, FinesPermission.ACCOUNT_MAINTENANCE)) {
+            throw new PermissionNotAllowedException(
+                businessUnitIdShort,
+                FinesPermission.ACCOUNT_MAINTENANCE);
+        }
 
         String postedBy = userState.getBusinessUnitUserForBusinessUnit(businessUnitIdShort)
             .map(uk.gov.hmcts.opal.common.user.authorisation.model.BusinessUnitUser::getBusinessUnitUserId)

--- a/src/main/resources/jsonSchemas/legacy/common-objects/accountLegacy.json
+++ b/src/main/resources/jsonSchemas/legacy/common-objects/accountLegacy.json
@@ -372,9 +372,10 @@
                     "description": "Date of issue"
                 },
                 "time_of_issue": {
-                    "type": "string",
-                    "maxLength": 5,
-                    "description": "Time of issue in HH:mm format"
+                    "type": ["string", "null"],
+                    "maxLength": 8,
+                    "pattern": "^([01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d$",
+                    "description": "Time of issue in HH:MM:SS format"
                 },
                 "fp_registration_number": {
                     "type": ["string", "null"],

--- a/src/main/resources/jsonSchemas/legacy/common-objects/accountLegacy.json
+++ b/src/main/resources/jsonSchemas/legacy/common-objects/accountLegacy.json
@@ -372,10 +372,9 @@
                     "description": "Date of issue"
                 },
                 "time_of_issue": {
-                    "type": ["string", "null"],
-                    "maxLength": 8,
-                    "pattern": "^([01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d$",
-                    "description": "Time of issue in HH:MM:SS format"
+                    "type": "string",
+                    "maxLength": 5,
+                    "description": "Time of issue in HH:mm format"
                 },
                 "fp_registration_number": {
                     "type": ["string", "null"],

--- a/src/main/resources/jsonSchemas/legacy/common-objects/accountLegacy.json
+++ b/src/main/resources/jsonSchemas/legacy/common-objects/accountLegacy.json
@@ -373,7 +373,8 @@
                 },
                 "time_of_issue": {
                     "type": "string",
-                    "description": "Time of issue"
+                    "maxLength": 5,
+                    "description": "Time of issue in HH:mm format"
                 },
                 "fp_registration_number": {
                     "type": ["string", "null"],

--- a/src/main/resources/jsonSchemas/legacy/common-objects/accountLegacy.json
+++ b/src/main/resources/jsonSchemas/legacy/common-objects/accountLegacy.json
@@ -372,9 +372,8 @@
                     "description": "Date of issue"
                 },
                 "time_of_issue": {
-                    "type": ["string", "null"],
-                    "format": "time",
-                    "description": "Date of issue"
+                    "type": "string",
+                    "description": "Time of issue"
                 },
                 "fp_registration_number": {
                     "type": ["string", "null"],

--- a/src/main/resources/jsonSchemas/opal/defendant-account/account.json
+++ b/src/main/resources/jsonSchemas/opal/defendant-account/account.json
@@ -372,9 +372,10 @@
                     "description": "Date of issue"
                 },
                 "time_of_issue": {
-                    "type": "string",
-                    "maxLength": 5,
-                    "description": "Time of issue in HH:mm format"
+                    "type": ["string", "null"],
+                    "maxLength": 8,
+                    "pattern": "^([01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d$",
+                    "description": "Time of issue in HH:MM:SS format"
                 },
                 "fp_registration_number": {
                     "type": ["string", "null"],

--- a/src/main/resources/jsonSchemas/opal/defendant-account/account.json
+++ b/src/main/resources/jsonSchemas/opal/defendant-account/account.json
@@ -372,10 +372,9 @@
                     "description": "Date of issue"
                 },
                 "time_of_issue": {
-                    "type": ["string", "null"],
-                    "maxLength": 8,
-                    "pattern": "^([01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d$",
-                    "description": "Time of issue in HH:MM:SS format"
+                    "type": "string",
+                    "maxLength": 5,
+                    "description": "Time of issue in HH:mm format"
                 },
                 "fp_registration_number": {
                     "type": ["string", "null"],

--- a/src/main/resources/jsonSchemas/opal/defendant-account/account.json
+++ b/src/main/resources/jsonSchemas/opal/defendant-account/account.json
@@ -373,7 +373,8 @@
                 },
                 "time_of_issue": {
                     "type": "string",
-                    "description": "Time of issue"
+                    "maxLength": 5,
+                    "description": "Time of issue in HH:mm format"
                 },
                 "fp_registration_number": {
                     "type": ["string", "null"],

--- a/src/main/resources/jsonSchemas/opal/defendant-account/account.json
+++ b/src/main/resources/jsonSchemas/opal/defendant-account/account.json
@@ -372,9 +372,8 @@
                     "description": "Date of issue"
                 },
                 "time_of_issue": {
-                    "type": ["string", "null"],
-                    "format": "time",
-                    "description": "Date of issue"
+                    "type": "string",
+                    "description": "Time of issue"
                 },
                 "fp_registration_number": {
                     "type": ["string", "null"],

--- a/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
@@ -263,6 +263,8 @@ class MinorCreditorServiceTest {
         UserState userState = mock(UserState.class);
         when(userState.hasBusinessUnitUserWithPermission((short) 10, FinesPermission.ADD_AND_REMOVE_PAYMENT_HOLD))
             .thenReturn(true);
+        when(userState.hasBusinessUnitUserWithPermission((short) 10, FinesPermission.ACCOUNT_MAINTENANCE))
+            .thenReturn(true);
         when(userState.getUserName()).thenReturn("test.user@hmcts.net");
         when(userState.getBusinessUnitUserForBusinessUnit((short) 10)).thenReturn(Optional.of(
             BusinessUnitUser.builder()


### PR DESCRIPTION
Jira Link
https://tools.hmcts.net/jira/browse/PO-2124


Change description 
Updated account.json and the matching legacy schema accountLegacy.json. time_of_issue is now validated as a plain "string" only, the obsolete format: "time" constraint is removed, and the description is corrected to "Time of issue".


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
