### PR TITLE
PO-6425 Add requires_employment_data to GET /results response

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
@@ -163,8 +163,10 @@ class ResultControllerIntegrationTest extends AbstractIntegrationTest {
             .andExpect(jsonPath("$.count").value(2))
             .andExpect(jsonPath("$.refData[0].result_id").value("AAAAAA"))
             .andExpect(jsonPath("$.refData[0].result_title").value("First Ever Result Entry for Testing"))
+            .andExpect(jsonPath("$.refData[0].requires_employment_data").value(nullValue()))
             .andExpect(jsonPath("$.refData[1].result_id").value("DDDDDD"))
-            .andExpect(jsonPath("$.refData[1].result_title").value("Bail Warrant - dated"));
+            .andExpect(jsonPath("$.refData[1].result_title").value("Bail Warrant - dated"))
+            .andExpect(jsonPath("$.refData[1].requires_employment_data").value(false));
 
         jsonSchemaValidationService.validateOrError(body, GET_RESULTS_REF_DATA_RESPONSE);
     }
@@ -190,7 +192,8 @@ class ResultControllerIntegrationTest extends AbstractIntegrationTest {
             .andExpect(jsonPath("$.refData[0].active").value(true))
             .andExpect(jsonPath("$.refData[0].result_type").value("Action"))
             .andExpect(jsonPath("$.refData[0].imposition_creditor").value(nullValue()))
-            .andExpect(jsonPath("$.refData[0].imposition_allocation_order").value(nullValue()));
+            .andExpect(jsonPath("$.refData[0].imposition_allocation_order").value(nullValue()))
+            .andExpect(jsonPath("$.refData[0].requires_employment_data").value(false));
 
         jsonSchemaValidationService.validateOrError(body, GET_RESULTS_REF_DATA_RESPONSE);
     }

--- a/src/integrationTest/resources/db/insertData/insert_into_results.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_results.sql
@@ -39,6 +39,7 @@ INSERT INTO results
     prevent_payment_card,
     lists_monies,
     result_parameters,
+    requires_employment_data,
     manual_enforcement
 )
 VALUES
@@ -67,6 +68,7 @@ VALUES
         FALSE,
         FALSE,
         NULL,
+        NULL,
         TRUE     -- manual_enforcement = true
     ),
     (
@@ -94,6 +96,7 @@ VALUES
         TRUE,
         TRUE,
         '{"param1":"value1","param2":"value2"}',
+        TRUE,
         FALSE
     ),
     (
@@ -121,6 +124,7 @@ VALUES
         FALSE,
         FALSE,
         '{"warrantDate":"2023-08-15","issuedBy":"Court A"}',
+        FALSE,
         TRUE
     ),
     (
@@ -147,6 +151,7 @@ VALUES
         FALSE,
         FALSE,
         FALSE,
+        NULL,
         NULL,
         FALSE
     );

--- a/src/main/java/uk/gov/hmcts/opal/dto/reference/ResultReferenceData.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/reference/ResultReferenceData.java
@@ -9,5 +9,6 @@ public record ResultReferenceData(
         @JsonProperty("active") boolean active,
         @JsonProperty("result_type") String resultType,
         @JsonProperty("imposition_creditor") String impositionCreditor,
-        @JsonProperty("imposition_allocation_order") Short impositionAllocationPriority) {
+        @JsonProperty("imposition_allocation_order") Short impositionAllocationPriority,
+        @JsonProperty("requires_employment_data") Boolean requiresEmploymentData) {
 }

--- a/src/main/java/uk/gov/hmcts/opal/entity/result/ResultEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/result/ResultEntity.java
@@ -109,6 +109,9 @@ public class ResultEntity {
     @Column(name = "result_parameters")
     private String resultParameters;
 
+    @Column(name = "requires_employment_data")
+    private Boolean requiresEmploymentData;
+
     @Column(name = "manual_enforcement", nullable = false)
     private boolean manualEnforcement;
 

--- a/src/main/resources/jsonSchemas/opal/reference-data/getResultsRefDataResponse.json
+++ b/src/main/resources/jsonSchemas/opal/reference-data/getResultsRefDataResponse.json
@@ -46,6 +46,10 @@
           "type": ["string", "null"],
           "description": "The creditor of the imposition"
         },
+        "requires_employment_data": {
+          "type": ["boolean", "null"],
+          "description": "Whether the result requires employment data to be present"
+        },
         "required": [
           "result_id",
           "result_title",

--- a/src/test/java/uk/gov/hmcts/opal/disco/opal/ResultServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/disco/opal/ResultServiceTest.java
@@ -68,7 +68,7 @@ class ResultServiceTest {
         // Arrange
         ResultEntity resultEntity = ResultEntity.builder().resultId("ABC").build();
         ResultReferenceData expectedRefData = new ResultReferenceData(
-            "ABC", null, null, false, null, null, null
+            "ABC", null, null, false, null, null, null, null
         );
         when(resultRepository.findById(any())).thenReturn(Optional.of(resultEntity));
         when(resultMapper.toRefData(resultEntity)).thenReturn(expectedRefData);
@@ -92,7 +92,7 @@ class ResultServiceTest {
         // Arrange
         ResultEntity resultEntity = ResultEntity.builder().resultId("ABC").build();
         ResultReferenceData dto = new ResultReferenceData(
-            "ABC", null, null, false, null, null, null);
+            "ABC", null, null, false, null, null, null, null);
 
         @SuppressWarnings("unchecked")
         SpecificationFluentQuery<ResultEntity> sfq = (SpecificationFluentQuery<ResultEntity>)
@@ -146,7 +146,7 @@ class ResultServiceTest {
         when(resultSpecs.referenceDataByIds(any(), any(), any(), any(), any(), any()))
             .thenReturn(noOpSpec());
 
-        ResultReferenceData dto = new ResultReferenceData("NBWIT", null, null, false, null, null, null);
+        ResultReferenceData dto = new ResultReferenceData("NBWIT", null, null, false, null, null, null, null);
         when(resultMapper.toRefData(any())).thenReturn(dto);
 
         // Act - enforcementOverride true (others null)
@@ -198,7 +198,7 @@ class ResultServiceTest {
 
         ResultEntity entity = ResultEntity.builder().build();
         ResultReferenceData expectedRefData = new ResultReferenceData(
-            null, null, null, false, null, null, null
+            null, null, null, false, null, null, null, null
         );
         when(resultMapper.toRefData(entity)).thenReturn(expectedRefData);
 
@@ -220,7 +220,8 @@ class ResultServiceTest {
             entity.isActive(),
             entity.getResultType(),
             entity.getImpositionCreditor(),
-            entity.getImpositionAllocationPriority()
+            entity.getImpositionAllocationPriority(),
+            entity.getRequiresEmploymentData()
         );
 
         // Assert
@@ -292,7 +293,7 @@ class ResultServiceTest {
         when(resultSpecs.referenceDataByIds(any(), any(), any(), any(), any(), any()))
             .thenReturn(noOpSpec());
 
-        ResultReferenceData dto = new ResultReferenceData("ABC", null, null, false, null, null, null);
+        ResultReferenceData dto = new ResultReferenceData("ABC", null, null, false, null, null, null, null);
         when(resultMapper.toRefData(any())).thenReturn(dto);
 
         // Act - pass Optional.of(ids) and null for all booleans
@@ -328,7 +329,7 @@ class ResultServiceTest {
         when(resultSpecs.referenceDataByIds(any(), any(), any(), any(), any(), any()))
             .thenReturn(noOpSpec());
 
-        ResultReferenceData dto = new ResultReferenceData("ACT-1", null, null, false, null, null, null);
+        ResultReferenceData dto = new ResultReferenceData("ACT-1", null, null, false, null, null, null, null);
         when(resultMapper.toRefData(any())).thenReturn(dto);
 
         // Act - active true (others null)
@@ -367,7 +368,7 @@ class ResultServiceTest {
         when(resultSpecs.referenceDataByIds(any(), any(), any(), any(), any(), any()))
             .thenReturn(noOpSpec());
 
-        ResultReferenceData dto = new ResultReferenceData("MEF-FALSE", null, null, false, null, null, null);
+        ResultReferenceData dto = new ResultReferenceData("MEF-FALSE", null, null, false, null, null, null, null);
         when(resultMapper.toRefData(any())).thenReturn(dto);
 
         // Act - pass explicit false
@@ -410,7 +411,7 @@ class ResultServiceTest {
         when(resultSpecs.referenceDataByIds(any(), any(), any(), any(), any(), any()))
             .thenReturn(noOpSpec());
 
-        ResultReferenceData dto = new ResultReferenceData("MIXED", null, null, false, null, null, null);
+        ResultReferenceData dto = new ResultReferenceData("MIXED", null, null, false, null, null, null, null);
         when(resultMapper.toRefData(any())).thenReturn(dto);
 
         // Act - mix of true/false/null


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-6425


### Change description ###
- Add requires_employment_data to the GET /results response payload
- Map results.requires_employment_data onto ResultEntity
- Extend ResultReferenceData so the field is returned by the ref-data endpoint
- Update the GET /results JSON schema to include nullable requires_employment_data
- Update integration test seed data to cover null, true, and false values
- Add integration assertions proving the field is present in the API response
- Fix unit tests that construct ResultReferenceData directly after the record signature change


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
