### PR TITLE
PO-2885: Update Courts to use Entity Graphs

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/repository/CourtRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/repository/CourtRepositoryIntegrationTest.java
@@ -1,0 +1,129 @@
+package uk.gov.hmcts.opal.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.PersistenceUnitUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import uk.gov.hmcts.opal.AbstractIntegrationTest;
+import uk.gov.hmcts.opal.entity.court.CourtEntity;
+import uk.gov.hmcts.opal.repository.jpa.CourtSpecs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
+
+@ActiveProfiles({"integration"})
+@DisplayName("Court Repository Integration Tests")
+@Sql(
+    scripts = "classpath:db/insertData/insert_into_courts_entity_graph.sql",
+    executionPhase = BEFORE_TEST_METHOD
+)
+@Sql(
+    scripts = "classpath:db/deleteData/delete_from_courts_entity_graph.sql",
+    executionPhase = AFTER_TEST_METHOD
+)
+class CourtRepositoryIntegrationTest extends AbstractIntegrationTest {
+
+    private static final long COURT_ID = 951002L;
+    private static final long PARENT_COURT_ID = 951001L;
+    private static final short BUSINESS_UNIT_ID = 951;
+    private static final short LOCAL_JUSTICE_AREA_ID = 951;
+
+    @Autowired
+    private CourtRepository courtRepository;
+
+    @Autowired
+    private CourtLiteRepository courtLiteRepository;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void shouldKeepAssociationsLazyWhenNoEntityGraphIsUsed() {
+        entityManager.clear();
+
+        CourtEntity court = entityManager.find(CourtEntity.class, COURT_ID);
+        PersistenceUnitUtil unitUtil = entityManagerFactory.getPersistenceUnitUtil();
+
+        assertNotNull(court);
+        assertFalse(unitUtil.isLoaded(court, "businessUnit"));
+        assertFalse(unitUtil.isLoaded(court, "localJusticeArea"));
+        assertFalse(unitUtil.isLoaded(court, "parentCourt"));
+    }
+
+    @Test
+    void shouldKeepAssociationsLazyWhenLiteEntityGraphIsUsedForDirectFetch() {
+        entityManager.clear();
+
+        CourtEntity court = courtLiteRepository.findById(COURT_ID).orElseThrow();
+
+        assertAssociationsRemainLazy(court);
+    }
+
+    @Test
+    void shouldKeepAssociationsLazyWhenLiteEntityGraphIsUsedForSpecificationFetch() {
+        entityManager.clear();
+
+        Page<CourtEntity> page = courtLiteRepository.findBy(
+            CourtSpecs.equalsCourtId(COURT_ID),
+            ffq -> ffq.page(Pageable.unpaged())
+        );
+        CourtEntity court = page.getContent().getFirst();
+
+        assertEquals(1, page.getContent().size());
+        assertAssociationsRemainLazy(court);
+    }
+
+    @Test
+    void shouldLoadFullEntityGraphForDirectFetch() {
+        entityManager.clear();
+
+        CourtEntity court = courtRepository.findById(COURT_ID).orElseThrow();
+        PersistenceUnitUtil unitUtil = entityManagerFactory.getPersistenceUnitUtil();
+
+        assertTrue(unitUtil.isLoaded(court, "businessUnit"));
+        assertTrue(unitUtil.isLoaded(court, "localJusticeArea"));
+        assertTrue(unitUtil.isLoaded(court, "parentCourt"));
+        assertEquals(BUSINESS_UNIT_ID, court.getBusinessUnit().getBusinessUnitId());
+        assertEquals(LOCAL_JUSTICE_AREA_ID, court.getLocalJusticeArea().getLocalJusticeAreaId());
+        assertEquals(PARENT_COURT_ID, court.getParentCourt().getCourtId());
+    }
+
+    @Test
+    void shouldLoadFullEntityGraphForSpecificationFetch() {
+        entityManager.clear();
+
+        Page<CourtEntity> page = courtRepository.findBy(
+            CourtSpecs.equalsCourtId(COURT_ID),
+            ffq -> ffq.page(Pageable.unpaged())
+        );
+        CourtEntity court = page.getContent().getFirst();
+        PersistenceUnitUtil unitUtil = entityManagerFactory.getPersistenceUnitUtil();
+
+        assertEquals(1, page.getContent().size());
+        assertTrue(unitUtil.isLoaded(court, "businessUnit"));
+        assertTrue(unitUtil.isLoaded(court, "localJusticeArea"));
+        assertTrue(unitUtil.isLoaded(court, "parentCourt"));
+    }
+
+    private void assertAssociationsRemainLazy(CourtEntity court) {
+        PersistenceUnitUtil unitUtil = entityManagerFactory.getPersistenceUnitUtil();
+
+        assertFalse(unitUtil.isLoaded(court, "businessUnit"));
+        assertFalse(unitUtil.isLoaded(court, "localJusticeArea"));
+        assertFalse(unitUtil.isLoaded(court, "parentCourt"));
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/opal/repository/CourtRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/repository/CourtRepositoryIntegrationTest.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.PersistenceUnitUtil;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +16,7 @@ import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.entity.court.CourtEntity;
 import uk.gov.hmcts.opal.repository.jpa.CourtSpecs;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -51,23 +53,28 @@ class CourtRepositoryIntegrationTest extends AbstractIntegrationTest {
     @PersistenceContext
     private EntityManager entityManager;
 
+    private PersistenceUnitUtil unitUtil;
+
+    @BeforeEach
+    void setUp() {
+        entityManager.clear();
+        unitUtil = entityManagerFactory.getPersistenceUnitUtil();
+    }
+
     @Test
     void shouldKeepAssociationsLazyWhenNoEntityGraphIsUsed() {
-        entityManager.clear();
-
         CourtEntity court = entityManager.find(CourtEntity.class, COURT_ID);
-        PersistenceUnitUtil unitUtil = entityManagerFactory.getPersistenceUnitUtil();
 
-        assertNotNull(court);
-        assertFalse(unitUtil.isLoaded(court, "businessUnit"));
-        assertFalse(unitUtil.isLoaded(court, "localJusticeArea"));
-        assertFalse(unitUtil.isLoaded(court, "parentCourt"));
+        assertAll(
+            () -> assertNotNull(court),
+            () -> assertFalse(unitUtil.isLoaded(court, "businessUnit")),
+            () -> assertFalse(unitUtil.isLoaded(court, "localJusticeArea")),
+            () -> assertFalse(unitUtil.isLoaded(court, "parentCourt"))
+        );
     }
 
     @Test
     void shouldKeepAssociationsLazyWhenLiteEntityGraphIsUsedForDirectFetch() {
-        entityManager.clear();
-
         CourtEntity court = courtLiteRepository.findById(COURT_ID).orElseThrow();
 
         assertAssociationsRemainLazy(court);
@@ -75,8 +82,6 @@ class CourtRepositoryIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     void shouldKeepAssociationsLazyWhenLiteEntityGraphIsUsedForSpecificationFetch() {
-        entityManager.clear();
-
         Page<CourtEntity> page = courtLiteRepository.findBy(
             CourtSpecs.equalsCourtId(COURT_ID),
             ffq -> ffq.page(Pageable.unpaged())
@@ -89,41 +94,39 @@ class CourtRepositoryIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     void shouldLoadFullEntityGraphForDirectFetch() {
-        entityManager.clear();
-
         CourtEntity court = courtRepository.findById(COURT_ID).orElseThrow();
-        PersistenceUnitUtil unitUtil = entityManagerFactory.getPersistenceUnitUtil();
 
-        assertTrue(unitUtil.isLoaded(court, "businessUnit"));
-        assertTrue(unitUtil.isLoaded(court, "localJusticeArea"));
-        assertTrue(unitUtil.isLoaded(court, "parentCourt"));
-        assertEquals(BUSINESS_UNIT_ID, court.getBusinessUnit().getBusinessUnitId());
-        assertEquals(LOCAL_JUSTICE_AREA_ID, court.getLocalJusticeArea().getLocalJusticeAreaId());
-        assertEquals(PARENT_COURT_ID, court.getParentCourt().getCourtId());
+        assertAll(
+            () -> assertTrue(unitUtil.isLoaded(court, "businessUnit")),
+            () -> assertTrue(unitUtil.isLoaded(court, "localJusticeArea")),
+            () -> assertTrue(unitUtil.isLoaded(court, "parentCourt")),
+            () -> assertEquals(BUSINESS_UNIT_ID, court.getBusinessUnit().getBusinessUnitId()),
+            () -> assertEquals(LOCAL_JUSTICE_AREA_ID, court.getLocalJusticeArea().getLocalJusticeAreaId()),
+            () -> assertEquals(PARENT_COURT_ID, court.getParentCourt().getCourtId())
+        );
     }
 
     @Test
     void shouldLoadFullEntityGraphForSpecificationFetch() {
-        entityManager.clear();
-
         Page<CourtEntity> page = courtRepository.findBy(
             CourtSpecs.equalsCourtId(COURT_ID),
             ffq -> ffq.page(Pageable.unpaged())
         );
         CourtEntity court = page.getContent().getFirst();
-        PersistenceUnitUtil unitUtil = entityManagerFactory.getPersistenceUnitUtil();
 
-        assertEquals(1, page.getContent().size());
-        assertTrue(unitUtil.isLoaded(court, "businessUnit"));
-        assertTrue(unitUtil.isLoaded(court, "localJusticeArea"));
-        assertTrue(unitUtil.isLoaded(court, "parentCourt"));
+        assertAll(
+            () -> assertEquals(1, page.getContent().size()),
+            () -> assertTrue(unitUtil.isLoaded(court, "businessUnit")),
+            () -> assertTrue(unitUtil.isLoaded(court, "localJusticeArea")),
+            () -> assertTrue(unitUtil.isLoaded(court, "parentCourt"))
+        );
     }
 
     private void assertAssociationsRemainLazy(CourtEntity court) {
-        PersistenceUnitUtil unitUtil = entityManagerFactory.getPersistenceUnitUtil();
-
-        assertFalse(unitUtil.isLoaded(court, "businessUnit"));
-        assertFalse(unitUtil.isLoaded(court, "localJusticeArea"));
-        assertFalse(unitUtil.isLoaded(court, "parentCourt"));
+        assertAll(
+            () -> assertFalse(unitUtil.isLoaded(court, "businessUnit")),
+            () -> assertFalse(unitUtil.isLoaded(court, "localJusticeArea")),
+            () -> assertFalse(unitUtil.isLoaded(court, "parentCourt"))
+        );
     }
 }

--- a/src/integrationTest/resources/db/deleteData/delete_from_courts_entity_graph.sql
+++ b/src/integrationTest/resources/db/deleteData/delete_from_courts_entity_graph.sql
@@ -1,0 +1,18 @@
+/**
+* OPAL Program
+*
+* MODULE      : delete_from_courts_entity_graph.sql
+*
+* DESCRIPTION : Deletes Courts, Business Units and Local Justice Areas for Court entity graph integration tests
+*
+* VERSION HISTORY:
+*
+* Date          Author       Version     Nature of Change
+* ----------    --------     --------    ----------------------------------------------------------------
+* 23/04/2026    S WILLIAMS   1.0         PO-2885: Delete rows for court entity graph integration tests
+*
+**/
+
+DELETE FROM courts WHERE court_id IN (951002, 951001);
+DELETE FROM local_justice_areas WHERE local_justice_area_id = 951;
+DELETE FROM business_units WHERE business_unit_id = 951;

--- a/src/integrationTest/resources/db/insertData/insert_into_courts_entity_graph.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_courts_entity_graph.sql
@@ -1,0 +1,56 @@
+/**
+* OPAL Program
+*
+* MODULE      : insert_into_courts_entity_graph.sql
+*
+* DESCRIPTION : Inserts Courts, Business Units and Local Justice Areas for Court entity graph integration tests
+*
+* VERSION HISTORY:
+*
+* Date          Author       Version     Nature of Change
+* ----------    --------     --------    ----------------------------------------------------------------
+* 23/04/2026    S WILLIAMS   1.0         PO-2885: Insert rows for court entity graph integration tests
+*
+**/
+
+INSERT INTO business_units (
+    business_unit_id,business_unit_name,business_unit_code,business_unit_type,
+    account_number_prefix,parent_business_unit_id,opal_domain,welsh_language
+    )
+VALUES (
+        951,'Court Graph Business Unit','CGBU','Area',
+        'CG',NULL,'Fines',false
+       );
+
+INSERT INTO local_justice_areas (
+    local_justice_area_id, name, address_line_1, address_line_2, address_line_3,
+    postcode, lja_code, lja_type, address_line_4, address_line_5, end_date
+)
+VALUES (951, 'Court Graph LJA', 'Court Graph Address 1', 'Court Graph Address 2', NULL,
+ 'CG1 1CG', '0951', 'LJA', NULL, NULL, NULL
+       );
+
+INSERT INTO courts (
+    court_id, business_unit_id, court_code, parent_court_id, name, name_cy,
+    address_line_1, address_line_2, address_line_3,
+    address_line_1_cy, address_line_2_cy, address_line_3_cy, postcode,
+    local_justice_area_id, national_court_code, gob_enforcing_court_code,
+    lja, court_type, division, session,
+    start_time, max_load, record_session_times, max_court_duration, group_code
+    )
+VALUES (
+    951001, 951, 951, NULL, 'Court Graph Parent', NULL,
+    'Parent Address 1', 'Parent Address 2', NULL,
+    NULL, NULL, NULL, 'CG1 1AA',
+    951, 11, 12,
+    951, 'MC', '01', 'AM',
+    '10:00', 2, 'Y', 180, 'PARENT'
+    ),
+    (
+    951002, 951, 952, 951001, 'Court Graph Child', NULL,
+    'Child Address 1', 'Child Address 2', NULL,
+    NULL, NULL, NULL, 'CG1 1AB',
+    951, 21, 22,
+    951, 'MC', '02', 'PM',
+    '14:00', 4, 'N', 240, 'CHILD'
+    );

--- a/src/main/java/uk/gov/hmcts/opal/controllers/CourtController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/CourtController.java
@@ -43,21 +43,21 @@ public class CourtController {
 
     @GetMapping(value = "/{courtId}")
     @Operation(summary = "Returns the court for the given courtId.")
-    public ResponseEntity<CourtEntity.Lite> getCourtById(
+    public ResponseEntity<CourtEntity> getCourtById(
         @PathVariable Long courtId, @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
 
         log.debug(":GET:getCourtById: courtId: {}", courtId);
 
         userStateService.checkForAuthorisedUser(authHeaderValue);
 
-        CourtEntity.Lite response = courtService.getCourtById(courtId);
+        CourtEntity response = courtService.getCourtById(courtId);
 
         return buildResponse(response);
     }
 
     @PostMapping(value = "/search", consumes = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Searches courts based upon criteria in request body")
-    public ResponseEntity<SearchDataResponse<CourtEntity.Lite>> postCourtsSearch(
+    public ResponseEntity<SearchDataResponse<CourtEntity>> postCourtsSearch(
         @RequestBody CourtSearchDto criteria,
         @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
 
@@ -65,9 +65,9 @@ public class CourtController {
 
         userStateService.checkForAuthorisedUser(authHeaderValue);
 
-        List<CourtEntity.Lite> results = courtService.searchCourts(criteria);
+        List<CourtEntity> results = courtService.searchCourts(criteria);
 
-        return ResponseEntity.ok(SearchDataResponse.<CourtEntity.Lite>builder()
+        return ResponseEntity.ok(SearchDataResponse.<CourtEntity>builder()
             .searchData(results)
             .build());
     }

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/search/LegacyCourtSearchResults.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/search/LegacyCourtSearchResults.java
@@ -17,6 +17,6 @@ import java.util.List;
 public class LegacyCourtSearchResults {
 
     @XmlElement(name = "courtEntity")
-    private List<CourtEntity.Lite> courtEntities;
+    private List<CourtEntity> courtEntities;
     private int totalCount;
 }

--- a/src/main/java/uk/gov/hmcts/opal/entity/court/CourtEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/court/CourtEntity.java
@@ -1,34 +1,59 @@
 package uk.gov.hmcts.opal.entity.court;
 
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
 import jakarta.persistence.Table;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import uk.gov.hmcts.opal.entity.AddressCyEntity;
+import uk.gov.hmcts.opal.entity.LocalJusticeAreaEntity;
+import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
 
-@Data
+@Getter
+@Setter
+@Entity
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-@MappedSuperclass
-@EqualsAndHashCode(callSuper = true)
-@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true, exclude = {"businessUnit", "localJusticeArea", "parentCourt"})
+@ToString(callSuper = true, exclude = {"businessUnit", "localJusticeArea", "parentCourt"})
+@Table(name = "courts")
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+@JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "courtId")
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
-public abstract class CourtEntity extends AddressCyEntity {
+@NamedEntityGraph(name = CourtEntity.ENTITY_GRAPH_LITE)
+@NamedEntityGraph(
+    name = CourtEntity.ENTITY_GRAPH_FULL,
+    attributeNodes = {
+        @NamedAttributeNode("businessUnit"),
+        @NamedAttributeNode("localJusticeArea"),
+        @NamedAttributeNode("parentCourt")
+    }
+)
+public class CourtEntity extends AddressCyEntity {
+
+    public static final String ENTITY_GRAPH_LITE = "CourtEntity.lite";
+    public static final String ENTITY_GRAPH_FULL = "CourtEntity.full";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -47,18 +72,51 @@ public abstract class CourtEntity extends AddressCyEntity {
     @Column(name = "local_justice_area_id", insertable = false, updatable = false)
     private Short localJusticeAreaId;
 
+    @Column(name = "parent_court_id", insertable = false, updatable = false)
+    private Long parentCourtId;
+
+    @Column(name = "national_court_code")
+    private Short nationalCourtCode;
+
+    @Column(name = "gob_enforcing_court_code")
+    private Short gobEnforcingCourtCode;
+
+    @Column(name = "lja")
+    private Short lja;
+
     @Column(name = "court_type", length = 2)
     private String courtType;
 
     @Column(name = "division", length = 2)
     private String division;
 
-    @Entity
-    @Getter
-    @EqualsAndHashCode(callSuper = true)
-    @Table(name = "courts")
-    @SuperBuilder
-    @NoArgsConstructor
-    public static class Lite extends CourtEntity {
-    }
+    @Column(name = "session", length = 2)
+    private String session;
+
+    @Column(name = "start_time", length = 10)
+    private String startTime;
+
+    @Column(name = "max_load")
+    private Integer maxLoad;
+
+    @Column(name = "record_session_times", length = 1)
+    private String recordSessionTimes;
+
+    @Column(name = "max_court_duration")
+    private Integer maxCourtDuration;
+
+    @Column(name = "group_code", length = 20)
+    private String groupCode;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "business_unit_id", insertable = false, updatable = false)
+    private BusinessUnitEntity businessUnit;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "local_justice_area_id", insertable = false, updatable = false)
+    private LocalJusticeAreaEntity localJusticeArea;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_court_id", insertable = false, updatable = false)
+    private CourtEntity parentCourt;
 }

--- a/src/main/java/uk/gov/hmcts/opal/entity/defendantaccount/DefendantAccountEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/defendantaccount/DefendantAccountEntity.java
@@ -91,13 +91,13 @@ public class DefendantAccountEntity implements Versioned {
     @XmlJavaTypeAdapter(LocalDateAdapter.class)
     private LocalDate completedDate;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "enforcing_court_id", referencedColumnName = "court_id")
-    private CourtEntity.Lite enforcingCourt;
+    private CourtEntity enforcingCourt;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "last_hearing_court_id", referencedColumnName = "court_id")
-    private CourtEntity.Lite lastHearingCourt;
+    private CourtEntity lastHearingCourt;
 
     @Column(name = "last_hearing_date")
     @XmlJavaTypeAdapter(LocalDateAdapter.class)

--- a/src/main/java/uk/gov/hmcts/opal/entity/enforcement/EnforcementEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/enforcement/EnforcementEntity.java
@@ -134,5 +134,5 @@ public class EnforcementEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "hearing_court_id", nullable = false, insertable = false, updatable = false)
-    private CourtEntity.Lite hearingCourt;
+    private CourtEntity hearingCourt;
 }

--- a/src/main/java/uk/gov/hmcts/opal/entity/imposition/ImpositionEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/imposition/ImpositionEntity.java
@@ -131,7 +131,7 @@ public class ImpositionEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "imposing_court_id", insertable = false, updatable = false, nullable = false)
-    private CourtEntity.Lite imposingCourt;
+    private CourtEntity imposingCourt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "creditor_account_id", insertable = false, updatable = false)

--- a/src/main/java/uk/gov/hmcts/opal/mapper/CourtMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/mapper/CourtMapper.java
@@ -6,5 +6,5 @@ import uk.gov.hmcts.opal.entity.court.CourtEntity;
 
 @Mapper(componentModel = "spring")
 public interface CourtMapper {
-    CourtReferenceData toRefData(CourtEntity.Lite entity);
+    CourtReferenceData toRefData(CourtEntity entity);
 }

--- a/src/main/java/uk/gov/hmcts/opal/repository/CourtLiteRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/CourtLiteRepository.java
@@ -11,15 +11,15 @@ import java.util.Optional;
 import java.util.function.Function;
 
 @Repository
-public interface CourtRepository extends JpaRepository<CourtEntity, Long>,
+public interface CourtLiteRepository extends JpaRepository<CourtEntity, Long>,
     JpaSpecificationExecutor<CourtEntity> {
 
     @Override
-    @EntityGraph(value = CourtEntity.ENTITY_GRAPH_FULL, type = EntityGraph.EntityGraphType.FETCH)
+    @EntityGraph(value = CourtEntity.ENTITY_GRAPH_LITE, type = EntityGraph.EntityGraphType.FETCH)
     Optional<CourtEntity> findById(Long courtId);
 
     @Override
-    @EntityGraph(value = CourtEntity.ENTITY_GRAPH_FULL, type = EntityGraph.EntityGraphType.FETCH)
+    @EntityGraph(value = CourtEntity.ENTITY_GRAPH_LITE, type = EntityGraph.EntityGraphType.FETCH)
     <S extends CourtEntity, R> R findBy(
         Specification<CourtEntity> spec,
         Function<? super JpaSpecificationExecutor.SpecificationFluentQuery<S>, R> queryFunction

--- a/src/main/java/uk/gov/hmcts/opal/repository/jpa/CourtSpecs.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/jpa/CourtSpecs.java
@@ -10,9 +10,9 @@ import uk.gov.hmcts.opal.entity.court.CourtEntity_;
 
 import java.util.Optional;
 
-public class CourtSpecs extends AddressCySpecs<CourtEntity.Lite> {
+public class CourtSpecs extends AddressCySpecs<CourtEntity> {
 
-    public Specification<CourtEntity.Lite> findBySearchCriteria(CourtSearchDto criteria) {
+    public Specification<CourtEntity> findBySearchCriteria(CourtSearchDto criteria) {
         return Specification.allOf(specificationList(
             findByAddressCyCriteria(criteria),
             numericLong(criteria.getCourtId()).map(CourtSpecs::equalsCourtId),
@@ -22,38 +22,38 @@ public class CourtSpecs extends AddressCySpecs<CourtEntity.Lite> {
         ));
     }
 
-    public Specification<CourtEntity.Lite> referenceDataFilter(Optional<String> filter,
-                                                               Optional<Short> businessUnitId) {
+    public Specification<CourtEntity> referenceDataFilter(Optional<String> filter,
+                                                          Optional<Short> businessUnitId) {
         return Specification.allOf(specificationList(
             filter.filter(s -> !s.isBlank()).map(this::likeAnyCourt),
             businessUnitId.map(CourtSpecs::equalsBusinessUnitId)
         ));
     }
 
-    public static Specification<CourtEntity.Lite> equalsCourtId(Long courtId) {
+    public static Specification<CourtEntity> equalsCourtId(Long courtId) {
         return (root, query, builder) -> equalsCourtIdPredicate(root, builder, courtId);
     }
 
-    public static Predicate equalsCourtIdPredicate(From<?, CourtEntity.Lite> from,
+    public static Predicate equalsCourtIdPredicate(From<?, CourtEntity> from,
                                                    CriteriaBuilder builder, Long courtId) {
         return builder.equal(from.get(CourtEntity_.courtId), courtId);
     }
 
-    public static Specification<CourtEntity.Lite> equalsBusinessUnitId(Short businessUnitId) {
+    public static Specification<CourtEntity> equalsBusinessUnitId(Short businessUnitId) {
         return (root, query, builder) ->
             builder.equal(root.get(CourtEntity_.businessUnitId), businessUnitId);
     }
 
-    public static Specification<CourtEntity.Lite> equalsCourtCode(String courtCode) {
+    public static Specification<CourtEntity> equalsCourtCode(String courtCode) {
         return (root, query, builder) -> builder.equal(root.get(CourtEntity_.courtCode), courtCode);
     }
 
-    public static Specification<CourtEntity.Lite> equalsLocalJusticeAreaId(Short localJusticeAreaId) {
+    public static Specification<CourtEntity> equalsLocalJusticeAreaId(Short localJusticeAreaId) {
         return (root, query, builder) ->
             builder.equal(root.get(CourtEntity_.localJusticeAreaId), localJusticeAreaId);
     }
 
-    public Specification<CourtEntity.Lite> likeAnyCourt(String filter) {
+    public Specification<CourtEntity> likeAnyCourt(String filter) {
         return Specification.anyOf(
             likeName(filter),
             likeNameCy(filter)

--- a/src/main/java/uk/gov/hmcts/opal/repository/jpa/DefendantAccountSpecs.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/jpa/DefendantAccountSpecs.java
@@ -125,11 +125,11 @@ public class DefendantAccountSpecs extends EntitySpecs<DefendantAccountEntity> {
     }
 
 
-    public static Join<DefendantAccountEntity, CourtEntity.Lite> joinEnforcingCourt(Root<DefendantAccountEntity> root) {
+    public static Join<DefendantAccountEntity, CourtEntity> joinEnforcingCourt(Root<DefendantAccountEntity> root) {
         return root.join(DefendantAccountEntity_.enforcingCourt);
     }
 
-    public static Join<DefendantAccountEntity, CourtEntity.Lite> joinLastHearingCourt(
+    public static Join<DefendantAccountEntity, CourtEntity> joinLastHearingCourt(
         Root<DefendantAccountEntity> root) {
         return root.join(DefendantAccountEntity_.lastHearingCourt);
     }

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/CourtService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/CourtService.java
@@ -15,7 +15,7 @@ import uk.gov.hmcts.opal.entity.AddressEntity_;
 import uk.gov.hmcts.opal.entity.court.CourtEntity;
 import uk.gov.hmcts.opal.dto.reference.CourtReferenceData;
 import uk.gov.hmcts.opal.mapper.CourtMapper;
-import uk.gov.hmcts.opal.repository.CourtRepository;
+import uk.gov.hmcts.opal.repository.CourtLiteRepository;
 import uk.gov.hmcts.opal.repository.jpa.CourtSpecs;
 
 import java.util.List;
@@ -27,23 +27,23 @@ import java.util.Optional;
 @Qualifier("courtService")
 public class CourtService {
 
-    private final CourtRepository courtRepository;
+    private final CourtLiteRepository courtLiteRepository;
 
     private final CourtMapper courtMapper;
 
     private final CourtSpecs specs = new CourtSpecs();
 
-    public CourtEntity.Lite getCourtById(long courtId) {
-        return courtRepository.findById(courtId)
+    public CourtEntity getCourtById(long courtId) {
+        return courtLiteRepository.findById(courtId)
             .orElseThrow(() -> new EntityNotFoundException("Court not found with id: " + courtId));
     }
 
-    public List<CourtEntity.Lite> searchCourts(CourtSearchDto criteria) {
+    public List<CourtEntity> searchCourts(CourtSearchDto criteria) {
 
         log.debug(":searchCourts: criteria: {}", criteria);
         Sort nameSort = Sort.by(Sort.Direction.ASC, AddressEntity_.NAME);
 
-        Page<CourtEntity.Lite> courtsPage = courtRepository
+        Page<CourtEntity> courtsPage = courtLiteRepository
             .findBy(specs.findBySearchCriteria(criteria),
                     ffq -> ffq
                         .sortBy(nameSort)
@@ -61,7 +61,7 @@ public class CourtService {
 
         Sort nameSort = Sort.by(Sort.Direction.ASC, AddressEntity_.NAME);
 
-        Page<CourtEntity.Lite> page = courtRepository
+        Page<CourtEntity> page = courtLiteRepository
             .findBy(specs.referenceDataFilter(filter, businessUnitId),
                     ffq -> ffq
                         .sortBy(nameSort)

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountBuilders.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountBuilders.java
@@ -688,18 +688,6 @@ public class OpalDefendantAccountBuilders {
             .build();
     }
 
-    static CourtEntity.Lite asLite(CourtEntity court) {
-        return CourtEntity.Lite.builder()
-            .courtId(court.getCourtId())
-            .businessUnitId(court.getBusinessUnitId())
-            .courtCode(court.getCourtCode())
-            .localJusticeAreaId(court.getLocalJusticeAreaId())
-            .courtType(court.getCourtType())
-            .division(court.getDivision())
-            .name(court.getName())
-            .build();
-    }
-
     static Enforcer buildEnforcer(EnforcerEntity enforcer) {
         return Optional.ofNullable(enforcer).map(enf -> Enforcer.builder()
                 .enforcerId(enf.getEnforcerId())
@@ -866,7 +854,7 @@ public class OpalDefendantAccountBuilders {
             .build();
     }
 
-    static EnforcementCourtDefendantAccount buildCourtReference(CourtEntity.Lite court) {
+    static EnforcementCourtDefendantAccount buildCourtReference(CourtEntity court) {
         return Optional.ofNullable(court)
             .filter(c -> c.getCourtId() != null)
             .map(c -> EnforcementCourtDefendantAccount.builder()
@@ -875,7 +863,7 @@ public class OpalDefendantAccountBuilders {
             .orElse(null);
     }
 
-    static CourtReferenceCommon buildCourtReferenceCommon(CourtEntity.Lite court) {
+    static CourtReferenceCommon buildCourtReferenceCommon(CourtEntity court) {
         return Optional.ofNullable(court)
             .map(c -> CourtReferenceCommon.builder()
                 .courtId(c.getCourtId())

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
@@ -96,7 +96,7 @@ import uk.gov.hmcts.opal.mapper.DefendantAccountHeaderSummaryMapper;
 import uk.gov.hmcts.opal.mapper.common.EnforcerDefendantAccountMapper;
 import uk.gov.hmcts.opal.mapper.request.PaymentTermsMapper;
 import uk.gov.hmcts.opal.repository.AliasRepository;
-import uk.gov.hmcts.opal.repository.CourtRepository;
+import uk.gov.hmcts.opal.repository.CourtLiteRepository;
 import uk.gov.hmcts.opal.repository.DebtorDetailRepository;
 import uk.gov.hmcts.opal.repository.DefendantAccountHeaderViewRepository;
 import uk.gov.hmcts.opal.repository.DefendantAccountPaymentTermsRepository;
@@ -139,8 +139,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
 
     private final DefendantAccountSummaryViewRepository defendantAccountSummaryViewRepository;
 
-    private final CourtRepository courtRepository;
-
+    private final CourtLiteRepository courtLiteRepository;
     private final AmendmentService amendmentService;
 
     private final EntityManager em;
@@ -712,9 +711,9 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
         if (courtId == null) {
             throw new IllegalArgumentException("enforcement_court.court_id is required");
         }
-        CourtEntity court = courtRepository.findById(courtId)
+        CourtEntity court = courtLiteRepository.findById(courtId)
             .orElseThrow(() -> new EntityNotFoundException("Court not found: " + courtId));
-        entity.setEnforcingCourt(OpalDefendantAccountBuilders.asLite(court));
+        entity.setEnforcingCourt(court);
         log.debug(":applyEnforcementCourt: accountId={}, courtId={}",
             entity.getDefendantAccountId(), court.getCourtId());
     }

--- a/src/test/java/uk/gov/hmcts/opal/controllers/CourtControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/CourtControllerTest.java
@@ -42,12 +42,12 @@ class CourtControllerTest {
     @Test
     void testGetCourt_Success() {
         // Arrange
-        CourtEntity.Lite entity = CourtEntity.Lite.builder().build();
+        CourtEntity entity = CourtEntity.builder().build();
 
         when(courtService.getCourtById(any(Long.class))).thenReturn(entity);
 
         // Act
-        ResponseEntity<CourtEntity.Lite> response = courtController.getCourtById(1L, BEARER_TOKEN);
+        ResponseEntity<CourtEntity> response = courtController.getCourtById(1L, BEARER_TOKEN);
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -58,20 +58,20 @@ class CourtControllerTest {
     @Test
     void testSearchCourts_Success() {
         // Arrange
-        CourtEntity.Lite entity = CourtEntity.Lite.builder().build();
-        List<CourtEntity.Lite> courtList = List.of(entity);
+        CourtEntity entity = CourtEntity.builder().build();
+        List<CourtEntity> courtList = List.of(entity);
 
         when(courtService.searchCourts(any())).thenReturn(courtList);
 
         // Act
         CourtSearchDto searchDto = CourtSearchDto.builder().build();
-        ResponseEntity<SearchDataResponse<CourtEntity.Lite>> response =
+        ResponseEntity<SearchDataResponse<CourtEntity>> response =
             courtController.postCourtsSearch(searchDto, BEARER_TOKEN);
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
 
-        SearchDataResponse<CourtEntity.Lite> responseBody = response.getBody();
+        SearchDataResponse<CourtEntity> responseBody = response.getBody();
         assertNotNull(responseBody);
         assertEquals(1, responseBody.getCount());
         assertEquals(courtList, responseBody.getSearchData());

--- a/src/test/java/uk/gov/hmcts/opal/disco/opal/CourtServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/disco/opal/CourtServiceTest.java
@@ -15,7 +15,7 @@ import uk.gov.hmcts.opal.dto.search.CourtSearchDto;
 import uk.gov.hmcts.opal.entity.court.CourtEntity;
 import uk.gov.hmcts.opal.dto.reference.CourtReferenceData;
 import uk.gov.hmcts.opal.mapper.CourtMapper;
-import uk.gov.hmcts.opal.repository.CourtRepository;
+import uk.gov.hmcts.opal.repository.CourtLiteRepository;
 import uk.gov.hmcts.opal.service.opal.CourtService;
 
 import java.util.List;
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.when;
 class CourtServiceTest {
 
     @Mock
-    private CourtRepository courtRepository;
+    private CourtLiteRepository courtLiteRepository;
 
     @Mock
     CourtMapper courtMapper;
@@ -42,11 +42,11 @@ class CourtServiceTest {
     @Test
     void testGetCourt() {
         // Arrange
-        CourtEntity.Lite courtEntity = CourtEntity.Lite.builder().build();
-        when(courtRepository.findById(any())).thenReturn(Optional.of(courtEntity));
+        CourtEntity courtEntity = CourtEntity.builder().build();
+        when(courtLiteRepository.findById(any())).thenReturn(Optional.of(courtEntity));
 
         // Act
-        CourtEntity.Lite result = courtService.getCourtById(1);
+        CourtEntity result = courtService.getCourtById(1);
 
         // Assert
         assertNotNull(result);
@@ -59,15 +59,15 @@ class CourtServiceTest {
         SpecificationFluentQuery sfq = Mockito.mock(SpecificationFluentQuery.class);
         when(sfq.sortBy(any())).thenReturn(sfq);
 
-        CourtEntity.Lite courtEntity = CourtEntity.Lite.builder().build();
-        Page<CourtEntity.Lite> mockPage = new PageImpl<>(List.of(courtEntity), Pageable.unpaged(), 999L);
-        when(courtRepository.findBy(any(Specification.class), any())).thenAnswer(iom -> {
+        CourtEntity courtEntity = CourtEntity.builder().build();
+        Page<CourtEntity> mockPage = new PageImpl<>(List.of(courtEntity), Pageable.unpaged(), 999L);
+        when(courtLiteRepository.findBy(any(Specification.class), any())).thenAnswer(iom -> {
             iom.getArgument(1, Function.class).apply(sfq);
             return mockPage;
         });
 
         // Act
-        List<CourtEntity.Lite> result = courtService.searchCourts(CourtSearchDto.builder().build());
+        List<CourtEntity> result = courtService.searchCourts(CourtSearchDto.builder().build());
 
         // Assert
         assertEquals(List.of(courtEntity), result);
@@ -81,7 +81,7 @@ class CourtServiceTest {
         when(sfq.sortBy(any())).thenReturn(sfq);
 
         // Create court entity with direct field values (no relationships)
-        CourtEntity.Lite courtEntity = CourtEntity.Lite.builder()
+        CourtEntity courtEntity = CourtEntity.builder()
             .courtId(1L)
             .businessUnitId((short) 73)
             .courtCode((short) 101)
@@ -92,7 +92,7 @@ class CourtServiceTest {
             .division("01")
             .build();
 
-        Page<CourtEntity.Lite> mockPage = new PageImpl<>(List.of(courtEntity), Pageable.unpaged(), 1L);
+        Page<CourtEntity> mockPage = new PageImpl<>(List.of(courtEntity), Pageable.unpaged(), 1L);
 
         // Create expected reference data
         CourtReferenceData refData = new CourtReferenceData(
@@ -106,8 +106,8 @@ class CourtServiceTest {
         );
 
         // Set up mocks
-        when(courtRepository.findBy(any(Specification.class), any())).thenAnswer(iom -> {
-            Function<SpecificationFluentQuery, Page<CourtEntity.Lite>> function = iom.getArgument(1);
+        when(courtLiteRepository.findBy(any(Specification.class), any())).thenAnswer(iom -> {
+            Function<SpecificationFluentQuery, Page<CourtEntity>> function = iom.getArgument(1);
             return function.apply(sfq);
         }).thenReturn(mockPage);
 

--- a/src/test/java/uk/gov/hmcts/opal/entity/DefendantAccountEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/entity/DefendantAccountEntityTest.java
@@ -35,8 +35,8 @@ public class DefendantAccountEntityTest {
         defendantAccount.setAccountBalance(BigDecimal.valueOf(1.1));
         defendantAccount.setAccountStatus(DefendantAccountStatus.LIVE);
         defendantAccount.setCompletedDate(now);
-        defendantAccount.setEnforcingCourt(CourtEntity.Lite.builder().build());
-        defendantAccount.setLastHearingCourt(CourtEntity.Lite.builder().build());
+        defendantAccount.setEnforcingCourt(CourtEntity.builder().build());
+        defendantAccount.setLastHearingCourt(CourtEntity.builder().build());
         defendantAccount.setLastHearingDate(now);
         defendantAccount.setLastMovementDate(now);
         defendantAccount.setLastEnforcement("123456");
@@ -78,8 +78,8 @@ public class DefendantAccountEntityTest {
         assertEquals(new BigDecimal("1.1"), defendantAccount.getAccountBalance());
         assertEquals(DefendantAccountStatus.LIVE, defendantAccount.getAccountStatus());
         assertEquals(now, defendantAccount.getCompletedDate());
-        assertEquals(CourtEntity.Lite.builder().build(), defendantAccount.getEnforcingCourt());
-        assertEquals(CourtEntity.Lite.builder().build(), defendantAccount.getLastHearingCourt());
+        assertEquals(CourtEntity.builder().build(), defendantAccount.getEnforcingCourt());
+        assertEquals(CourtEntity.builder().build(), defendantAccount.getLastHearingCourt());
         assertEquals(now, defendantAccount.getLastHearingDate());
         assertEquals(now, defendantAccount.getLastMovementDate());
         assertEquals("123456", defendantAccount.getLastEnforcement());

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceEnforcementStatusTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceEnforcementStatusTest.java
@@ -34,7 +34,7 @@ import uk.gov.hmcts.opal.dto.legacy.common.LjaReference;
 import uk.gov.hmcts.opal.dto.legacy.common.ResultReference;
 import uk.gov.hmcts.opal.dto.legacy.common.ResultResponses;
 import uk.gov.hmcts.opal.entity.LocalJusticeAreaEntity;
-import uk.gov.hmcts.opal.entity.court.CourtEntity.Lite;
+import uk.gov.hmcts.opal.entity.court.CourtEntity;
 import uk.gov.hmcts.opal.generated.model.AccountStatusReferenceCommon;
 import uk.gov.hmcts.opal.generated.model.AccountStatusReferenceCommon.AccountStatusCodeEnum;
 import uk.gov.hmcts.opal.generated.model.EnforcementActionDefendantAccount;
@@ -54,7 +54,7 @@ class LegacyDefAccServiceEnforcementStatusTest extends AbstractLegacyDefAccServi
             .body(Mockito.<ParameterizedTypeReference<LegacyGetDefendantAccountEnforcementStatusResponse>>any()))
             .thenReturn(responseBody);
 
-        when(courtService.getCourtById(anyLong())).thenReturn(Lite.builder().courtCode((short)123).build());
+        when(courtService.getCourtById(anyLong())).thenReturn(CourtEntity.builder().courtCode((short)123).build());
         when(ljaService.getLocalJusticeAreaById(anyShort())).thenReturn(
             LocalJusticeAreaEntity.builder().ljaCode("6-7").build());
 
@@ -132,7 +132,7 @@ class LegacyDefAccServiceEnforcementStatusTest extends AbstractLegacyDefAccServi
 
         ResponseEntity<String> serverSuccessResponse = new ResponseEntity<>(responseBody.toXml(), HttpStatus.OK);
         when(restClient.responseSpec.toEntity(String.class)).thenReturn(serverSuccessResponse);
-        when(courtService.getCourtById(anyLong())).thenReturn(Lite.builder().courtCode((short)123).build());
+        when(courtService.getCourtById(anyLong())).thenReturn(CourtEntity.builder().courtCode((short)123).build());
 
         // Act
         EnforcementStatus response = legacyDefendantAccountService.getEnforcementStatus(72L);
@@ -201,7 +201,7 @@ class LegacyDefAccServiceEnforcementStatusTest extends AbstractLegacyDefAccServi
         )).thenReturn(responseBody);
         when(restClient.responseSpec.toEntity(String.class))
             .thenReturn(new ResponseEntity<>(responseBody.toXml(), HttpStatus.SERVICE_UNAVAILABLE));
-        when(courtService.getCourtById(anyLong())).thenReturn(Lite.builder().courtCode((short)123).build());
+        when(courtService.getCourtById(anyLong())).thenReturn(CourtEntity.builder().courtCode((short)123).build());
 
         EnforcementStatus response = legacyDefendantAccountService.getEnforcementStatus(66L);
 
@@ -245,7 +245,7 @@ class LegacyDefAccServiceEnforcementStatusTest extends AbstractLegacyDefAccServi
         )).thenReturn(responseBody);
         when(restClient.responseSpec.toEntity(String.class))
             .thenReturn(new ResponseEntity<>(responseBody.toXml(), HttpStatus.SERVICE_UNAVAILABLE));
-        when(courtService.getCourtById(anyLong())).thenReturn(Lite.builder().courtCode((short)123).build());
+        when(courtService.getCourtById(anyLong())).thenReturn(CourtEntity.builder().courtCode((short)123).build());
         when(ljaService.getLocalJusticeAreaById(anyShort())).thenThrow(new EntityNotFoundException("Lja not found"));
 
         EntityNotFoundException error = assertThrows(EntityNotFoundException.class,

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountEnforcementServiceTest.java
@@ -63,7 +63,7 @@ import uk.gov.hmcts.opal.dto.legacy.common.EnforcerReference;
 import uk.gov.hmcts.opal.dto.legacy.common.LjaReference;
 import uk.gov.hmcts.opal.dto.legacy.common.ResultReference;
 import uk.gov.hmcts.opal.dto.legacy.common.ResultResponses;
-import uk.gov.hmcts.opal.entity.court.CourtEntity.Lite;
+import uk.gov.hmcts.opal.entity.court.CourtEntity;
 import uk.gov.hmcts.opal.generated.model.AccountStatusReferenceCommon;
 import uk.gov.hmcts.opal.generated.model.AccountStatusReferenceCommon.AccountStatusCodeEnum;
 import uk.gov.hmcts.opal.generated.model.EnforcementActionDefendantAccount;
@@ -311,7 +311,7 @@ public class LegacyDefendantAccountEnforcementServiceTest {
             .body(Mockito.<ParameterizedTypeReference<LegacyGetDefendantAccountEnforcementStatusResponse>>any()))
             .thenReturn(responseBody);
 
-        when(courtService.getCourtById(anyLong())).thenReturn(Lite.builder().courtCode((short)123).build());
+        when(courtService.getCourtById(anyLong())).thenReturn(CourtEntity.builder().courtCode((short)123).build());
 
         ResponseEntity<String> serverSuccessResponse =
             new ResponseEntity<>(responseBody.toXml(), HttpStatus.OK);
@@ -387,7 +387,7 @@ public class LegacyDefendantAccountEnforcementServiceTest {
 
         ResponseEntity<String> serverSuccessResponse = new ResponseEntity<>(responseBody.toXml(), HttpStatus.OK);
         when(restClient.responseSpec.toEntity(String.class)).thenReturn(serverSuccessResponse);
-        when(courtService.getCourtById(anyLong())).thenReturn(Lite.builder().courtCode((short)123).build());
+        when(courtService.getCourtById(anyLong())).thenReturn(CourtEntity.builder().courtCode((short)123).build());
 
         // Act
         EnforcementStatus response = legacyDefendantAccountEnforcementService
@@ -460,7 +460,7 @@ public class LegacyDefendantAccountEnforcementServiceTest {
         )).thenReturn(responseBody);
         when(restClient.responseSpec.toEntity(String.class))
             .thenReturn(new ResponseEntity<>(responseBody.toXml(), HttpStatus.SERVICE_UNAVAILABLE));
-        when(courtService.getCourtById(anyLong())).thenReturn(Lite.builder().courtCode((short)123).build());
+        when(courtService.getCourtById(anyLong())).thenReturn(CourtEntity.builder().courtCode((short)123).build());
 
         EnforcementStatus response = legacyDefendantAccountEnforcementService
             .getEnforcementStatus(66L);
@@ -604,7 +604,7 @@ public class LegacyDefendantAccountEnforcementServiceTest {
             .thenReturn(responseBody);
 
         when(courtService.getCourtById(anyLong()))
-            .thenReturn(Lite.builder().courtCode((short) 123).build());
+            .thenReturn(CourtEntity.builder().courtCode((short) 123).build());
 
         ResponseEntity<String> serverSuccessResponse =
             new ResponseEntity<>(responseBody.toXml(), HttpStatus.OK);

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountUpdateTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountUpdateTest.java
@@ -41,7 +41,7 @@ import uk.gov.hmcts.opal.generated.model.EnforcerDefendantAccount;
 import uk.gov.hmcts.opal.generated.model.LocalJusticeAreaDefendantAccount;
 import uk.gov.hmcts.opal.generated.model.UpdateDefendantAccountRequestPayload;
 import uk.gov.hmcts.opal.mapper.common.EnforcerDefendantAccountMapper;
-import uk.gov.hmcts.opal.repository.CourtRepository;
+import uk.gov.hmcts.opal.repository.CourtLiteRepository;
 import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
 import uk.gov.hmcts.opal.repository.EnforcerRepository;
 import uk.gov.hmcts.opal.repository.LocalJusticeAreaRepository;
@@ -58,7 +58,7 @@ class OpalDefendantAccountUpdateTest {
     private NoteRepository noteRepository;
 
     @Mock
-    private CourtRepository courtRepo;
+    private CourtLiteRepository courtLiteRepo;
 
     @Mock
     private LocalJusticeAreaRepository ljaRepo;
@@ -104,12 +104,12 @@ class OpalDefendantAccountUpdateTest {
         // Echo the saved entity (so assertions see updated values)
         when(defendantAccountRepository.save(any(DefendantAccountEntity.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        CourtEntity.Lite court = CourtEntity.Lite.builder()
+        CourtEntity court = CourtEntity.builder()
             .courtId(100L)
             .name("Central Magistrates")
             .build();
 
-        when(courtRepo.findById(100L)).thenReturn(Optional.of(court));
+        when(courtLiteRepo.findById(100L)).thenReturn(Optional.of(court));
 
         // Reference entities: stub getters so the service can copy IDs onto the account
         ResultEntity.Lite eor = mock(ResultEntity.Lite.class);
@@ -463,11 +463,11 @@ class OpalDefendantAccountUpdateTest {
         doNothing().when(entityManager).lock(any(), any());
 
         long courtId = 780000000185L;
-        CourtEntity.Lite court = CourtEntity.Lite.builder()
+        CourtEntity court = CourtEntity.builder()
             .courtId(courtId)
             .name("Test Court")
             .build();
-        when(courtRepo.findById(courtId)).thenReturn(Optional.of(court));
+        when(courtLiteRepo.findById(courtId)).thenReturn(Optional.of(court));
 
         var req = UpdateDefendantAccountRequest.builder()
             .payload(UpdateDefendantAccountRequestPayload.builder()


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-2885
BE - Update 'Court' to use entity graphs

### Change description ###
 - Removed CourtEntity.Lite and consolidated court mappings into a single CourtEntity
 - Added named lite and full entity graphs for CourtEntity
 - Kept court associations LAZY by default and used entity graphs to control eager loading where needed
 - Updated court repository/service fetch paths to use the correct lite or full entity graph
 - Updated impacted specs, mappers, entities, and services to use the unified court
    entity
 - Added and updated unit/integration tests to cover the refactor and validate entity graph behaviour


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
