### PR TITLE
PO-3696 Add ETag support for minor creditor at a glance endpoint

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerIntegrationTest.java
@@ -309,6 +309,7 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
 
         final boolean initialHoldPayout = getCurrentCreditorAccountHoldPayout();
         Integer currentVersion = getCurrentCreditorAccountVersion();
+        String currentEtag = "\"" + currentVersion + "\"";
 
         String requestJson = patchMinorCreditorPayoutHoldRequestJson();
 
@@ -316,7 +317,7 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
             patch(URL_BASE + "/" + PATCH_MINOR_CREDITOR_ACCOUNT_ID)
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", AUTH_HEADER)
-                .header("If-Match", currentVersion)
+                .header("If-Match", currentEtag)
                 .header("Business-Unit-Id", String.valueOf(PATCH_MINOR_CREDITOR_BUSINESS_UNIT_ID))
                 .content(requestJson));
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerIntegrationTest.java
@@ -1017,6 +1017,7 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
         resultActions
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(header().string("etag", "\"1\""))
 
             // party
             .andExpect(jsonPath("$.party.party_id").value("99000000000901"))

--- a/src/main/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiController.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.opal.controllers;
 
 import static uk.gov.hmcts.opal.util.HttpUtil.buildResponse;
 
+import java.math.BigInteger;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,7 +32,7 @@ public class MinorCreditorApiController implements MinorCreditorApi {
     public ResponseEntity<MinorCreditorAccountResponseMinorCreditor> patchMinorCreditorAccount(
         Long id,
         String businessUnitId,
-        Long ifMatch,
+        String ifMatch,
         String authHeaderValue,
         PatchMinorCreditorAccountRequest patchMinorCreditorAccountRequest) {
 
@@ -39,7 +40,7 @@ public class MinorCreditorApiController implements MinorCreditorApi {
 
         MinorCreditorAccountResponse result =
             minorCreditorService.updateMinorCreditorAccount(id, patchMinorCreditorAccountRequest,
-                Optional.ofNullable(ifMatch).map(java.math.BigInteger::valueOf).orElse(null),
+                Optional.ofNullable(ifMatch).map(BigInteger::new).orElse(null),
                 authHeaderValue, businessUnitId);
 
         return buildResponse(result);

--- a/src/main/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiController.java
@@ -1,8 +1,8 @@
 package uk.gov.hmcts.opal.controllers;
 
 import static uk.gov.hmcts.opal.util.HttpUtil.buildResponse;
+import static uk.gov.hmcts.opal.util.VersionUtils.extractOptionalBigInteger;
 
-import java.math.BigInteger;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,7 +40,7 @@ public class MinorCreditorApiController implements MinorCreditorApi {
 
         MinorCreditorAccountResponse result =
             minorCreditorService.updateMinorCreditorAccount(id, patchMinorCreditorAccountRequest,
-                Optional.ofNullable(ifMatch).map(BigInteger::new).orElse(null),
+                extractOptionalBigInteger(ifMatch).orElse(null),
                 authHeaderValue, businessUnitId);
 
         return buildResponse(result);

--- a/src/main/java/uk/gov/hmcts/opal/dto/GetMinorCreditorAccountAtAGlanceResponse.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/GetMinorCreditorAccountAtAGlanceResponse.java
@@ -1,20 +1,26 @@
 package uk.gov.hmcts.opal.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigInteger;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.opal.dto.common.AddressDetails;
 import uk.gov.hmcts.opal.dto.common.PartyDetails;
+import uk.gov.hmcts.opal.util.Versioned;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class GetMinorCreditorAccountAtAGlanceResponse implements ToJsonString {
+public class GetMinorCreditorAccountAtAGlanceResponse implements ToJsonString, Versioned {
+
+    @JsonIgnore
+    private BigInteger version;
 
     @JsonProperty("party")
     private PartyDetails party;

--- a/src/main/java/uk/gov/hmcts/opal/mapper/response/GetMinorCreditorAccountAtAGlanceResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/mapper/response/GetMinorCreditorAccountAtAGlanceResponseMapper.java
@@ -24,6 +24,7 @@ import uk.gov.hmcts.opal.mapper.common.PaymentMapper;
     }
 )
 public interface GetMinorCreditorAccountAtAGlanceResponseMapper {
+    @Mapping(target = "version", source = "creditorAccountVersion")
     GetMinorCreditorAccountAtAGlanceResponse toDto(LegacyGetMinorCreditorAccountAtAGlanceResponse legacy);
 
     @Mappings({
@@ -35,6 +36,7 @@ public interface GetMinorCreditorAccountAtAGlanceResponseMapper {
         @Mapping(target = "address.postcode", source = "entity.postcode"),
 
         @Mapping(target = "creditorAccountId", source = "entity.creditorId"),
+        @Mapping(target = "version", source = "entity.versionNumber"),
 
         @Mapping(target = "defendant.accountId", source = "entity.defendantAccountId"),
         @Mapping(target = "defendant.accountNumber", source = "entity.defendantAccountNumber"),

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorService.java
@@ -109,7 +109,9 @@ public class LegacyMinorCreditorService implements MinorCreditorServiceInterface
 
         checkResponseForError(response, "getMinorCreditorAtAGlance");
 
-        return atAGlanceResponseMapper.toDto(response.responseEntity);
+        GetMinorCreditorAccountAtAGlanceResponse mapped = atAGlanceResponseMapper.toDto(response.responseEntity);
+        mapped.setVersion(response.responseEntity.getCreditorAccountVersion());
+        return mapped;
     }
 
     private LegacyMinorCreditorSearchResultsRequest createRequest(MinorCreditorSearch request) {

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorService.java
@@ -77,7 +77,14 @@ public class OpalMinorCreditorService implements MinorCreditorServiceInterface {
                 "Party not found: " + minorCreditorEntity.getPartyId()
             ));
 
-        return atAGlanceResponseMapper.toDto(minorCreditorEntity, partyEntity);
+        GetMinorCreditorAccountAtAGlanceResponse response =
+            atAGlanceResponseMapper.toDto(minorCreditorEntity, partyEntity);
+
+        if (minorCreditorEntity.getVersionNumber() != null) {
+            response.setVersion(BigInteger.valueOf(minorCreditorEntity.getVersionNumber()));
+        }
+
+        return response;
     }
 
     @Override

--- a/src/main/resources/openapi/MinorCreditor.yaml
+++ b/src/main/resources/openapi/MinorCreditor.yaml
@@ -84,7 +84,7 @@ paths:
           name: If-Match
           description: Version of the minor creditor account. DB Mapping - creditor_accounts.version
           schema:
-            $ref: "./types.yaml#/components/schemas/BigInt"
+            type: string
         - in: header
           name: Authorization
           description: Bearer token
@@ -121,7 +121,7 @@ paths:
             ETag:
               description: Version of the minor creditor account. DB Mapping - creditor_accounts.version
               schema:
-                $ref: "./types.yaml#/components/schemas/BigInt"
+                type: string
           content:
             application/json:
               schema:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-3696


### Change description ###
Adds ETag support to the minor creditor at a glance response by carrying the creditor account version through the backend response path.
This updates the existing integration coverage to assert the ETag header. End-to-end verification depends on the related version_number data change in PO-3697.

- Updates the minor creditor PATCH OpenAPI contract so If-Match and the returned ETag are treated as string header values.
- Updates MinorCreditorApiController to handle If-Match using the shared version parsing utility, so quoted ETag values returned by the API are accepted correctly.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
