### PR TITLE
PO-3854: Align ControlTotalEntity with database enum

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/entity/ControlTotalEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/ControlTotalEntity.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -16,9 +17,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnTransformer;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
 
 import java.math.BigDecimal;
+import uk.gov.hmcts.opal.entity.converter.AssociatedRecordTypeConverter;
 
 @Entity
 @Table(name = "control_totals")
@@ -47,8 +50,10 @@ public class ControlTotalEntity {
     @Column(name = "amount", precision = 18, scale = 2, nullable = false)
     private BigDecimal amount;
 
-    @Column(name = "associated_record_type", length = 30)
-    private String associatedRecordType;
+    @Convert(converter = AssociatedRecordTypeConverter.class)
+    @ColumnTransformer(write = "?::t_associated_record_type_enum")
+    @Column(name = "associated_record_type", length = 30, columnDefinition = "t_associated_record_type_enum")
+    private AssociatedRecordType associatedRecordType;
 
     @Column(name = "associated_record_id", length = 30)
     private String associatedRecordId;

--- a/src/main/resources/db/migration/data/dev/V1_115__update_control_totals_dev_test_data_for_r1b_enums.sql
+++ b/src/main/resources/db/migration/data/dev/V1_115__update_control_totals_dev_test_data_for_r1b_enums.sql
@@ -1,0 +1,18 @@
+/**
+* OPAL Program
+*
+* MODULE      : update_control_totals_dev_test_data_for_r1b_enums.sql
+*
+* DESCRIPTION : Update control_totals dev test data for R1b enum values
+*
+* VERSION HISTORY:
+*
+* Date          Author    Version     Nature of Change
+* ----------    ------    --------    ----------------------------------------------------------------------------
+* 03/06/2026    TMc       1.0         PO-3622 - Update columns on CONTROL_TOTALS table to use PostgreSQL ENUM
+*
+**/
+
+UPDATE control_totals
+SET associated_record_type = 'report_instances'
+WHERE associated_record_type = 'REPORT_INSTANCE';

--- a/src/main/resources/db/migration/ddl/V1_120__alter_control_totals_associated_record_type_to_enum.sql
+++ b/src/main/resources/db/migration/ddl/V1_120__alter_control_totals_associated_record_type_to_enum.sql
@@ -1,0 +1,20 @@
+/**
+* OPAL Program
+*
+* MODULE      : alter_control_totals_associated_record_type_to_enum.sql
+*
+* DESCRIPTION : Alter control_totals.associated_record_type to use PostgreSQL enum
+*
+* VERSION HISTORY:
+*
+* Date          Author         Version     Nature of Change
+* ----------    -----------    --------    ----------------------------------------------------------------------------
+* 03/06/2026    TMc            1.0         PO-3622 - Update columns on CONTROL_TOTALS table to use PostgreSQL ENUM
+*
+**/
+
+ALTER TABLE control_totals
+    ALTER COLUMN associated_record_type TYPE t_associated_record_type_enum
+    USING associated_record_type::t_associated_record_type_enum;
+
+COMMENT ON COLUMN control_totals.associated_record_type IS 'Type of record that is identified by associated_record_id. Specific values can be found in the DB LLD on Confluence.';


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-3854
BE - Database enum alignment - ControlTotalsEntity


### Change description ###
- Refactor ControlTotalEntity.associatedRecordType to use the AssociatedRecordType enum instead of a String


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
