### PR TITLE
Tidy up: Make env var and constant names for feature flags consistent

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiController.java
@@ -35,7 +35,7 @@ public class MinorCreditorApiController implements MinorCreditorApi {
     @Override
     @FeatureToggle(
         feature = FeatureFlags.RELEASE_1B,
-        defaultValueProperty = FeatureFlags.RELEASE_1B_DEFAULT_VALUE_PROPERTY
+        defaultValueProperty = FeatureFlags.RELEASE_1B_ENABLED_PROPERTY
     )
     public ResponseEntity<MinorCreditorAccountResponseMinorCreditor> patchMinorCreditorAccount(
         Long id,

--- a/src/main/java/uk/gov/hmcts/opal/util/FeatureFlags.java
+++ b/src/main/java/uk/gov/hmcts/opal/util/FeatureFlags.java
@@ -6,7 +6,7 @@ public final class FeatureFlags {
     public static final String RELEASE_1A = "release-1a";
     public static final String RELEASE_1A_ENABLED_PROPERTY = DEFAULT_VALUE_PROPERTY_PREFIX + RELEASE_1A;
     public static final String RELEASE_1B = "release-1b";
-    public static final String RELEASE_1B_DEFAULT_VALUE_PROPERTY = DEFAULT_VALUE_PROPERTY_PREFIX + RELEASE_1B;
+    public static final String RELEASE_1B_ENABLED_PROPERTY = DEFAULT_VALUE_PROPERTY_PREFIX + RELEASE_1B;
 
     private FeatureFlags() {
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -122,8 +122,8 @@ launchdarkly:
   file:
     - ${LAUNCH_DARKLY_FILE:bin/utils/launchdarkly-flags.json}
   default-flag-values:
-    release-1a: ${LAUNCH_DARKLY_FLAG_RELEASE_1A:true}
-    release-1b: ${LAUNCH_DARKLY_RELEASE_1B:false}
+    release-1a: ${RELEASE_1A_ENABLED:true}
+    release-1b: ${RELEASE_1B_ENABLED:false}
 
 opal:
   redis:


### PR DESCRIPTION

### Change description ###

This is a small PR to make the feature flags names on env and constants the consistent. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
