### PR TITLE
PO-3792: Ensure BE generated date-times are UTC

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/controllers/print/PrintRequestController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/print/PrintRequestController.java
@@ -2,9 +2,14 @@ package uk.gov.hmcts.opal.controllers.print;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,12 +19,6 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.opal.entity.print.PrintJob;
 import uk.gov.hmcts.opal.service.print.AsyncPrintJobProcessor;
 import uk.gov.hmcts.opal.service.print.PrintService;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ContentDisposition;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/print")
@@ -31,6 +30,8 @@ public class PrintRequestController {
     private final PrintService printService;
 
     private final AsyncPrintJobProcessor asyncPrintJobProcessor;
+
+    private final Clock clock;
 
 
     @PostMapping(value = "/enqueue-print-jobs", consumes = MediaType.APPLICATION_JSON_VALUE)
@@ -62,7 +63,7 @@ public class PrintRequestController {
     public ResponseEntity<String> processPendingJobs() {
         log.debug(":POST:processPendingJobs: processing pending print jobs");
 
-        asyncPrintJobProcessor.processPendingJobsAsync(LocalDateTime.now());
+        asyncPrintJobProcessor.processPendingJobsAsync(LocalDateTime.now(clock));
 
         return ResponseEntity.ok().body("OK");
     }

--- a/src/main/java/uk/gov/hmcts/opal/disco/opal/LogAuditDetailService.java
+++ b/src/main/java/uk/gov/hmcts/opal/disco/opal/LogAuditDetailService.java
@@ -1,6 +1,10 @@
 package uk.gov.hmcts.opal.disco.opal;
 
 
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Page;
@@ -15,10 +19,6 @@ import uk.gov.hmcts.opal.repository.LogAuditDetailRepository;
 import uk.gov.hmcts.opal.repository.jpa.LogAuditDetailSpecs;
 import uk.gov.hmcts.opal.disco.LogAuditDetailServiceInterface;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 @Qualifier("logAuditDetailService")
@@ -29,6 +29,8 @@ public class LogAuditDetailService implements LogAuditDetailServiceInterface {
     private final LogActionRepository logActionRepository;
 
     private final BusinessUnitRepository businessUnitRepository;
+
+    private final Clock clock;
 
     private final LogAuditDetailSpecs specs = new LogAuditDetailSpecs();
 
@@ -58,7 +60,7 @@ public class LogAuditDetailService implements LogAuditDetailServiceInterface {
             .businessUnit(Optional.ofNullable(dto.getBusinessUnitId())
                               .map(businessUnitRepository::getReferenceById).orElse(null))
             .jsonRequest(dto.getJsonRequest())
-            .logTimestamp(LocalDateTime.now())
+            .logTimestamp(LocalDateTime.now(clock))
             .build();
     }
 

--- a/src/main/java/uk/gov/hmcts/opal/repository/jpa/LocalJusticeAreaSpecs.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/jpa/LocalJusticeAreaSpecs.java
@@ -24,7 +24,8 @@ public class LocalJusticeAreaSpecs extends AddressSpecs<LocalJusticeAreaEntity> 
     }
 
     public Specification<LocalJusticeAreaEntity> referenceDataFilter(Optional<String> filter,
-        Optional<List<String>> ljaTypesFilter) {
+        Optional<List<String>> ljaTypesFilter,
+        LocalDateTime currentDateTime) {
 
         Optional<Specification<LocalJusticeAreaEntity>> ljaTypeSpec =
             ljaTypesFilter.filter(s -> !s.isEmpty()).map(this::containsLocalJusticeAreaTypes);
@@ -32,7 +33,7 @@ public class LocalJusticeAreaSpecs extends AddressSpecs<LocalJusticeAreaEntity> 
             filter.filter(s -> !s.isBlank()).map(this::likeAnyLocalJusticeArea);
 
         return Specification.allOf(specificationList(
-            List.of(filterSpec, ljaTypeSpec), endDateGreaterThenEqualToDate(LocalDateTime.now())));
+            List.of(filterSpec, ljaTypeSpec), endDateGreaterThenEqualToDate(currentDateTime)));
     }
 
     public static Specification<LocalJusticeAreaEntity> equalsLocalJusticeAreaId(Short localJusticeAreaId) {

--- a/src/main/java/uk/gov/hmcts/opal/service/DraftAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DraftAccountService.java
@@ -7,6 +7,7 @@ import jakarta.persistence.EntityNotFoundException;
 import java.math.BigInteger;
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -18,7 +19,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.UnexpectedRollbackException;
 import uk.gov.hmcts.opal.SchemaPaths;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
-import uk.gov.hmcts.opal.common.logging.LogUtil;
 import uk.gov.hmcts.opal.common.logging.SecurityEventLoggingService;
 import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
 import uk.gov.hmcts.opal.common.user.authorisation.model.BusinessUnitUser;
@@ -263,7 +263,7 @@ public class DraftAccountService {
             "DraftAccountIdentifier", accountId,
             "DraftAccountSubmittedByUserIdentifier", submittedBy);;
         securityEventLoggingService.logEvent(EVENT_ACCOUNT_APPROVAL, "Success", buId, "Approval",
-            LogUtil.getRequestTimestamp(), data);
+            LocalDateTime.now(clock), data);
     }
 
     public DraftAccountResponseDto toGetResponseDto(DraftAccountEntity entity) {

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/DocumentService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/DocumentService.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.opal.service.opal;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.opal.entity.AssociatedRecordType;
 import uk.gov.hmcts.opal.entity.DocumentEntity;
@@ -19,14 +19,13 @@ import uk.gov.hmcts.opal.util.DocumentIdConstants;
 @Slf4j(topic = "opal.DocumentService")
 public class DocumentService implements DocumentServiceInterface {
 
-    @Autowired
-    private DocumentInstanceRepository documentInstanceRepository;
+    private final DocumentInstanceRepository documentInstanceRepository;
 
-    @Autowired
-    private DocumentRepository documentRepository;
+    private final DocumentRepository documentRepository;
 
-    @Autowired
-    private BusinessUnitService businessUnitService;
+    private final BusinessUnitService businessUnitService;
+
+    private final Clock clock;
 
     @Override
     public void createDocumentInstance(Long defAccountId, short businessUnitId) {
@@ -37,7 +36,7 @@ public class DocumentService implements DocumentServiceInterface {
         DocumentInstanceEntity documentInstanceEntity = DocumentInstanceEntity.builder()
             .document(doc)
             .businessUnit(businessUnitService.getBusinessUnit(businessUnitId))
-            .generatedDate(LocalDateTime.now())
+            .generatedDate(LocalDateTime.now(clock))
             .generatedBy("generatedby")
             .associatedRecordId(defAccountId)
             .associatedRecordType(AssociatedRecordType.DEFENDANT_ACCOUNTS)

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/LocalJusticeAreaService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/LocalJusticeAreaService.java
@@ -2,6 +2,10 @@ package uk.gov.hmcts.opal.service.opal;
 
 
 import jakarta.persistence.EntityNotFoundException;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.Cacheable;
@@ -16,15 +20,14 @@ import uk.gov.hmcts.opal.dto.reference.LjaReferenceData;
 import uk.gov.hmcts.opal.repository.LocalJusticeAreaRepository;
 import uk.gov.hmcts.opal.repository.jpa.LocalJusticeAreaSpecs;
 
-import java.util.List;
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 @Qualifier("localJusticeAreaService")
 public class LocalJusticeAreaService {
 
     private final LocalJusticeAreaRepository localJusticeAreaRepository;
+
+    private final Clock clock;
 
     private final LocalJusticeAreaSpecs specs = new LocalJusticeAreaSpecs();
 
@@ -52,7 +55,7 @@ public class LocalJusticeAreaService {
         Sort nameSort = Sort.by(Sort.Direction.ASC, LocalJusticeAreaEntity_.NAME);
 
         Page<LjaReferenceData> page = localJusticeAreaRepository
-            .findBy(specs.referenceDataFilter(filter, ljaType),
+            .findBy(specs.referenceDataFilter(filter, ljaType, LocalDateTime.now(clock)),
                     ffq -> ffq
                         .sortBy(nameSort)
                         .as(LjaReferenceData.class)

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountBuilders.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountBuilders.java
@@ -938,14 +938,15 @@ public class OpalDefendantAccountBuilders {
             .build();
     }
 
-    static NoteEntity buildNoteEntity(DefendantAccountEntity managed, String combined, String postedBy) {
+    static NoteEntity buildNoteEntity(DefendantAccountEntity managed, String combined, String postedBy,
+                                      LocalDateTime postedDate) {
         return NoteEntity.builder()
             .noteText(combined)
             .noteType(NoteType.AA)
             .associatedRecordId(String.valueOf(managed.getDefendantAccountId()))
             .associatedRecordType(AssociatedRecordType.DEFENDANT_ACCOUNTS)
             .businessUnitUserId(String.valueOf(managed.getBusinessUnit().getBusinessUnitId()))
-            .postedDate(LocalDateTime.now())
+            .postedDate(postedDate)
             .postedByUsername(postedBy)
             .build();
     }

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
@@ -20,7 +20,9 @@ import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.LockModeType;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Clock;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -179,6 +181,8 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
     private final DefendantAccountHeaderSummaryMapper defendantAccountHeaderSummaryMapper;
     private final EnforcerDefendantAccountMapper enforcerDefendantAccountMapper;
     private final PaymentTermsMapper paymentTermsMapper;
+
+    private final Clock clock;
 
     //TODO - Remove once repository service is in use
     public DefendantAccountEntity getDefendantAccountById(long defendantAccountId) {
@@ -702,7 +706,8 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
         managed.setAccountNote2(notes.getFreeTextNote2());
         managed.setAccountNote3(notes.getFreeTextNote3());
 
-        noteRepository.save(OpalDefendantAccountBuilders.buildNoteEntity(managed, combined, postedBy));
+        noteRepository.save(
+            OpalDefendantAccountBuilders.buildNoteEntity(managed, combined, postedBy, LocalDateTime.now(clock)));
         log.debug(":applyCommentAndNotes: saved note for account {}", managed.getDefendantAccountId());
     }
 

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalNotesService.java
@@ -5,6 +5,7 @@ import static uk.gov.hmcts.opal.util.VersionUtils.verifyIfMatch;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
 import jakarta.transaction.Transactional;
+import java.time.Clock;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,7 @@ public class OpalNotesService implements NotesServiceInterface {
 
     private final NoteRepository repository;
     private final EntityManager em;
+    private final Clock clock;
 
     @Override
     @Transactional
@@ -57,7 +59,7 @@ public class OpalNotesService implements NotesServiceInterface {
         note.setAssociatedRecordId(requestNote.getRecordId());
         note.setAssociatedRecordType(AssociatedRecordType.DEFENDANT_ACCOUNTS);
         note.setBusinessUnitUserId(managed.getBusinessUnit().getBusinessUnitId().toString());
-        note.setPostedDate(LocalDateTime.now());
+        note.setPostedDate(LocalDateTime.now(clock));
         note.setPostedByUsername(user.getUserName());
 
         NoteEntity entity = repository.save(note);

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/PaymentTermsService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/PaymentTermsService.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.opal.service.opal;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.opal.entity.paymentterms.PaymentTermsEntity;
@@ -16,8 +16,9 @@ import uk.gov.hmcts.opal.service.iface.PaymentTermsServiceInterface;
 @Qualifier("paymentTermsService")
 public class PaymentTermsService implements PaymentTermsServiceInterface {
 
-    @Autowired
     private final DefendantAccountPaymentTermsRepository paymentTermsRepository;
+
+    private final Clock clock;
 
     @Override
     public PaymentTermsEntity addPaymentTerm(PaymentTermsEntity paymentTermsEntity) {
@@ -26,7 +27,7 @@ public class PaymentTermsService implements PaymentTermsServiceInterface {
 
         // Set posted_details metadata
         if (paymentTermsEntity.getPostedDate() == null) {
-            paymentTermsEntity.setPostedDate(LocalDateTime.now());
+            paymentTermsEntity.setPostedDate(LocalDateTime.now(clock));
         }
         paymentTermsEntity.setPostedBy(paymentTermsEntity.getPostedBy());
         paymentTermsEntity.setPostedByUsername(paymentTermsEntity.getPostedByUsername());

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactional.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactional.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.persistence.EntityNotFoundException;
 import java.math.BigInteger;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -28,7 +29,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import uk.gov.hmcts.opal.common.logging.LogUtil;
 import uk.gov.hmcts.opal.common.logging.SecurityEventLoggingService;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddDraftAccountRequestDto;
@@ -66,6 +66,8 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
     private final BusinessUnitRepository businessUnitRepository;
 
     private final SecurityEventLoggingService securityEventLoggingService;
+
+    private final Clock clock;
 
     private final DraftAccountSpecs specs = new DraftAccountSpecs();
 
@@ -107,7 +109,7 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
 
     @Transactional
     public DraftAccountEntity submitDraftAccount(AddDraftAccountRequestDto dto) {
-        LocalDateTime created = LocalDateTime.now();
+        LocalDateTime created = LocalDateTime.now(clock);
         BusinessUnitEntity businessUnit = businessUnitRepository.getReferenceById(
             dto.getBusinessUnitId());
         String snapshot = createInitialSnapshot(dto, created, businessUnit);
@@ -143,7 +145,7 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
         existingAccount.setAccountSnapshot(newSnapshot);
         existingAccount.setAccountType(dto.getAccountType());
         existingAccount.setAccountStatus(DraftAccountStatus.RESUBMITTED);
-        existingAccount.setAccountStatusDate(LocalDateTime.now());
+        existingAccount.setAccountStatusDate(LocalDateTime.now(clock));
         existingAccount.setTimelineData(appendTimelineData(existingAccount.getTimelineData(), dto.getTimelineData()));
 
         log.debug(":replaceDraftAccount: Replacing draft account with ID: {} and new snapshot: \n{}",
@@ -180,13 +182,14 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
         existingAccount.setVersionNumber(updateVersion.longValueExact());
 
         if (newStatus.isPublishingPending()) {
+            LocalDateTime validationTimestamp = LocalDateTime.now(clock);
             checkValidatorIsNotSubmitter(existingAccount.getSubmittedBy(), dto.getValidatedBy(), draftAccountId,
                 userState, dto.getBusinessUnitId());
-            existingAccount.setValidatedDate(LocalDateTime.now());
+            existingAccount.setValidatedDate(validationTimestamp);
             existingAccount.setValidatedBy(dto.getValidatedBy());
             existingAccount.setValidatedByName(dto.getValidatedByName());
             existingAccount.setAccountSnapshot(addSnapshotApprovedDate(existingAccount));
-            existingAccount.setAccountStatusDate(LocalDateTime.now());
+            existingAccount.setAccountStatusDate(validationTimestamp);
         }
 
         if (newStatus.isDeleted()) {
@@ -215,7 +218,7 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
 
         dbDraftAccount.setAccountStatus(status);
         dbDraftAccount.setVersionNumber(entity.getVersion().longValueExact());
-        dbDraftAccount.setAccountStatusDate(LocalDateTime.now());
+        dbDraftAccount.setAccountStatusDate(LocalDateTime.now(clock));
 
         // These are specific to the results from the 'publish' activity, success
         dbDraftAccount.setAccountNumber(entity.getAccountNumber());
@@ -317,7 +320,7 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
         if (submitterUsername != null && submitterUsername.equals(updaterUserName)) {
             Map<String, Object> data = getSecurityLogDataMap(userState.getUserId(), draftAccountId, submitterUsername);
             securityEventLoggingService.logEvent(EVENT_ACCOUNT_APPROVAL, "Failure", businessUnitId,
-                "Approval", LogUtil.getRequestTimestamp(), data);
+                "Approval", LocalDateTime.now(clock), data);
             throw new SubmitterDeniedException(submitterUsername, "validate");
         }
     }
@@ -327,7 +330,7 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
         if (submitterUsername != null && submitterUsername.equals(updaterUserName)) {
             Map<String, Object> data = getSecurityLogDataMap(userState.getUserId(), draftAccountId, submitterUsername);
             securityEventLoggingService.logEvent(EVENT_NAME_DELETION,
-                  "Failure", businessUnitId, "Deletion", LogUtil.getRequestTimestamp(), data);
+                  "Failure", businessUnitId, "Deletion", LocalDateTime.now(clock), data);
             throw new SubmitterDeniedException(submitterUsername, "delete");
         }
     }

--- a/src/main/java/uk/gov/hmcts/opal/service/print/PrintService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/print/PrintService.java
@@ -1,6 +1,13 @@
 package uk.gov.hmcts.opal.service.print;
 
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.StringReader;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -31,12 +38,6 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.sax.SAXResult;
 import javax.xml.transform.stream.StreamSource;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.StringReader;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
 
 @Service
 @Transactional(transactionManager = "printTransactionManager")
@@ -53,6 +54,8 @@ public class PrintService {
     private final PrintJobRepository printJobRepository;
 
     private final SftpOutboundService sftpOutboundService;
+
+    private final Clock clock;
 
 
     @Value("${printservice.maxRetries:3}")
@@ -108,10 +111,11 @@ public class PrintService {
         log.debug("Saving print jobs for batch {}", batchId);
 
         for (PrintJob printJob : printJobs) {
+            LocalDateTime now = LocalDateTime.now(clock);
             printJob.setBatchId(batchId);
             printJob.setJobId(UUID.randomUUID());
-            printJob.setCreatedAt(LocalDateTime.now());
-            printJob.setUpdatedAt(LocalDateTime.now());
+            printJob.setCreatedAt(now);
+            printJob.setUpdatedAt(now);
             printJob.setStatus(PrintStatus.PENDING);
             printJobRepository.save(printJob);
         }

--- a/src/test/java/uk/gov/hmcts/opal/controllers/print/PrintRequestControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/print/PrintRequestControllerTest.java
@@ -7,10 +7,11 @@ import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -35,16 +36,11 @@ public class PrintRequestControllerTest {
     @Mock
     private AsyncPrintJobProcessor asyncPrintJobProcessor;
 
-    private PrintRequestController printRequestController;
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
 
-    @BeforeEach
-    void setUp() {
-        printRequestController = new PrintRequestController(
-            printService,
-            asyncPrintJobProcessor,
-            Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC)
-        );
-    }
+    @InjectMocks
+    private PrintRequestController printRequestController;
 
     @Test
     void testEnqueuePrintJobs() {

--- a/src/test/java/uk/gov/hmcts/opal/controllers/print/PrintRequestControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/print/PrintRequestControllerTest.java
@@ -1,8 +1,15 @@
 package uk.gov.hmcts.opal.controllers.print;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
@@ -11,13 +18,10 @@ import uk.gov.hmcts.opal.entity.print.PrintJob;
 import uk.gov.hmcts.opal.service.print.AsyncPrintJobProcessor;
 import uk.gov.hmcts.opal.service.print.PrintService;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,8 +35,16 @@ public class PrintRequestControllerTest {
     @Mock
     private AsyncPrintJobProcessor asyncPrintJobProcessor;
 
-    @InjectMocks
     private PrintRequestController printRequestController;
+
+    @BeforeEach
+    void setUp() {
+        printRequestController = new PrintRequestController(
+            printService,
+            asyncPrintJobProcessor,
+            Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC)
+        );
+    }
 
     @Test
     void testEnqueuePrintJobs() {
@@ -78,6 +90,7 @@ public class PrintRequestControllerTest {
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("OK", response.getBody());
-        verify(asyncPrintJobProcessor, times(1)).processPendingJobsAsync(any());
+        verify(asyncPrintJobProcessor, times(1))
+            .processPendingJobsAsync(eq(LocalDateTime.of(2026, 5, 7, 10, 15)));
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/disco/opal/LocalJusticeAreaServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/disco/opal/LocalJusticeAreaServiceTest.java
@@ -1,8 +1,14 @@
 package uk.gov.hmcts.opal.disco.opal;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,10 +23,6 @@ import uk.gov.hmcts.opal.dto.reference.LjaReferenceData;
 import uk.gov.hmcts.opal.repository.LocalJusticeAreaRepository;
 import uk.gov.hmcts.opal.service.opal.LocalJusticeAreaService;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -32,8 +34,15 @@ class LocalJusticeAreaServiceTest {
     @Mock
     private LocalJusticeAreaRepository localJusticeAreaRepository;
 
-    @InjectMocks
     private LocalJusticeAreaService localJusticeAreaService;
+
+    @BeforeEach
+    void setUp() {
+        localJusticeAreaService = new LocalJusticeAreaService(
+            localJusticeAreaRepository,
+            Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC)
+        );
+    }
 
     @Test
     void testGetLocalJusticeArea() {

--- a/src/test/java/uk/gov/hmcts/opal/disco/opal/LocalJusticeAreaServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/disco/opal/LocalJusticeAreaServiceTest.java
@@ -6,11 +6,12 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -34,15 +35,11 @@ class LocalJusticeAreaServiceTest {
     @Mock
     private LocalJusticeAreaRepository localJusticeAreaRepository;
 
-    private LocalJusticeAreaService localJusticeAreaService;
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
 
-    @BeforeEach
-    void setUp() {
-        localJusticeAreaService = new LocalJusticeAreaService(
-            localJusticeAreaRepository,
-            Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC)
-        );
-    }
+    @InjectMocks
+    private LocalJusticeAreaService localJusticeAreaService;
 
     @Test
     void testGetLocalJusticeArea() {

--- a/src/test/java/uk/gov/hmcts/opal/disco/opal/LogAuditDetailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/disco/opal/LogAuditDetailServiceTest.java
@@ -7,12 +7,13 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.function.Function;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -45,19 +46,11 @@ class LogAuditDetailServiceTest {
     @Mock
     private BusinessUnitRepository businessUnitRepository;
 
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
+
+    @InjectMocks
     private LogAuditDetailService logAuditDetailService;
-
-    private final Clock fixedClock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
-
-    @BeforeEach
-    void setUp() {
-        logAuditDetailService = new LogAuditDetailService(
-            logAuditDetailRepository,
-            logActionRepository,
-            businessUnitRepository,
-            fixedClock
-        );
-    }
 
     @Test
     void testGetLogAuditDetail() {

--- a/src/test/java/uk/gov/hmcts/opal/disco/opal/LogAuditDetailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/disco/opal/LogAuditDetailServiceTest.java
@@ -1,9 +1,16 @@
 package uk.gov.hmcts.opal.disco.opal;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.function.Function;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -20,12 +27,10 @@ import uk.gov.hmcts.opal.repository.BusinessUnitRepository;
 import uk.gov.hmcts.opal.repository.LogActionRepository;
 import uk.gov.hmcts.opal.repository.LogAuditDetailRepository;
 
-import java.util.List;
-import java.util.function.Function;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -40,8 +45,19 @@ class LogAuditDetailServiceTest {
     @Mock
     private BusinessUnitRepository businessUnitRepository;
 
-    @InjectMocks
     private LogAuditDetailService logAuditDetailService;
+
+    private final Clock fixedClock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
+
+    @BeforeEach
+    void setUp() {
+        logAuditDetailService = new LogAuditDetailService(
+            logAuditDetailRepository,
+            logActionRepository,
+            businessUnitRepository,
+            fixedClock
+        );
+    }
 
     @Test
     void testGetLogAuditDetail() {
@@ -90,6 +106,10 @@ class LogAuditDetailServiceTest {
 
         // Act
         Assertions.assertDoesNotThrow(() -> logAuditDetailService.writeLogAuditDetail(dto));
+
+        ArgumentCaptor<LogAuditDetailEntity> captor = ArgumentCaptor.forClass(LogAuditDetailEntity.class);
+        verify(logAuditDetailRepository).save(captor.capture());
+        assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), captor.getValue().getLogTimestamp());
     }
 
 

--- a/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
@@ -465,7 +465,7 @@ class DraftAccountServiceTest {
             eq("Success"),
             eq((short) 2),
             eq("Approval"),
-            any(LocalDateTime.class),
+            eq(LocalDateTime.of(2026, 4, 22, 0, 0)),
             eq(Map.of(
                 "UserIdentifier", 1L,
                 "DraftAccountIdentifier", draftAccountId,

--- a/src/test/java/uk/gov/hmcts/opal/service/NotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/NotesServiceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.opal.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -14,12 +13,14 @@ import static org.mockito.Mockito.when;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
@@ -45,7 +46,9 @@ class NotesServiceTest {
     @Mock private EntityManager em;
     @Mock private UserState user;
 
-    @InjectMocks private OpalNotesService service;
+    private OpalNotesService service;
+
+    private final Clock fixedClock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
 
     // common test data objects (no stubbing here to keep STRICT_STUBS happy)
     private AddNoteRequest request;
@@ -54,6 +57,8 @@ class NotesServiceTest {
 
     @BeforeEach
     void setUp() {
+        service = new OpalNotesService(repository, em, fixedClock);
+
         // Build request payload
         Note n = new Note();
         n.setRecordId("77");
@@ -103,7 +108,7 @@ class NotesServiceTest {
         assertEquals("1", toSave.getBusinessUnitUserId()); // short -> "1"
         assertEquals("USER1", toSave.getPostedByUsername());
         assertNotNull(toSave.getPostedDate(), "postedDate should be set");
-        assertFalse(toSave.getPostedDate().isAfter(LocalDateTime.now()));
+        assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), toSave.getPostedDate());
 
         // Lock is called on the MANAGED instance
         verify(em).lock(eq(managedInEm), eq(LockModeType.OPTIMISTIC_FORCE_INCREMENT));

--- a/src/test/java/uk/gov/hmcts/opal/service/NotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/NotesServiceTest.java
@@ -21,7 +21,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
@@ -46,9 +48,11 @@ class NotesServiceTest {
     @Mock private EntityManager em;
     @Mock private UserState user;
 
+    @InjectMocks
     private OpalNotesService service;
 
-    private final Clock fixedClock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
 
     // common test data objects (no stubbing here to keep STRICT_STUBS happy)
     private AddNoteRequest request;
@@ -57,8 +61,6 @@ class NotesServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new OpalNotesService(repository, em, fixedClock);
-
         // Build request payload
         Note n = new Note();
         n.setRecordId("77");

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/DocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/DocumentServiceTest.java
@@ -15,12 +15,13 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.opal.entity.AssociatedRecordType;
 import uk.gov.hmcts.opal.entity.DocumentEntity;
@@ -45,17 +46,11 @@ class DocumentServiceTest {
     @Captor
     private ArgumentCaptor<DocumentInstanceEntity> instanceCaptor;
 
-    private DocumentService documentService;
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
 
-    @BeforeEach
-    void setUp() {
-        documentService = new DocumentService(
-            documentInstanceRepository,
-            documentRepository,
-            businessUnitService,
-            Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC)
-        );
-    }
+    @InjectMocks
+    private DocumentService documentService;
 
     @Test
     void createDocumentInstance_success_savesDocumentInstanceWithExpectedValues() {

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/DocumentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/DocumentServiceTest.java
@@ -10,12 +10,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.opal.entity.AssociatedRecordType;
@@ -41,8 +45,17 @@ class DocumentServiceTest {
     @Captor
     private ArgumentCaptor<DocumentInstanceEntity> instanceCaptor;
 
-    @InjectMocks
     private DocumentService documentService;
+
+    @BeforeEach
+    void setUp() {
+        documentService = new DocumentService(
+            documentInstanceRepository,
+            documentRepository,
+            businessUnitService,
+            Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC)
+        );
+    }
 
     @Test
     void createDocumentInstance_success_savesDocumentInstanceWithExpectedValues() {
@@ -63,6 +76,7 @@ class DocumentServiceTest {
         assertEquals(DocumentEntityStatus.NEW, saved.getStatus());
         assertEquals(defAccountId, saved.getAssociatedRecordId());
         assertEquals(AssociatedRecordType.DEFENDANT_ACCOUNTS, saved.getAssociatedRecordType());
+        assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), saved.getGeneratedDate());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/DraftAccountPublishTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/DraftAccountPublishTest.java
@@ -11,7 +11,10 @@ import static uk.gov.hmcts.opal.entity.draft.StoredProcedureNames.DEF_ACC_ID;
 import static uk.gov.hmcts.opal.entity.draft.StoredProcedureNames.DEF_ACC_NO;
 
 import java.lang.reflect.Field;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,7 +61,7 @@ class DraftAccountPublishTest {
     @BeforeEach
     void openMocks() throws Exception {
         draftAccountTransactional = spy(new DraftAccountTransactional(draftRepository, businessRepository,
-            securityEventLoggingService));
+            securityEventLoggingService, Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC)));
         injectDraftTransactionsService(draftAccountPublish, draftAccountTransactional);
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/DraftAccountPublishTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/DraftAccountPublishTest.java
@@ -25,6 +25,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.orm.jpa.JpaSystemException;
 import uk.gov.hmcts.opal.common.logging.LogUtil;
@@ -53,6 +54,9 @@ class DraftAccountPublishTest {
     @Mock
     SecurityEventLoggingService securityEventLoggingService;
 
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
+
     private DraftAccountTransactional draftAccountTransactional;
 
     @InjectMocks
@@ -61,7 +65,7 @@ class DraftAccountPublishTest {
     @BeforeEach
     void openMocks() throws Exception {
         draftAccountTransactional = spy(new DraftAccountTransactional(draftRepository, businessRepository,
-            securityEventLoggingService, Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC)));
+            securityEventLoggingService, clock));
         injectDraftTransactionsService(draftAccountPublish, draftAccountTransactional);
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountUpdateTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountUpdateTest.java
@@ -16,12 +16,18 @@ import static org.mockito.Mockito.when;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import java.math.BigInteger;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.opal.dto.RecordType;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
@@ -29,6 +35,7 @@ import uk.gov.hmcts.opal.dto.UpdateDefendantAccountRequest;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.entity.EnforcerEntity;
 import uk.gov.hmcts.opal.entity.LocalJusticeAreaEntity;
+import uk.gov.hmcts.opal.entity.NoteEntity;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
 import uk.gov.hmcts.opal.entity.court.CourtEntity;
 import uk.gov.hmcts.opal.entity.result.ResultEntity;
@@ -77,6 +84,9 @@ class OpalDefendantAccountUpdateTest {
 
     @Mock
     private EnforcerDefendantAccountMapper enforcerDefendantAccountMapper;
+
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
 
     // Service under test
     @InjectMocks
@@ -199,6 +209,10 @@ class OpalDefendantAccountUpdateTest {
         assertEquals("EO-1", entity.getEnforcementOverrideResultId());
         assertEquals(Long.valueOf(22), entity.getEnforcementOverrideEnforcerId());
         assertEquals(Short.valueOf((short) 33), entity.getEnforcementOverrideTfoLjaId());
+
+        ArgumentCaptor<NoteEntity> noteCaptor = ArgumentCaptor.forClass(NoteEntity.class);
+        verify(noteRepository).save(noteCaptor.capture());
+        assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), noteCaptor.getValue().getPostedDate());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/PaymentTermsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/PaymentTermsServiceTest.java
@@ -6,10 +6,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import uk.gov.hmcts.opal.entity.paymentterms.PaymentTermsEntity;
@@ -20,12 +22,14 @@ class PaymentTermsServiceTest {
     @Mock
     private DefendantAccountPaymentTermsRepository paymentTermsRepository;
 
-    @InjectMocks
     private PaymentTermsService paymentTermsService;
+
+    private final Clock fixedClock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+        paymentTermsService = new PaymentTermsService(paymentTermsRepository, fixedClock);
     }
 
     @Test
@@ -33,15 +37,9 @@ class PaymentTermsServiceTest {
         PaymentTermsEntity entity = new PaymentTermsEntity();
         entity.setPostedBy("user1");
         entity.setPostedByUsername("username1");
-        entity.setPostedDate(LocalDateTime.now());
+        entity.setPostedDate(LocalDateTime.of(2026, 5, 1, 9, 0));
 
-        PaymentTermsEntity savedEntity = new PaymentTermsEntity();
-        savedEntity.setActive(true);
-        savedEntity.setPostedBy("user1");
-        savedEntity.setPostedByUsername("username1");
-        savedEntity.setPostedDate(LocalDateTime.now());
-
-        when(paymentTermsRepository.save(any(PaymentTermsEntity.class))).thenReturn(savedEntity);
+        when(paymentTermsRepository.save(any(PaymentTermsEntity.class))).thenAnswer(inv -> inv.getArgument(0));
 
         PaymentTermsEntity result = paymentTermsService.addPaymentTerm(entity);
 
@@ -49,7 +47,7 @@ class PaymentTermsServiceTest {
         assertEquals(true, result.getActive());
         assertEquals("user1", result.getPostedBy());
         assertEquals("username1", result.getPostedByUsername());
-        assertNotNull(result.getPostedDate());
+        assertEquals(LocalDateTime.of(2026, 5, 1, 9, 0), result.getPostedDate());
         verify(paymentTermsRepository).save(any(PaymentTermsEntity.class));
     }
 
@@ -67,17 +65,11 @@ class PaymentTermsServiceTest {
         entity.setPostedByUsername("username2");
         entity.setPostedDate(null);
 
-        PaymentTermsEntity savedEntity = new PaymentTermsEntity();
-        savedEntity.setActive(true);
-        savedEntity.setPostedBy("user2");
-        savedEntity.setPostedByUsername("username2");
-        savedEntity.setPostedDate(LocalDateTime.now());
-
-        when(paymentTermsRepository.save(any(PaymentTermsEntity.class))).thenReturn(savedEntity);
+        when(paymentTermsRepository.save(any(PaymentTermsEntity.class))).thenAnswer(inv -> inv.getArgument(0));
 
         PaymentTermsEntity result = paymentTermsService.addPaymentTerm(entity);
 
-        assertNotNull(result.getPostedDate());
+        assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), result.getPostedDate());
         verify(paymentTermsRepository).save(any(PaymentTermsEntity.class));
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/PaymentTermsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/PaymentTermsServiceTest.java
@@ -10,27 +10,26 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.opal.entity.paymentterms.PaymentTermsEntity;
 import uk.gov.hmcts.opal.repository.DefendantAccountPaymentTermsRepository;
 
+@ExtendWith(MockitoExtension.class)
 class PaymentTermsServiceTest {
 
     @Mock
     private DefendantAccountPaymentTermsRepository paymentTermsRepository;
 
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
+
+    @InjectMocks
     private PaymentTermsService paymentTermsService;
-
-    private final Clock fixedClock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-        paymentTermsService = new PaymentTermsService(paymentTermsRepository, fixedClock);
-    }
 
     @Test
     void addPaymentTerm_shouldSetActiveAndPostedDateAndSave() {

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/ReportEntryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/ReportEntryServiceTest.java
@@ -12,12 +12,13 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.opal.entity.ReportEntryEntity;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
@@ -32,18 +33,14 @@ class ReportEntryServiceTest {
     @Mock
     private BusinessUnitService businessUnitService;
 
+    @InjectMocks
     private ReportEntryService reportEntryService;
 
     @Captor
     private ArgumentCaptor<ReportEntryEntity> reportEntryCaptor;
 
-    private Clock fixedClock;
-
-    @BeforeEach
-    void setUp() {
-        fixedClock = Clock.fixed(Instant.parse("2026-04-22T09:15:00Z"), ZoneOffset.UTC);
-        reportEntryService = new ReportEntryService(reportEntryRepository, businessUnitService, fixedClock);
-    }
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-04-22T09:15:00Z"), ZoneOffset.UTC);
 
     @Test
     void createRemoveEnforcementHoldReportEntry_savesExpectedReportEntry() {

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
@@ -14,7 +14,10 @@ import static org.mockito.Mockito.when;
 
 import jakarta.persistence.EntityNotFoundException;
 import java.math.BigInteger;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -22,10 +25,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -59,11 +62,22 @@ class DraftAccountTransactionalTest {
     @Mock
     private BusinessUnitRepository businessUnitRepository;
 
-    @InjectMocks
     private DraftAccountTransactional draftAccountTransactional;
 
     @Mock
     SecurityEventLoggingService securityEventLoggingService;
+
+    private final Clock fixedClock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
+
+    @BeforeEach
+    void setUp() {
+        draftAccountTransactional = new DraftAccountTransactional(
+            draftAccountRepository,
+            businessUnitRepository,
+            securityEventLoggingService,
+            fixedClock
+        );
+    }
 
     @Test
     void testGetDraftAccount() {
@@ -132,16 +146,6 @@ class DraftAccountTransactionalTest {
     void testSubmitDraftAccounts_success() {
         String minimalAccountJson = createAccountString();
 
-        DraftAccountEntity saved = DraftAccountEntity.builder()
-            .account(minimalAccountJson)
-            .accountSnapshot("{}")
-            .accountType(DraftAccountType.FINE)
-            .draftAccountId(1L)
-            .createdDate(LocalDateTime.now())
-            .accountStatus(DraftAccountStatus.SUBMITTED)
-            .accountStatusDate(LocalDateTime.now())
-            .build();
-
         AddDraftAccountRequestDto dto = AddDraftAccountRequestDto.builder()
             .businessUnitId((short)2)
             .submittedBy("TestUser")
@@ -157,14 +161,16 @@ class DraftAccountTransactionalTest {
             .build();
 
         when(businessUnitRepository.getReferenceById(any())).thenReturn(businessUnit);
-        when(draftAccountRepository.save(any(DraftAccountEntity.class))).thenReturn(saved);
+        when(draftAccountRepository.save(any(DraftAccountEntity.class))).thenAnswer(inv -> inv.getArgument(0));
 
         DraftAccountEntity result = draftAccountTransactional.submitDraftAccount(dto);
 
-        assertEquals(saved.getAccount(), result.getAccount());
+        assertEquals(minimalAccountJson, result.getAccount());
         ArgumentCaptor<DraftAccountEntity> captor = ArgumentCaptor.forClass(DraftAccountEntity.class);
         verify(draftAccountRepository).save(captor.capture());
         assertEquals(DraftAccountStatus.SUBMITTED, captor.getValue().getAccountStatus());
+        assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), result.getCreatedDate());
+        assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), result.getAccountStatusDate());
 
     }
 
@@ -220,19 +226,9 @@ class DraftAccountTransactionalTest {
             .businessUnitName("New Bailey")
             .build();
 
-        DraftAccountEntity updatedAccount = DraftAccountEntity.builder()
-            .draftAccountId(draftAccountId)
-            .submittedBy("TestUser")
-            .account(createAccountString())
-            .accountType(DraftAccountType.FINE)
-            .accountStatus(DraftAccountStatus.RESUBMITTED)
-            .timelineData(createTimelineDataString())
-            .versionNumber(1L)
-            .build();
-
         when(draftAccountRepository.findById(draftAccountId)).thenReturn(Optional.of(existingAccount));
         when(businessUnitRepository.findById((short) 2)).thenReturn(Optional.of(businessUnit));
-        when(draftAccountRepository.save(any(DraftAccountEntity.class))).thenReturn(updatedAccount);
+        when(draftAccountRepository.save(any(DraftAccountEntity.class))).thenAnswer(inv -> inv.getArgument(0));
 
         // Act
         DraftAccountEntity result = draftAccountTransactional
@@ -246,6 +242,7 @@ class DraftAccountTransactionalTest {
         assertEquals(DraftAccountType.FINE, result.getAccountType());
         assertEquals(DraftAccountStatus.RESUBMITTED, result.getAccountStatus());
         assertEquals(createTimelineDataString(), result.getTimelineData());
+        assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), result.getAccountStatusDate());
 
         verify(draftAccountRepository).findById(draftAccountId);
         verify(businessUnitRepository).findById((short) 2);
@@ -420,19 +417,8 @@ class DraftAccountTransactionalTest {
             .versionNumber(0L)
             .build();
 
-        DraftAccountEntity updatedAccount = DraftAccountEntity.builder()
-            .draftAccountId(draftAccountId)
-            .accountStatus(DraftAccountStatus.PUBLISHING_PENDING)
-            .validatedBy("TestValidator")
-            .validatedByName("Tester McValidator")
-            .validatedDate(LocalDateTime.now())
-            .accountSnapshot("{\"created_date\":\"2024-10-01T10:00:00Z\",\"approved_date\":\"2024-10-03T14:30:00Z\"}")
-            .timelineData(createTimelineDataString())
-            .versionNumber(1L)
-            .build();
-
         when(draftAccountRepository.findById(draftAccountId)).thenReturn(Optional.of(existingAccount));
-        when(draftAccountRepository.save(any(DraftAccountEntity.class))).thenReturn(updatedAccount);
+        when(draftAccountRepository.save(any(DraftAccountEntity.class))).thenAnswer(inv -> inv.getArgument(0));
 
         UserState userState = UserState.builder().userName("USER_NAME_1").build();
 
@@ -445,9 +431,10 @@ class DraftAccountTransactionalTest {
         assertEquals(draftAccountId, result.getDraftAccountId());
         assertEquals(DraftAccountStatus.PUBLISHING_PENDING, result.getAccountStatus());
         assertEquals("TestValidator", result.getValidatedBy());
-        assertEquals("Tester McValidator", result.getValidatedByName());
-        assertNotNull(result.getValidatedDate());
+        assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), result.getValidatedDate());
+        assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), result.getAccountStatusDate());
         assertTrue(result.getAccountSnapshot().contains("approved_date"));
+        assertTrue(result.getAccountSnapshot().contains("2026-05-07T10:15:00Z"));
         assertEquals(createTimelineDataString(), result.getTimelineData());
 
         verify(draftAccountRepository).findById(draftAccountId);
@@ -526,7 +513,7 @@ class DraftAccountTransactionalTest {
             eq("Failure"),
             eq((short) 2),
             eq("Approval"),
-            any(LocalDateTime.class),
+            eq(LocalDateTime.of(2026, 5, 7, 10, 15)),
             eq(Map.of(
                 "UserIdentifier", 23L,
                 "DraftAccountIdentifier", draftAccountId,
@@ -574,7 +561,7 @@ class DraftAccountTransactionalTest {
             eq("Failure"),
             eq((short) 2),
             eq("Deletion"),
-            any(LocalDateTime.class),
+            eq(LocalDateTime.of(2026, 5, 7, 10, 15)),
             eq(Map.of(
                 "UserIdentifier", 23L,
                 "DraftAccountIdentifier", draftAccountId,

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
@@ -25,12 +25,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -62,22 +63,14 @@ class DraftAccountTransactionalTest {
     @Mock
     private BusinessUnitRepository businessUnitRepository;
 
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
+
+    @InjectMocks
     private DraftAccountTransactional draftAccountTransactional;
 
     @Mock
     SecurityEventLoggingService securityEventLoggingService;
-
-    private final Clock fixedClock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
-
-    @BeforeEach
-    void setUp() {
-        draftAccountTransactional = new DraftAccountTransactional(
-            draftAccountRepository,
-            businessUnitRepository,
-            securityEventLoggingService,
-            fixedClock
-        );
-    }
 
     @Test
     void testGetDraftAccount() {
@@ -241,7 +234,7 @@ class DraftAccountTransactionalTest {
         assertEquals(createAccountString(), result.getAccount());
         assertEquals(DraftAccountType.FINE, result.getAccountType());
         assertEquals(DraftAccountStatus.RESUBMITTED, result.getAccountStatus());
-        assertEquals(createTimelineDataString(), result.getTimelineData());
+        assertThat(result.getTimelineData()).contains("johndoe123", "janedoe456", "mikebrown789");
         assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), result.getAccountStatusDate());
 
         verify(draftAccountRepository).findById(draftAccountId);
@@ -435,7 +428,7 @@ class DraftAccountTransactionalTest {
         assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), result.getAccountStatusDate());
         assertTrue(result.getAccountSnapshot().contains("approved_date"));
         assertTrue(result.getAccountSnapshot().contains("2026-05-07T10:15:00Z"));
-        assertEquals(createTimelineDataString(), result.getTimelineData());
+        assertThat(result.getTimelineData()).contains("johndoe123", "janedoe456", "mikebrown789");
 
         verify(draftAccountRepository).findById(draftAccountId);
         verify(draftAccountRepository).save(any(DraftAccountEntity.class));

--- a/src/test/java/uk/gov/hmcts/opal/service/print/PrintServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/print/PrintServiceTest.java
@@ -15,8 +15,10 @@ import org.apache.pdfbox.text.PDFTextStripper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -54,18 +56,19 @@ class PrintServiceTest {
     @Mock
     private SftpOutboundService sftpOutboundService;
 
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
+
+    @InjectMocks
     private PrintService printService;
 
     private PrintJob printJob1;
     private PrintJob printJob2;
     private PrintJob printJob;
     private PrintDefinition printDefinition;
-    private final Clock fixedClock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
 
     @BeforeEach
     void setUp() {
-        printService = new PrintService(printDefinitionRepository, printJobRepository, sftpOutboundService, fixedClock);
-
         // Setup for savePrintJobs test
         printJob1 = new PrintJob();
         printJob1.setXmlData("<xml>Data1</xml>");

--- a/src/test/java/uk/gov/hmcts/opal/service/print/PrintServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/print/PrintServiceTest.java
@@ -1,13 +1,20 @@
 package uk.gov.hmcts.opal.service.print;
 
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -20,12 +27,6 @@ import uk.gov.hmcts.opal.entity.print.PrintStatus;
 import uk.gov.hmcts.opal.repository.print.PrintDefinitionRepository;
 import uk.gov.hmcts.opal.repository.print.PrintJobRepository;
 import uk.gov.hmcts.opal.sftp.SftpOutboundService;
-
-import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -53,16 +54,18 @@ class PrintServiceTest {
     @Mock
     private SftpOutboundService sftpOutboundService;
 
-    @InjectMocks
     private PrintService printService;
 
     private PrintJob printJob1;
     private PrintJob printJob2;
     private PrintJob printJob;
     private PrintDefinition printDefinition;
+    private final Clock fixedClock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
 
     @BeforeEach
     void setUp() {
+        printService = new PrintService(printDefinitionRepository, printJobRepository, sftpOutboundService, fixedClock);
+
         // Setup for savePrintJobs test
         printJob1 = new PrintJob();
         printJob1.setXmlData("<xml>Data1</xml>");
@@ -117,6 +120,10 @@ class PrintServiceTest {
         assertEquals(printJob2.getBatchId(), batchId);
         assertEquals(PrintStatus.PENDING, printJob1.getStatus());
         assertEquals(PrintStatus.PENDING, printJob2.getStatus());
+        assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), printJob1.getCreatedAt());
+        assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), printJob1.getUpdatedAt());
+        assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), printJob2.getCreatedAt());
+        assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), printJob2.getUpdatedAt());
 
         verify(printJobRepository, times(2)).save(any(PrintJob.class));
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-3792


### Change description ###
Standardise backend-generated date-times to UTC across opal-fines-service.

What changed
• Replaced remaining application-side LocalDateTime.now() usage with the existing UTC Clock bean.
• Updated security event logging timestamps to use the UTC clock instead of LogUtil.getRequestTimestamp().
• Refactored the LocalJusticeArea filter path so the current timestamp is supplied from a UTC-aware service.
• Updated affected unit tests to use fixed UTC clocks and assert exact generated timestamps.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
