### PR TITLE
PO-2888: Updated Result to use entity graphs

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/repository/ResultRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/repository/ResultRepositoryIntegrationTest.java
@@ -1,0 +1,111 @@
+package uk.gov.hmcts.opal.repository;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityGraph;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.PersistenceUnitUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.test.context.jdbc.Sql;
+import uk.gov.hmcts.opal.AbstractIntegrationTest;
+import uk.gov.hmcts.opal.entity.result.ResultEntity;
+
+import java.util.Map;
+
+@DisplayName("Result Repository Integration Tests")
+@Sql(
+    scripts = "classpath:db/insertData/insert_into_result_entity_graph.sql",
+    executionPhase = BEFORE_TEST_METHOD
+)
+@Sql(
+    scripts = "classpath:db/deleteData/delete_from_result_entity_graph.sql",
+    executionPhase = AFTER_TEST_METHOD
+)
+class ResultRepositoryIntegrationTest extends AbstractIntegrationTest {
+
+    private static final String RESULT_ID = "RG9200";
+    private static final long ENFORCEMENT_ID = 920001L;
+
+    @Autowired
+    private ResultRepository resultRepository;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private PersistenceUnitUtil unitUtil;
+
+    @BeforeEach
+    void setUp() {
+        entityManager.clear();
+        unitUtil = entityManagerFactory.getPersistenceUnitUtil();
+    }
+
+    @Test
+    void shouldKeepEnforcementsLazyWhenNoEntityGraphIsUsed() {
+        ResultEntity result = entityManager.find(ResultEntity.class, RESULT_ID);
+
+        assertAll(
+            () -> assertNotNull(result),
+            () -> assertFalse(unitUtil.isLoaded(result, "enforcements"))
+        );
+    }
+
+    @Test
+    void shouldKeepEnforcementsLazyForRepositoryFindById() {
+        ResultEntity result = resultRepository.findById(RESULT_ID).orElseThrow();
+
+        assertAll(
+            () -> assertNotNull(result),
+            () -> assertFalse(unitUtil.isLoaded(result, "enforcements"))
+        );
+    }
+
+    @Test
+    void shouldLoadFullEntityGraphWhenRequestedExplicitly() {
+        EntityGraph<?> fullGraph = entityManager.getEntityGraph(ResultEntity.ENTITY_GRAPH_FULL);
+        ResultEntity result = entityManager.find(
+            ResultEntity.class,
+            RESULT_ID,
+            Map.of("jakarta.persistence.fetchgraph", fullGraph)
+        );
+
+        assertAll(
+            () -> assertNotNull(result),
+            () -> assertTrue(unitUtil.isLoaded(result, "enforcements")),
+            () -> assertEquals(1, result.getEnforcements().size()),
+            () -> assertEquals(ENFORCEMENT_ID, result.getEnforcements().get(0).getEnforcementId())
+        );
+    }
+
+    @Test
+    void shouldKeepEnforcementsLazyForSpecificationFetch() {
+        Specification<ResultEntity> spec =
+            (root, query, builder) -> builder.equal(root.get("resultId"), RESULT_ID);
+
+        Page<ResultEntity> page = resultRepository.findBy(spec, query -> query.page(Pageable.unpaged()));
+        ResultEntity result = page.getContent().get(0);
+
+        assertAll(
+            () -> assertEquals(1, page.getTotalElements()),
+            () -> assertNotNull(result),
+            () -> assertFalse(unitUtil.isLoaded(result, "enforcements"))
+        );
+    }
+}

--- a/src/integrationTest/resources/db/deleteData/delete_from_result_entity_graph.sql
+++ b/src/integrationTest/resources/db/deleteData/delete_from_result_entity_graph.sql
@@ -1,0 +1,22 @@
+/**
+* OPAL Program
+*
+* MODULE      : delete_from_result_entity_graph.sql
+*
+* DESCRIPTION : Deletes targeted result entity graph test data after repository integration tests.
+*
+* VERSION HISTORY:
+*
+* Date        Author      Version  Nature of Change
+* ----------  ----------  -------  -------------------------------------------------------------
+* 27/04/2026  Dat Nguyen       1.0      Remove result data used to verify lazy loading and entity graph fetch behaviour.
+*
+*/
+
+DELETE FROM enforcements WHERE enforcement_id = 920001;
+DELETE FROM defendant_accounts WHERE defendant_account_id = 920002;
+DELETE FROM results WHERE result_id = 'RG9200';
+DELETE FROM enforcers WHERE enforcer_id = 920003;
+DELETE FROM courts WHERE court_id = 920004;
+DELETE FROM local_justice_areas WHERE local_justice_area_id = 920;
+DELETE FROM business_units WHERE business_unit_id = 920;

--- a/src/integrationTest/resources/db/insertData/insert_into_result_entity_graph.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_result_entity_graph.sql
@@ -1,0 +1,190 @@
+/**
+* OPAL Program
+*
+* MODULE      : insert_into_result_entity_graph.sql
+*
+* DESCRIPTION : Inserts targeted result entity graph test data for repository integration tests.
+*
+* VERSION HISTORY:
+*
+* Date        Author      Version  Nature of Change
+* ----------  ----------  -------  -------------------------------------------------------------
+* 27/04/2026  Dat Nguyen       1.0      Add result data to verify lazy loading and named entity graph fetch behaviour.
+*
+*/
+
+INSERT INTO business_units (
+    business_unit_id,
+    business_unit_name,
+    business_unit_type
+) VALUES (
+    920,
+    'Result Graph BU',
+    'Accounting Division'
+);
+
+INSERT INTO local_justice_areas (
+    local_justice_area_id,
+    name,
+    address_line_1
+) VALUES (
+    920,
+    'Result Graph LJA',
+    '1 Result Street'
+);
+
+INSERT INTO courts (
+    court_id,
+    business_unit_id,
+    court_code,
+    name,
+    local_justice_area_id
+) VALUES (
+    920004,
+    920,
+    920,
+    'Result Graph Court',
+    920
+);
+
+INSERT INTO enforcers (
+    enforcer_id,
+    business_unit_id,
+    enforcer_code,
+    name
+) VALUES (
+    920003,
+    920,
+    920,
+    'Result Graph Enforcer'
+);
+
+INSERT INTO results (
+    result_id,
+    result_title,
+    result_title_cy,
+    result_type,
+    active,
+    imposition,
+    imposition_category,
+    imposition_allocation_priority,
+    imposition_accruing,
+    imposition_creditor,
+    enforcement,
+    enforcement_override,
+    further_enforcement_warn,
+    further_enforcement_disallow,
+    enforcement_hold,
+    requires_enforcer,
+    generates_hearing,
+    generates_warrant,
+    collection_order,
+    extend_ttp_disallow,
+    extend_ttp_preserve_last_enf,
+    prevent_payment_card,
+    lists_monies,
+    manual_enforcement,
+    allow_payment_terms,
+    requires_employment_data,
+    allow_additional_action,
+    requires_lja,
+    enf_next_permitted_actions,
+    result_parameters
+) VALUES (
+    'RG9200',
+    'Result Graph Result',
+    'Result Graph Result',
+    'Result',
+    TRUE,
+    FALSE,
+    NULL,
+    NULL,
+    FALSE,
+    NULL,
+    TRUE,
+    FALSE,
+    FALSE,
+    FALSE,
+    FALSE,
+    TRUE,
+    TRUE,
+    FALSE,
+    FALSE,
+    FALSE,
+    FALSE,
+    FALSE,
+    FALSE,
+    FALSE,
+    FALSE,
+    FALSE,
+    FALSE,
+    FALSE,
+    'RG9201,RG9202',
+    '{"param":"value"}'
+);
+
+INSERT INTO defendant_accounts (
+    defendant_account_id,
+    version_number,
+    business_unit_id,
+    account_number,
+    amount_paid,
+    account_balance,
+    amount_imposed,
+    allow_writeoffs,
+    allow_cheques,
+    account_type,
+    collection_order,
+    payment_card_requested,
+    account_status,
+    last_enforcement
+) VALUES (
+    920002,
+    0,
+    920,
+    '920002A',
+    0.00,
+    250.00,
+    250.00,
+    'N',
+    'N',
+    'Fine',
+    'N',
+    'N',
+    'L',
+    'RG9200'
+);
+
+INSERT INTO enforcements (
+    enforcement_id,
+    defendant_account_id,
+    posted_date,
+    posted_by,
+    result_id,
+    reason,
+    enforcer_id,
+    jail_days,
+    warrant_reference,
+    case_reference,
+    hearing_date,
+    hearing_court_id,
+    enforcement_account_type,
+    posted_by_name,
+    result_responses
+) VALUES (
+    920001,
+    920002,
+    TIMESTAMP '2026-04-01 09:30:00',
+    'result.graph',
+    'RG9200',
+    'Result graph reason',
+    920003,
+    14,
+    'WAR-920001',
+    'CASE-920001',
+    TIMESTAMP '2026-04-15 10:45:00',
+    920004,
+    'COLL',
+    'Result Graph User',
+    '{"param":"value"}'
+);

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/search/LegacyResultSearchResults.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/search/LegacyResultSearchResults.java
@@ -17,6 +17,6 @@ import java.util.List;
 public class LegacyResultSearchResults {
 
     @XmlElement(name = "resultEntity")
-    private List<ResultEntity.Lite> resultEntities;
+    private List<ResultEntity> resultEntities;
     private int totalCount;
 }

--- a/src/main/java/uk/gov/hmcts/opal/entity/enforcement/EnforcementEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/enforcement/EnforcementEntity.java
@@ -86,7 +86,7 @@ public class EnforcementEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "result_id", insertable = false, updatable = false)
-    private ResultEntity.Lite result;
+    private ResultEntity result;
 
     @Column(name = "reason", length = 50)
     private String reason;

--- a/src/main/java/uk/gov/hmcts/opal/entity/result/ResultEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/result/ResultEntity.java
@@ -3,24 +3,40 @@ package uk.gov.hmcts.opal.entity.result;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
-import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
+import uk.gov.hmcts.opal.entity.enforcement.EnforcementEntity;
+
+import java.util.List;
 
 @Getter
 @Setter
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
-@MappedSuperclass
+@Entity
+@Table(name = "results")
 @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
-public abstract class ResultEntity {
+@NamedEntityGraph(name = ResultEntity.ENTITY_GRAPH_LITE)
+@NamedEntityGraph(
+    name = ResultEntity.ENTITY_GRAPH_FULL,
+    attributeNodes = {
+        @NamedAttributeNode("enforcements")
+    }
+)
+public class ResultEntity {
+
+    public static final String ENTITY_GRAPH_LITE = "ResultEntity.lite";
+    public static final String ENTITY_GRAPH_FULL = "ResultEntity.full";
 
     @Id
     @Column(name = "result_id")
@@ -99,14 +115,6 @@ public abstract class ResultEntity {
     @Column(name = "enf_next_permitted_actions")
     private String enfNextPermittedActions;
 
-    @Entity
-    @Getter
-    @EqualsAndHashCode(callSuper = true)
-    @Table(name = "results")
-    @SuperBuilder
-    @NoArgsConstructor
-    public static class Lite extends ResultEntity {
-
-    }
-
+    @OneToMany(mappedBy = "result", fetch = FetchType.LAZY)
+    private List<EnforcementEntity> enforcements;
 }

--- a/src/main/java/uk/gov/hmcts/opal/mapper/ResultMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/mapper/ResultMapper.java
@@ -11,9 +11,9 @@ import java.util.List;
 @Mapper(componentModel = "spring")
 public interface ResultMapper {
 
-    ResultReferenceData toRefData(ResultEntity.Lite entity);
+    ResultReferenceData toRefData(ResultEntity entity);
 
-    default ResultReferenceDataResponse toReferenceDataResponse(List<ResultEntity.Lite> entities) {
+    default ResultReferenceDataResponse toReferenceDataResponse(List<ResultEntity> entities) {
         List<ResultReferenceData> dtoList = entities.stream()
             .map(this::toRefData)
             .toList();
@@ -23,6 +23,5 @@ public interface ResultMapper {
             .build();
     }
 
-    // NEW — used by GET /results/{resultId}
-    ResultDto toDto(ResultEntity.Lite entity);
+    ResultDto toDto(ResultEntity entity);
 }

--- a/src/main/java/uk/gov/hmcts/opal/repository/ResultRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/ResultRepository.java
@@ -1,14 +1,31 @@
 package uk.gov.hmcts.opal.repository;
 
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
-import uk.gov.hmcts.opal.entity.result.ResultEntity.Lite;
+import uk.gov.hmcts.opal.entity.result.ResultEntity;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
 
 @Repository
-public interface ResultRepository extends JpaRepository<Lite, String>,
-    JpaSpecificationExecutor<Lite> {
-    List<Lite> findByResultIdIn(List<String> resultIds);
+public interface ResultRepository extends JpaRepository<ResultEntity, String>,
+    JpaSpecificationExecutor<ResultEntity> {
+
+    @Override
+    @EntityGraph(value = ResultEntity.ENTITY_GRAPH_LITE, type = EntityGraph.EntityGraphType.FETCH)
+    Optional<ResultEntity> findById(String resultId);
+
+    @Override
+    @EntityGraph(value = ResultEntity.ENTITY_GRAPH_LITE, type = EntityGraph.EntityGraphType.FETCH)
+    <S extends ResultEntity, R> R findBy(
+        Specification<ResultEntity> spec,
+        Function<? super JpaSpecificationExecutor.SpecificationFluentQuery<S>, R> queryFunction
+    );
+
+    @EntityGraph(value = ResultEntity.ENTITY_GRAPH_LITE, type = EntityGraph.EntityGraphType.FETCH)
+    List<ResultEntity> findByResultIdIn(List<String> resultIds);
 }

--- a/src/main/java/uk/gov/hmcts/opal/repository/jpa/ResultSpecs.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/jpa/ResultSpecs.java
@@ -1,38 +1,36 @@
 package uk.gov.hmcts.opal.repository.jpa;
 
-import org.springframework.stereotype.Component;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
 import uk.gov.hmcts.opal.dto.search.ResultSearchDto;
 import uk.gov.hmcts.opal.entity.result.ResultEntity;
 import uk.gov.hmcts.opal.entity.result.ResultEntity_;
-import uk.gov.hmcts.opal.entity.result.ResultEntity.Lite;
 
 import java.util.List;
 import java.util.Optional;
 
-
 @Component
-public class ResultSpecsLite extends EntitySpecs<Lite> {
+public class ResultSpecs extends EntitySpecs<ResultEntity> {
 
-    public Specification<Lite> findBySearchCriteria(ResultSearchDto criteria) {
+    public Specification<ResultEntity> findBySearchCriteria(ResultSearchDto criteria) {
         return Specification.allOf(specificationList(
-            notBlank(criteria.getResultId()).map(ResultSpecsLite::likeResultId),
-            notBlank(criteria.getResultTitle()).map(ResultSpecsLite::likeResultTitle),
-            notBlank(criteria.getResultTitleCy()).map(ResultSpecsLite::likeResultTitleCy),
-            notBlank(criteria.getResultType()).map(ResultSpecsLite::likeResultType),
+            notBlank(criteria.getResultId()).map(ResultSpecs::likeResultId),
+            notBlank(criteria.getResultTitle()).map(ResultSpecs::likeResultTitle),
+            notBlank(criteria.getResultTitleCy()).map(ResultSpecs::likeResultTitleCy),
+            notBlank(criteria.getResultType()).map(ResultSpecs::likeResultType),
             numericShort(criteria.getImpositionAllocationPriority())
-                .map(ResultSpecsLite::equalsImpositionAllocationPriority),
-            notBlank(criteria.getImpositionCreditor()).map(ResultSpecsLite::likeImpositionCreditor)
+                .map(ResultSpecs::equalsImpositionAllocationPriority),
+            notBlank(criteria.getImpositionCreditor()).map(ResultSpecs::likeImpositionCreditor)
         ));
     }
 
-    public Specification<Lite> referenceDataFilter(Optional<String> filter) {
+    public Specification<ResultEntity> referenceDataFilter(Optional<String> filter) {
         return Specification.allOf(specificationList(
             filter.filter(s -> !s.isBlank()).map(this::likeAnyResult)
         ));
     }
 
-    public Specification<ResultEntity.Lite> referenceDataByIds(
+    public Specification<ResultEntity> referenceDataByIds(
         Optional<List<String>> resultIds,
         Boolean active,
         Boolean manualEnforcement,
@@ -42,54 +40,53 @@ public class ResultSpecsLite extends EntitySpecs<Lite> {
 
         return Specification.allOf(specificationList(
             // optional resultIds clause
-            resultIds.map(ResultSpecsLite::equalsAnyResultId),
+            resultIds.map(ResultSpecs::equalsAnyResultId),
 
-            Optional.ofNullable(active).map(ResultSpecsLite::hasActive),
-            Optional.ofNullable(manualEnforcement).map(ResultSpecsLite::hasManualEnforcementOnly),
-            Optional.ofNullable(generatesHearing).map(ResultSpecsLite::hasGeneratesHearing),
-            Optional.ofNullable(enforcement).map(ResultSpecsLite::hasEnforcement),
-            Optional.ofNullable(enforcementOverride).map(ResultSpecsLite::hasEnforcementOverride)
+            Optional.ofNullable(active).map(ResultSpecs::hasActive),
+            Optional.ofNullable(manualEnforcement).map(ResultSpecs::hasManualEnforcementOnly),
+            Optional.ofNullable(generatesHearing).map(ResultSpecs::hasGeneratesHearing),
+            Optional.ofNullable(enforcement).map(ResultSpecs::hasEnforcement),
+            Optional.ofNullable(enforcementOverride).map(ResultSpecs::hasEnforcementOverride)
 
         ));
     }
 
-
-    public static Specification<ResultEntity.Lite> equalsAnyResultId(List<String> resultIds) {
+    public static Specification<ResultEntity> equalsAnyResultId(List<String> resultIds) {
         return (root, query, builder) -> root.get(ResultEntity_.resultId).in(resultIds);
     }
 
-    public static Specification<Lite> likeResultId(String resultId) {
+    public static Specification<ResultEntity> likeResultId(String resultId) {
         return (root, query, builder) -> likeWildcardPredicate(
             root.get(ResultEntity_.resultId), builder, resultId);
     }
 
-    public static Specification<Lite> likeResultTitle(String resultTitle) {
+    public static Specification<ResultEntity> likeResultTitle(String resultTitle) {
         return (root, query, builder) -> likeWildcardPredicate(root.get(ResultEntity_.resultTitle), builder,
                                                                resultTitle);
     }
 
-    public static Specification<ResultEntity.Lite> likeResultTitleCy(String resultTitleCy) {
+    public static Specification<ResultEntity> likeResultTitleCy(String resultTitleCy) {
         return (root, query, builder) -> likeWildcardPredicate(root.get(ResultEntity_.resultTitleCy), builder,
                                                                resultTitleCy);
     }
 
-    public static Specification<Lite> likeResultType(String resultType) {
+    public static Specification<ResultEntity> likeResultType(String resultType) {
         return (root, query, builder) ->
             likeWildcardPredicate(root.get(ResultEntity_.resultType), builder, resultType);
     }
 
-    public static Specification<Lite>
+    public static Specification<ResultEntity>
         equalsImpositionAllocationPriority(Short impositionAllocationPriority) {
         return (root, query, builder) -> builder.equal(root.get(ResultEntity_.impositionAllocationPriority),
                                                        impositionAllocationPriority);
     }
 
-    public static Specification<ResultEntity.Lite> likeImpositionCreditor(String impositionCreditor) {
+    public static Specification<ResultEntity> likeImpositionCreditor(String impositionCreditor) {
         return (root, query, builder) -> likeWildcardPredicate(root.get(ResultEntity_.impositionCreditor), builder,
                                                                impositionCreditor);
     }
 
-    public Specification<Lite> likeAnyResult(String filter) {
+    public Specification<ResultEntity> likeAnyResult(String filter) {
         return Specification.anyOf(
             likeResultId(filter),
             likeResultTitle(filter),
@@ -97,29 +94,28 @@ public class ResultSpecsLite extends EntitySpecs<Lite> {
         );
     }
 
-    public static Specification<ResultEntity.Lite> hasActive(boolean active) {
+    public static Specification<ResultEntity> hasActive(boolean active) {
         return (root, query, builder) -> builder.equal(root.get(
             ResultEntity_.active), active);
     }
 
-    public static Specification<ResultEntity.Lite> hasManualEnforcementOnly(boolean manualEnforcement) {
+    public static Specification<ResultEntity> hasManualEnforcementOnly(boolean manualEnforcement) {
         return (root, query, builder) -> builder.equal(root.get(
             ResultEntity_.manualEnforcement), manualEnforcement);
     }
 
-    public static Specification<ResultEntity.Lite> hasGeneratesHearing(boolean generatesHearing) {
+    public static Specification<ResultEntity> hasGeneratesHearing(boolean generatesHearing) {
         return (root, query, builder) -> builder.equal(root.get(
             ResultEntity_.generatesHearing), generatesHearing);
     }
 
-    public static Specification<ResultEntity.Lite> hasEnforcement(boolean hasEnforcement) {
+    public static Specification<ResultEntity> hasEnforcement(boolean hasEnforcement) {
         return (root, query, builder) -> builder.equal(root.get(
             ResultEntity_.enforcement), hasEnforcement);
     }
 
-    public static Specification<ResultEntity.Lite> hasEnforcementOverride(boolean enforcementOverride) {
+    public static Specification<ResultEntity> hasEnforcementOverride(boolean enforcementOverride) {
         return (root, query, builder) -> builder.equal(root.get(ResultEntity_.enforcementOverride),
             enforcementOverride);
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountBuilders.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountBuilders.java
@@ -704,7 +704,7 @@ public class OpalDefendantAccountBuilders {
             .orElse(null);
     }
 
-    static EnforcementOverrideResult buildEnforcementOverrideResult(ResultEntity.Lite entity) {
+    static EnforcementOverrideResult buildEnforcementOverrideResult(ResultEntity entity) {
         return Optional.ofNullable(entity).map(r -> EnforcementOverrideResult.builder()
                 .enforcementOverrideId(r.getResultId())
                 .enforcementOverrideTitle(r.getResultTitle())
@@ -713,7 +713,7 @@ public class OpalDefendantAccountBuilders {
     }
 
     static EnforcementOverrideResultDefendantAccount buildEnforcementOverrideResultDefendantAccount(
-        ResultEntity.Lite entity) {
+        ResultEntity entity) {
         return Optional.ofNullable(entity).map(r -> EnforcementOverrideResultDefendantAccount.builder()
                 .enforcementOverrideResultId(r.getResultId())
                 .build())
@@ -750,7 +750,7 @@ public class OpalDefendantAccountBuilders {
 
     static EnforcementStatus buildEnforcementStatus(DefendantAccountEntity defendantEntity,
         DefendantAccountPartiesEntity defendantParty, DebtorDetailEntity debtDetails,
-        ResultEntity.Lite recentResult, EnforcementOverride override,
+        ResultEntity recentResult, EnforcementOverride override,
         EnforcementActionDefendantAccount enfActDefAcc) {
 
         return EnforcementStatus.builder()
@@ -772,7 +772,7 @@ public class OpalDefendantAccountBuilders {
             return null;
         }
 
-        ResultEntity.Lite recentResult = recentEnforcement.getResult();
+        ResultEntity recentResult = recentEnforcement.getResult();
 
         return EnforcementActionDefendantAccount.builder()
             .enforcementAction(ResultReferenceCommon.builder()

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
@@ -1131,7 +1131,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
         EnforcementEntity mostRecentEnforcement = fetchEnforcementMostRecent(defAccount);
 
         if (mostRecentEnforcement != null) {
-            ResultEntity.Lite resultEntityLite = resultService.getResultById(mostRecentEnforcement.getResultId());
+            ResultEntity resultEntityLite = resultService.getResultById(mostRecentEnforcement.getResultId());
 
             // If resultEntity exists and extend_ttp_preserve_last_enf is not TRUE, clear last_enforcement
             if (!resultEntityLite.isExtendTtpPreserveLastEnf()) {
@@ -1160,7 +1160,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
         return dto.getAccountBalance() != null && dto.getAccountBalance().compareTo(BigDecimal.ZERO) != 0;
     }
 
-    private ResultEntity.Lite fetchResultEntity(String resultId) {
+    private ResultEntity fetchResultEntity(String resultId) {
         return Optional.ofNullable(resultId).flatMap(resultRepository::findById).orElse(null);
     }
 

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/ResultService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/ResultService.java
@@ -14,11 +14,10 @@ import uk.gov.hmcts.opal.dto.ResultDto;
 import uk.gov.hmcts.opal.dto.reference.ResultReferenceDataResponse;
 import uk.gov.hmcts.opal.dto.search.ResultSearchDto;
 import uk.gov.hmcts.opal.entity.result.ResultEntity;
-import uk.gov.hmcts.opal.entity.result.ResultEntity.Lite;
 import uk.gov.hmcts.opal.dto.reference.ResultReferenceData;
 import uk.gov.hmcts.opal.mapper.ResultMapper;
 import uk.gov.hmcts.opal.repository.ResultRepository;
-import uk.gov.hmcts.opal.repository.jpa.ResultSpecsLite;
+import uk.gov.hmcts.opal.repository.jpa.ResultSpecs;
 
 import java.util.List;
 import java.util.Optional;
@@ -30,10 +29,10 @@ public class ResultService {
 
     private final ResultRepository resultRepository;
     private final ResultMapper resultMapper;
-    private final ResultSpecsLite specsLite;
+    private final ResultSpecs resultSpecs;
 
     @Transactional(readOnly = true)
-    public ResultEntity.Lite getResultById(String resultId) {
+    public ResultEntity getResultById(String resultId) {
         return resultRepository.findById(resultId)
             .orElseThrow(() -> new EntityNotFoundException("'Result' not found with id: " + resultId));
     }
@@ -44,11 +43,9 @@ public class ResultService {
     }
 
     public ResultDto getResult(String resultId) {
-        // Fetch the full Lite entity (same logic as existing)
-        ResultEntity.Lite entity = resultRepository.findById(resultId)
+        ResultEntity entity = resultRepository.findById(resultId)
             .orElseThrow(() -> new EntityNotFoundException("'Result' not found with id: " + resultId));
 
-        // Map to full DTO
         return resultMapper.toDto(entity);
     }
 
@@ -62,8 +59,8 @@ public class ResultService {
 
         Sort idSort = Sort.by(Sort.Direction.ASC, "resultId");
 
-        Page<Lite> page = resultRepository.findBy(
-            specsLite.referenceDataByIds(resultIds, active, manualEnforcement, generatesHearing, enforcement,
+        Page<ResultEntity> page = resultRepository.findBy(
+            resultSpecs.referenceDataByIds(resultIds, active, manualEnforcement, generatesHearing, enforcement,
                 enforcementOverride),
             ffq -> ffq
                 .sortBy(idSort)
@@ -73,10 +70,10 @@ public class ResultService {
         return resultMapper.toReferenceDataResponse(page.getContent());
     }
 
-    public List<ResultEntity.Lite> searchResults(ResultSearchDto criteria) {
-        Page<ResultEntity.Lite> page = resultRepository
+    public List<ResultEntity> searchResults(ResultSearchDto criteria) {
+        Page<ResultEntity> page = resultRepository
             .findBy(
-                specsLite.findBySearchCriteria(criteria),
+                resultSpecs.findBySearchCriteria(criteria),
                     ffq -> ffq.page(Pageable.unpaged()));
 
         return page.getContent();
@@ -87,9 +84,9 @@ public class ResultService {
 
         Sort nameSort = Sort.by(Sort.Direction.ASC, "resultTitle");
 
-        Page<ResultEntity.Lite> page = resultRepository
+        Page<ResultEntity> page = resultRepository
             .findBy(
-                specsLite.referenceDataFilter(filter),
+                resultSpecs.referenceDataFilter(filter),
                     ffq -> ffq
                         .sortBy(nameSort)
                         .page(Pageable.unpaged()));

--- a/src/main/java/uk/gov/hmcts/opal/service/persistence/ResultRepositoryService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/persistence/ResultRepositoryService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import uk.gov.hmcts.opal.entity.result.ResultEntity.Lite;
+import uk.gov.hmcts.opal.entity.result.ResultEntity;
 import uk.gov.hmcts.opal.repository.ResultRepository;
 
 import java.util.Optional;
@@ -17,7 +17,7 @@ public class ResultRepositoryService {
     private final ResultRepository resultRepository;
 
     @Transactional(readOnly = true)
-    public Optional<Lite> getResultById(String resultId) {
+    public Optional<ResultEntity> getResultById(String resultId) {
         return Optional.ofNullable(resultId).flatMap(resultRepository::findById);
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/disco/opal/ResultServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/disco/opal/ResultServiceTest.java
@@ -25,10 +25,9 @@ import uk.gov.hmcts.opal.dto.reference.ResultReferenceData;
 import uk.gov.hmcts.opal.dto.reference.ResultReferenceDataResponse;
 import uk.gov.hmcts.opal.dto.search.ResultSearchDto;
 import uk.gov.hmcts.opal.entity.result.ResultEntity;
-import uk.gov.hmcts.opal.entity.result.ResultEntity.Lite;
 import uk.gov.hmcts.opal.mapper.ResultMapper;
 import uk.gov.hmcts.opal.repository.ResultRepository;
-import uk.gov.hmcts.opal.repository.jpa.ResultSpecsLite;
+import uk.gov.hmcts.opal.repository.jpa.ResultSpecs;
 import uk.gov.hmcts.opal.service.opal.ResultService;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,9 +37,9 @@ class ResultServiceTest {
     private ResultRepository resultRepository;
 
     @Mock
-    private ResultSpecsLite specsLite;
+    private ResultSpecs resultSpecs;
 
-    private Specification<Lite> noOpSpec() {
+    private Specification<ResultEntity> noOpSpec() {
         return (root, query, builder) -> builder.conjunction();
     }
 
@@ -53,20 +52,21 @@ class ResultServiceTest {
     @Test
     void testGetResult() {
         // Arrange
-        ResultEntity.Lite resultEntity = Lite.builder().build();
+        ResultEntity resultEntity = ResultEntity.builder().build();
         when(resultRepository.findById(any())).thenReturn(Optional.of(resultEntity));
 
         // Act
-        ResultEntity.Lite result = resultService.getResultById("ABC");
+        ResultEntity result = resultService.getResultById("ABC");
 
         // Assert
         assertNotNull(result);
+        verify(resultRepository).findById("ABC");
     }
 
     @Test
     void testGetResultReferenceData() {
         // Arrange
-        ResultEntity.Lite resultEntity = ResultEntity.Lite.builder().resultId("ABC").build();
+        ResultEntity resultEntity = ResultEntity.builder().resultId("ABC").build();
         ResultReferenceData expectedRefData = new ResultReferenceData(
             "ABC", null, null, false, null, null, null
         );
@@ -78,6 +78,7 @@ class ResultServiceTest {
 
         // Assert
         assertNotNull(result);
+        verify(resultRepository).findById("ABC");
     }
 
     // helper to keep arrange/act style identical to original
@@ -89,16 +90,16 @@ class ResultServiceTest {
     @Test
     void testGetResultsByIds() {
         // Arrange
-        Lite resultEntity = Lite.builder().resultId("ABC").build();
+        ResultEntity resultEntity = ResultEntity.builder().resultId("ABC").build();
         ResultReferenceData dto = new ResultReferenceData(
             "ABC", null, null, false, null, null, null);
 
         @SuppressWarnings("unchecked")
-        SpecificationFluentQuery<Lite> sfq = (SpecificationFluentQuery<Lite>)
+        SpecificationFluentQuery<ResultEntity> sfq = (SpecificationFluentQuery<ResultEntity>)
             Mockito.mock(SpecificationFluentQuery.class);
         when(sfq.sortBy(any())).thenReturn(sfq);
 
-        Page<Lite> mockPage = new PageImpl<>(List.of(resultEntity), Pageable.unpaged(), 999L);
+        Page<ResultEntity> mockPage = new PageImpl<>(List.of(resultEntity), Pageable.unpaged(), 999L);
 
         // match the repository call with any(Specification.class), any(Function.class)
         when(resultRepository.findBy(any(Specification.class), any(Function.class))).thenAnswer(iom -> {
@@ -107,7 +108,7 @@ class ResultServiceTest {
         });
 
         when(resultMapper.toRefData(any())).thenReturn(dto);
-        when(specsLite.referenceDataByIds(any(), any(), any(), any(), any(), any()))
+        when(resultSpecs.referenceDataByIds(any(), any(), any(), any(), any(), any()))
             .thenReturn(noOpSpec());
 
         // Act
@@ -128,12 +129,12 @@ class ResultServiceTest {
     void testGetResultsByIds_enforcementOverrideTrue() {
         // Arrange - enforcementOverride = true, other booleans null
         @SuppressWarnings("unchecked")
-        SpecificationFluentQuery<Lite> sfq = (SpecificationFluentQuery<Lite>)
+        SpecificationFluentQuery<ResultEntity> sfq = (SpecificationFluentQuery<ResultEntity>)
             Mockito.mock(SpecificationFluentQuery.class);
         when(sfq.sortBy(any())).thenReturn(sfq);
 
-        Lite resultEntity = Lite.builder().resultId("NBWIT").build();
-        Page<Lite> mockPage = new PageImpl<>(List.of(resultEntity), Pageable.unpaged(), 1L);
+        ResultEntity resultEntity = ResultEntity.builder().resultId("NBWIT").build();
+        Page<ResultEntity> mockPage = new PageImpl<>(List.of(resultEntity), Pageable.unpaged(), 1L);
 
         // repository stub executes the function argument provided by the service
         when(resultRepository.findBy(any(Specification.class), any(Function.class))).thenAnswer(invocation -> {
@@ -142,7 +143,7 @@ class ResultServiceTest {
         });
 
         // ensure specsLite is stubbed (service will call it)
-        when(specsLite.referenceDataByIds(any(), any(), any(), any(), any(), any()))
+        when(resultSpecs.referenceDataByIds(any(), any(), any(), any(), any(), any()))
             .thenReturn(noOpSpec());
 
         ResultReferenceData dto = new ResultReferenceData("NBWIT", null, null, false, null, null, null);
@@ -166,21 +167,21 @@ class ResultServiceTest {
     void testSearchResults() {
         // Arrange
         @SuppressWarnings("unchecked")
-        SpecificationFluentQuery<Lite> sfq = (SpecificationFluentQuery<Lite>)
+        SpecificationFluentQuery<ResultEntity> sfq = (SpecificationFluentQuery<ResultEntity>)
             Mockito.mock(SpecificationFluentQuery.class);
 
-        ResultEntity.Lite resultEntity = ResultEntity.Lite.builder().build();
-        Page<ResultEntity.Lite> mockPage = new PageImpl<>(List.of(resultEntity), Pageable.unpaged(), 999L);
+        ResultEntity resultEntity = ResultEntity.builder().build();
+        Page<ResultEntity> mockPage = new PageImpl<>(List.of(resultEntity), Pageable.unpaged(), 999L);
 
         when(resultRepository.findBy(any(Specification.class), any(Function.class))).thenAnswer(iom -> {
             iom.getArgument(1, Function.class).apply(sfq);
             return mockPage;
         });
 
-        when(specsLite.findBySearchCriteria(any())).thenReturn(noOpSpec());
+        when(resultSpecs.findBySearchCriteria(any())).thenReturn(noOpSpec());
 
         // Act
-        List<ResultEntity.Lite> result = resultService.searchResults(ResultSearchDto.builder().build());
+        List<ResultEntity> result = resultService.searchResults(ResultSearchDto.builder().build());
 
         // Assert
         assertEquals(List.of(resultEntity), result);
@@ -191,23 +192,23 @@ class ResultServiceTest {
     void testResultsReferenceData() {
         // Arrange
         @SuppressWarnings("unchecked")
-        SpecificationFluentQuery<Lite> sfq = (SpecificationFluentQuery<Lite>)
+        SpecificationFluentQuery<ResultEntity> sfq = (SpecificationFluentQuery<ResultEntity>)
             Mockito.mock(SpecificationFluentQuery.class);
         when(sfq.sortBy(any())).thenReturn(sfq);
 
-        ResultEntity.Lite entity = ResultEntity.Lite.builder().build();
+        ResultEntity entity = ResultEntity.builder().build();
         ResultReferenceData expectedRefData = new ResultReferenceData(
             null, null, null, false, null, null, null
         );
         when(resultMapper.toRefData(entity)).thenReturn(expectedRefData);
 
-        Page<ResultEntity.Lite> mockPage = new PageImpl<>(List.of(entity), Pageable.unpaged(), 999L);
+        Page<ResultEntity> mockPage = new PageImpl<>(List.of(entity), Pageable.unpaged(), 999L);
         when(resultRepository.findBy(any(Specification.class), any(Function.class))).thenAnswer(iom -> {
             iom.getArgument(1, Function.class).apply(sfq);
             return mockPage;
         });
 
-        when(specsLite.referenceDataFilter(any())).thenReturn(noOpSpec());
+        when(resultSpecs.referenceDataFilter(any())).thenReturn(noOpSpec());
 
         // Act
         List<ResultReferenceData> result = resultService.getReferenceData(Optional.empty());
@@ -229,7 +230,7 @@ class ResultServiceTest {
     @Test
     void testGetResult_ReturnsFullDto() {
         // Arrange
-        ResultEntity.Lite entity = ResultEntity.Lite.builder()
+        ResultEntity entity = ResultEntity.builder()
             .resultId("ABC")
             .resultTitle("Result Title")
             .resultTitleCy("Welsh Title")
@@ -276,19 +277,19 @@ class ResultServiceTest {
     void testGetResultsByIds_allNullBooleans() {
         // Arrange - resultIds present, all Boolean flags null -> should behave like no boolean filters
         @SuppressWarnings("unchecked")
-        SpecificationFluentQuery<Lite> sfq = (SpecificationFluentQuery<Lite>)
+        SpecificationFluentQuery<ResultEntity> sfq = (SpecificationFluentQuery<ResultEntity>)
             Mockito.mock(SpecificationFluentQuery.class);
         when(sfq.sortBy(any())).thenReturn(sfq);
 
-        Lite resultEntity = Lite.builder().resultId("ABC").build();
-        Page<Lite> mockPage = new PageImpl<>(List.of(resultEntity), Pageable.unpaged(), 1L);
+        ResultEntity resultEntity = ResultEntity.builder().resultId("ABC").build();
+        Page<ResultEntity> mockPage = new PageImpl<>(List.of(resultEntity), Pageable.unpaged(), 1L);
 
         when(resultRepository.findBy(any(Specification.class), any(Function.class))).thenAnswer(invocation -> {
             invocation.getArgument(1, Function.class).apply(sfq);
             return mockPage;
         });
 
-        when(specsLite.referenceDataByIds(any(), any(), any(), any(), any(), any()))
+        when(resultSpecs.referenceDataByIds(any(), any(), any(), any(), any(), any()))
             .thenReturn(noOpSpec());
 
         ResultReferenceData dto = new ResultReferenceData("ABC", null, null, false, null, null, null);
@@ -312,19 +313,19 @@ class ResultServiceTest {
     void testGetResultsByIds_activeTrue() {
         // Arrange - active = true, other booleans null
         @SuppressWarnings("unchecked")
-        SpecificationFluentQuery<Lite> sfq = (SpecificationFluentQuery<Lite>)
+        SpecificationFluentQuery<ResultEntity> sfq = (SpecificationFluentQuery<ResultEntity>)
             Mockito.mock(SpecificationFluentQuery.class);
         when(sfq.sortBy(any())).thenReturn(sfq);
 
-        Lite resultEntity = Lite.builder().resultId("ACT-1").active(true).build();
-        Page<Lite> mockPage = new PageImpl<>(List.of(resultEntity), Pageable.unpaged(), 1L);
+        ResultEntity resultEntity = ResultEntity.builder().resultId("ACT-1").active(true).build();
+        Page<ResultEntity> mockPage = new PageImpl<>(List.of(resultEntity), Pageable.unpaged(), 1L);
 
         when(resultRepository.findBy(any(Specification.class), any(Function.class))).thenAnswer(invocation -> {
             invocation.getArgument(1, Function.class).apply(sfq);
             return mockPage;
         });
 
-        when(specsLite.referenceDataByIds(any(), any(), any(), any(), any(), any()))
+        when(resultSpecs.referenceDataByIds(any(), any(), any(), any(), any(), any()))
             .thenReturn(noOpSpec());
 
         ResultReferenceData dto = new ResultReferenceData("ACT-1", null, null, false, null, null, null);
@@ -348,19 +349,22 @@ class ResultServiceTest {
     void testGetResultsByIds_manualEnforcementFalse_explicitFilteringOmitted() {
         // Arrange
         @SuppressWarnings("unchecked")
-        SpecificationFluentQuery<Lite> sfq = (SpecificationFluentQuery<Lite>)
+        SpecificationFluentQuery<ResultEntity> sfq = (SpecificationFluentQuery<ResultEntity>)
             Mockito.mock(SpecificationFluentQuery.class);
         when(sfq.sortBy(any())).thenReturn(sfq);
 
-        Lite resultEntity = Lite.builder().resultId("MEF-FALSE").manualEnforcement(false).build();
-        Page<Lite> mockPage = new PageImpl<>(List.of(resultEntity), Pageable.unpaged(), 1L);
+        ResultEntity resultEntity = ResultEntity.builder()
+            .resultId("MEF-FALSE")
+            .manualEnforcement(false)
+            .build();
+        Page<ResultEntity> mockPage = new PageImpl<>(List.of(resultEntity), Pageable.unpaged(), 1L);
 
         when(resultRepository.findBy(any(Specification.class), any(Function.class))).thenAnswer(invocation -> {
             invocation.getArgument(1, Function.class).apply(sfq);
             return mockPage;
         });
 
-        when(specsLite.referenceDataByIds(any(), any(), any(), any(), any(), any()))
+        when(resultSpecs.referenceDataByIds(any(), any(), any(), any(), any(), any()))
             .thenReturn(noOpSpec());
 
         ResultReferenceData dto = new ResultReferenceData("MEF-FALSE", null, null, false, null, null, null);
@@ -384,11 +388,11 @@ class ResultServiceTest {
     void testGetResultsByIds_multipleBooleansMixed() {
         // Arrange - multiple booleans provided (true/false/null) to exercise combinations
         @SuppressWarnings("unchecked")
-        SpecificationFluentQuery<Lite> sfq = (SpecificationFluentQuery<Lite>)
+        SpecificationFluentQuery<ResultEntity> sfq = (SpecificationFluentQuery<ResultEntity>)
             Mockito.mock(SpecificationFluentQuery.class);
         when(sfq.sortBy(any())).thenReturn(sfq);
 
-        Lite resultEntity = Lite.builder()
+        ResultEntity resultEntity = ResultEntity.builder()
             .resultId("MIXED")
             .active(true)
             .manualEnforcement(true)
@@ -396,14 +400,14 @@ class ResultServiceTest {
             .enforcement(true)
             .build();
 
-        Page<Lite> mockPage = new PageImpl<>(List.of(resultEntity), Pageable.unpaged(), 1L);
+        Page<ResultEntity> mockPage = new PageImpl<>(List.of(resultEntity), Pageable.unpaged(), 1L);
 
         when(resultRepository.findBy(any(Specification.class), any(Function.class))).thenAnswer(invocation -> {
             invocation.getArgument(1, Function.class).apply(sfq);
             return mockPage;
         });
 
-        when(specsLite.referenceDataByIds(any(), any(), any(), any(), any(), any()))
+        when(resultSpecs.referenceDataByIds(any(), any(), any(), any(), any(), any()))
             .thenReturn(noOpSpec());
 
         ResultReferenceData dto = new ResultReferenceData("MIXED", null, null, false, null, null, null);

--- a/src/test/java/uk/gov/hmcts/opal/mapper/ResultMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/mapper/ResultMapperTest.java
@@ -18,7 +18,7 @@ class ResultMapperTest {
     @Test
     void toRefData_shouldMapLiteEntityToDto() {
         // Arrange
-        ResultEntity.Lite entity = ResultEntity.Lite.builder()
+        ResultEntity entity = ResultEntity.builder()
             .resultId("R123")
             .resultTitle("Test Result")
             .resultTitleCy("Test Result Welsh")
@@ -45,7 +45,7 @@ class ResultMapperTest {
     @Test
     void toRefDataFromFull_shouldMapFullEntityToDto() {
         // Arrange
-        ResultEntity.Lite entity = ResultEntity.Lite.builder()
+        ResultEntity entity = ResultEntity.builder()
             .resultId("R456")
             .resultTitle("Full Result")
             .resultTitleCy("Full Result Welsh")
@@ -76,7 +76,7 @@ class ResultMapperTest {
     @Test
     void toReferenceDataResponse_shouldConvertListToResponse() {
         // Arrange
-        ResultEntity.Lite entity1 = ResultEntity.Lite.builder()
+        ResultEntity entity1 = ResultEntity.builder()
             .resultId("R1")
             .resultTitle("Result 1")
             .resultTitleCy("Result 1 Welsh")
@@ -84,7 +84,7 @@ class ResultMapperTest {
             .active(true)
             .build();
 
-        ResultEntity.Lite entity2 = ResultEntity.Lite.builder()
+        ResultEntity entity2 = ResultEntity.builder()
             .resultId("R2")
             .resultTitle("Result 2")
             .resultTitleCy("Result 2 Welsh")
@@ -92,7 +92,7 @@ class ResultMapperTest {
             .active(false)
             .build();
 
-        List<ResultEntity.Lite> entities = List.of(entity1, entity2);
+        List<ResultEntity> entities = List.of(entity1, entity2);
 
         // Act
         ResultReferenceDataResponse response = resultMapper.toReferenceDataResponse(entities);
@@ -110,7 +110,7 @@ class ResultMapperTest {
     @Test
     void toDto_shouldMapLiteEntityToFullResultDto() {
         // Arrange — build full entity
-        ResultEntity.Lite entity = ResultEntity.Lite.builder()
+        ResultEntity entity = ResultEntity.builder()
             .resultId("R999")
             .resultTitle("Full Title")
             .resultTitleCy("Teitl Llawn")

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceAddPaymentTermsTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceAddPaymentTermsTest.java
@@ -137,7 +137,7 @@ public class OpalDefendantAccountServiceAddPaymentTermsTest {
         when(enforcementRepository.findFirstByDefendantAccountIdAndResultIdOrderByPostedDateDesc(any(Long.class),
             any(String.class))).thenReturn(Optional.of(enforcementLite));
 
-        ResultEntity.Lite resultEntityLite = new ResultEntity.Lite();
+        ResultEntity resultEntityLite = new ResultEntity();
         resultEntityLite.setResultId(String.valueOf(55L));
         resultEntityLite.setExtendTtpPreserveLastEnf(Boolean.FALSE);
         //when(resultRepository.findById(Long.valueOf("55"))).thenReturn(Optional.of(resultEntityLite));

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountUpdateTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountUpdateTest.java
@@ -112,7 +112,7 @@ class OpalDefendantAccountUpdateTest {
         when(courtLiteRepo.findById(100L)).thenReturn(Optional.of(court));
 
         // Reference entities: stub getters so the service can copy IDs onto the account
-        ResultEntity.Lite eor = mock(ResultEntity.Lite.class);
+        ResultEntity eor = mock(ResultEntity.class);
         when(eor.getResultId()).thenReturn("EO-1");
         when(resultRepo.findById("EO-1")).thenReturn(Optional.of(eor));
 

--- a/src/test/java/uk/gov/hmcts/opal/service/persistence/ResultRepositoryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/persistence/ResultRepositoryServiceTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.hmcts.opal.entity.result.ResultEntity.Lite;
+import uk.gov.hmcts.opal.entity.result.ResultEntity;
 import uk.gov.hmcts.opal.repository.ResultRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,12 +28,12 @@ class ResultRepositoryServiceTest {
     void shouldReturnResultWhenIdIsProvidedAndResultExists() {
         // given
         String resultId = "RESULT_123";
-        Lite lite = mock(Lite.class);
+        ResultEntity lite = mock(ResultEntity.class);
 
         when(resultRepository.findById(resultId)).thenReturn(Optional.of(lite));
 
         // when
-        Optional<Lite> result = resultRepositoryService.getResultById(resultId);
+        Optional<ResultEntity> result = resultRepositoryService.getResultById(resultId);
 
         // then
         assertThat(result).isPresent();
@@ -49,7 +49,7 @@ class ResultRepositoryServiceTest {
         when(resultRepository.findById(resultId)).thenReturn(Optional.empty());
 
         // when
-        Optional<Lite> result = resultRepositoryService.getResultById(resultId);
+        Optional<ResultEntity> result = resultRepositoryService.getResultById(resultId);
 
         // then
         assertThat(result).isEmpty();
@@ -59,7 +59,7 @@ class ResultRepositoryServiceTest {
     @Test
     void shouldReturnEmptyAndNotCallRepositoryWhenIdIsNull() {
         // when
-        Optional<Lite> result = resultRepositoryService.getResultById(null);
+        Optional<ResultEntity> result = resultRepositoryService.getResultById(null);
 
         // then
         assertThat(result).isEmpty();


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-2888


### Change description ###
Refactors the Result entity to use a single entity with entity graphs in place of the previous lite/full entity split.

- Removes separate lite and full Result entities
- Sets Result associations to LAZY by default
- Updates Result fetch paths to use appropriate entity graph
- Adds integration test coverage for default lazy loading and entity graph loading


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
