### PR TITLE
PO-2132 Add Opal Major Creditor At-A-Glance

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MajorCreditorAccountControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MajorCreditorAccountControllerIntegrationTest.java
@@ -1,0 +1,266 @@
+package uk.gov.hmcts.opal.controllers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.REQUEST_TIMEOUT;
+import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.controllers.util.UserStateUtil.allPermissionsUser;
+import static uk.gov.hmcts.opal.controllers.util.UserStateUtil.permissionUser;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
+import uk.gov.hmcts.opal.AbstractIntegrationTest;
+import uk.gov.hmcts.opal.SchemaPaths;
+import uk.gov.hmcts.opal.dto.ToJsonString;
+import uk.gov.hmcts.opal.service.UserStateService;
+import uk.gov.hmcts.opal.service.opal.JsonSchemaValidationService;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
+
+@ActiveProfiles({"integration", "opal"})
+@TestPropertySource(properties = {
+    "launchdarkly.enabled=false",
+    "launchdarkly.default-flag-values.release-1b=true"
+})
+@Sql(scripts = "classpath:db/insertData/insert_into_major_creditor_accounts_at_a_glance.sql",
+    executionPhase = BEFORE_TEST_METHOD)
+@Sql(scripts = "classpath:db/deleteData/delete_from_major_creditor_accounts_at_a_glance.sql",
+    executionPhase = AFTER_TEST_METHOD)
+@Slf4j(topic = "opal.MajorCreditorAccountControllerIntegrationTest")
+@DisplayName("Major Creditor Account Controller Integration Tests")
+class MajorCreditorAccountControllerIntegrationTest extends AbstractIntegrationTest {
+
+    private static final String URL_BASE = "/major-creditor-accounts";
+    private static final String RESPONSE_SCHEMA = SchemaPaths.GET_MAJOR_CREDITOR_ACCOUNT_AT_A_GLANCE_RESPONSE;
+
+    @MockitoBean
+    private UserStateService userStateService;
+
+    @MockitoSpyBean
+    private JsonSchemaValidationService jsonSchemaValidationService;
+
+    @Test
+    @JiraStory("PO-2132")
+    @JiraEpic("PO-2122")
+    @DisplayName("PO-2132: GET /major-creditor-accounts/{id}/at-a-glance returns 200 for a major creditor account")
+    void getAtAGlance_returnsMajorCreditorResponse() throws Exception {
+        when(userStateService.checkForAuthorisedUser(any())).thenReturn(allPermissionsUser());
+
+        ResultActions resultActions = mockMvc.perform(get(URL_BASE + "/{id}/at-a-glance", 978010L)
+            .header("authorization", "Bearer some_value"));
+
+        String body = resultActions.andReturn().getResponse().getContentAsString();
+        log.info(":getAtAGlance_returnsMajorCreditorResponse: Response body:\n{}", ToJsonString.toPrettyJson(body));
+
+        resultActions.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(header().string("ETag", "\"7\""))
+            .andExpect(jsonPath("$.major_creditor.creditor_account_id").value(978010))
+            .andExpect(jsonPath("$.major_creditor.name").value("Major Creditor Services Ltd"))
+            .andExpect(jsonPath("$.major_creditor.code").value("MC01"))
+            .andExpect(jsonPath("$.major_creditor.pay_by_bacs").value(true))
+            .andExpect(jsonPath("$.major_creditor.address.address_line_1").value("1 Credit Lane"))
+            .andExpect(jsonPath("$.major_creditor.address.address_line_2").value("Creditville"))
+            .andExpect(jsonPath("$.major_creditor.address.address_line_3").value("Credittown"))
+            .andExpect(jsonPath("$.major_creditor.address.postcode").value("MC1 1AA"))
+            .andExpect(jsonPath("$.major_creditor.account_version").doesNotExist())
+            .andExpect(jsonPath("$.major_creditor.bacs_details").doesNotExist());
+
+        jsonSchemaValidationService.validateOrError(body, RESPONSE_SCHEMA);
+    }
+
+    @Test
+    @JiraStory("PO-2132")
+    @JiraEpic("PO-2122")
+    @DisplayName(
+        "PO-2132: GET /major-creditor-accounts/{id}/at-a-glance returns central fund fields without MJ-only values"
+    )
+    void getAtAGlance_returnsCentralFundResponse() throws Exception {
+        when(userStateService.checkForAuthorisedUser(any())).thenReturn(allPermissionsUser());
+
+        ResultActions resultActions = mockMvc.perform(get(URL_BASE + "/{id}/at-a-glance", 978011L)
+            .header("authorization", "Bearer some_value"));
+
+        String body = resultActions.andReturn().getResponse().getContentAsString();
+        log.info(":getAtAGlance_returnsCentralFundResponse: Response body:\n{}", ToJsonString.toPrettyJson(body));
+
+        resultActions.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(header().string("ETag", "\"3\""))
+            .andExpect(jsonPath("$.major_creditor.creditor_account_id").value(978011))
+            .andExpect(jsonPath("$.major_creditor.name").value("HM Courts & Tribunals Service"))
+            .andExpect(jsonPath("$.major_creditor.code").doesNotExist())
+            .andExpect(jsonPath("$.major_creditor.pay_by_bacs").doesNotExist())
+            .andExpect(jsonPath("$.major_creditor.address.address_line_1").value("HMCS add 1"))
+            .andExpect(jsonPath("$.major_creditor.address.address_line_2").value("HMCS add 2"))
+            .andExpect(jsonPath("$.major_creditor.address.address_line_3").value("HMCS add 3"))
+            .andExpect(jsonPath("$.major_creditor.address.postcode").doesNotExist());
+
+        jsonSchemaValidationService.validateOrError(body, RESPONSE_SCHEMA);
+    }
+
+    @Test
+    @JiraStory("PO-2132")
+    @JiraEpic("PO-2122")
+    @DisplayName("PO-2132: GET /major-creditor-accounts/{id}/at-a-glance returns 200 when permission exists in same BU")
+    void getAtAGlance_returnsOkWhenUserHasPermissionInSameBusinessUnit() throws Exception {
+        when(userStateService.checkForAuthorisedUser(any()))
+            .thenReturn(permissionUser((short) 978, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS));
+
+        mockMvc.perform(get(URL_BASE + "/{id}/at-a-glance", 978010L)
+                .header("authorization", "Bearer some_value"))
+            .andExpect(status().isOk())
+            .andExpect(header().string("ETag", "\"7\""));
+    }
+
+    @Test
+    @JiraStory("PO-2132")
+    @JiraEpic("PO-2122")
+    @DisplayName(
+        "PO-2132: GET /major-creditor-accounts/{id}/at-a-glance returns 200 when permission exists in different BU"
+    )
+    void getAtAGlance_returnsOkWhenUserHasPermissionInDifferentBusinessUnit() throws Exception {
+        when(userStateService.checkForAuthorisedUser(any()))
+            .thenReturn(permissionUser((short) 77, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS));
+
+        mockMvc.perform(get(URL_BASE + "/{id}/at-a-glance", 978010L)
+                .header("authorization", "Bearer some_value"))
+            .andExpect(status().isOk())
+            .andExpect(header().string("ETag", "\"7\""));
+    }
+
+    @Test
+    @JiraStory("PO-2132")
+    @JiraEpic("PO-2122")
+    @DisplayName(
+        "PO-2132: GET /major-creditor-accounts/{id}/at-a-glance returns consistent body and ETag on repeated requests"
+    )
+    void getAtAGlance_returnsConsistentBodyAndEtag() throws Exception {
+        when(userStateService.checkForAuthorisedUser(any())).thenReturn(allPermissionsUser());
+
+        ResultActions first = mockMvc.perform(get(URL_BASE + "/{id}/at-a-glance", 978010L)
+            .header("authorization", "Bearer some_value"));
+        ResultActions second = mockMvc.perform(get(URL_BASE + "/{id}/at-a-glance", 978010L)
+            .header("authorization", "Bearer some_value"));
+
+        String firstBody = first.andReturn().getResponse().getContentAsString();
+        String secondBody = second.andReturn().getResponse().getContentAsString();
+        String firstEtag = first.andReturn().getResponse().getHeader("ETag");
+        String secondEtag = second.andReturn().getResponse().getHeader("ETag");
+
+        org.junit.jupiter.api.Assertions.assertEquals(firstBody, secondBody);
+        org.junit.jupiter.api.Assertions.assertEquals(firstEtag, secondEtag);
+    }
+
+    @Test
+    @JiraStory("PO-2132")
+    @JiraEpic("PO-2122")
+    @DisplayName("PO-2132: GET /major-creditor-accounts/{id}/at-a-glance returns 404 for an unknown account")
+    void getAtAGlance_returnsNotFoundForUnknownAccount() throws Exception {
+        when(userStateService.checkForAuthorisedUser(any())).thenReturn(allPermissionsUser());
+
+        mockMvc.perform(get(URL_BASE + "/{id}/at-a-glance", 999999L)
+                .header("authorization", "Bearer some_value"))
+            .andExpect(status().isNotFound())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.status").value(404))
+            .andExpect(jsonPath("$.retriable").value(false));
+    }
+
+    @Test
+    @JiraStory("PO-2132")
+    @JiraEpic("PO-2122")
+    @DisplayName("PO-2132: GET /major-creditor-accounts/{id}/at-a-glance returns 401 when authentication fails")
+    void getAtAGlance_returnsUnauthorized() throws Exception {
+        doThrow(new ResponseStatusException(UNAUTHORIZED, "Unauthorized"))
+            .when(userStateService).checkForAuthorisedUser(any());
+
+        mockMvc.perform(get(URL_BASE + "/{id}/at-a-glance", 978010L))
+            .andExpect(status().isUnauthorized())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.detail").value("Unauthorized"))
+            .andExpect(jsonPath("$.retriable").value(false));
+    }
+
+    @Test
+    @JiraStory("PO-2132")
+    @JiraEpic("PO-2122")
+    @DisplayName("PO-2132: GET /major-creditor-accounts/{id}/at-a-glance returns 403 when permission is missing")
+    void getAtAGlance_returnsForbidden() throws Exception {
+        doThrow(new ResponseStatusException(FORBIDDEN, "Forbidden"))
+            .when(userStateService).checkForAuthorisedUser(any());
+
+        mockMvc.perform(get(URL_BASE + "/{id}/at-a-glance", 978010L)
+                .header("authorization", "Bearer some_value"))
+            .andExpect(status().isForbidden())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.detail").value("Forbidden"))
+            .andExpect(jsonPath("$.retriable").value(false));
+    }
+
+    @Test
+    @JiraStory("PO-2132")
+    @JiraEpic("PO-2122")
+    @DisplayName("PO-2132: GET /major-creditor-accounts/{id}/at-a-glance returns 408 on timeout")
+    void getAtAGlance_returnsRequestTimeout() throws Exception {
+        doThrow(new ResponseStatusException(REQUEST_TIMEOUT, "Timeout"))
+            .when(userStateService).checkForAuthorisedUser(any());
+
+        mockMvc.perform(get(URL_BASE + "/{id}/at-a-glance", 978010L)
+                .header("authorization", "Bearer some_value"))
+            .andExpect(status().isRequestTimeout())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.detail").value("Timeout"));
+    }
+
+    @Test
+    @JiraStory("PO-2132")
+    @JiraEpic("PO-2122")
+    @DisplayName("PO-2132: GET /major-creditor-accounts/{id}/at-a-glance returns 503 when service is unavailable")
+    void getAtAGlance_returnsServiceUnavailable() throws Exception {
+        doThrow(new ResponseStatusException(SERVICE_UNAVAILABLE, "Gateway down"))
+            .when(userStateService).checkForAuthorisedUser(any());
+
+        mockMvc.perform(get(URL_BASE + "/{id}/at-a-glance", 978010L)
+                .header("authorization", "Bearer some_value"))
+            .andExpect(status().isServiceUnavailable())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.detail").value("Gateway down"));
+    }
+
+    @Test
+    @JiraStory("PO-2132")
+    @JiraEpic("PO-2122")
+    @DisplayName("PO-2132: GET /major-creditor-accounts/{id}/at-a-glance returns 500 on server error")
+    void getAtAGlance_returnsInternalServerError() throws Exception {
+        doThrow(new ResponseStatusException(INTERNAL_SERVER_ERROR, "Boom"))
+            .when(userStateService).checkForAuthorisedUser(any());
+
+        mockMvc.perform(get(URL_BASE + "/{id}/at-a-glance", 978010L)
+                .header("authorization", "Bearer some_value"))
+            .andExpect(status().isInternalServerError())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.detail").value("Boom"));
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/util/Release1bFeatureToggleRequestUtil.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/util/Release1bFeatureToggleRequestUtil.java
@@ -19,6 +19,7 @@ public final class Release1bFeatureToggleRequestUtil {
     private static final String IF_MATCH = "\"0\"";
     private static final String DEFENDANT_ACCOUNT_ID = "999999";
     private static final String DEFENDANT_ACCOUNT_PARTY_ID = "999999";
+    private static final String MAJOR_CREDITOR_ACCOUNT_ID = "999999";
     private static final String MINOR_CREDITOR_ACCOUNT_ID = "999999";
 
     private Release1bFeatureToggleRequestUtil() {
@@ -256,6 +257,10 @@ public final class Release1bFeatureToggleRequestUtil {
                       "account_number": "12345678"
                     }
                     """)
+            ),
+            Arguments.of(
+                "Get Major Creditor Account At A Glance",
+                getWithAuthorization("/major-creditor-accounts/" + MAJOR_CREDITOR_ACCOUNT_ID + "/at-a-glance")
             ),
             Arguments.of(
                 "Get Minor Creditor Account Header Summary",

--- a/src/integrationTest/resources/db/deleteData/delete_from_major_creditor_accounts_at_a_glance.sql
+++ b/src/integrationTest/resources/db/deleteData/delete_from_major_creditor_accounts_at_a_glance.sql
@@ -1,0 +1,4 @@
+DELETE FROM configuration_items WHERE configuration_item_id = 978020;
+DELETE FROM creditor_accounts WHERE creditor_account_id IN (978010, 978011);
+DELETE FROM major_creditors WHERE major_creditor_id = 978001;
+DELETE FROM business_units WHERE business_unit_id = 978;

--- a/src/integrationTest/resources/db/insertData/insert_into_major_creditor_accounts_at_a_glance.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_major_creditor_accounts_at_a_glance.sql
@@ -1,0 +1,47 @@
+INSERT INTO business_units (
+    business_unit_id, business_unit_name, business_unit_code, business_unit_type,
+    account_number_prefix, parent_business_unit_id, opal_domain, welsh_language
+)
+VALUES
+    (978, 'Major Creditor BU', 'MCBU', 'Area', 'MC', NULL, 'Fines', false)
+ON CONFLICT (business_unit_id) DO NOTHING;
+
+INSERT INTO major_creditors (
+    major_creditor_id, business_unit_id, major_creditor_code,
+    name, address_line_1, address_line_2, address_line_3, postcode
+)
+VALUES (
+    978001, 978, 'MC01',
+    'Major Creditor Services Ltd', '1 Credit Lane', 'Creditville', 'Credittown', 'MC1 1AA'
+);
+
+INSERT INTO creditor_accounts (
+    creditor_account_id, business_unit_id, account_number,
+    creditor_account_type, prosecution_service, major_creditor_id,
+    minor_creditor_party_id, from_suspense, hold_payout, pay_by_bacs,
+    bank_sort_code, bank_account_number, bank_account_name,
+    bank_account_reference, bank_account_type, version_number, last_changed_date
+)
+VALUES
+    (
+        978010, 978, 'MC123456',
+        'MJ', false, 978001,
+        NULL, false, false, true,
+        '112233', '12345678', 'Major Creditor',
+        'MCREF001', '1', 7, '2026-02-27 10:00:00'
+    ),
+    (
+        978011, 978, 'CF123456',
+        'CF', false, NULL,
+        NULL, false, false, false,
+        NULL, NULL, NULL,
+        NULL, NULL, 3, '2026-02-27 10:05:00'
+    );
+
+INSERT INTO configuration_items (
+    configuration_item_id, item_name, business_unit_id, item_value, item_values
+)
+VALUES (
+    978020, 'CENTRAL_FUND_ACCOUNT', 978, NULL,
+    '{"name":"HM Courts & Tribunals Service","address_line_1":"HMCS add 1","address_line_2":"HMCS add 2","address_line_3":"HMCS add 3","pay_by_bacs":"N"}'
+);

--- a/src/main/java/uk/gov/hmcts/opal/SchemaPaths.java
+++ b/src/main/java/uk/gov/hmcts/opal/SchemaPaths.java
@@ -4,6 +4,7 @@ public class SchemaPaths {
 
     public static final String DEFENDANT_ACCOUNT = "opal/defendant-account";
     public static final String DRAFT_ACCOUNT = "opal/draft-account";
+    public static final String MAJOR_CREDITOR = "opal/major-creditor";
     public static final String PAYMENT_TERMS = "opal/payment-terms";
     public static final String REFERENCE_DATA = "opal/reference-data";
     public static final String TIMELINE = "opal/timeline";
@@ -35,6 +36,9 @@ public class SchemaPaths {
 
     public static final String GET_DEFENDANT_ACCOUNT_IMPOSITIONS_RESPONSE =
         DEFENDANT_ACCOUNT + "/getDefendantAccountImpositionsResponse.json";
+
+    public static final String GET_MAJOR_CREDITOR_ACCOUNT_AT_A_GLANCE_RESPONSE =
+        MAJOR_CREDITOR + "/getMajorCreditorAccountAtAGlanceResponse.json";
 
     public static final String POST_DEFENDANT_ACCOUNT_ADD_PARTY = DEFENDANT_ACCOUNT
         + "/addDefendantAccountPartyRequest.json";

--- a/src/main/java/uk/gov/hmcts/opal/controllers/MajorCreditorAccountController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/MajorCreditorAccountController.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.opal.controllers;
+
+import static uk.gov.hmcts.opal.util.FeatureFlags.RELEASE_1B;
+import static uk.gov.hmcts.opal.util.FeatureFlags.RELEASE_1B_ENABLED_PROPERTY;
+import static uk.gov.hmcts.opal.util.HttpUtil.buildResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.opal.common.launchdarkly.FeatureToggle;
+import uk.gov.hmcts.opal.dto.GetMajorCreditorAccountAtAGlanceResponse;
+import uk.gov.hmcts.opal.service.MajorCreditorAccountService;
+
+@RestController
+@RequestMapping("/major-creditor-accounts")
+@Slf4j(topic = "opal.MajorCreditorAccountController")
+@RequiredArgsConstructor
+@Tag(name = "Major Creditor Account Controller")
+public class MajorCreditorAccountController {
+
+    private final MajorCreditorAccountService majorCreditorAccountService;
+
+    @GetMapping(value = "/{creditorAccountId}/at-a-glance")
+    @Operation(summary = "Get Major Creditor Account At A Glance")
+    @FeatureToggle(feature = RELEASE_1B, defaultValueProperty = RELEASE_1B_ENABLED_PROPERTY)
+    public ResponseEntity<GetMajorCreditorAccountAtAGlanceResponse> getAtAGlance(
+        @PathVariable Long creditorAccountId,
+        @RequestHeader(value = "Authorization", required = false) String authHeaderValue
+    ) {
+        log.debug(":GET:getAtAGlance: creditorAccountId={}", creditorAccountId);
+
+        return buildResponse(majorCreditorAccountService.getAtAGlance(creditorAccountId, authHeaderValue));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/GetMajorCreditorAccountAtAGlanceResponse.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/GetMajorCreditorAccountAtAGlanceResponse.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.opal.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigInteger;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.opal.dto.common.AddressDetails;
+import uk.gov.hmcts.opal.util.Versioned;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GetMajorCreditorAccountAtAGlanceResponse implements ToJsonString, Versioned {
+
+    @JsonIgnore
+    private BigInteger version;
+
+    @JsonProperty("major_creditor")
+    private MajorCreditor majorCreditor;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class MajorCreditor {
+
+        @JsonProperty("creditor_account_id")
+        private Long creditorAccountId;
+
+        @JsonProperty("name")
+        private String name;
+
+        @JsonProperty("code")
+        private String code;
+
+        @JsonProperty("address")
+        private AddressDetails address;
+
+        @JsonProperty("pay_by_bacs")
+        private Boolean payByBacs;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/entity/majorcreditor/MajorCreditorAccountAtAGlanceEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/majorcreditor/MajorCreditorAccountAtAGlanceEntity.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.opal.entity.majorcreditor;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.Immutable;
+
+@Getter
+@Entity
+@Table(name = "v_major_creditor_account_at_a_glance")
+@Immutable
+@SuperBuilder
+@NoArgsConstructor
+public class MajorCreditorAccountAtAGlanceEntity {
+
+    @Id
+    @Column(name = "creditor_account_id")
+    private Long creditorAccountId;
+
+    @Column(name = "bacs_details")
+    private String bacsDetails;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "address_line_1")
+    private String addressLine1;
+
+    @Column(name = "address_line_2")
+    private String addressLine2;
+
+    @Column(name = "address_line_3")
+    private String addressLine3;
+
+    @Column(name = "postcode")
+    private String postcode;
+}

--- a/src/main/java/uk/gov/hmcts/opal/repository/MajorCreditorAccountAtAGlanceRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/MajorCreditorAccountAtAGlanceRepository.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.opal.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.hmcts.opal.entity.majorcreditor.MajorCreditorAccountAtAGlanceEntity;
+
+@Repository
+public interface MajorCreditorAccountAtAGlanceRepository
+    extends JpaRepository<MajorCreditorAccountAtAGlanceEntity, Long> {
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/MajorCreditorAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/MajorCreditorAccountService.java
@@ -6,8 +6,10 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
+import uk.gov.hmcts.opal.dto.GetMajorCreditorAccountAtAGlanceResponse;
 import uk.gov.hmcts.opal.dto.GetMajorCreditorAccountHeaderSummaryResponse;
 import uk.gov.hmcts.opal.generated.model.BusinessUnitSummaryCommon;
+import uk.gov.hmcts.opal.service.opal.OpalMajorCreditorAccountService;
 import uk.gov.hmcts.opal.service.proxy.MajorCreditorAccountProxy;
 
 @Service
@@ -17,6 +19,7 @@ public class MajorCreditorAccountService {
 
     private final UserStateService userStateService;
     private final MajorCreditorAccountProxy majorCreditorAccountProxy;
+    private final OpalMajorCreditorAccountService opalMajorCreditorAccountService;
 
     public GetMajorCreditorAccountHeaderSummaryResponse getHeaderSummary(Long majorCreditorAccountId) {
         log.debug(":getHeaderSummary: id={}", majorCreditorAccountId);
@@ -36,6 +39,18 @@ public class MajorCreditorAccountService {
         }
 
         return response;
+    }
+
+    public GetMajorCreditorAccountAtAGlanceResponse getAtAGlance(Long creditorAccountId, String authHeaderValue) {
+        log.debug(":getAtAGlance: creditorAccountId={}", creditorAccountId);
+
+        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+
+        if (!userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
+            throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
+        }
+
+        return opalMajorCreditorAccountService.getAtAGlance(creditorAccountId);
     }
 
     private static Short getBusinessUnitId(BusinessUnitSummaryCommon businessUnitDetails) {

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalMajorCreditorAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalMajorCreditorAccountService.java
@@ -1,12 +1,21 @@
 package uk.gov.hmcts.opal.service.opal;
 
 import jakarta.persistence.EntityNotFoundException;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.opal.dto.GetMajorCreditorAccountAtAGlanceResponse;
 import uk.gov.hmcts.opal.dto.GetMajorCreditorAccountHeaderSummaryResponse;
+import uk.gov.hmcts.opal.dto.common.AddressDetails;
+import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
+import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountType;
+import uk.gov.hmcts.opal.entity.majorcreditor.MajorCreditorAccountAtAGlanceEntity;
+import uk.gov.hmcts.opal.entity.majorcreditor.MajorCreditorEntity;
 import uk.gov.hmcts.opal.mapper.MajorCreditorAccountHeaderEntityMapper;
+import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
+import uk.gov.hmcts.opal.repository.MajorCreditorAccountAtAGlanceRepository;
 import uk.gov.hmcts.opal.repository.MajorCreditorAccountHeaderRepository;
 import uk.gov.hmcts.opal.service.iface.MajorCreditorAccountServiceInterface;
 
@@ -17,6 +26,8 @@ public class OpalMajorCreditorAccountService implements MajorCreditorAccountServ
 
     private final MajorCreditorAccountHeaderRepository majorCreditorAccountHeaderRepository;
     private final MajorCreditorAccountHeaderEntityMapper majorCreditorAccountHeaderEntityMapper;
+    private final CreditorAccountRepository creditorAccountRepository;
+    private final MajorCreditorAccountAtAGlanceRepository majorCreditorAccountAtAGlanceRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -28,5 +39,73 @@ public class OpalMajorCreditorAccountService implements MajorCreditorAccountServ
             .orElseThrow(() -> new EntityNotFoundException(
                 "Major creditor account not found: " + majorCreditorAccountId
             ));
+    }
+
+    @Transactional(readOnly = true)
+    public GetMajorCreditorAccountAtAGlanceResponse getAtAGlance(Long creditorAccountId) {
+        log.debug(":getAtAGlance (Opal): creditorAccountId={}", creditorAccountId);
+
+        CreditorAccountEntity creditorAccount = creditorAccountRepository.findFullByCreditorAccountId(creditorAccountId)
+            .orElseThrow(() -> new EntityNotFoundException(
+                "Major creditor account not found: " + creditorAccountId
+            ));
+
+        CreditorAccountType accountType = creditorAccount.getCreditorAccountType();
+        if (accountType == null || !(accountType.isMajorCreditor() || accountType.isCentralFund())) {
+            throw new EntityNotFoundException("Account is not a major creditor account: " + creditorAccountId);
+        }
+
+        MajorCreditorAccountAtAGlanceEntity entity = majorCreditorAccountAtAGlanceRepository.findById(creditorAccountId)
+            .orElseThrow(() -> new EntityNotFoundException(
+                "Major creditor at a glance not found: " + creditorAccountId
+            ));
+
+        return GetMajorCreditorAccountAtAGlanceResponse.builder()
+            .version(creditorAccount.getVersion())
+            .majorCreditor(buildMajorCreditor(entity, creditorAccount, accountType))
+            .build();
+    }
+
+    private GetMajorCreditorAccountAtAGlanceResponse.MajorCreditor buildMajorCreditor(
+        MajorCreditorAccountAtAGlanceEntity entity,
+        CreditorAccountEntity creditorAccount,
+        CreditorAccountType accountType
+    ) {
+        return GetMajorCreditorAccountAtAGlanceResponse.MajorCreditor.builder()
+            .creditorAccountId(entity.getCreditorAccountId())
+            .name(entity.getName())
+            .code(getMajorCreditorCode(creditorAccount, accountType))
+            .address(buildAddress(entity))
+            .payByBacs(accountType.isMajorCreditor() ? creditorAccount.isPayByBacs() : null)
+            .build();
+    }
+
+    private String getMajorCreditorCode(CreditorAccountEntity creditorAccount, CreditorAccountType accountType) {
+        if (!accountType.isMajorCreditor()) {
+            return null;
+        }
+
+        MajorCreditorEntity majorCreditor = creditorAccount.getMajorCreditor();
+        return majorCreditor != null ? majorCreditor.getMajorCreditorCode() : null;
+    }
+
+    private AddressDetails buildAddress(MajorCreditorAccountAtAGlanceEntity entity) {
+        if (hasNoAddress(entity)) {
+            return null;
+        }
+
+        return AddressDetails.builder()
+            .addressLine1(entity.getAddressLine1())
+            .addressLine2(entity.getAddressLine2())
+            .addressLine3(entity.getAddressLine3())
+            .postcode(entity.getPostcode())
+            .build();
+    }
+
+    private boolean hasNoAddress(MajorCreditorAccountAtAGlanceEntity entity) {
+        return Objects.isNull(entity.getAddressLine1())
+            && Objects.isNull(entity.getAddressLine2())
+            && Objects.isNull(entity.getAddressLine3())
+            && Objects.isNull(entity.getPostcode());
     }
 }

--- a/src/main/resources/jsonSchemas/opal/major-creditor/getMajorCreditorAccountAtAGlanceResponse.json
+++ b/src/main/resources/jsonSchemas/opal/major-creditor/getMajorCreditorAccountAtAGlanceResponse.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": [
+    "major_creditor"
+  ],
+  "properties": {
+    "major_creditor": {
+      "type": "object",
+      "required": [
+        "creditor_account_id",
+        "name"
+      ],
+      "properties": {
+        "creditor_account_id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "code": {
+          "type": "string"
+        },
+        "address": {
+          "type": "object",
+          "properties": {
+            "address_line_1": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "address_line_2": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "address_line_3": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "address_line_4": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "address_line_5": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "postcode": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "pay_by_bacs": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/test/java/uk/gov/hmcts/opal/controllers/MajorCreditorAccountControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/MajorCreditorAccountControllerTest.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.opal.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.hmcts.opal.dto.GetMajorCreditorAccountAtAGlanceResponse;
+import uk.gov.hmcts.opal.service.MajorCreditorAccountService;
+
+@ExtendWith(MockitoExtension.class)
+class MajorCreditorAccountControllerTest {
+
+    private static final String AUTH_HEADER = "Bearer token";
+
+    @Mock
+    private MajorCreditorAccountService majorCreditorAccountService;
+
+    @InjectMocks
+    private MajorCreditorAccountController majorCreditorAccountController;
+
+    @Test
+    void getAtAGlance_returnsResponseWithEtag() {
+        GetMajorCreditorAccountAtAGlanceResponse response = GetMajorCreditorAccountAtAGlanceResponse.builder()
+            .version(BigInteger.ONE)
+            .build();
+        when(majorCreditorAccountService.getAtAGlance(101L, AUTH_HEADER)).thenReturn(response);
+
+        ResponseEntity<GetMajorCreditorAccountAtAGlanceResponse> result =
+            majorCreditorAccountController.getAtAGlance(101L, AUTH_HEADER);
+
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals(response, result.getBody());
+        assertEquals("\"1\"", result.getHeaders().getETag());
+        verify(majorCreditorAccountService).getAtAGlance(101L, AUTH_HEADER);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/MajorCreditorAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/MajorCreditorAccountServiceTest.java
@@ -16,8 +16,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
+import uk.gov.hmcts.opal.controllers.util.UserStateUtil;
+import uk.gov.hmcts.opal.dto.GetMajorCreditorAccountAtAGlanceResponse;
 import uk.gov.hmcts.opal.dto.GetMajorCreditorAccountHeaderSummaryResponse;
 import uk.gov.hmcts.opal.generated.model.BusinessUnitSummaryCommon;
+import uk.gov.hmcts.opal.service.opal.OpalMajorCreditorAccountService;
 import uk.gov.hmcts.opal.service.proxy.MajorCreditorAccountProxy;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,6 +31,9 @@ class MajorCreditorAccountServiceTest {
 
     @Mock
     private MajorCreditorAccountProxy majorCreditorAccountProxy;
+
+    @Mock
+    private OpalMajorCreditorAccountService opalMajorCreditorAccountService;
 
     @InjectMocks
     private MajorCreditorAccountService majorCreditorAccountService;
@@ -87,6 +93,34 @@ class MajorCreditorAccountServiceTest {
         assertThat(exception.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         assertThat(exception.getBusinessUnitId()).isEqualTo((short) 77);
         verify(majorCreditorAccountProxy).getHeaderSummary(123L);
+    }
+
+    @Test
+    void getAtAGlance_returnsResponseWhenUserHasPermission() {
+        GetMajorCreditorAccountAtAGlanceResponse response = GetMajorCreditorAccountAtAGlanceResponse.builder().build();
+        when(userStateService.checkForAuthorisedUser("Bearer token"))
+            .thenReturn(UserStateUtil.allFinesPermissionUser());
+        when(opalMajorCreditorAccountService.getAtAGlance(123L)).thenReturn(response);
+
+        GetMajorCreditorAccountAtAGlanceResponse result =
+            majorCreditorAccountService.getAtAGlance(123L, "Bearer token");
+
+        assertEquals(response, result);
+        verify(opalMajorCreditorAccountService).getAtAGlance(123L);
+    }
+
+    @Test
+    void getAtAGlance_throwsWhenUserLacksPermission() {
+        UserState userState = mock(UserState.class);
+        when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
+        when(userStateService.checkForAuthorisedUser("Bearer token")).thenReturn(userState);
+
+        PermissionNotAllowedException exception = assertThrows(
+            PermissionNotAllowedException.class,
+            () -> majorCreditorAccountService.getAtAGlance(123L, "Bearer token")
+        );
+
+        assertThat(exception.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
     }
 
     private GetMajorCreditorAccountHeaderSummaryResponse responseWithBusinessUnit(String businessUnitId) {

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalMajorCreditorAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalMajorCreditorAccountServiceTest.java
@@ -1,0 +1,108 @@
+package uk.gov.hmcts.opal.service.opal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.EntityNotFoundException;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.opal.dto.GetMajorCreditorAccountAtAGlanceResponse;
+import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
+import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountType;
+import uk.gov.hmcts.opal.entity.majorcreditor.MajorCreditorAccountAtAGlanceEntity;
+import uk.gov.hmcts.opal.entity.majorcreditor.MajorCreditorEntity;
+import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
+import uk.gov.hmcts.opal.repository.MajorCreditorAccountAtAGlanceRepository;
+import uk.gov.hmcts.opal.util.VersionUtils;
+
+@ExtendWith(MockitoExtension.class)
+class OpalMajorCreditorAccountServiceTest {
+
+    @Mock
+    private CreditorAccountRepository creditorAccountRepository;
+
+    @Mock
+    private MajorCreditorAccountAtAGlanceRepository majorCreditorAccountAtAGlanceRepository;
+
+    @InjectMocks
+    private OpalMajorCreditorAccountService service;
+
+    @Test
+    void getAtAGlance_mapsMajorCreditorAccount() {
+        Long accountId = 123L;
+        CreditorAccountEntity creditorAccount = CreditorAccountEntity.builder()
+            .creditorAccountId(accountId)
+            .creditorAccountType(CreditorAccountType.MJ)
+            .payByBacs(true)
+            .versionNumber(4L)
+            .majorCreditor(MajorCreditorEntity.builder().majorCreditorCode("ABCD").build())
+            .build();
+        MajorCreditorAccountAtAGlanceEntity entity = MajorCreditorAccountAtAGlanceEntity.builder()
+            .creditorAccountId(accountId)
+            .name("Major Creditor Ltd")
+            .addressLine1("1 Main Street")
+            .addressLine2("Town")
+            .addressLine3("County")
+            .postcode("AB1 2CD")
+            .build();
+
+        when(creditorAccountRepository.findFullByCreditorAccountId(accountId)).thenReturn(Optional.of(creditorAccount));
+        when(majorCreditorAccountAtAGlanceRepository.findById(accountId)).thenReturn(Optional.of(entity));
+
+        GetMajorCreditorAccountAtAGlanceResponse result = service.getAtAGlance(accountId);
+
+        assertEquals(accountId, result.getMajorCreditor().getCreditorAccountId());
+        assertEquals("Major Creditor Ltd", result.getMajorCreditor().getName());
+        assertEquals("ABCD", result.getMajorCreditor().getCode());
+        assertEquals(true, result.getMajorCreditor().getPayByBacs());
+        assertEquals("1 Main Street", result.getMajorCreditor().getAddress().getAddressLine1());
+        assertEquals("\"4\"", VersionUtils.createETag(result));
+    }
+
+    @Test
+    void getAtAGlance_mapsCentralFundAccountWithoutMajorCreditorSpecificFields() {
+        Long accountId = 456L;
+        CreditorAccountEntity creditorAccount = CreditorAccountEntity.builder()
+            .creditorAccountId(accountId)
+            .creditorAccountType(CreditorAccountType.CF)
+            .payByBacs(false)
+            .versionNumber(2L)
+            .build();
+        MajorCreditorAccountAtAGlanceEntity entity = MajorCreditorAccountAtAGlanceEntity.builder()
+            .creditorAccountId(accountId)
+            .name("HM Courts & Tribunals Service")
+            .addressLine1("HMCS add 1")
+            .addressLine2("HMCS add 2")
+            .addressLine3("HMCS add 3")
+            .build();
+
+        when(creditorAccountRepository.findFullByCreditorAccountId(accountId)).thenReturn(Optional.of(creditorAccount));
+        when(majorCreditorAccountAtAGlanceRepository.findById(accountId)).thenReturn(Optional.of(entity));
+
+        GetMajorCreditorAccountAtAGlanceResponse result = service.getAtAGlance(accountId);
+
+        assertEquals("HM Courts & Tribunals Service", result.getMajorCreditor().getName());
+        assertNull(result.getMajorCreditor().getCode());
+        assertNull(result.getMajorCreditor().getPayByBacs());
+        assertNull(result.getMajorCreditor().getAddress().getPostcode());
+    }
+
+    @Test
+    void getAtAGlance_throwsWhenAccountTypeIsUnsupported() {
+        Long accountId = 789L;
+        CreditorAccountEntity creditorAccount = CreditorAccountEntity.builder()
+            .creditorAccountId(accountId)
+            .creditorAccountType(CreditorAccountType.MN)
+            .build();
+
+        when(creditorAccountRepository.findFullByCreditorAccountId(accountId)).thenReturn(Optional.of(creditorAccount));
+
+        assertThrows(EntityNotFoundException.class, () -> service.getAtAGlance(accountId));
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-2132


### Change description ###

- Adds `GET /major-creditor-accounts/{id}/at-a-glance` for Opal mode
- Implements `release-1b` feature gating on the new endpoint
- Enforces `Search and View Accounts` permission checks
- Supports both Major Creditor (`MJ`) and Central Fund (`CF`) account types
- Returns `ETag` from `creditor_accounts.version`
- Maps the response to the major-creditor at-a-glance OpenAPI shape
- Reads display data from `v_major_creditor_account_at_a_glance` and enriches MJ-only fields from account/entity data
- Adds unit tests for controller and service logic
- Adds integration coverage for MJ happy path, CF happy path, repeated GET consistency, same-BU and different-BU permission success, `401` / `403` / `404` / `408` / `500` / `503` responses, and `release-1b` disabled behavior
- Adds schema-based response validation and assertions that undocumented fields are not exposed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
