### PR TITLE
PO-6425 Add requires_employment_data to GET /results/{resultId}

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/opal/steps/GetResultsStepDef.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/steps/GetResultsStepDef.java
@@ -71,6 +71,18 @@ public class GetResultsStepDef extends BaseStepDef {
     }
 
     /**
+     * Requests the single-result endpoint for the supplied result identifier.
+     *
+     * @param resultId result identifier to request.
+     */
+    @When("I request result with identifier {string}")
+    public void getResultById(String resultId) {
+        authorisedJsonRequest()
+            .when()
+            .get(getTestUrl() + RESULTS_URI + "/" + resultId);
+    }
+
+    /**
      * Asserts that the results response contains the expected number of records.
      *
      * @param count expected number of matching records.
@@ -94,6 +106,22 @@ public class GetResultsStepDef extends BaseStepDef {
             String actual = then().extract().body().jsonPath().getString("refData.find { it.result_id == '"
                                                                              + resultID + "' }." + key);
             assertEquals(expected.get(key), actual, "Values are not equal");
+        }
+    }
+
+    /**
+     * Asserts that the single-result response contains the expected field values.
+     *
+     * @param data Cucumber table containing the expected values for the assertion.
+     */
+    @Then("the result response contains")
+    public void resultResponseContains(DataTable data) {
+        Map<String, String> expected = data.asMap(String.class, String.class);
+        then().assertThat().statusCode(200);
+
+        for (Map.Entry<String, String> entry : expected.entrySet()) {
+            String actual = then().extract().body().jsonPath().getString(entry.getKey());
+            assertEquals(entry.getValue(), actual, "Values are not equal");
         }
     }
 

--- a/src/functionalTest/resources/features/opalMode/results/Results.feature
+++ b/src/functionalTest/resources/features/opalMode/results/Results.feature
@@ -60,7 +60,7 @@ Feature: Results Reference Data
       | imposition_creditor         |                                         |
       | imposition_allocation_order |                                         |
 
-  @JIRA-STORY:PO-6425
+  @JIRA-STORY:PO-6425 @JIRA-EPIC:PO-1674
   Scenario: Result by ID includes employment data requirement flag
     When I request result with identifier "AEO"
     Then the result response contains

--- a/src/functionalTest/resources/features/opalMode/results/Results.feature
+++ b/src/functionalTest/resources/features/opalMode/results/Results.feature
@@ -60,6 +60,13 @@ Feature: Results Reference Data
       | imposition_creditor         |                                         |
       | imposition_allocation_order |                                         |
 
+  @JIRA-STORY:PO-6425
+  Scenario: Result by ID includes employment data requirement flag
+    When I request result with identifier "AEO"
+    Then the result response contains
+      | result_id                | AEO  |
+      | requires_employment_data | true |
+
   @JIRA-STORY:PO-3765 @Ignore @release-1b
   Scenario: Result filtering is available when release-1b is enabled
     When I request results for identifiers "NBWT,NAP" using filter "enforcement_override" with value "true"

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
@@ -84,7 +84,8 @@ class ResultControllerIntegrationTest extends AbstractIntegrationTest {
             .andExpect(jsonPath("$.extend_ttp_preserve_last_enf").value(true))
             .andExpect(jsonPath("$.prevent_payment_card").value(true))
             .andExpect(jsonPath("$.lists_monies").value(true))
-            .andExpect(jsonPath("$.result_parameters").value("{\"param1\":\"value1\",\"param2\":\"value2\"}"));
+            .andExpect(jsonPath("$.result_parameters").value("{\"param1\":\"value1\",\"param2\":\"value2\"}"))
+            .andExpect(jsonPath("$.requires_employment_data").value(true));
     }
 
     @Test

--- a/src/integrationTest/resources/db/insertData/insert_into_results.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_results.sql
@@ -39,6 +39,7 @@ INSERT INTO results
     prevent_payment_card,
     lists_monies,
     result_parameters,
+    requires_employment_data,
     manual_enforcement
 )
 VALUES
@@ -67,6 +68,7 @@ VALUES
         FALSE,
         FALSE,
         NULL,
+        NULL,
         TRUE     -- manual_enforcement = true
     ),
     (
@@ -94,6 +96,7 @@ VALUES
         TRUE,
         TRUE,
         '{"param1":"value1","param2":"value2"}',
+        TRUE,
         FALSE
     ),
     (
@@ -121,6 +124,7 @@ VALUES
         FALSE,
         FALSE,
         '{"warrantDate":"2023-08-15","issuedBy":"Court A"}',
+        FALSE,
         TRUE
     ),
     (
@@ -147,6 +151,7 @@ VALUES
         FALSE,
         FALSE,
         FALSE,
+        NULL,
         NULL,
         FALSE
     );

--- a/src/main/java/uk/gov/hmcts/opal/dto/ResultDto.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/ResultDto.java
@@ -82,4 +82,7 @@ public class ResultDto {
 
     @JsonProperty("result_parameters")
     private String resultParameters;
+
+    @JsonProperty("requires_employment_data")
+    private Boolean requiresEmploymentData;
 }

--- a/src/main/java/uk/gov/hmcts/opal/entity/result/ResultEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/result/ResultEntity.java
@@ -109,6 +109,9 @@ public class ResultEntity {
     @Column(name = "result_parameters")
     private String resultParameters;
 
+    @Column(name = "requires_employment_data")
+    private Boolean requiresEmploymentData;
+
     @Column(name = "manual_enforcement", nullable = false)
     private boolean manualEnforcement;
 

--- a/src/test/java/uk/gov/hmcts/opal/disco/opal/ResultServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/disco/opal/ResultServiceTest.java
@@ -236,6 +236,7 @@ class ResultServiceTest {
             .resultTitleCy("Welsh Title")
             .resultType("TYPE1")
             .active(true)
+            .requiresEmploymentData(true)
             .build();
 
         uk.gov.hmcts.opal.dto.ResultDto dto = uk.gov.hmcts.opal.dto.ResultDto.builder()
@@ -244,6 +245,7 @@ class ResultServiceTest {
             .resultTitleCy("Welsh Title")
             .resultType("TYPE1")
             .active(true)
+            .requiresEmploymentData(true)
             .build();
 
         when(resultRepository.findById("ABC")).thenReturn(Optional.of(entity));
@@ -256,6 +258,7 @@ class ResultServiceTest {
         assertNotNull(result);
         assertEquals("ABC", result.getResultId());
         assertEquals("Result Title", result.getResultTitle());
+        assertEquals(true, result.getRequiresEmploymentData());
         verify(resultRepository).findById("ABC");
         verify(resultMapper).toDto(entity);
     }

--- a/src/test/java/uk/gov/hmcts/opal/mapper/ResultMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/mapper/ResultMapperTest.java
@@ -134,6 +134,7 @@ class ResultMapperTest {
             .preventPaymentCard(true)
             .listsMonies(true)
             .resultParameters("A,B,C")
+            .requiresEmploymentData(true)
             .build();
 
         // Act
@@ -164,6 +165,7 @@ class ResultMapperTest {
         assertEquals(entity.isPreventPaymentCard(), dto.isPreventPaymentCard());
         assertEquals(entity.isListsMonies(), dto.isListsMonies());
         assertEquals(entity.getResultParameters(), dto.getResultParameters());
+        assertEquals(entity.getRequiresEmploymentData(), dto.getRequiresEmploymentData());
     }
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-6425


### Change description ###

- Add requires_employment_data to the full GET /results/{resultId} response payload
- Map results.requires_employment_data onto ResultEntity
- Extend ResultDto so the field is returned in the single-result endpoint
- Update integration test seed data to cover the new field
- Add integration assertions for GET /results/{resultId}
- Update mapper and service unit tests to cover the new DTO field


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
