### PR TITLE
PO-6359: Update fines-service for feature-disabled auth handling

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/opal/steps/Release1aFeatureToggleStepDef.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/steps/Release1aFeatureToggleStepDef.java
@@ -75,7 +75,7 @@ public class Release1aFeatureToggleStepDef extends BaseStepDef {
     @Then("the response reports that the feature is disabled")
     public void theResponseReportsThatTheFeatureIsDisabled() {
         lastResponse().then()
-            .statusCode(405)
+            .statusCode(404)
             .body("title", equalTo("Feature Disabled"))
             .body("detail", equalTo("The requested feature is not currently available"))
             .body("type", equalTo("https://hmcts.gov.uk/problems/feature-disabled"))

--- a/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountSearchFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountSearchFeatureToggles.feature
@@ -7,7 +7,7 @@ Feature: Defendant Account Search Feature Toggles
   @R1BOff @JIRA-STORY:PO-3768 @JIRA-STORY:PO-3762 @JIRA-EPIC:PO-3685
   Scenario: Search endpoint is unavailable when release 1b is disabled
     When I search defendant accounts using prosecutor case reference "R1B-OFF-CHECK" without consolidation
-    Then the request is rejected with status 405
+    Then the request is rejected with status 404
     And the response reports that the feature is disabled
 
   @R1B @R1COff @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
@@ -20,7 +20,7 @@ Feature: Defendant Account Search Feature Toggles
   Scenario: Consolidated search is unavailable when release 1c is disabled
     Given a searchable defendant account exists for feature-toggle search
     When I search the created defendant account with consolidation
-    Then the request is rejected with status 405
+    Then the request is rejected with status 404
     And the response reports that the feature is disabled
 
   @R1B @R1C @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685

--- a/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1aFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1aFeatureToggles.feature
@@ -7,7 +7,7 @@ Feature: Fines Service Release 1a Feature Toggles
   @R1AOff @JIRA-STORY:PO-3754 @JIRA-EPIC:PO-3685
   Scenario Outline: Release 1a gated endpoint is unavailable when release 1a is disabled
     When I call the release 1a gated endpoint "<endpoint>"
-    Then the request is rejected with status 405
+    Then the request is rejected with status 404
     And the response reports that the feature is disabled
 
     Examples:

--- a/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1bFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1bFeatureToggles.feature
@@ -7,7 +7,7 @@ Feature: Fines Service Release 1b Feature Toggles
   @R1BOff @JIRA-STORY:PO-3762 @JIRA-EPIC:PO-3685
   Scenario Outline: Release 1b gated endpoint is unavailable when release 1b is disabled
     When I call the release 1b gated endpoint "<endpoint>"
-    Then the request is rejected with status 405
+    Then the request is rejected with status 404
     And the response reports that the feature is disabled
 
     Examples:

--- a/src/functionalTest/resources/features/opalMode/results/Results.feature
+++ b/src/functionalTest/resources/features/opalMode/results/Results.feature
@@ -75,4 +75,4 @@ Feature: Results Reference Data
   @JIRA-STORY:PO-3765 @Ignore @release-1b
   Scenario: Result filtering is rejected when release-1b is disabled
     When I request results using filter "active" with value "true"
-    Then the response status code is 405
+    Then the response status code is 404

--- a/src/functionalTest/resources/features/opalMode/results/ResultsFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/results/ResultsFeatureToggles.feature
@@ -7,7 +7,7 @@ Feature: Results Feature Toggles
   @R1AOff @JIRA-STORY:PO-3765 @JIRA-STORY:PO-3754 @JIRA-EPIC:PO-3685
   Scenario: Results endpoint is unavailable when release 1a is disabled
     When I request results for identifiers "FO,ABDC"
-    Then the request is rejected with status 405
+    Then the request is rejected with status 404
     And the response reports that the feature is disabled
 
   @R1A @R1BOff @JIRA-STORY:PO-3765 @JIRA-EPIC:PO-3685
@@ -41,7 +41,7 @@ Feature: Results Feature Toggles
       | generates_hearing       | false |
       | enforcement             | true  |
       | enforcement_override    | true  |
-    Then the request is rejected with status 405
+    Then the request is rejected with status 404
     And the response reports that the feature is disabled
 
   @R1A @R1B @JIRA-STORY:PO-3765 @JIRA-EPIC:PO-3685

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CentralFundControllerFeatureFlagIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CentralFundControllerFeatureFlagIntegrationTest.java
@@ -31,7 +31,7 @@ class CentralFundControllerFeatureFlagIntegrationTest extends AbstractIntegratio
     @DisplayName("PO-2320: GET central fund returns 404 when release-1b is disabled")
     @JiraStory("PO-2320")
     @JiraEpic("PO-1286")
-    void getCentralFund_whenFeatureDisabled_returnsMethodNotAllowed() throws Exception {
+    void getCentralFund_whenFeatureDisabled_returnsNotFound() throws Exception {
         mockMvc.perform(get("/central-funds/73").header(HttpHeaders.AUTHORIZATION, AUTH_HEADER))
             .andExpect(status().isNotFound())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/JwtControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/JwtControllerIntegrationTest.java
@@ -1,10 +1,19 @@
 package uk.gov.hmcts.opal.controllers;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.gov.hmcts.opal.AbstractIntegrationWithSecurityTest;
@@ -38,6 +47,49 @@ class JwtControllerIntegrationTest extends AbstractIntegrationWithSecurityTest {
                 .with(userStateStub.getAuthenticaitonRequestPostProcessor())
                 .header(AUTHORIZATION, userStateStub.getAuthorizationToken()))
             .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Testing Feature-Disabled User Service Lookup")
+    @JiraStory("PO-6359")
+    @JiraEpic("PO-3685")
+    void testFeatureDisabledUserStateLookupGivesServiceUnavailableProblemJson() throws Exception {
+        WireMock.configureFor("localhost", 4553);
+        StubMapping disabledUserStateStub = stubFor(get("/opal/v2/users/0/state")
+            .withHeader("Authorization", equalTo("Bearer " + validToken))
+            .atPriority(1)
+            .willReturn(aResponse()
+                .withStatus(404)
+                .withHeader("Content-Type", MediaType.APPLICATION_PROBLEM_JSON_VALUE)
+                .withBody(
+                    """
+                    {
+                      "type":"https://hmcts.gov.uk/problems/feature-disabled",
+                      "title":"Feature Disabled",
+                      "status":404,
+                      "detail":"The requested feature is not currently available"
+                    }
+                    """
+                )));
+
+        try {
+            mockMvc.perform(MockMvcRequestBuilders.get(URL)
+                    .header(AUTHORIZATION, "Bearer " + validToken))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("$.type")
+                    .value("https://hmcts.gov.uk/problems/downstream-service-unavailable"))
+                .andExpect(jsonPath("$.title").value("Service Unavailable"))
+                .andExpect(jsonPath("$.status").value(503))
+                .andExpect(jsonPath("$.detail").value(
+                    "Authentication was not possible because the required user-service endpoint is disabled."
+                ))
+                .andExpect(jsonPath("$.instance").exists())
+                .andExpect(jsonPath("$.operation_id").exists())
+                .andExpect(jsonPath("$.retriable").value(false));
+        } finally {
+            WireMock.removeStub(disabledUserStateStub);
+        }
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagIntegrationTest.java
@@ -50,7 +50,7 @@ class MinorCreditorApiControllerFeatureFlagIntegrationTest extends AbstractInteg
     @JiraStory("PO-1992")
     @JiraEpic("PO-2234")
     @JiraTestKey("PO-5977")
-    void patchMinorCreditorAccount_whenLocalDefaultDisabled_returns405() throws Exception {
+    void patchMinorCreditorAccount_whenLocalDefaultDisabled_returns404() throws Exception {
         PatchMinorCreditorAccountRequest request = patchMinorCreditorAccountRequest();
 
         ResultActions result = mockMvc.perform(patch("/minor-creditor-accounts/" + MINOR_CREDITOR_ACCOUNT_ID)
@@ -61,7 +61,7 @@ class MinorCreditorApiControllerFeatureFlagIntegrationTest extends AbstractInteg
                             .content(objectMapper.writeValueAsString(request)));
 
         String body = result.andReturn().getResponse().getContentAsString();
-        log.info(":patchMinorCreditorAccount_whenLocalDefaultDisabled_returns405 body:\n{}",
+        log.info(":patchMinorCreditorAccount_whenLocalDefaultDisabled_returns404 body:\n{}",
             ToJsonString.toPrettyJson(body));
         result.andExpect(status().isNotFound())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE))

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/Release1AFeatureToggleIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/Release1AFeatureToggleIntegrationTest.java
@@ -22,11 +22,11 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 
 /**
- * Verifies that all Release 1A endpoints guarded by @FeatureToggle return 405 when the release-1a flag is disabled.
+ * Verifies that all Release 1A endpoints guarded by @FeatureToggle return 404 when the release-1a flag is disabled.
  */
 @ActiveProfiles({"integration"})
 @Slf4j(topic = "opal.Release1AFeatureToggleIntegrationTest")
-@DisplayName("Release 1A - returns 405 when release-1a flag is disabled")
+@DisplayName("Release 1A - returns 404 when release-1a flag is disabled")
 @TestPropertySource(properties = {
     "launchdarkly.enabled=false",
     "launchdarkly.default-flag-values.release-1a=false"
@@ -86,7 +86,7 @@ class Release1AFeatureToggleIntegrationTest extends AbstractFeatureToggleIntegra
     @JiraStory("PO-2833")
     @JiraEpic("PO-2352")
     @JiraTestKey("PO-6232")
-    void shouldReturn405WhenRelease1aIsDisabled(String description, MockHttpServletRequestBuilder request)
+    void shouldReturn404WhenRelease1aIsDisabled(String description, MockHttpServletRequestBuilder request)
         throws Exception {
         log.debug("Testing feature-disabled 404 for: {}", description);
         mockMvc.perform(request)

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/Release1BFeatureToggleIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/Release1BFeatureToggleIntegrationTest.java
@@ -17,11 +17,11 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 
 
 /**
- * Verifies that all Release 1B endpoints guarded by @FeatureToggle return 405 when the release-1b flag is disabled.
+ * Verifies that all Release 1B endpoints guarded by @FeatureToggle return 404 when the release-1b flag is disabled.
  */
 @ActiveProfiles({"integration"})
 @Slf4j(topic = "opal.Release1BFeatureToggleIntegrationTest")
-@DisplayName("Release 1B - returns 405 when release-1b flag is disabled")
+@DisplayName("Release 1B - returns 404 when release-1b flag is disabled")
 @TestPropertySource(properties = {
     "launchdarkly.enabled=false",
     "launchdarkly.default-flag-values.release-1b=false"
@@ -40,7 +40,7 @@ class Release1BFeatureToggleIntegrationTest extends AbstractFeatureToggleIntegra
     @DisplayName("should return 404 Not Found")
     @JiraStory("PO-2077")
     @JiraEpic("PO-979")
-    void shouldReturn405WhenRelease1bIsDisabled(String description, MockHttpServletRequestBuilder request)
+    void shouldReturn404WhenRelease1bIsDisabled(String description, MockHttpServletRequestBuilder request)
         throws Exception {
         log.debug("Testing feature-disabled 404 for: {}", description);
         mockMvc.perform(request)

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/Release1CEnforcementOperationalReportingFeatureToggleIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/Release1CEnforcementOperationalReportingFeatureToggleIntegrationTest.java
@@ -17,12 +17,12 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 
 /**
- * Verifies that all Release 1C Enforcement Operational Reporting endpoints guarded by @FeatureToggle return 405 when
+ * Verifies that all Release 1C Enforcement Operational Reporting endpoints guarded by @FeatureToggle return 404 when
  * the release-1c-enforcement-operational-reporting flag is disabled.
  */
 @ActiveProfiles({"integration"})
 @Slf4j(topic = "opal.Release1CEnforcementOperationalReportingFeatureToggleIntegrationTest")
-@DisplayName("Release 1C Enforcement Operational Reporting - returns 405 when flag is disabled")
+@DisplayName("Release 1C Enforcement Operational Reporting - returns 404 when flag is disabled")
 @TestPropertySource(properties = {
     "launchdarkly.enabled=false",
     "launchdarkly.default-flag-values.release-1c-enforcement-operational-reporting=false"

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/TestingSupportControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/TestingSupportControllerIntegrationTest.java
@@ -38,6 +38,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration"})
 @Slf4j(topic = "opal.TestingSupportControllerTest")
+@SuppressWarnings("java:S1874")
 class TestingSupportControllerIntegrationTest extends AbstractIntegrationTest {
 
     // Limit JdbcTemplate use to narrow test setup or persistence-side-effect checks.

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/TestingSupportControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/TestingSupportControllerIntegrationTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.opal.controllers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -9,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +21,14 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
+import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.common.launchdarkly.service.FeatureToggleApi;
+import uk.gov.hmcts.opal.common.user.authorisation.client.mapper.UserStateMapper;
+import uk.gov.hmcts.opal.common.user.authorisation.client.service.UserStateClientService;
+import uk.gov.hmcts.opal.common.user.authorisation.model.Domain;
+import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
+import uk.gov.hmcts.opal.common.user.authorisation.model.UserStateV2;
+import uk.gov.hmcts.opal.controllers.util.UserStateUtil;
 import uk.gov.hmcts.opal.dto.AppMode;
 import uk.gov.hmcts.opal.dto.ToJsonString;
 import uk.gov.hmcts.opal.service.opal.DynamicConfigService;
@@ -40,6 +49,12 @@ class TestingSupportControllerIntegrationTest extends AbstractIntegrationTest {
 
     @MockitoBean
     private FeatureToggleApi featureToggleApi;
+
+    @MockitoBean
+    private UserStateClientService userStateClientService;
+
+    @MockitoBean
+    private UserStateMapper userStateMapper;
 
     @Test
     @JiraStory("PO-256")
@@ -92,6 +107,32 @@ class TestingSupportControllerIntegrationTest extends AbstractIntegrationTest {
                 .header("Authorization", userStateStub.getBearerToken()))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$").value("opal-test@HMCTS.NET"));
+    }
+
+    @Test
+    @JiraStory("PO-256")
+    @JiraEpic("PO-2233")
+    @JiraTestKey("PO-6282")
+    void testGetUserState() throws Exception {
+        UserState userState = UserStateUtil.permissionUser((short) 5, FinesPermission.ACCOUNT_ENQUIRY);
+        UserStateV2 userStateV2 = mock(UserStateV2.class);
+        when(userStateClientService.getUserStateByAuthenticatedUser()).thenReturn(Optional.of(userStateV2));
+        when(userStateMapper.toUserState(userStateV2, Domain.FINES)).thenReturn(userState);
+
+        mockMvc.perform(get("/testing-support/user-client/0"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.user_name").value(userState.getUserName()))
+            .andExpect(jsonPath("$.user_id").value(userState.getUserId()));
+    }
+
+    @Test
+    @JiraStory("PO-256")
+    @JiraEpic("PO-2233")
+    @JiraTestKey("PO-6280")
+    void testGetUserStateNotFound() throws Exception {
+        mockMvc.perform(get("/testing-support/user-client/999"))
+            .andExpect(status().isNotFound());
     }
 
     @Sql(

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/util/UserStateUtil.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/util/UserStateUtil.java
@@ -42,8 +42,16 @@ public class UserStateUtil {
         return allFinesPermissionUser();
     }
 
+    public static UserStateV2 allFinesPermissionUserStateV2() {
+        return allFinesPermissionsToken().getUserState();
+    }
+
     public static UserState noPermissionsUser() {
         return noFinesPermissionUser();
+    }
+
+    public static UserStateV2 noFinesPermissionUserStateV2() {
+        return noFinesPermissionsToken().getUserState();
     }
 
     public static UserState permissionUser(Short buid, FinesPermission... permissions) {
@@ -84,6 +92,10 @@ public class UserStateUtil {
             .name("Normal User")
             .businessUnitUser(permissions)
             .build();
+    }
+
+    public static UserStateV2 permissionUserStateV2(Short buid, FinesPermission... permissions) {
+        return permissionsToken(buid, permissions).getUserState();
     }
 
     public static BusinessUnitUser permissions(Short buid, Permission... permissions) {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/TestingSupportController.java
@@ -28,6 +28,7 @@ import uk.gov.hmcts.opal.service.opal.DynamicConfigService;
 @Slf4j(topic = "opal.TestingSupportController")
 @Tag(name = "Testing Support Controller")
 @ConditionalOnProperty(prefix = "opal.testing-support-endpoints", name = "enabled", havingValue = "true")
+@SuppressWarnings("java:S1874")
 public class TestingSupportController {
     private static final long CURRENT_USER_ID = 0L;
 

--- a/src/main/java/uk/gov/hmcts/opal/controllers/TestingSupportController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/TestingSupportController.java
@@ -14,10 +14,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.opal.common.launchdarkly.service.FeatureToggleApi;
 import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
+import uk.gov.hmcts.opal.common.user.authorisation.client.mapper.UserStateMapper;
 import uk.gov.hmcts.opal.common.user.authorisation.client.service.UserStateClientService;
+import uk.gov.hmcts.opal.common.user.authorisation.model.Domain;
+import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AppMode;
-import uk.gov.hmcts.opal.service.opal.DynamicConfigService;
 import uk.gov.hmcts.opal.service.opal.DefendantAccountDeletionService;
+import uk.gov.hmcts.opal.service.opal.DynamicConfigService;
 
 @RestController
 @RequestMapping("/testing-support")
@@ -26,12 +29,14 @@ import uk.gov.hmcts.opal.service.opal.DefendantAccountDeletionService;
 @Tag(name = "Testing Support Controller")
 @ConditionalOnProperty(prefix = "opal.testing-support-endpoints", name = "enabled", havingValue = "true")
 public class TestingSupportController {
+    private static final long CURRENT_USER_ID = 0L;
 
     private final DynamicConfigService dynamicConfigService;
     private final FeatureToggleApi featureToggleApi;
     private final AccessTokenService accessTokenService;
     private final DefendantAccountDeletionService defendantAccountDeletionService;
     private final UserStateClientService userStateClientService;
+    private final UserStateMapper userStateMapper;
 
     @GetMapping("/app-mode")
     @Operation(summary = "Retrieves the value for app mode.")
@@ -52,6 +57,19 @@ public class TestingSupportController {
     @GetMapping("/token/parse")
     public ResponseEntity<String> parseToken(@RequestHeader("Authorization") String authorization) {
         return ResponseEntity.ok(this.accessTokenService.extractPreferredUsername(authorization));
+    }
+
+    @GetMapping("/user-client/{userId}")
+    @Operation(summary = "Retrieves user state via User Service client")
+    public ResponseEntity<UserState> getUserState(@PathVariable Long userId) {
+        if (!Long.valueOf(CURRENT_USER_ID).equals(userId)) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return userStateClientService.getUserStateByAuthenticatedUser()
+            .map(userStateV2 -> userStateMapper.toUserState(userStateV2, Domain.FINES))
+            .map(ResponseEntity::ok)
+            .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @DeleteMapping("/defendant-accounts/{defendantAccountId}")

--- a/src/main/java/uk/gov/hmcts/opal/service/UserStateService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/UserStateService.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.opal.service;
 
+import static uk.gov.hmcts.opal.util.HttpUtil.extractPreferredUsername;
+
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,8 +17,6 @@ import uk.gov.hmcts.opal.common.user.authorisation.client.service.UserStateClien
 import uk.gov.hmcts.opal.common.user.authorisation.model.Domain;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserStateV2;
-
-import static uk.gov.hmcts.opal.util.HttpUtil.extractPreferredUsername;
 
 @Service
 @RequiredArgsConstructor
@@ -36,7 +37,13 @@ public class UserStateService {
     @Deprecated(since = "2")
     @SuppressWarnings("java:S1133")
     public UserState checkForAuthorisedUser() {
-        return checkForAuthorisedUser("");
+        Optional<?> authenticatedUserState = userStateClientService.getUserStateByAuthenticatedUser();
+
+        return authenticatedUserState
+            .filter(UserStateV2.class::isInstance)
+            .map(UserStateV2.class::cast)
+            .map(this::mapAuthenticatedUserState)
+            .orElseGet(this::getUserStateV1FromSecurityContext);
     }
 
     /**
@@ -47,15 +54,7 @@ public class UserStateService {
     @Deprecated(since = "2")
     @SuppressWarnings("java:S1133")
     public UserState checkForAuthorisedUser(String authorization) {
-        return userStateClientService.getUserStateByAuthenticatedUser()
-            .map(userStateV2 -> {
-                UserState userState = userStateMapper.toUserState(userStateV2, Domain.FINES);
-                log.debug(":checkForAuthorisedUser: using authenticated user state from user service: userId={}, "
-                        + "userName={}, businessUnits={}",
-                    userState.getUserId(), userState.getUserName(), summariseBusinessUnits(userState));
-                return userState;
-            })
-            .orElseGet(this::getUserStateV1FromSecurityContext);
+        return checkForAuthorisedUser();
     }
 
     /**
@@ -88,6 +87,14 @@ public class UserStateService {
 
     public String getPreferredUsername(String authorization) {
         return extractPreferredUsername(authorization, tokenService);
+    }
+
+    private UserState mapAuthenticatedUserState(UserStateV2 userStateV2) {
+        UserState userState = userStateMapper.toUserState(userStateV2, Domain.FINES);
+        log.debug(":checkForAuthorisedUser: using authenticated user state from user service: userId={}, "
+                + "userName={}, businessUnits={}",
+            userState.getUserId(), userState.getUserName(), summariseBusinessUnits(userState));
+        return userState;
     }
 
     private String summariseBusinessUnits(UserState userState) {

--- a/src/main/java/uk/gov/hmcts/opal/service/UserStateService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/UserStateService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service;
 
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.opal.common.spring.security.OpalJwtAuthenticationToken;
 import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
 import uk.gov.hmcts.opal.common.user.authorisation.client.mapper.UserStateMapper;
+import uk.gov.hmcts.opal.common.user.authorisation.client.service.UserStateClientService;
 import uk.gov.hmcts.opal.common.user.authorisation.model.Domain;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserStateV2;
@@ -24,8 +26,40 @@ public class UserStateService {
 
     private final UserStateMapper userStateMapper;
 
+    private final UserStateClientService userStateClientService;
+
     /**
-0     * Returns the V1 user state from the current security context.
+     * Returns the authorised user state from the current authenticated user service context.
+     *
+     * @deprecated Use {@link #getUserStateFromSecurityContext()} for V2 user state.
+     */
+    @Deprecated(since = "2")
+    @SuppressWarnings("java:S1133")
+    public UserState checkForAuthorisedUser() {
+        return checkForAuthorisedUser("");
+    }
+
+    /**
+     * Returns the authorised user state from the current authenticated user service context.
+     *
+     * @deprecated Use {@link #getUserStateFromSecurityContext()} for V2 user state.
+     */
+    @Deprecated(since = "2")
+    @SuppressWarnings("java:S1133")
+    public UserState checkForAuthorisedUser(String authorization) {
+        return userStateClientService.getUserStateByAuthenticatedUser()
+            .map(userStateV2 -> {
+                UserState userState = userStateMapper.toUserState(userStateV2, Domain.FINES);
+                log.debug(":checkForAuthorisedUser: using authenticated user state from user service: userId={}, "
+                        + "userName={}, businessUnits={}",
+                    userState.getUserId(), userState.getUserName(), summariseBusinessUnits(userState));
+                return userState;
+            })
+            .orElseGet(this::getUserStateV1FromSecurityContext);
+    }
+
+    /**
+     * Returns the V1 user state from the current security context.
      *
      * @deprecated Use {@link #getUserStateFromSecurityContext()} for V2 user state.
      */
@@ -33,15 +67,11 @@ public class UserStateService {
     @SuppressWarnings({"java:S1874", "java:S1133"})
     @Deprecated(since = "2")
     public UserState getUserStateV1FromSecurityContext() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (!(authentication instanceof OpalJwtAuthenticationToken authToken)) {
-            throw new AccessDeniedException("Unexpected token type");
-        }
-        UserStateV2 userStateV2 = authToken.getUserState();
-        if (userStateV2 == null) {
-            throw new AccessDeniedException("User state not found in token");
-        }
-        return userStateMapper.toUserState(userStateV2, Domain.FINES);
+        UserState userState = userStateMapper.toUserState(getUserStateFromSecurityContext(), Domain.FINES);
+        log.debug(":getUserStateV1FromSecurityContext: using authenticated user state from token: userId={}, "
+                + "userName={}, businessUnits={}",
+            userState.getUserId(), userState.getUserName(), summariseBusinessUnits(userState));
+        return userState;
     }
 
     public UserStateV2 getUserStateFromSecurityContext() {
@@ -58,5 +88,14 @@ public class UserStateService {
 
     public String getPreferredUsername(String authorization) {
         return extractPreferredUsername(authorization, tokenService);
+    }
+
+    private String summariseBusinessUnits(UserState userState) {
+        if (userState.getBusinessUnitUser() == null || userState.getBusinessUnitUser().isEmpty()) {
+            return "[]";
+        }
+        return userState.getBusinessUnitUser().stream()
+            .map(businessUnitUser -> String.valueOf(businessUnitUser.getBusinessUnitId()))
+            .collect(Collectors.joining(",", "[", "]"));
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/UserStateService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/UserStateService.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.opal.common.user.authorisation.model.UserStateV2;
 @Service
 @RequiredArgsConstructor
 @Slf4j(topic = "opal.UserStateService")
+@SuppressWarnings("java:S1874")
 public class UserStateService {
 
     private final AccessTokenService tokenService;

--- a/src/test/java/uk/gov/hmcts/opal/controllers/TestingSupportControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/TestingSupportControllerTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.when;
     }
 )
 @Isolated
+@SuppressWarnings("java:S1874")
 class TestingSupportControllerTest {
 
     @Autowired

--- a/src/test/java/uk/gov/hmcts/opal/controllers/TestingSupportControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/TestingSupportControllerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.controllers;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,14 +8,22 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.common.launchdarkly.service.FeatureToggleApi;
 import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
+import uk.gov.hmcts.opal.common.user.authorisation.client.mapper.UserStateMapper;
 import uk.gov.hmcts.opal.common.user.authorisation.client.service.UserStateClientService;
+import uk.gov.hmcts.opal.common.user.authorisation.model.Domain;
+import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
+import uk.gov.hmcts.opal.common.user.authorisation.model.UserStateV2;
+import uk.gov.hmcts.opal.controllers.util.UserStateUtil;
 import uk.gov.hmcts.opal.dto.AppMode;
 import uk.gov.hmcts.opal.service.opal.DefendantAccountDeletionService;
 import uk.gov.hmcts.opal.service.opal.DynamicConfigService;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest(
@@ -44,10 +53,14 @@ class TestingSupportControllerTest {
     @MockitoBean
     private AccessTokenService accessTokenService;
 
-    @MockitoBean DefendantAccountDeletionService defendantAccountDeletionService;
+    @MockitoBean
+    private DefendantAccountDeletionService defendantAccountDeletionService;
 
     @MockitoBean
     private UserStateClientService userStateClientService;
+
+    @MockitoBean
+    private UserStateMapper userStateMapper;
 
     @Test
     void getAppMode() {
@@ -89,5 +102,26 @@ class TestingSupportControllerTest {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("my@email.com", response.getBody());
+    }
+
+    @Test
+    void getUserState_shouldReturnResponse() {
+        UserState userState = UserStateUtil.permissionUser((short) 1, FinesPermission.ACCOUNT_ENQUIRY);
+        UserStateV2 userStateV2 = mock(UserStateV2.class);
+        when(userStateClientService.getUserStateByAuthenticatedUser()).thenReturn(Optional.of(userStateV2));
+        when(userStateMapper.toUserState(userStateV2, Domain.FINES)).thenReturn(userState);
+
+        ResponseEntity<UserState> response = controller.getUserState(0L);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(userState, response.getBody());
+    }
+
+    @Test
+    void getUserState_shouldReturnNotFound() {
+        ResponseEntity<UserState> response = controller.getUserState(99L);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertFalse(response.hasBody());
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/UserStateServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/UserStateServiceTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("java:S1874")
 class UserStateServiceTest {
 
     @Mock

--- a/src/test/java/uk/gov/hmcts/opal/service/UserStateServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/UserStateServiceTest.java
@@ -146,7 +146,6 @@ class UserStateServiceTest {
         // Arrange
         Authentication authentication = mock(Authentication.class);
         setAuthentication(authentication);
-        when(userStateClientService.getUserStateByAuthenticatedUser()).thenReturn(Optional.empty());
 
         // Act
         AccessDeniedException ade = assertThrows(AccessDeniedException.class,
@@ -162,7 +161,6 @@ class UserStateServiceTest {
         // Arrange
         OpalJwtAuthenticationToken authToken = mock(OpalJwtAuthenticationToken.class);
         setAuthentication(authToken);
-        when(userStateClientService.getUserStateByAuthenticatedUser()).thenReturn(Optional.empty());
         when(authToken.getUserState()).thenReturn(null);
 
         // Act

--- a/src/test/java/uk/gov/hmcts/opal/service/UserStateServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/UserStateServiceTest.java
@@ -1,16 +1,9 @@
 package uk.gov.hmcts.opal.service;
 
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -20,10 +13,19 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import uk.gov.hmcts.opal.common.spring.security.OpalJwtAuthenticationToken;
 import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
-import uk.gov.hmcts.opal.common.user.authorisation.model.Domain;
 import uk.gov.hmcts.opal.common.user.authorisation.client.mapper.UserStateMapper;
+import uk.gov.hmcts.opal.common.user.authorisation.client.service.UserStateClientService;
+import uk.gov.hmcts.opal.common.user.authorisation.model.Domain;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserStateV2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class UserStateServiceTest {
@@ -34,8 +36,26 @@ class UserStateServiceTest {
     @Mock
     private UserStateMapper userStateMapper;
 
+    @Mock
+    private UserStateClientService userStateClientService;
+
     @InjectMocks
     private UserStateService userStateService;
+
+    @Test
+    void testCheckForAuthorisedUser_usesCurrentAuthenticatedUserStateWhenAvailable() {
+        // Arrange
+        final UserState expectedUserState = mock(UserState.class);
+        UserStateV2 userStateV2 = mock(UserStateV2.class);
+        when(userStateClientService.getUserStateByAuthenticatedUser()).thenReturn(Optional.of(userStateV2));
+        when(userStateMapper.toUserState(userStateV2, Domain.FINES)).thenReturn(expectedUserState);
+
+        // Act
+        UserState userState = userStateService.checkForAuthorisedUser("");
+
+        // Assert
+        assertSame(expectedUserState, userState);
+    }
 
     @Test
     void testGetUserStateFromSecurityContext_returnsTokenUserState() {
@@ -89,6 +109,7 @@ class UserStateServiceTest {
         UserStateV2 userStateV2 = mock(UserStateV2.class);
         UserState userState = mock(UserState.class);
         setAuthentication(authToken);
+        when(userStateClientService.getUserStateByAuthenticatedUser()).thenReturn(Optional.empty());
         when(authToken.getUserState()).thenReturn(userStateV2);
         when(userStateMapper.toUserState(userStateV2, Domain.FINES)).thenReturn(userState);
 
@@ -104,6 +125,7 @@ class UserStateServiceTest {
         // Arrange
         Authentication authentication = mock(Authentication.class);
         setAuthentication(authentication);
+        when(userStateClientService.getUserStateByAuthenticatedUser()).thenReturn(Optional.empty());
 
         // Act
         AccessDeniedException ade = assertThrows(AccessDeniedException.class,
@@ -119,6 +141,7 @@ class UserStateServiceTest {
         // Arrange
         OpalJwtAuthenticationToken authToken = mock(OpalJwtAuthenticationToken.class);
         setAuthentication(authToken);
+        when(userStateClientService.getUserStateByAuthenticatedUser()).thenReturn(Optional.empty());
         when(authToken.getUserState()).thenReturn(null);
 
         // Act

--- a/src/test/java/uk/gov/hmcts/opal/service/UserStateServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/UserStateServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service;
 
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -103,21 +104,40 @@ class UserStateServiceTest {
     }
 
     @Test
-    void testGetUser_StateV1FromSecurityContext_mapsV2StateToV1FinesDomain() {
+    void testCheckForAuthorisedUser_mapsV2StateToV1FinesDomain() {
         // Arrange
         OpalJwtAuthenticationToken authToken = mock(OpalJwtAuthenticationToken.class);
         UserStateV2 userStateV2 = mock(UserStateV2.class);
-        UserState userState = mock(UserState.class);
+        final UserState userState = mock(UserState.class);
         setAuthentication(authToken);
         when(userStateClientService.getUserStateByAuthenticatedUser()).thenReturn(Optional.empty());
         when(authToken.getUserState()).thenReturn(userStateV2);
         when(userStateMapper.toUserState(userStateV2, Domain.FINES)).thenReturn(userState);
 
         // Act
-        UserState result = userStateService.getUserStateV1FromSecurityContext();
+        UserState result = userStateService.checkForAuthorisedUser();
 
         // Assert
         assertSame(userState, result);
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void testCheckForAuthorisedUser_fallsBackToSecurityContextWhenAuthenticatedUserStateHasUnexpectedType() {
+        // Arrange
+        OpalJwtAuthenticationToken authToken = mock(OpalJwtAuthenticationToken.class);
+        UserStateV2 userStateV2 = mock(UserStateV2.class);
+        final UserState expectedUserState = mock(UserState.class);
+        setAuthentication(authToken);
+        when(userStateClientService.getUserStateByAuthenticatedUser()).thenReturn((Optional) Optional.of(Map.of()));
+        when(authToken.getUserState()).thenReturn(userStateV2);
+        when(userStateMapper.toUserState(userStateV2, Domain.FINES)).thenReturn(expectedUserState);
+
+        // Act
+        UserState userState = userStateService.checkForAuthorisedUser();
+
+        // Assert
+        assertSame(expectedUserState, userState);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-6359


### Change description ###
- Upgrade opal-common-lib to latest release
- Update feature-toggle tests to expect 404 for disabled local endpoints
- Add JWT integration coverage for 503 application/problem+json when the user-service auth lookup is disabled
- Align user-state and testing-support code with the shared current-user UserStateV2 flow


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
