### PR TITLE
PO-2833 : fixing IT config so env variable not used for user service URL

### DIFF
--- a/src/integrationTest/resources/application-integration-with-spring-security.yaml
+++ b/src/integrationTest/resources/application-integration-with-spring-security.yaml
@@ -39,11 +39,11 @@ testcontainers:
   reuse:
     enable: true
 legacy-gateway:
-  url: ${OPAL_LEGACY_GATEWAY_URL:http://localhost:4553/opal}
+  url: http://localhost:4553/opal
 
 user:
   service:
-    url: ${OPAL_USER_SERVICE_API_URL:http://localhost:4553/opal}
+    url: http://localhost:4553/opal
 
 security-it:
   key: ...some random string...

--- a/src/integrationTest/resources/application-integration.yaml
+++ b/src/integrationTest/resources/application-integration.yaml
@@ -41,11 +41,11 @@ testcontainers:
   reuse:
     enable: true
 legacy-gateway:
-  url: ${OPAL_LEGACY_GATEWAY_URL:http://localhost:4553/opal}
+  url: http://localhost:4553/opal
 opal:
   report:
     consumer:
       enabled: false
 user:
   service:
-    url: ${OPAL_USER_SERVICE_API_URL:http://localhost:4553/opal}
+    url: http://localhost:4553/opal


### PR DESCRIPTION
IT config should not use env variables for user service URL. We always want to localhost WireMock endpoint