### PR TITLE
PO-2878: Add Content Digest Interceptor/Filter and integration tests

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/opal/steps/ContentDigestStepDef.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/steps/ContentDigestStepDef.java
@@ -1,0 +1,69 @@
+package uk.gov.hmcts.opal.steps;
+
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import io.restassured.specification.RequestSpecification;
+import net.serenitybdd.rest.SerenityRest;
+
+import java.util.Map;
+
+import static net.serenitybdd.rest.SerenityRest.then;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.hmcts.opal.utils.ContentDigestUtils.contentDigestHeaderForEmptyBody;
+import static uk.gov.hmcts.opal.utils.ContentDigestUtils.invalidContentDigestHeader;
+import static uk.gov.hmcts.opal.utils.ContentDigestUtils.malformedContentDigestHeader;
+
+public class ContentDigestStepDef extends BaseStepDef {
+
+    private static final String CONTENT_DIGEST = "Content-Digest";
+
+    @When("I make a content digest request without a Content-Digest header")
+    public void getRootWithoutContentDigestHeader() {
+        getRoot(Map.of("Accept", "*/*"));
+    }
+
+    @When("I make a content digest request with a valid Content-Digest header")
+    public void getRootWithValidContentDigestHeader() {
+        getRoot(Map.of("Accept", "*/*", CONTENT_DIGEST, contentDigestHeaderForEmptyBody()));
+    }
+
+    @When("I make a content digest request with an invalid Content-Digest header")
+    public void getRootWithInvalidContentDigestHeader() {
+        getRoot(Map.of("Accept", "*/*", CONTENT_DIGEST, invalidContentDigestHeader()));
+    }
+
+    @When("I make a content digest request with a malformed Content-Digest header")
+    public void getRootWithMalformedContentDigestHeader() {
+        getRoot(Map.of("Accept", "*/*", CONTENT_DIGEST, malformedContentDigestHeader()));
+    }
+
+    @Then("The content digest response returns {int}")
+    public void contentDigestResponseReturns(int statusCode) {
+        then()
+            .log().ifValidationFails()
+            .statusCode(statusCode);
+    }
+
+    @Then("The content digest response does not contain a Content-Digest header")
+    public void responseDoesNotContainContentDigestHeader() {
+        assertThat(SerenityRest.lastResponse().getHeader(CONTENT_DIGEST)).isNull();
+    }
+
+    @Then("The content digest response contains the following")
+    public void responseContainsTheFollowing(DataTable data) {
+        Map<String, String> expectedData = data.asMap(String.class, String.class);
+
+        expectedData.forEach((field, expected) ->
+            assertEquals(expected, SerenityRest.lastResponse().jsonPath().getString(field),
+                "Unexpected response field '" + field + "'"));
+    }
+
+    private static void getRoot(Map<String, String> headers) {
+        RequestSpecification request = SerenityRest.given();
+        headers.forEach(request::header);
+        request.when().get(getTestUrl() + "/");
+    }
+
+}

--- a/src/functionalTest/java/uk/gov/hmcts/opal/utils/ContentDigestUtils.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/utils/ContentDigestUtils.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.opal.utils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+public final class ContentDigestUtils {
+
+    private static final byte[] EMPTY_BODY = new byte[0];
+
+    private ContentDigestUtils() {
+    }
+
+    public static String contentDigestHeaderForEmptyBody() {
+        return contentDigestHeaderFor(EMPTY_BODY);
+    }
+
+    public static String invalidContentDigestHeader() {
+        return contentDigestHeaderFor("different".getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static String malformedContentDigestHeader() {
+        return "not-a-digest";
+    }
+
+    private static String contentDigestHeaderFor(byte[] content) {
+        try {
+            MessageDigest messageDigest = MessageDigest.getInstance("SHA-512");
+            String digest = Base64.getEncoder().encodeToString(messageDigest.digest(content));
+            return "sha-512=:" + digest + ":";
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-512 digest algorithm is not available", e);
+        }
+    }
+}

--- a/src/functionalTest/resources/features/opalMode/contentDigest/ContentDigest.feature
+++ b/src/functionalTest/resources/features/opalMode/contentDigest/ContentDigest.feature
@@ -1,0 +1,25 @@
+@Opal @JIRA-LABEL:content-digest @JIRA-STORY:PO-2878
+Feature: Content-Digest handling
+
+  Scenario: Missing request Content-Digest succeeds when content digest is disabled
+    When I make a content digest request without a Content-Digest header
+    Then The content digest response returns 200
+    And The content digest response does not contain a Content-Digest header
+
+  Scenario: Valid request Content-Digest succeeds
+    When I make a content digest request with a valid Content-Digest header
+    Then The content digest response returns 200
+
+  Scenario: Invalid request Content-Digest returns a problem response
+    When I make a content digest request with an invalid Content-Digest header
+    Then The content digest response returns 400
+    And The content digest response contains the following
+      | title  | Digest validation failed                      |
+      | detail | Body hash did not match for algorithm: sha-512 |
+
+  Scenario: Malformed request Content-Digest returns a problem response
+    When I make a content digest request with a malformed Content-Digest header
+    Then The content digest response returns 400
+    And The content digest response contains the following
+      | title  | Invalid Content-Digest header          |
+      | detail | No valid digest entries found in header. |

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/AbstractContentDigestIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/AbstractContentDigestIntegrationTest.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.opal.controllers;
+
+import org.springframework.test.web.servlet.MvcResult;
+import uk.gov.hmcts.opal.AbstractIntegrationTest;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+abstract class AbstractContentDigestIntegrationTest extends AbstractIntegrationTest {
+
+    protected static final String CONTENT_DIGEST = "Content-Digest";
+    protected static final String ROOT_ENDPOINT = "/";
+
+    private static final byte[] EMPTY_BODY = new byte[0];
+
+    protected static String validEmptyBodyDigest() throws NoSuchAlgorithmException {
+        return contentDigestHeaderFor(EMPTY_BODY);
+    }
+
+    protected static String invalidDigest() throws NoSuchAlgorithmException {
+        return contentDigestHeaderFor("different".getBytes(StandardCharsets.UTF_8));
+    }
+
+    protected static String malformedDigest() {
+        return "not-a-digest";
+    }
+
+    protected static void assertContentDigestProblem(MvcResult result, String title, String detail) throws Exception {
+        jsonPath("$.type").value("https://hmcts.gov.uk/problems/content-digest").match(result);
+        jsonPath("$.title").value(title).match(result);
+        jsonPath("$.detail").value(detail).match(result);
+    }
+
+    protected static void assertValidResponseDigest(MvcResult result) throws NoSuchAlgorithmException {
+        byte[] body = result.getResponse().getContentAsByteArray();
+        assertThat(result.getResponse().getHeader(CONTENT_DIGEST)).isEqualTo(contentDigestHeaderFor(body));
+    }
+
+    private static String contentDigestHeaderFor(byte[] content) throws NoSuchAlgorithmException {
+        MessageDigest messageDigest = MessageDigest.getInstance("SHA-512");
+        String digest = Base64.getEncoder().encodeToString(messageDigest.digest(content));
+        return "sha-512=:" + digest + ":";
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ContentDigestIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ContentDigestIntegrationTest.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.opal.controllers;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Content-Digest default configuration integration tests")
+class ContentDigestIntegrationTest extends AbstractContentDigestIntegrationTest {
+
+    @Test
+    void missingHeader_returnsSuccessWithoutResponseContentDigest() throws Exception {
+        mockMvc.perform(get(ROOT_ENDPOINT))
+            .andExpect(status().isOk())
+            .andExpect(header().doesNotExist(CONTENT_DIGEST));
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ContentDigestRequestAndResponseIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ContentDigestRequestAndResponseIntegrationTest.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.opal.controllers;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Content-Digest request and response integration tests")
+@TestPropertySource(properties = {
+    "opal.common.content-digest.request.enforce=false",
+    "opal.common.content-digest.request.auto-generate=true",
+    "opal.common.content-digest.response.enforce=true"
+})
+class ContentDigestRequestAndResponseIntegrationTest extends AbstractContentDigestIntegrationTest {
+
+    @Test
+    void invalidHeaderWhenEnforced_returnsContentDigestProblemResponse() throws Exception {
+        MvcResult result = mockMvc.perform(get(ROOT_ENDPOINT).header(CONTENT_DIGEST, invalidDigest()))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+        assertContentDigestProblem(result, "Digest validation failed",
+            "Body hash did not match for algorithm: sha-512");
+        assertValidResponseDigest(result);
+    }
+
+    @Test
+    void malformedHeaderWhenEnforced_returnsContentDigestProblemResponse() throws Exception {
+        MvcResult result = mockMvc.perform(get(ROOT_ENDPOINT).header(CONTENT_DIGEST, malformedDigest()))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+        assertContentDigestProblem(result, "Invalid Content-Digest header",
+            "No valid digest entries found in header.");
+        assertValidResponseDigest(result);
+    }
+
+    @Test
+    void validHeaderWhenEnforced_returnsSuccessWithResponseContentDigest() throws Exception {
+        MvcResult result = mockMvc.perform(get(ROOT_ENDPOINT).header(CONTENT_DIGEST, validEmptyBodyDigest()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        assertValidResponseDigest(result);
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ContentDigestResponseGenerationIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ContentDigestResponseGenerationIntegrationTest.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.opal.controllers;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Content-Digest response generation integration tests")
+@TestPropertySource(properties = {
+    "opal.common.content-digest.request.enforce=false",
+    "opal.common.content-digest.request.auto-generate=true",
+    "opal.common.content-digest.response.enforce=false"
+})
+class ContentDigestResponseGenerationIntegrationTest extends AbstractContentDigestIntegrationTest {
+
+    @Test
+    void missingHeader_returnsSuccessWithResponseContentDigest() throws Exception {
+        MvcResult result = mockMvc.perform(get(ROOT_ENDPOINT))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        assertValidResponseDigest(result);
+    }
+
+    @Test
+    void invalidHeader_returnsContentDigestProblemResponse() throws Exception {
+        MvcResult result = mockMvc.perform(get(ROOT_ENDPOINT).header(CONTENT_DIGEST, invalidDigest()))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+        assertContentDigestProblem(result, "Digest validation failed",
+            "Body hash did not match for algorithm: sha-512");
+        assertValidResponseDigest(result);
+    }
+
+    @Test
+    void malformedHeader_returnsContentDigestProblemResponse() throws Exception {
+        MvcResult result = mockMvc.perform(get(ROOT_ENDPOINT).header(CONTENT_DIGEST, malformedDigest()))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+        assertContentDigestProblem(result, "Invalid Content-Digest header",
+            "No valid digest entries found in header.");
+        assertValidResponseDigest(result);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -150,6 +150,15 @@ opal:
     password: ${OPAL_TEST_USER_PASSWORD}
   common:
     domain: fines
+    content-digest:
+      request:
+        enforce: ${OPAL_COMMON_CONTENT_DIGEST_REQUEST_ENFORCE:false}
+        auto-generate: ${OPAL_COMMON_CONTENT_DIGEST_REQUEST_AUTO_GENERATE:false}
+      response:
+        enforce: ${OPAL_COMMON_CONTENT_DIGEST_RESPONSE_ENFORCE:false}
+        algorithm: ${OPAL_COMMON_CONTENT_DIGEST_RESPONSE_ALGORITHM:SHA-512}
+      supported-algorithms:
+        sha-512: SHA-512
 
   report:
     storage:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-2878
BE - Add Content Digest interceptor and filter - Fines service

### Change description ###
- Added Content-Digest support to `opal-fines-service` using the shared common-lib interceptor/filter, configured under `opal.common.content-digest`
- Added integration coverage for Content-Digest request validation and response generation
- Added functional coverage for missing, valid, invalid, and malformed Content-Digest headers

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
