### PR TITLE
Fix-out-of-memory-errors-on-PR's

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -254,7 +254,7 @@ tasks.withType(JavaExec).configureEach {
 tasks.withType(Test).configureEach {
   useJUnitPlatform()
 
-  systemProperty 'spring.test.context.cache.maxSize', 5
+  systemProperty 'spring.test.context.cache.maxSize', 4
 
   testLogging {
     exceptionFormat = 'full'


### PR DESCRIPTION

### JIRA link (if applicable) ###

happening on multiple PR's

https://tools.hmcts.net/jira/browse/PO-3768

### Change description ###

updated build.gradle to lower the amount of spring cache contexts held to save some space

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
