### PR TITLE
PO-1991 - Get Minor Creditor Account Legacy

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyMinorCreditorIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyMinorCreditorIntegrationTest.java
@@ -37,4 +37,29 @@ public class LegacyMinorCreditorIntegrationTest extends MinorCreditorControllerI
     void testGetMinorCreditorHeaderSummary_500Error() throws Exception {
         super.legacyGetMinorCreditorHeaderSummaryImpl_500Error(log);
     }
+
+    @Test
+    void testGetMinorCreditorAccountSuccess() throws Exception {
+        super.getMinorCreditorAccountImpl_Success(log);
+    }
+
+    @Test
+    void testGetMinorCreditorAccountFiltersBacsWithoutPermission() throws Exception {
+        super.getMinorCreditorAccountImpl_filtersBacsDetailsWithoutPermission(log);
+    }
+
+    @Test
+    void testGetMinorCreditorAccountMissingAuthHeaderReturns401() throws Exception {
+        super.getMinorCreditorAccount_missingAuthHeader_returns401();
+    }
+
+    @Test
+    void testGetMinorCreditorAccountAuthenticatedWithoutPermissionReturns403() throws Exception {
+        super.getMinorCreditorAccount_authenticatedWithoutPermission_returns403();
+    }
+
+    @Test
+    void testGetMinorCreditorAccount_500Error() throws Exception {
+        super.legacyGetMinorCreditorAccountImpl_500Error(log);
+    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerIntegrationTest.java
@@ -1323,7 +1323,7 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
             .permissionName("View Creditor BACS")
             .build();
 
-        when(userStateService.checkForAuthorisedUser(any()))
+        when(userStateService.checkForAuthorisedUser())
             .thenReturn(permissionUser((short) 77, searchPermission, bacsPermission));
 
         ResultActions resultActions = mockMvc.perform(get(URL_BASE + "/{id}", "99000000000801")
@@ -1360,7 +1360,7 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
     }
 
     void getMinorCreditorAccountImpl_filtersBacsDetailsWithoutPermission(Logger log) throws Exception {
-        when(userStateService.checkForAuthorisedUser(any()))
+        when(userStateService.checkForAuthorisedUser())
             .thenReturn(permissionUser((short) 77, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS));
 
         ResultActions resultActions = mockMvc.perform(get(URL_BASE + "/{id}", "99000000000801")
@@ -1385,7 +1385,7 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
 
     void getMinorCreditorAccount_missingAuthHeader_returns401() throws Exception {
         doThrow(new ResponseStatusException(UNAUTHORIZED, "Unauthorized"))
-            .when(userStateService).checkForAuthorisedUser(any());
+            .when(userStateService).checkForAuthorisedUser();
 
         mockMvc.perform(get(URL_BASE + "/{id}", 104L)
                 .accept(MediaType.APPLICATION_JSON))
@@ -1395,7 +1395,7 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
 
     void getMinorCreditorAccount_authenticatedWithoutPermission_returns403() throws Exception {
         doThrow(new ResponseStatusException(FORBIDDEN, "Forbidden"))
-            .when(userStateService).checkForAuthorisedUser(any());
+            .when(userStateService).checkForAuthorisedUser();
 
         mockMvc.perform(get(URL_BASE + "/{id}", 104L)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -1405,7 +1405,7 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
     }
 
     void legacyGetMinorCreditorAccountImpl_500Error(Logger log) throws Exception {
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(allPermissionsUser());
+        when(userStateService.checkForAuthorisedUser()).thenReturn(allPermissionsUser());
 
         ResultActions resultActions = mockMvc.perform(get(URL_BASE + "/{id}", "500")
             .contentType(MediaType.APPLICATION_JSON)

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerIntegrationTest.java
@@ -12,6 +12,7 @@ import org.springframework.web.server.ResponseStatusException;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.common.user.authorisation.client.service.UserStateClientService;
+import uk.gov.hmcts.opal.common.user.authorisation.model.Permission;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.MinorCreditorSearch;
 import uk.gov.hmcts.opal.dto.ToJsonString;
@@ -1312,6 +1313,109 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
             // payment
             .andExpect(jsonPath("$.payment.is_bacs").value(true))
             .andExpect(jsonPath("$.payment.hold_payment").value(false));
+    }
+
+    void getMinorCreditorAccountImpl_Success(Logger log) throws Exception {
+        Permission searchPermission = uk.gov.hmcts.opal.controllers.util.UserStateUtil.permissionFor(
+            FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
+        Permission bacsPermission = Permission.builder()
+            .permissionId(999L)
+            .permissionName("View Creditor BACS")
+            .build();
+
+        when(userStateService.checkForAuthorisedUser(any()))
+            .thenReturn(permissionUser((short) 77, searchPermission, bacsPermission));
+
+        ResultActions resultActions = mockMvc.perform(get(URL_BASE + "/{id}", "99000000000801")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header("authorization", AUTH_HEADER));
+
+        String body = resultActions.andReturn().getResponse().getContentAsString();
+
+        log.info(":testGetMinorCreditorAccount_Success: Response body:\n{}", ToJsonString.toPrettyJson(body));
+
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(header().string("ETag", "\"1\""))
+
+            .andExpect(jsonPath("$.creditor_account_id").value(99000000000801L))
+
+            .andExpect(jsonPath("$.party_details.party_id").value("99000000000901"))
+            .andExpect(jsonPath("$.party_details.organisation_flag").value(true))
+            .andExpect(jsonPath("$.party_details.organisation_details.organisation_name")
+                .value("Speed Camera Services Ltd"))
+
+            .andExpect(jsonPath("$.address.address_line_1").value("10 Technology Way"))
+            .andExpect(jsonPath("$.address.address_line_2").value("Reading"))
+            .andExpect(jsonPath("$.address.postcode").value("RG6 1PT"))
+
+            .andExpect(jsonPath("$.payment.account_name").value("Speed Camera Services"))
+            .andExpect(jsonPath("$.payment.sort_code").value("123456"))
+            .andExpect(jsonPath("$.payment.account_number").value("12345678"))
+            .andExpect(jsonPath("$.payment.account_reference").value("SCREF001"))
+            .andExpect(jsonPath("$.payment.pay_by_bacs").value(true))
+            .andExpect(jsonPath("$.payment.hold_payment").value(false));
+
+    }
+
+    void getMinorCreditorAccountImpl_filtersBacsDetailsWithoutPermission(Logger log) throws Exception {
+        when(userStateService.checkForAuthorisedUser(any()))
+            .thenReturn(permissionUser((short) 77, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS));
+
+        ResultActions resultActions = mockMvc.perform(get(URL_BASE + "/{id}", "99000000000801")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header("authorization", AUTH_HEADER));
+
+        String body = resultActions.andReturn().getResponse().getContentAsString();
+
+        log.info(":testGetMinorCreditorAccount_FiltersBacs: Response body:\n{}", ToJsonString.toPrettyJson(body));
+
+        resultActions
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(header().string("ETag", "\"1\""))
+            .andExpect(jsonPath("$.payment.account_name").doesNotExist())
+            .andExpect(jsonPath("$.payment.sort_code").doesNotExist())
+            .andExpect(jsonPath("$.payment.account_number").doesNotExist())
+            .andExpect(jsonPath("$.payment.account_reference").doesNotExist())
+            .andExpect(jsonPath("$.payment.pay_by_bacs").value(true))
+            .andExpect(jsonPath("$.payment.hold_payment").value(false));
+    }
+
+    void getMinorCreditorAccount_missingAuthHeader_returns401() throws Exception {
+        doThrow(new ResponseStatusException(UNAUTHORIZED, "Unauthorized"))
+            .when(userStateService).checkForAuthorisedUser(any());
+
+        mockMvc.perform(get(URL_BASE + "/{id}", 104L)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnauthorized())
+            .andExpect(content().string(""));
+    }
+
+    void getMinorCreditorAccount_authenticatedWithoutPermission_returns403() throws Exception {
+        doThrow(new ResponseStatusException(FORBIDDEN, "Forbidden"))
+            .when(userStateService).checkForAuthorisedUser(any());
+
+        mockMvc.perform(get(URL_BASE + "/{id}", 104L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("authorization", AUTH_HEADER))
+            .andExpect(status().isForbidden())
+            .andExpect(content().string(""));
+    }
+
+    void legacyGetMinorCreditorAccountImpl_500Error(Logger log) throws Exception {
+        when(userStateService.checkForAuthorisedUser(any())).thenReturn(allPermissionsUser());
+
+        ResultActions resultActions = mockMvc.perform(get(URL_BASE + "/{id}", "500")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header("authorization", AUTH_HEADER));
+
+        String body = resultActions.andReturn().getResponse().getContentAsString();
+        log.info(":testGetMinorCreditorAccount_500Error: Response body:\n{}", ToJsonString.toPrettyJson(body));
+
+        resultActions.andExpect(status().is5xxServerError())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
     }
 
     void getMinorCreditorAtAGlanceImpl_failure_creditorNotFound(Logger log) throws Exception {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiController.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.opal.controllers;
 
 import static uk.gov.hmcts.opal.util.HttpUtil.buildCreatedResponse;
+import static uk.gov.hmcts.opal.util.HttpUtil.buildResponse;
 import static uk.gov.hmcts.opal.util.VersionUtils.extractOptionalBigInteger;
 
 import java.util.Optional;
@@ -28,6 +29,15 @@ public class MinorCreditorApiController implements MinorCreditorApi {
     @Override
     public Optional<NativeWebRequest> getRequest() {
         return Optional.ofNullable(request);
+    }
+
+    @Override
+    public ResponseEntity<MinorCreditorAccountResponseMinorCreditor> getMinorCreditorAccount(Long id) {
+        log.debug(":GET:getMinorCreditorAccount: id={}", id);
+
+        MinorCreditorAccountResponse result = minorCreditorService.getMinorCreditorAccount(id);
+
+        return buildResponse(result);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiController.java
@@ -4,12 +4,10 @@ import static uk.gov.hmcts.opal.util.HttpUtil.buildCreatedResponse;
 import static uk.gov.hmcts.opal.util.HttpUtil.buildResponse;
 import static uk.gov.hmcts.opal.util.VersionUtils.extractOptionalBigInteger;
 
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.context.request.NativeWebRequest;
 import uk.gov.hmcts.opal.common.launchdarkly.FeatureToggle;
 import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
 import uk.gov.hmcts.opal.generated.http.api.MinorCreditorApi;
@@ -24,12 +22,6 @@ import uk.gov.hmcts.opal.util.FeatureFlags;
 public class MinorCreditorApiController implements MinorCreditorApi {
 
     private final MinorCreditorService minorCreditorService;
-    private final NativeWebRequest request;
-
-    @Override
-    public Optional<NativeWebRequest> getRequest() {
-        return Optional.ofNullable(request);
-    }
 
     @Override
     public ResponseEntity<MinorCreditorAccountResponseMinorCreditor> getMinorCreditorAccount(Long id) {

--- a/src/main/java/uk/gov/hmcts/opal/dto/MinorCreditorAccountResponse.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/MinorCreditorAccountResponse.java
@@ -22,4 +22,7 @@ public class MinorCreditorAccountResponse extends MinorCreditorAccountResponseMi
 
     @JsonIgnore
     private BigInteger version;
+
+    @JsonIgnore
+    private Short businessUnitId;
 }

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyGetMinorCreditorAccountRequest.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyGetMinorCreditorAccountRequest.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.opal.dto.legacy;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.extern.jackson.Jacksonized;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Jacksonized
+public class LegacyGetMinorCreditorAccountRequest {
+
+    @JsonProperty("accountId")
+    private String accountId;
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyGetMinorCreditorAccountResponse.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyGetMinorCreditorAccountResponse.java
@@ -21,7 +21,6 @@ import uk.gov.hmcts.opal.dto.legacy.common.LegacyPartyDetails;
     "partyDetails",
     "address",
     "payment",
-    "businessUnitId",
     "errorResponse"
 })
 @Data
@@ -44,9 +43,6 @@ public class LegacyGetMinorCreditorAccountResponse implements ToXmlString, HasEr
 
     @XmlElement(name = "payment", required = true)
     private LegacyCreditorAccountPaymentDetails payment;
-
-    @XmlElement(name = "business_unit_id")
-    private Short businessUnitId;
 
     @XmlElement(name = "error_response")
     private ErrorResponse errorResponse;

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyGetMinorCreditorAccountResponse.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyGetMinorCreditorAccountResponse.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.opal.dto.legacy;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.opal.dto.ToXmlString;
+import uk.gov.hmcts.opal.dto.legacy.common.LegacyCreditorAccountPaymentDetails;
+import uk.gov.hmcts.opal.dto.legacy.common.LegacyPartyDetails;
+
+@XmlRootElement(name = "response")
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(propOrder = {
+    "accountVersion",
+    "creditorAccountId",
+    "partyDetails",
+    "address",
+    "payment",
+    "businessUnitId",
+    "errorResponse"
+})
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LegacyGetMinorCreditorAccountResponse implements ToXmlString, HasErrorResponse {
+
+    @XmlElement(name = "account_version", required = true)
+    private Long accountVersion;
+
+    @XmlElement(name = "creditor_account_id", required = true)
+    private Long creditorAccountId;
+
+    @XmlElement(name = "party_details", required = true)
+    private LegacyPartyDetails partyDetails;
+
+    @XmlElement(name = "address", required = true)
+    private AddressDetailsLegacy address;
+
+    @XmlElement(name = "payment", required = true)
+    private LegacyCreditorAccountPaymentDetails payment;
+
+    @XmlElement(name = "business_unit_id")
+    private Short businessUnitId;
+
+    @XmlElement(name = "error_response")
+    private ErrorResponse errorResponse;
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyGetMinorCreditorAccountResponse.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyGetMinorCreditorAccountResponse.java
@@ -9,6 +9,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.hmcts.opal.common.legacy.model.ErrorResponse;
+import uk.gov.hmcts.opal.common.legacy.model.HasErrorResponse;
 import uk.gov.hmcts.opal.dto.ToXmlString;
 import uk.gov.hmcts.opal.dto.legacy.common.LegacyCreditorAccountPaymentDetails;
 import uk.gov.hmcts.opal.dto.legacy.common.LegacyPartyDetails;

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/common/LegacyCreditorAccountPaymentDetails.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/common/LegacyCreditorAccountPaymentDetails.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.opal.dto.legacy.common;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@XmlAccessorType(XmlAccessType.FIELD)
+public class LegacyCreditorAccountPaymentDetails {
+
+    @XmlElement(name = "account_name")
+    private String accountName;
+
+    @XmlElement(name = "sort_code")
+    private String sortCode;
+
+    @XmlElement(name = "account_number")
+    private String accountNumber;
+
+    @XmlElement(name = "account_reference")
+    private String accountReference;
+
+    @XmlElement(name = "pay_by_bacs", required = true)
+    private Boolean payByBacs;
+
+    @XmlElement(name = "hold_payment", required = true)
+    private Boolean holdPayment;
+}

--- a/src/main/java/uk/gov/hmcts/opal/mapper/legacy/LegacyMinorCreditorAccountResponseMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/mapper/legacy/LegacyMinorCreditorAccountResponseMapper.java
@@ -1,0 +1,116 @@
+package uk.gov.hmcts.opal.mapper.legacy;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+import org.mapstruct.Builder;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
+import uk.gov.hmcts.opal.dto.legacy.AddressDetailsLegacy;
+import uk.gov.hmcts.opal.dto.legacy.LegacyGetMinorCreditorAccountResponse;
+import uk.gov.hmcts.opal.dto.legacy.common.LegacyCreditorAccountPaymentDetails;
+import uk.gov.hmcts.opal.dto.legacy.common.LegacyPartyDetails;
+import uk.gov.hmcts.opal.dto.legacy.common.OrganisationDetails;
+import uk.gov.hmcts.opal.generated.model.AddressDetailsCommon;
+import uk.gov.hmcts.opal.generated.model.IndividualAliasCommon;
+import uk.gov.hmcts.opal.generated.model.IndividualDetailsCommon;
+import uk.gov.hmcts.opal.generated.model.MinorCreditorAccountResponseMinorCreditorPayment;
+import uk.gov.hmcts.opal.generated.model.OrganisationAliasCommon;
+import uk.gov.hmcts.opal.generated.model.OrganisationDetailsCommon;
+import uk.gov.hmcts.opal.generated.model.PartyDetailsCommon;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE,
+    builder = @Builder(disableBuilder = true))
+public interface LegacyMinorCreditorAccountResponseMapper {
+
+    @Mapping(target = "creditorAccountId", source = "creditorAccountId")
+    @Mapping(target = "partyDetails", source = "partyDetails")
+    @Mapping(target = "address", source = "address")
+    @Mapping(target = "payment", source = "payment")
+    @Mapping(target = "version", expression = "java(toVersion(response))")
+    MinorCreditorAccountResponse toMinorCreditorAccountResponse(LegacyGetMinorCreditorAccountResponse response);
+
+    default BigInteger toVersion(LegacyGetMinorCreditorAccountResponse response) {
+        return response == null || response.getAccountVersion() == null
+            ? null
+            : BigInteger.valueOf(response.getAccountVersion());
+    }
+
+    @Mapping(target = "organisationFlag", source = "organisationFlag")
+    @Mapping(target = "organisationDetails", expression = "java(toOrganisationDetailsCommon(legacy))")
+    @Mapping(target = "individualDetails", expression = "java(toIndividualDetailsCommon(legacy))")
+    PartyDetailsCommon toPartyDetailsCommon(LegacyPartyDetails legacy);
+
+    AddressDetailsCommon toAddressDetailsCommon(AddressDetailsLegacy legacy);
+
+    MinorCreditorAccountResponseMinorCreditorPayment toMinorCreditorPayment(
+        LegacyCreditorAccountPaymentDetails paymentDetails
+    );
+
+    default OrganisationDetailsCommon toOrganisationDetailsCommon(LegacyPartyDetails legacy) {
+        if (legacy == null || !Boolean.TRUE.equals(legacy.getOrganisationFlag())) {
+            return null;
+        }
+        OrganisationDetails organisationDetails = legacy.getOrganisationDetails();
+        if (organisationDetails == null) {
+            return null;
+        }
+
+        return OrganisationDetailsCommon.builder()
+            .organisationName(organisationDetails.getOrganisationName())
+            .organisationAliases(toOrganisationAliases(organisationDetails.getOrganisationAliases()))
+            .build();
+    }
+
+    default IndividualDetailsCommon toIndividualDetailsCommon(LegacyPartyDetails legacy) {
+        if (legacy == null || Boolean.TRUE.equals(legacy.getOrganisationFlag())) {
+            return null;
+        }
+        uk.gov.hmcts.opal.dto.legacy.common.IndividualDetails individualDetails = legacy.getIndividualDetails();
+        if (individualDetails == null) {
+            return null;
+        }
+
+        return IndividualDetailsCommon.builder()
+            .title(individualDetails.getTitle())
+            .forenames(individualDetails.getFirstNames())
+            .surname(individualDetails.getSurname())
+            .dateOfBirth(individualDetails.getDateOfBirth() == null ? null
+                : individualDetails.getDateOfBirth().toString())
+            .age(individualDetails.getAge())
+            .nationalInsuranceNumber(individualDetails.getNationalInsuranceNumber())
+            .individualAliases(toIndividualAliases(individualDetails.getIndividualAliases()))
+            .build();
+    }
+
+    default List<OrganisationAliasCommon> toOrganisationAliases(OrganisationDetails.OrganisationAlias[] aliases) {
+        if (aliases == null) {
+            return null;
+        }
+        return Arrays.stream(aliases)
+            .map(alias -> OrganisationAliasCommon.builder()
+                .aliasId(alias.getAliasId())
+                .sequenceNumber(alias.getSequenceNumber() == null ? null : Integer.valueOf(alias.getSequenceNumber()))
+                .organisationName(alias.getOrganisationName())
+                .build())
+            .toList();
+    }
+
+    default List<IndividualAliasCommon> toIndividualAliases(
+        uk.gov.hmcts.opal.dto.legacy.common.IndividualDetails.IndividualAlias[] aliases
+    ) {
+        if (aliases == null) {
+            return null;
+        }
+        return Arrays.stream(aliases)
+            .map(alias -> IndividualAliasCommon.builder()
+                .aliasId(alias.getAliasId())
+                .sequenceNumber(alias.getSequenceNumber() == null ? null : Integer.valueOf(alias.getSequenceNumber()))
+                .surname(alias.getSurname())
+                .forenames(alias.getForenames())
+                .build())
+            .toList();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/MinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/MinorCreditorService.java
@@ -1,11 +1,14 @@
 package uk.gov.hmcts.opal.service;
 
 import java.math.BigInteger;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
+import uk.gov.hmcts.opal.common.user.authorisation.model.BusinessUnitUser;
+import uk.gov.hmcts.opal.common.user.authorisation.model.Permission;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.GetMinorCreditorAccountAtAGlanceResponse;
 import uk.gov.hmcts.opal.dto.GetMinorCreditorAccountHeaderSummaryResponse;
@@ -20,6 +23,8 @@ import uk.gov.hmcts.opal.service.proxy.MinorCreditorSearchProxy;
 @Slf4j(topic = "opal.MinorCreditorService")
 @RequiredArgsConstructor
 public class MinorCreditorService {
+
+    private static final String VIEW_CREDITOR_BACS_PERMISSION = "View Creditor BACS";
 
     private final MinorCreditorSearchProxy minorCreditorSearchProxy;
 
@@ -36,6 +41,21 @@ public class MinorCreditorService {
         } else {
             throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         }
+    }
+
+    public MinorCreditorAccountResponse getMinorCreditorAccount(Long minorCreditorAccountId) {
+        log.debug(":getMinorCreditorAccount: id={}", minorCreditorAccountId);
+
+        UserState userState = userStateService.checkForAuthorisedUser();
+
+        if (!userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
+            throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
+        }
+
+        MinorCreditorAccountResponse response =
+            minorCreditorSearchProxy.getMinorCreditorAccount(minorCreditorAccountId);
+        filterBacsDetailsIfRequired(response, userState);
+        return response;
     }
 
     public GetMinorCreditorAccountAtAGlanceResponse getMinorCreditorAtAGlance(Long minorCreditorId,
@@ -117,4 +137,25 @@ public class MinorCreditorService {
             businessUnitIdShort);
     }
 
+    private void filterBacsDetailsIfRequired(MinorCreditorAccountResponse response, UserState userState) {
+        if (response == null || response.getPayment() == null) {
+            return;
+        }
+
+        Short businessUnitId = response.getBusinessUnitId();
+        boolean canViewBacs = Optional.ofNullable(businessUnitId)
+            .flatMap(userState::getBusinessUnitUserForBusinessUnit)
+            .map(BusinessUnitUser::getPermissions)
+            .stream()
+            .flatMap(java.util.Set::stream)
+            .map(Permission::getPermissionName)
+            .anyMatch(VIEW_CREDITOR_BACS_PERMISSION::equals);
+
+        if (!canViewBacs) {
+            response.getPayment().setAccountName(null);
+            response.getPayment().setSortCode(null);
+            response.getPayment().setAccountNumber(null);
+            response.getPayment().setAccountReference(null);
+        }
+    }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/UserStateService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/UserStateService.java
@@ -25,7 +25,7 @@ public class UserStateService {
     private final UserStateMapper userStateMapper;
 
     //Stop gap solution until we have service layer checking permissions from auth token directly
-    public UserState checkForAuthorisedUser(String authorization) {
+    public UserState checkForAuthorisedUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (!(authentication instanceof OpalJwtAuthenticationToken authToken)) {
             throw new AccessDeniedException("Unexpected token type");
@@ -35,6 +35,10 @@ public class UserStateService {
             throw new AccessDeniedException("User state not found in token");
         }
         return userStateMapper.toUserState(userStateV2, Domain.FINES);
+    }
+
+    public UserState checkForAuthorisedUser(String authorization) {
+        return checkForAuthorisedUser();
     }
 
     public String getPreferredUsername(String authorization) {

--- a/src/main/java/uk/gov/hmcts/opal/service/UserStateService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/UserStateService.java
@@ -24,7 +24,7 @@ public class UserStateService {
 
     private final UserStateMapper userStateMapper;
 
-    //Stop gap solution until we have service layer checking permissions from auth token directly
+    // Stop gap solution until we have service layer checking permissions from auth token directly.
     public UserState checkForAuthorisedUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (!(authentication instanceof OpalJwtAuthenticationToken authToken)) {

--- a/src/main/java/uk/gov/hmcts/opal/service/iface/MinorCreditorServiceInterface.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/iface/MinorCreditorServiceInterface.java
@@ -12,6 +12,8 @@ public interface MinorCreditorServiceInterface {
 
     PostMinorCreditorAccountsSearchResponse searchMinorCreditors(MinorCreditorSearch minorCreditorSearchDto);
 
+    MinorCreditorAccountResponse getMinorCreditorAccount(Long minorCreditorAccountId);
+
     GetMinorCreditorAccountAtAGlanceResponse getMinorCreditorAtAGlance(Long minorCreditorId);
 
     GetMinorCreditorAccountHeaderSummaryResponse getHeaderSummary(

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorService.java
@@ -13,15 +13,20 @@ import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
 import uk.gov.hmcts.opal.dto.MinorCreditorSearch;
 import uk.gov.hmcts.opal.dto.PostMinorCreditorAccountsSearchResponse;
 import uk.gov.hmcts.opal.dto.legacy.GetMinorCreditorAccountHeaderSummaryLegacyResponse;
+import uk.gov.hmcts.opal.dto.legacy.LegacyGetMinorCreditorAccountRequest;
+import uk.gov.hmcts.opal.dto.legacy.LegacyGetMinorCreditorAccountResponse;
 import uk.gov.hmcts.opal.dto.legacy.LegacyGetMinorCreditorAccountAtAGlanceRequest;
 import uk.gov.hmcts.opal.dto.legacy.LegacyGetMinorCreditorAccountAtAGlanceResponse;
 import uk.gov.hmcts.opal.dto.legacy.GetMinorCreditorAccountHeaderSummaryLegacyRequest;
 import uk.gov.hmcts.opal.dto.legacy.GetMinorCreditorAccountHeaderSummaryLegacyResponse.CreditorHeaderLegacy;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyMinorCreditorSearchResultsRequest;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyMinorCreditorSearchResultsResponse;
+import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
 import uk.gov.hmcts.opal.mapper.legacy.GetMinorCreditorAccountHeaderSummaryResponseLegacyMapper;
+import uk.gov.hmcts.opal.mapper.legacy.LegacyMinorCreditorAccountResponseMapper;
 import uk.gov.hmcts.opal.mapper.response.GetMinorCreditorAccountAtAGlanceResponseMapper;
 import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
+import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
 import uk.gov.hmcts.opal.service.iface.MinorCreditorServiceInterface;
 
 import java.math.BigDecimal;
@@ -37,10 +42,13 @@ public class LegacyMinorCreditorService implements MinorCreditorServiceInterface
     private final GatewayService gatewayService;
 
     private final GetMinorCreditorAccountAtAGlanceResponseMapper atAGlanceResponseMapper;
+    private final LegacyMinorCreditorAccountResponseMapper minorCreditorAccountResponseMapper;
+    private final CreditorAccountRepository creditorAccountRepository;
 
     private final GetMinorCreditorAccountHeaderSummaryResponseLegacyMapper headerSummaryResponseMapper;
 
     private static final String SEARCH_MINOR_CREDITORS = "LIBRA.search_minor_creditors";
+    private static final String GET_MINOR_CREDITOR_ACCOUNT_PARTY = "GET_MINOR_CREDITOR_ACCOUNT_PARTY";
 
     private static final String GET_MINOR_CREDITORS_ACCOUNT_AT_A_GLANCE =
         "LIBRA.get_minor_creditors_account_at_a_glance";
@@ -100,6 +108,34 @@ public class LegacyMinorCreditorService implements MinorCreditorServiceInterface
         mapped.setVersion(BigInteger.valueOf(creditor.getAccountVersion()));
 
         return mapped;
+    }
+
+    @Override
+    public MinorCreditorAccountResponse getMinorCreditorAccount(Long minorCreditorAccountId) {
+        Response<LegacyGetMinorCreditorAccountResponse> response =
+            gatewayService.postToGateway(
+                GET_MINOR_CREDITOR_ACCOUNT_PARTY,
+                LegacyGetMinorCreditorAccountResponse.class,
+                LegacyGetMinorCreditorAccountRequest.builder()
+                    .accountId(String.valueOf(minorCreditorAccountId))
+                    .build(),
+                null
+            );
+
+        checkResponseForError(response, "getMinorCreditorAccount");
+
+        MinorCreditorAccountResponse mappedResponse =
+            minorCreditorAccountResponseMapper.toMinorCreditorAccountResponse(response.responseEntity);
+
+        if (mappedResponse != null) {
+            mappedResponse.setBusinessUnitId(
+                creditorAccountRepository.findById(minorCreditorAccountId)
+                    .map(CreditorAccountEntity::getBusinessUnitId)
+                    .orElse(null)
+            );
+        }
+
+        return mappedResponse;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorService.java
@@ -63,6 +63,11 @@ public class OpalMinorCreditorService implements MinorCreditorServiceInterface {
     }
 
     @Override
+    public MinorCreditorAccountResponse getMinorCreditorAccount(Long minorCreditorAccountId) {
+        throw new UnsupportedOperationException("Getting a minor creditor account is not yet supported in Opal");
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public GetMinorCreditorAccountAtAGlanceResponse getMinorCreditorAtAGlance(Long minorCreditorId) {
         log.debug(":getMinorCreditorAtAGlance (Opal): minorCreditorId={}", minorCreditorId);

--- a/src/main/java/uk/gov/hmcts/opal/service/proxy/MinorCreditorSearchProxy.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/proxy/MinorCreditorSearchProxy.java
@@ -33,6 +33,12 @@ public class MinorCreditorSearchProxy implements MinorCreditorServiceInterface, 
         return getCurrentModeService().searchMinorCreditors(criteria);
     }
 
+    @Override
+    public MinorCreditorAccountResponse getMinorCreditorAccount(Long minorCreditorAccountId) {
+        log.debug(":getMinorCreditorAccount: minorCreditorAccountId={}", minorCreditorAccountId);
+        return getCurrentModeService().getMinorCreditorAccount(minorCreditorAccountId);
+    }
+
     public GetMinorCreditorAccountHeaderSummaryResponse getHeaderSummary(Long minorCreditorAccountId) {
         log.debug(":getHeaderSummary: minorCreditorAccountId={}", minorCreditorAccountId);
         return getCurrentModeService().getHeaderSummary(minorCreditorAccountId);

--- a/src/test/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerTest.java
@@ -28,15 +28,18 @@ class MinorCreditorApiControllerTest {
 
     @Test
     void given_validRequest_when_getMinorCreditorAccount_then_returnsOkResponse() {
+        // Arrange
         MinorCreditorAccountResponse response = new MinorCreditorAccountResponse();
         response.setCreditorAccountId(101L);
         response.setVersion(BigInteger.valueOf(7));
 
         when(minorCreditorService.getMinorCreditorAccount(101L)).thenReturn(response);
 
+        // Act
         ResponseEntity<MinorCreditorAccountResponseMinorCreditor> result =
             minorCreditorApiController.getMinorCreditorAccount(101L);
 
+        // Assert
         assertEquals(HttpStatus.OK, result.getStatusCode());
         assertEquals("\"7\"", result.getHeaders().getETag());
         assertSame(response, result.getBody());

--- a/src/test/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerTest.java
@@ -13,8 +13,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.context.request.NativeWebRequest;
 import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
+import uk.gov.hmcts.opal.generated.model.MinorCreditorAccountResponseMinorCreditor;
 import uk.gov.hmcts.opal.service.MinorCreditorService;
 
 @ExtendWith(MockitoExtension.class)
@@ -22,9 +22,6 @@ class MinorCreditorApiControllerTest {
 
     @Mock
     private MinorCreditorService minorCreditorService;
-
-    @Mock
-    private NativeWebRequest request;
 
     @InjectMocks
     private MinorCreditorApiController minorCreditorApiController;
@@ -37,7 +34,8 @@ class MinorCreditorApiControllerTest {
 
         when(minorCreditorService.getMinorCreditorAccount(101L)).thenReturn(response);
 
-        ResponseEntity<?> result = minorCreditorApiController.getMinorCreditorAccount(101L);
+        ResponseEntity<MinorCreditorAccountResponseMinorCreditor> result =
+            minorCreditorApiController.getMinorCreditorAccount(101L);
 
         assertEquals(HttpStatus.OK, result.getStatusCode());
         assertEquals("\"7\"", result.getHeaders().getETag());

--- a/src/test/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerTest.java
@@ -1,0 +1,47 @@
+package uk.gov.hmcts.opal.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.NativeWebRequest;
+import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
+import uk.gov.hmcts.opal.service.MinorCreditorService;
+
+@ExtendWith(MockitoExtension.class)
+class MinorCreditorApiControllerTest {
+
+    @Mock
+    private MinorCreditorService minorCreditorService;
+
+    @Mock
+    private NativeWebRequest request;
+
+    @InjectMocks
+    private MinorCreditorApiController minorCreditorApiController;
+
+    @Test
+    void given_validRequest_when_getMinorCreditorAccount_then_returnsOkResponse() {
+        MinorCreditorAccountResponse response = new MinorCreditorAccountResponse();
+        response.setCreditorAccountId(101L);
+        response.setVersion(BigInteger.valueOf(7));
+
+        when(minorCreditorService.getMinorCreditorAccount(101L)).thenReturn(response);
+
+        ResponseEntity<?> result = minorCreditorApiController.getMinorCreditorAccount(101L);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals("\"7\"", result.getHeaders().getETag());
+        assertSame(response, result.getBody());
+        verify(minorCreditorService).getMinorCreditorAccount(101L);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/mapper/legacy/LegacyMinorCreditorAccountResponseMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/mapper/legacy/LegacyMinorCreditorAccountResponseMapperTest.java
@@ -1,0 +1,152 @@
+package uk.gov.hmcts.opal.mapper.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import uk.gov.hmcts.opal.dto.legacy.common.IndividualDetails;
+import uk.gov.hmcts.opal.dto.legacy.common.LegacyPartyDetails;
+import uk.gov.hmcts.opal.dto.legacy.common.OrganisationDetails;
+import uk.gov.hmcts.opal.generated.model.IndividualAliasCommon;
+import uk.gov.hmcts.opal.generated.model.IndividualDetailsCommon;
+import uk.gov.hmcts.opal.generated.model.OrganisationAliasCommon;
+
+class LegacyMinorCreditorAccountResponseMapperTest {
+
+    private final LegacyMinorCreditorAccountResponseMapper mapper =
+        Mappers.getMapper(LegacyMinorCreditorAccountResponseMapper.class);
+
+    @Test
+    void toIndividualDetailsCommon_returnsNull_whenLegacyIndividualDetailsIsNull() {
+        LegacyPartyDetails legacy = LegacyPartyDetails.builder()
+            .organisationFlag(false)
+            .individualDetails(null)
+            .build();
+
+        assertNull(mapper.toIndividualDetailsCommon(legacy));
+    }
+
+    @Test
+    void toIndividualDetailsCommon_mapsFieldsAndAliases() {
+        IndividualDetails.IndividualAlias firstAlias = IndividualDetails.IndividualAlias.builder()
+            .aliasId("IA1")
+            .sequenceNumber((short) 1)
+            .surname("AliasSurname1")
+            .forenames("AliasForenames1")
+            .build();
+
+        IndividualDetails.IndividualAlias secondAlias = IndividualDetails.IndividualAlias.builder()
+            .aliasId("IA2")
+            .sequenceNumber(null)
+            .surname("AliasSurname2")
+            .forenames("AliasForenames2")
+            .build();
+
+        LegacyPartyDetails legacy = LegacyPartyDetails.builder()
+            .organisationFlag(false)
+            .individualDetails(IndividualDetails.builder()
+                .title("Ms")
+                .firstNames("Jane Mary")
+                .surname("Smith")
+                .dateOfBirth(LocalDate.of(1990, 5, 21))
+                .age("34")
+                .nationalInsuranceNumber("AB123456C")
+                .individualAliases(new IndividualDetails.IndividualAlias[] {firstAlias, secondAlias})
+                .build())
+            .build();
+
+        IndividualDetailsCommon result = mapper.toIndividualDetailsCommon(legacy);
+
+        assertNotNull(result);
+        assertEquals("Ms", result.getTitle());
+        assertEquals("Jane Mary", result.getForenames());
+        assertEquals("Smith", result.getSurname());
+        assertEquals("1990-05-21", result.getDateOfBirth());
+        assertEquals("34", result.getAge());
+        assertEquals("AB123456C", result.getNationalInsuranceNumber());
+
+        List<IndividualAliasCommon> aliases = result.getIndividualAliases();
+        assertNotNull(aliases);
+        assertEquals(2, aliases.size());
+        assertEquals("IA1", aliases.get(0).getAliasId());
+        assertEquals(1, aliases.get(0).getSequenceNumber());
+        assertEquals("AliasSurname1", aliases.get(0).getSurname());
+        assertEquals("AliasForenames1", aliases.get(0).getForenames());
+        assertEquals("IA2", aliases.get(1).getAliasId());
+        assertNull(aliases.get(1).getSequenceNumber());
+        assertEquals("AliasSurname2", aliases.get(1).getSurname());
+        assertEquals("AliasForenames2", aliases.get(1).getForenames());
+    }
+
+    @Test
+    void toOrganisationAliases_returnsNull_whenAliasesAreNull() {
+        assertNull(mapper.toOrganisationAliases(null));
+    }
+
+    @Test
+    void toOrganisationAliases_mapsAliasFields() {
+        OrganisationDetails.OrganisationAlias firstAlias = OrganisationDetails.OrganisationAlias.builder()
+            .aliasId("OA1")
+            .sequenceNumber((short) 3)
+            .organisationName("Org Alias One")
+            .build();
+
+        OrganisationDetails.OrganisationAlias secondAlias = OrganisationDetails.OrganisationAlias.builder()
+            .aliasId("OA2")
+            .sequenceNumber(null)
+            .organisationName("Org Alias Two")
+            .build();
+
+        List<OrganisationAliasCommon> result =
+            mapper.toOrganisationAliases(new OrganisationDetails.OrganisationAlias[] {firstAlias, secondAlias});
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals("OA1", result.get(0).getAliasId());
+        assertEquals(3, result.get(0).getSequenceNumber());
+        assertEquals("Org Alias One", result.get(0).getOrganisationName());
+        assertEquals("OA2", result.get(1).getAliasId());
+        assertNull(result.get(1).getSequenceNumber());
+        assertEquals("Org Alias Two", result.get(1).getOrganisationName());
+    }
+
+    @Test
+    void toIndividualAliases_returnsNull_whenAliasesAreNull() {
+        assertNull(mapper.toIndividualAliases(null));
+    }
+
+    @Test
+    void toIndividualAliases_mapsAliasFields() {
+        IndividualDetails.IndividualAlias firstAlias = IndividualDetails.IndividualAlias.builder()
+            .aliasId("IA3")
+            .sequenceNumber((short) 4)
+            .surname("Brown")
+            .forenames("Pat")
+            .build();
+
+        IndividualDetails.IndividualAlias secondAlias = IndividualDetails.IndividualAlias.builder()
+            .aliasId("IA4")
+            .sequenceNumber(null)
+            .surname("Green")
+            .forenames("Sam")
+            .build();
+
+        List<IndividualAliasCommon> result =
+            mapper.toIndividualAliases(new IndividualDetails.IndividualAlias[] {firstAlias, secondAlias});
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals("IA3", result.get(0).getAliasId());
+        assertEquals(4, result.get(0).getSequenceNumber());
+        assertEquals("Brown", result.get(0).getSurname());
+        assertEquals("Pat", result.get(0).getForenames());
+        assertEquals("IA4", result.get(1).getAliasId());
+        assertNull(result.get(1).getSequenceNumber());
+        assertEquals("Green", result.get(1).getSurname());
+        assertEquals("Sam", result.get(1).getForenames());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
@@ -23,6 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
 import uk.gov.hmcts.opal.common.user.authorisation.model.BusinessUnitUser;
+import uk.gov.hmcts.opal.common.user.authorisation.model.Permission;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.controllers.util.UserStateUtil;
 import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
@@ -33,6 +34,7 @@ import uk.gov.hmcts.opal.dto.GetMinorCreditorAccountHeaderSummaryResponse;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.opal.generated.model.AddressDetailsCommon;
 import uk.gov.hmcts.opal.generated.model.CreditorAccountPaymentDetailsCommon;
+import uk.gov.hmcts.opal.generated.model.MinorCreditorAccountResponseMinorCreditorPayment;
 import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
 import uk.gov.hmcts.opal.generated.model.PartyDetailsCommon;
 import uk.gov.hmcts.opal.service.proxy.MinorCreditorSearchProxy;
@@ -133,6 +135,82 @@ class MinorCreditorServiceTest {
             () -> minorCreditorService.getMinorCreditorAtAGlance(123L, "authHeaderValue")
         );
         assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
+    }
+
+    @Test
+    void testGetMinorCreditorAccount() {
+        Long id = 123L;
+        MinorCreditorAccountResponse response = responseWithBacsDetails();
+
+        when(minorCreditorSearchProxy.getMinorCreditorAccount(id)).thenReturn(response);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(UserStateUtil.allFinesPermissionUser());
+
+        MinorCreditorAccountResponse result = minorCreditorService.getMinorCreditorAccount(id);
+
+        assertNotNull(result);
+        assertEquals(response, result);
+        verify(minorCreditorSearchProxy).getMinorCreditorAccount(eq(id));
+    }
+
+    @Test
+    void testGetMinorCreditorAccount_permissionNotAllowed() {
+        UserState noPermissionUser = mock(UserState.class);
+        when(noPermissionUser.anyBusinessUnitUserHasPermission(
+            FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(noPermissionUser);
+
+        PermissionNotAllowedException ex = Assertions.assertThrows(
+            PermissionNotAllowedException.class,
+            () -> minorCreditorService.getMinorCreditorAccount(123L)
+        );
+
+        assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
+    }
+
+    @Test
+    void testGetMinorCreditorAccount_filtersBacsDetailsWithoutPermission() {
+        Long id = 123L;
+        MinorCreditorAccountResponse response = responseWithBacsDetails();
+
+        when(minorCreditorSearchProxy.getMinorCreditorAccount(id)).thenReturn(response);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(
+            UserStateUtil.permissionUser((short) 10, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)
+        );
+
+        MinorCreditorAccountResponse result = minorCreditorService.getMinorCreditorAccount(id);
+
+        assertNotNull(result.getPayment());
+        assertEquals(null, result.getPayment().getAccountName());
+        assertEquals(null, result.getPayment().getSortCode());
+        assertEquals(null, result.getPayment().getAccountNumber());
+        assertEquals(null, result.getPayment().getAccountReference());
+        assertEquals(true, result.getPayment().getPayByBacs());
+        assertEquals(false, result.getPayment().getHoldPayment());
+    }
+
+    @Test
+    void testGetMinorCreditorAccount_keepsBacsDetailsWithPermission() {
+        Long id = 123L;
+        MinorCreditorAccountResponse response = responseWithBacsDetails();
+
+        Permission searchPermission = UserStateUtil.permissionFor(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
+        Permission bacsPermission = Permission.builder()
+            .permissionId(999L)
+            .permissionName("View Creditor BACS")
+            .build();
+
+        when(minorCreditorSearchProxy.getMinorCreditorAccount(id)).thenReturn(response);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(
+            UserStateUtil.permissionUser((short) 10, searchPermission, bacsPermission)
+        );
+
+        MinorCreditorAccountResponse result = minorCreditorService.getMinorCreditorAccount(id);
+
+        assertNotNull(result.getPayment());
+        assertEquals("Test Name", result.getPayment().getAccountName());
+        assertEquals("123456", result.getPayment().getSortCode());
+        assertEquals("12345678", result.getPayment().getAccountNumber());
+        assertEquals("REF123", result.getPayment().getAccountReference());
     }
 
     @Test
@@ -321,6 +399,20 @@ class MinorCreditorServiceTest {
                          .sortCode("112233")
                          .accountNumber("12345678")
                          .accountReference("PAY-REF"));
+    }
+
+    private MinorCreditorAccountResponse responseWithBacsDetails() {
+        MinorCreditorAccountResponse response = new MinorCreditorAccountResponse();
+        response.setCreditorAccountId(123L);
+        response.setBusinessUnitId((short) 10);
+        response.setPayment(new MinorCreditorAccountResponseMinorCreditorPayment()
+            .accountName("Test Name")
+            .sortCode("123456")
+            .accountNumber("12345678")
+            .accountReference("REF123")
+            .payByBacs(true)
+            .holdPayment(false));
+        return response;
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
@@ -107,15 +107,18 @@ class MinorCreditorServiceTest {
 
     @Test
     void testGetMinorCreditorAccountAtAGlance() {
+        // Arrange
         Long id = 123L;
         GetMinorCreditorAccountAtAGlanceResponse response = GetMinorCreditorAccountAtAGlanceResponse.builder().build();
 
         when(minorCreditorSearchProxy.getMinorCreditorAtAGlance(id)).thenReturn(response);
         when(userStateService.checkForAuthorisedUser(any())).thenReturn(UserStateUtil.allFinesPermissionUser());
 
+        // Act
         GetMinorCreditorAccountAtAGlanceResponse result =
             minorCreditorService.getMinorCreditorAtAGlance(id, "authHeaderValue");
 
+        // Assert
         assertNotNull(result);
         assertEquals(response, result);
         verify(minorCreditorSearchProxy).getMinorCreditorAtAGlance(eq(id));
@@ -139,14 +142,17 @@ class MinorCreditorServiceTest {
 
     @Test
     void testGetMinorCreditorAccount() {
+        // Arrange
         Long id = 123L;
         MinorCreditorAccountResponse response = responseWithBacsDetails();
 
         when(minorCreditorSearchProxy.getMinorCreditorAccount(id)).thenReturn(response);
         when(userStateService.checkForAuthorisedUser()).thenReturn(UserStateUtil.allFinesPermissionUser());
 
+        // Act
         MinorCreditorAccountResponse result = minorCreditorService.getMinorCreditorAccount(id);
 
+        // Assert
         assertNotNull(result);
         assertEquals(response, result);
         verify(minorCreditorSearchProxy).getMinorCreditorAccount(eq(id));
@@ -154,11 +160,13 @@ class MinorCreditorServiceTest {
 
     @Test
     void testGetMinorCreditorAccount_permissionNotAllowed() {
+        // Arrange
         UserState noPermissionUser = mock(UserState.class);
         when(noPermissionUser.anyBusinessUnitUserHasPermission(
             FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
         when(userStateService.checkForAuthorisedUser()).thenReturn(noPermissionUser);
 
+        // Act & Assert
         PermissionNotAllowedException ex = Assertions.assertThrows(
             PermissionNotAllowedException.class,
             () -> minorCreditorService.getMinorCreditorAccount(123L)
@@ -169,6 +177,7 @@ class MinorCreditorServiceTest {
 
     @Test
     void testGetMinorCreditorAccount_filtersBacsDetailsWithoutPermission() {
+        // Arrange
         Long id = 123L;
         MinorCreditorAccountResponse response = responseWithBacsDetails();
 
@@ -177,8 +186,10 @@ class MinorCreditorServiceTest {
             UserStateUtil.permissionUser((short) 10, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)
         );
 
+        // Act
         MinorCreditorAccountResponse result = minorCreditorService.getMinorCreditorAccount(id);
 
+        // Assert
         assertNotNull(result.getPayment());
         assertEquals(null, result.getPayment().getAccountName());
         assertEquals(null, result.getPayment().getSortCode());
@@ -190,6 +201,7 @@ class MinorCreditorServiceTest {
 
     @Test
     void testGetMinorCreditorAccount_keepsBacsDetailsWithPermission() {
+        // Arrange
         Long id = 123L;
         MinorCreditorAccountResponse response = responseWithBacsDetails();
 
@@ -204,8 +216,10 @@ class MinorCreditorServiceTest {
             UserStateUtil.permissionUser((short) 10, searchPermission, bacsPermission)
         );
 
+        // Act
         MinorCreditorAccountResponse result = minorCreditorService.getMinorCreditorAccount(id);
 
+        // Assert
         assertNotNull(result.getPayment());
         assertEquals("Test Name", result.getPayment().getAccountName());
         assertEquals("123456", result.getPayment().getSortCode());

--- a/src/test/java/uk/gov/hmcts/opal/service/UserStateServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/UserStateServiceTest.java
@@ -47,7 +47,7 @@ class UserStateServiceTest {
         when(userStateMapper.toUserState(userStateV2, Domain.FINES)).thenReturn(expectedUserState);
 
         // Act
-        UserState userState = userStateService.checkForAuthorisedUser("");
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         // Assert
         assertSame(expectedUserState, userState);
@@ -61,7 +61,7 @@ class UserStateServiceTest {
 
         // Act
         AccessDeniedException ade = assertThrows(AccessDeniedException.class,
-                                                 () -> userStateService.checkForAuthorisedUser(""));
+                                                 () -> userStateService.checkForAuthorisedUser());
 
         // Assert
         assertEquals("Unexpected token type", ade.getMessage());
@@ -76,7 +76,7 @@ class UserStateServiceTest {
 
         // Act
         AccessDeniedException ade = assertThrows(AccessDeniedException.class,
-                                                 () -> userStateService.checkForAuthorisedUser(""));
+                                                 () -> userStateService.checkForAuthorisedUser());
 
         // Assert
         assertEquals("User state not found in token", ade.getMessage());
@@ -104,5 +104,4 @@ class UserStateServiceTest {
         securityContext.setAuthentication(authentication);
         SecurityContextHolder.setContext(securityContext);
     }
-
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/UserStateServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/UserStateServiceTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -65,6 +66,7 @@ class UserStateServiceTest {
 
         // Assert
         assertEquals("Unexpected token type", ade.getMessage());
+        verifyNoInteractions(tokenService);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorServiceTest.java
@@ -69,6 +69,7 @@ class LegacyMinorCreditorServiceTest {
 
     @Test
     void searchMinorCreditors_shouldMapLegacyResponseToDto() {
+        // Arrange
         MinorCreditorSearch search = MinorCreditorSearch.builder()
             .businessUnitIds(List.of(1))
             .accountNumber("ACC-1")
@@ -109,8 +110,10 @@ class LegacyMinorCreditorServiceTest {
         when(gatewayService.postToGateway(any(), eq(LegacyMinorCreditorSearchResultsResponse.class), any(), any()))
             .thenReturn(response);
 
+        // Act
         PostMinorCreditorAccountsSearchResponse result = legacyMinorCreditorService.searchMinorCreditors(search);
 
+        // Assert
         assertEquals(1, result.getCount());
         assertEquals(1, result.getCreditorAccounts().size());
         assertEquals("2", result.getCreditorAccounts().getFirst().getCreditorAccountId());
@@ -119,6 +122,7 @@ class LegacyMinorCreditorServiceTest {
 
     @Test
     void searchMinorCreditors_shouldMapNullDefendantToNull() {
+        // Arrange
         MinorCreditorSearch search = MinorCreditorSearch.builder()
             .businessUnitIds(List.of(1))
             .accountNumber("ACC-2")
@@ -155,14 +159,17 @@ class LegacyMinorCreditorServiceTest {
             any())
         ).thenReturn(response);
 
+        // Act
         PostMinorCreditorAccountsSearchResponse result = legacyMinorCreditorService.searchMinorCreditors(search);
 
+        // Assert
         assertEquals(1, result.getCount());
         assertNull(result.getCreditorAccounts().getFirst().getDefendant());
     }
 
     @Test
     void searchMinorCreditors_shouldHandleGatewayException() {
+        // Arrange
         MinorCreditorSearch search = MinorCreditorSearch.builder().activeAccountsOnly(true).build();
 
         GatewayService.Response<LegacyMinorCreditorSearchResultsResponse> responseWithException =
@@ -172,13 +179,17 @@ class LegacyMinorCreditorServiceTest {
         when(gatewayService.postToGateway(any(), eq(LegacyMinorCreditorSearchResultsResponse.class), any(), any()))
             .thenReturn(responseWithException);
 
+        // Act
         PostMinorCreditorAccountsSearchResponse result = legacyMinorCreditorService.searchMinorCreditors(search);
+
+        // Assert
         assertEquals(0, result.getCount());
         assertEquals(0, result.getCreditorAccounts().size());
     }
 
     @Test
     void searchMinorCreditors_shouldHandleLegacyFailure() {
+        // Arrange
         MinorCreditorSearch search = MinorCreditorSearch.builder().activeAccountsOnly(true).build();
         LegacyMinorCreditorSearchResultsResponse legacyResponse = LegacyMinorCreditorSearchResultsResponse.builder()
             .creditorAccounts(List.of())
@@ -190,15 +201,17 @@ class LegacyMinorCreditorServiceTest {
         when(gatewayService.postToGateway(any(), eq(LegacyMinorCreditorSearchResultsResponse.class), any(), any()))
             .thenReturn(response);
 
+        // Act
         PostMinorCreditorAccountsSearchResponse result = legacyMinorCreditorService.searchMinorCreditors(search);
 
+        // Assert
         assertEquals(0, result.getCount());
         assertEquals(0, result.getCreditorAccounts().size());
     }
 
     @Test
     void searchMinorCreditors_shouldLogLegacyFailureEntity() {
-
+        // Arrange
         MinorCreditorSearch search = MinorCreditorSearch.builder().activeAccountsOnly(true).build();
         LegacyMinorCreditorSearchResultsResponse legacyResponse = LegacyMinorCreditorSearchResultsResponse.builder()
             .count(0)
@@ -215,6 +228,7 @@ class LegacyMinorCreditorServiceTest {
             any())
         ).thenReturn(response);
 
+        // Act
         legacyMinorCreditorService.searchMinorCreditors(search);
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorServiceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import java.math.BigInteger;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -23,6 +24,7 @@ import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.opal.common.legacy.service.GatewayService;
 import uk.gov.hmcts.opal.dto.GetMinorCreditorAccountAtAGlanceResponse;
 import uk.gov.hmcts.opal.dto.GetMinorCreditorAccountHeaderSummaryResponse;
+import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
 import uk.gov.hmcts.opal.dto.MinorCreditorSearch;
 import uk.gov.hmcts.opal.dto.PostMinorCreditorAccountsSearchResponse;
 import uk.gov.hmcts.opal.dto.legacy.CreditorAccount;
@@ -32,10 +34,17 @@ import uk.gov.hmcts.opal.dto.legacy.LegacyGetMinorCreditorAccountAtAGlanceReques
 import uk.gov.hmcts.opal.dto.legacy.LegacyGetMinorCreditorAccountAtAGlanceResponse;
 import uk.gov.hmcts.opal.dto.legacy.GetMinorCreditorAccountHeaderSummaryLegacyRequest;
 import uk.gov.hmcts.opal.dto.legacy.GetMinorCreditorAccountHeaderSummaryLegacyResponse.CreditorHeaderLegacy;
+import uk.gov.hmcts.opal.dto.legacy.LegacyGetMinorCreditorAccountRequest;
+import uk.gov.hmcts.opal.dto.legacy.LegacyGetMinorCreditorAccountResponse;
+import uk.gov.hmcts.opal.dto.legacy.common.LegacyCreditorAccountPaymentDetails;
+import uk.gov.hmcts.opal.dto.legacy.common.LegacyPartyDetails;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyMinorCreditorSearchResultsResponse;
+import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
 import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
 import uk.gov.hmcts.opal.mapper.legacy.GetMinorCreditorAccountHeaderSummaryResponseLegacyMapper;
+import uk.gov.hmcts.opal.mapper.legacy.LegacyMinorCreditorAccountResponseMapper;
 import uk.gov.hmcts.opal.mapper.response.GetMinorCreditorAccountAtAGlanceResponseMapper;
+import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
 
 @ExtendWith(MockitoExtension.class)
 class LegacyMinorCreditorServiceTest {
@@ -48,6 +57,12 @@ class LegacyMinorCreditorServiceTest {
 
     @Mock
     private GetMinorCreditorAccountHeaderSummaryResponseLegacyMapper headerSummaryResponseMapper;
+
+    @Mock
+    private LegacyMinorCreditorAccountResponseMapper minorCreditorAccountResponseMapper;
+
+    @Mock
+    private CreditorAccountRepository creditorAccountRepository;
 
     @InjectMocks
     private LegacyMinorCreditorService legacyMinorCreditorService;
@@ -314,6 +329,39 @@ class LegacyMinorCreditorServiceTest {
         );
         verify(atAGlanceResponseMapper, times(1)).toDto(legacyResponse);
         verifyNoMoreInteractions(gatewayService, atAGlanceResponseMapper);
+    }
+
+    @Test
+    void getMinorCreditorAccount_shouldMapLegacyResponseToDto() {
+        LegacyGetMinorCreditorAccountResponse legacyResponse = LegacyGetMinorCreditorAccountResponse.builder()
+            .creditorAccountId(101L)
+            .accountVersion(7L)
+            .partyDetails(LegacyPartyDetails.builder().build())
+            .payment(LegacyCreditorAccountPaymentDetails.builder().payByBacs(true).holdPayment(false).build())
+            .build();
+
+        GatewayService.Response<LegacyGetMinorCreditorAccountResponse> gatewayResponse =
+            new GatewayService.Response<>(HttpStatus.OK, legacyResponse, null, null);
+
+        MinorCreditorAccountResponse mappedResponse = new MinorCreditorAccountResponse();
+        mappedResponse.setCreditorAccountId(101L);
+
+        when(gatewayService.postToGateway(
+            eq("GET_MINOR_CREDITOR_ACCOUNT_PARTY"),
+            eq(LegacyGetMinorCreditorAccountResponse.class),
+            eq(LegacyGetMinorCreditorAccountRequest.builder().accountId("101").build()),
+            any()
+        )).thenReturn(gatewayResponse);
+        when(minorCreditorAccountResponseMapper.toMinorCreditorAccountResponse(legacyResponse))
+            .thenReturn(mappedResponse);
+        when(creditorAccountRepository.findById(101L)).thenReturn(
+            Optional.of(CreditorAccountEntity.builder().businessUnitId((short) 77).build())
+        );
+
+        MinorCreditorAccountResponse result = legacyMinorCreditorService.getMinorCreditorAccount(101L);
+
+        assertEquals(101L, result.getCreditorAccountId());
+        assertEquals((short) 77, result.getBusinessUnitId());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-1991


### Change description ###

- Adds legacy-mode support for GET /minor-creditor-accounts/{id}
- Wires the endpoint through controller, shared service, proxy, and legacy service
- Uses legacy gateway actionType GET_MINOR_CREDITOR_ACCOUNT_PARTY with accountId request mapping
- Maps legacy response DTOs into the API response using legacy-specific mappers
- Applies Search and View Accounts auth and filters BACS details unless the user has View Creditor BACS in the account business unit
- Leaves Opal mode unsupported in this ticket
- Adds test coverage for controller/service/legacy service and legacy integration scenarios
- Adds matching legacy stub mapping and XML response in opal-legacy-db-stub


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
