### PR TITLE
Added a test key PO-2507: Update GDPR compliance NFR tags and logging docs

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,7 +1,7 @@
 #!groovy
 import uk.gov.hmcts.contino.GithubAPI
 
-@Library("Infrastructure")
+@Library("Infrastructure@2.0.0")
 
 def type = "java"
 def product = "opal"

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,7 +1,7 @@
 #!groovy
 import uk.gov.hmcts.contino.GithubAPI
 
-@Library("Infrastructure@2.0.0")
+@Library("Infrastructure@master")
 
 def type = "java"
 def product = "opal"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -19,7 +19,7 @@ import uk.gov.hmcts.contino.GradleBuilder
 import java.time.DayOfWeek
 import java.time.ZonedDateTime
 
-@Library("Infrastructure")
+@Library("Infrastructure@2.0.0")
 
 def type = "java"
 def product = "opal"
@@ -63,7 +63,7 @@ withNightlyPipeline(type, product, component) {
      }
    }
       def today = ZonedDateTime.now().getDayOfWeek()
-      def shouldRunWithZephyr = params.ZephyrExecution || today == DayOfWeek.FRIDAY;
+      def shouldRunWithZephyr = params.ZephyrExecution || today == DayOfWeek.FRIDAY
       if (shouldRunWithZephyr) {
           env.EXECUTION_BUILD = env.GIT_COMMIT
           env.EXECUTION_ENVIRONMENT = env.ENVIRONMENT_NAME

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -19,7 +19,7 @@ import uk.gov.hmcts.contino.GradleBuilder
 import java.time.DayOfWeek
 import java.time.ZonedDateTime
 
-@Library("Infrastructure@2.0.0")
+@Library("Infrastructure@master")
 
 def type = "java"
 def product = "opal"

--- a/src/functionalTest/java/uk/gov/hmcts/opal/steps/LoggingSteps.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/steps/LoggingSteps.java
@@ -51,7 +51,7 @@ public class LoggingSteps extends BaseStepDef {
     @Then("the logging service emits PDPO logs for the created draft account id")
     public void loggingServiceEmitsPdpoLogsForTheCreatedDraftAccountId() {
         latestPdpoSearchResponse = waitForPdpoLogs(Map.of(
-            "individualId",
+            "individual_id",
             scenarioContext().getLastDraftAccountIdOrFail()
         ));
     }

--- a/src/functionalTest/java/uk/gov/hmcts/opal/steps/LoggingSteps.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/steps/LoggingSteps.java
@@ -193,7 +193,9 @@ public class LoggingSteps extends BaseStepDef {
 
         if (node.isObject()) {
             for (var field : node.properties()) {
-                if (expectedFieldName.equals(field.getKey()) || containsFieldName(field.getValue(), expectedFieldName)) {
+                boolean fieldNameMatches = expectedFieldName.equals(field.getKey());
+                boolean childFieldNameMatches = containsFieldName(field.getValue(), expectedFieldName);
+                if (fieldNameMatches || childFieldNameMatches) {
                     return true;
                 }
             }

--- a/src/functionalTest/java/uk/gov/hmcts/opal/steps/LoggingSteps.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/steps/LoggingSteps.java
@@ -1,19 +1,26 @@
 package uk.gov.hmcts.opal.steps;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.restassured.response.Response;
+import net.serenitybdd.rest.SerenityRest;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Defines Cucumber steps and helper logic for PDPO logging assertions.
  */
 public class LoggingSteps extends BaseStepDef {
 
-    private static final Logger log = LoggerFactory.getLogger(LoggingSteps.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final String SEARCH_PATH = "/test-support/search";
 
@@ -27,21 +34,7 @@ public class LoggingSteps extends BaseStepDef {
             .map(Integer::parseInt)
             .orElse(1000);
 
-    // Map business_identifier -> expected individuals[].type (entity type)
-    private static final Map<String, String> BUSINESS_TO_ENTITY_TYPE = Map.ofEntries(
-        Map.entry("Submit Draft Account - Defendant", "DRAFT_ACCOUNT"),
-        Map.entry("Submit Draft Account - Parent or Guardian", "DRAFT_ACCOUNT"),
-        Map.entry("Submit Draft Account - Minor Creditor", "DRAFT_ACCOUNT"),
-        Map.entry("Update Draft Account - Defendant", "DRAFT_ACCOUNT"),
-        Map.entry("Update Draft Account - Parent or Guardian", "DRAFT_ACCOUNT"),
-        Map.entry("Update Draft Account - Minor Creditor", "DRAFT_ACCOUNT"),
-        Map.entry("Re-submit Draft Account - Defendant", "DRAFT_ACCOUNT"),
-        Map.entry("Re-submit Draft Account - Parent or Guardian", "DRAFT_ACCOUNT"),
-        Map.entry("Re-submit Draft Account - Minor Creditor", "DRAFT_ACCOUNT"),
-        Map.entry("Get Draft Account - Defendant", "DRAFT_ACCOUNT"),
-        Map.entry("Get Draft Account - Parent or Guardian", "DRAFT_ACCOUNT"),
-        Map.entry("Get Draft Account - Minor Creditor", "DRAFT_ACCOUNT")
-    );
+    private JsonNode latestPdpoSearchResponse;
 
     /**
      * Stores an invalid bearer token in the Serenity session for the current scenario.
@@ -51,4 +44,195 @@ public class LoggingSteps extends BaseStepDef {
         BearerTokenStepDef.setTokenOverride("invalid-token");
     }
 
+    /**
+     * Searches the logging-service test-support API until at least one PDPO log exists for the
+     * created draft account identifier.
+     */
+    @Then("the logging service emits PDPO logs for the created draft account id")
+    public void loggingServiceEmitsPdpoLogsForTheCreatedDraftAccountId() {
+        latestPdpoSearchResponse = waitForPdpoLogs(Map.of(
+            "individualId",
+            scenarioContext().getLastDraftAccountIdOrFail()
+        ));
+    }
+
+    /**
+     * Verifies that the last PDPO search response does not expose the supplied JSON field names.
+     *
+     * @param fieldNames field names that must be absent from the emitted PDPO logs.
+     */
+    @Then("the emitted PDPO logs do not contain these field names")
+    public void emittedPdpoLogsDoNotContainTheseFieldNames(DataTable fieldNames) {
+        JsonNode response = requireLatestPdpoSearchResponse();
+        for (String fieldName : fieldNames.asList(String.class)) {
+            assertFalse(
+                containsFieldName(response, fieldName),
+                () -> "Expected emitted PDPO logs not to contain field name '" + fieldName + "' but found: "
+                    + response
+            );
+        }
+    }
+
+    /**
+     * Verifies that the last PDPO search response does not expose the supplied scalar values.
+     *
+     * @param values values that must be absent from the emitted PDPO logs.
+     */
+    @Then("the emitted PDPO logs do not contain these values")
+    public void emittedPdpoLogsDoNotContainTheseValues(DataTable values) {
+        JsonNode response = requireLatestPdpoSearchResponse();
+        for (String value : values.asList(String.class)) {
+            assertFalse(
+                containsScalarValue(response, value),
+                () -> "Expected emitted PDPO logs not to contain value '" + value + "' but found: " + response
+            );
+        }
+    }
+
+    /**
+     * Polls the logging-service test-support search endpoint until matching PDPO logs are available.
+     *
+     * @param criteria search criteria to submit to the logging-service test-support API.
+     * @return the first non-empty PDPO log search response.
+     */
+    private JsonNode waitForPdpoLogs(Map<String, String> criteria) {
+        long timeoutNanos = TimeUnit.SECONDS.toNanos(DEFAULT_TIMEOUT_SECONDS);
+        long deadline = System.nanoTime() + timeoutNanos;
+        Response lastResponse = null;
+
+        while (System.nanoTime() < deadline) {
+            lastResponse = SerenityRest.given()
+                .accept("*/*")
+                .contentType("application/json")
+                .body(writeJson(criteria))
+                .when()
+                .post(getLoggingTestUrl() + SEARCH_PATH);
+
+            if (lastResponse.statusCode() != 200) {
+                fail("Expected PDPO log search to return 200 but was " + lastResponse.statusCode()
+                    + " with body: " + lastResponse.asString());
+            }
+
+            JsonNode responseBody = readJson(lastResponse.asString());
+            if (responseBody.isArray() && !responseBody.isEmpty()) {
+                return responseBody;
+            }
+
+            sleepBeforeRetry();
+        }
+
+        String lastBody = lastResponse == null ? "<no response>" : lastResponse.asString();
+        fail("Timed out waiting for PDPO logs matching " + criteria + ". Last response body: " + lastBody);
+        return null;
+    }
+
+    /**
+     * Returns the most recent PDPO log search response, failing the scenario if no search has run.
+     *
+     * @return the latest PDPO log search response stored for the scenario.
+     */
+    private JsonNode requireLatestPdpoSearchResponse() {
+        assertNotNull(
+            latestPdpoSearchResponse,
+            "No PDPO log response is available. Search for emitted PDPO logs before asserting contents."
+        );
+        return latestPdpoSearchResponse;
+    }
+
+    /**
+     * Serialises a Java value into JSON for the logging-service test-support request body.
+     *
+     * @param value value to serialise.
+     * @return JSON representation of the supplied value.
+     */
+    private static String writeJson(Object value) {
+        try {
+            return MAPPER.writeValueAsString(value);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to serialise PDPO log search payload", e);
+        }
+    }
+
+    /**
+     * Parses a logging-service test-support response body into a JSON tree.
+     *
+     * @param value raw JSON response body.
+     * @return parsed JSON tree.
+     */
+    private static JsonNode readJson(String value) {
+        try {
+            return MAPPER.readTree(value);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to parse PDPO log search response", e);
+        }
+    }
+
+    /**
+     * Pauses between polling attempts, preserving interrupt status if the wait is interrupted.
+     */
+    private static void sleepBeforeRetry() {
+        try {
+            Thread.sleep(DEFAULT_POLL_MILLIS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for PDPO logs", e);
+        }
+    }
+
+    /**
+     * Recursively checks whether a JSON tree contains the supplied field name.
+     *
+     * @param node JSON tree or subtree to inspect.
+     * @param expectedFieldName field name that must be found.
+     * @return {@code true} if the field name exists anywhere in the tree.
+     */
+    private static boolean containsFieldName(JsonNode node, String expectedFieldName) {
+        if (node == null) {
+            return false;
+        }
+
+        if (node.isObject()) {
+            for (var field : node.properties()) {
+                if (expectedFieldName.equals(field.getKey()) || containsFieldName(field.getValue(), expectedFieldName)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if (node.isArray()) {
+            for (JsonNode child : node) {
+                if (containsFieldName(child, expectedFieldName)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Recursively checks whether a JSON tree contains the supplied scalar value.
+     *
+     * @param node JSON tree or subtree to inspect.
+     * @param expectedValue scalar value that must be found.
+     * @return {@code true} if the scalar value exists anywhere in the tree.
+     */
+    private static boolean containsScalarValue(JsonNode node, String expectedValue) {
+        if (node == null) {
+            return false;
+        }
+
+        if (node.isValueNode()) {
+            return expectedValue.equals(node.asText());
+        }
+
+        for (JsonNode child : node) {
+            if (containsScalarValue(child, expectedValue)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/add/AddDraftAccount.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/add/AddDraftAccount.feature
@@ -85,7 +85,16 @@ Feature: Create Draft Accounts
       | account_status    | Submitted                                              |
       | submitted_by      | PG1234                                                 |
       | submitted_by_name | opal-test                                              |
-    Then the logging service emits PDPO logs for the created draft account id
+    Then the draft account is created successfully with the following data
+      | business_unit_id                   | 77                               |
+      | account_type                       | Fine                             |
+      | account_status                     | Submitted                        |
+      | account_snapshot.defendant_name    | LNAME, FNAME                     |
+      | account_snapshot.date_of_birth     | 2000-01-01                       |
+      | account_snapshot.account_type      | Fine                             |
+      | account_snapshot.submitted_by      | L077JG                           |
+      | account_snapshot.submitted_by_name | opal-test                        |
+    And the logging service emits PDPO logs for the created draft account id
     And the emitted PDPO logs do not contain these field names
       | surname         |
       | forenames       |

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/add/AddDraftAccount.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/add/AddDraftAccount.feature
@@ -76,6 +76,29 @@ Feature: Create Draft Accounts
     #      | 500000000        | OPAL_USER_ID    | Submit Draft Account - Defendant            | <CREATED_DRAFT_ACCOUNT_ID>   |1              |
     #      | 500000000        | OPAL_USER_ID    | Submit Draft Account - Minor Creditor       | <CREATED_DRAFT_ACCOUNT_ID>   |1              |
 
+  @JIRA-STORY:PO-2357 @JIRA-NFR:PO-2507 @cleanUpData @JIRA-EPIC:PO-2355
+  Scenario: Emitted PDPO logs do not expose personal details
+    When I create a draft account with the following details
+      | business_unit_id  | 77                                                     |
+      | account           | draftAccounts/accountJson/parentOrGuardianAccount.json |
+      | account_type      | Fine                                                   |
+      | account_status    | Submitted                                              |
+      | submitted_by      | PG1234                                                 |
+      | submitted_by_name | opal-test                                              |
+    Then the logging service emits PDPO logs for the created draft account id
+    And the emitted PDPO logs do not contain these field names
+      | surname         |
+      | forenames       |
+      | dob             |
+      | email_address_1 |
+      | email_address_2 |
+    And the emitted PDPO logs do not contain these values
+      | LNAME              |
+      | Opal parent1       |
+      | 2000-01-01         |
+      | PGemail1@email.com |
+      | PGemail2@test.com  |
+
   @JIRA-STORY:PO-559 @JIRA-STORY:PO-2357 @JIRA-EPIC:PO-2219 @cleanUpData @JIRA-TEST-KEY:PO-5624
   Scenario: Reject draft-account creation with an invalid token
     When I attempt to create a draft account with an invalid token using created by ID "invalidToken"

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/add/AddDraftAccountAuthorisation.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/add/AddDraftAccountAuthorisation.feature
@@ -13,7 +13,7 @@ Feature: Add Draft Account Authorisation
       | submitted_by_name | Laura Clerk                                 |
     Then the request is rejected as unauthorized
 
-  @JIRA-STORY:PO-827 @JIRA-EPIC:PO-2219 @cleanUpData @JIRA-TEST-KEY:PO-5626
+  @JIRA-STORY:PO-827 @JIRA-EPIC:PO-2219 @cleanUpData @JIRA-NFR:PO-2507 @JIRA-TEST-KEY:PO-5626
   Scenario: Post Draft Account - No Permission
     When the "opal-test-2@dev.platform.hmcts.net" user attempts to create a draft account with the following details
       | business_unit_id  | 73                                          |
@@ -24,7 +24,7 @@ Feature: Add Draft Account Authorisation
       | submitted_by_name | Laura Clerk                                 |
     Then the request is rejected as forbidden
 
-  @JIRA-STORY:PO-827 @JIRA-EPIC:PO-2219 @cleanUpData @JIRA-TEST-KEY:PO-5627
+  @JIRA-STORY:PO-827 @JIRA-EPIC:PO-2219 @cleanUpData @JIRA-NFR:PO-2507 @JIRA-TEST-KEY:PO-5627
   Scenario: Post Draft Account - Permission in different BU
     When the "opal-test@dev.platform.hmcts.net" user attempts to create a draft account with the following details
       | business_unit_id  | 26                                          |

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/get/GetDraftAccountAuthorisation.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/get/GetDraftAccountAuthorisation.feature
@@ -1,7 +1,7 @@
 @Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:authorisation
 Feature: Get Draft Account Authorisation
 
-  @JIRA-STORY:PO-828 @JIRA-EPIC:PO-2219 @cleanUpData @JIRA-TEST-KEY:PO-5642
+  @JIRA-STORY:PO-828 @JIRA-EPIC:PO-2219 @cleanUpData @JIRA-NFR:PO-2507 @JIRA-TEST-KEY:PO-5642
   Scenario: Get Draft Account - No Permission
     Given I am testing as the "opal-test@dev.platform.hmcts.net" user
     And a draft account exists with the following details
@@ -31,7 +31,7 @@ Feature: Get Draft Account Authorisation
     When the "opal-test-10@dev.platform.hmcts.net" user attempts to view the created draft account
     Then access to the created draft account is denied
 
-  @JIRA-STORY:PO-828 @JIRA-EPIC:PO-2219 @cleanUpData @JIRA-TEST-KEY:PO-5644
+  @JIRA-STORY:PO-828 @JIRA-EPIC:PO-2219 @cleanUpData @JIRA-NFR:PO-2507 @JIRA-TEST-KEY:PO-5644
   Scenario: Get Draft Account - Permission in different BU
     Given I am testing as the "opal-test@dev.platform.hmcts.net" user
     And a draft account exists with the following details

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/list/GetDraftAccountsAuthorisation.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/list/GetDraftAccountsAuthorisation.feature
@@ -1,7 +1,7 @@
 @Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:authorisation
 Feature: Get Draft Accounts Authorisation
 
-  @JIRA-STORY:PO-829 @JIRA-EPIC:PO-2219 @cleanUpData @JIRA-TEST-KEY:PO-5662
+  @JIRA-STORY:PO-829 @JIRA-EPIC:PO-2219 @cleanUpData @JIRA-NFR:PO-2507 @JIRA-TEST-KEY:PO-5662
   Scenario: Get Draft Accounts - No Permission
     Given I am testing as the "opal-test@dev.platform.hmcts.net" user
     And a draft account exists with the following details
@@ -15,7 +15,7 @@ Feature: Get Draft Accounts Authorisation
     When the "opal-test-2@dev.platform.hmcts.net" user attempts to list draft accounts for business unit "78"
     Then the request is rejected as forbidden
 
-  @JIRA-STORY:PO-829 @JIRA-EPIC:PO-2219 @cleanUpData @JIRA-TEST-KEY:PO-5663
+  @JIRA-STORY:PO-829 @JIRA-EPIC:PO-2219 @cleanUpData @JIRA-NFR:PO-2507 @JIRA-TEST-KEY:PO-5663
   Scenario: Get Draft Accounts - account created in BU requesting user doesn't have permission to
     Given I am testing as the "opal-test@dev.platform.hmcts.net" user
     And the following draft accounts exist

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/replace/ReplaceDraftAccountAuthorisation.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/replace/ReplaceDraftAccountAuthorisation.feature
@@ -25,7 +25,7 @@ Feature: Replace Draft Account Authorisation
 
     #    And no PDPO logs exist for created_by id "invalidToken", type "OPAL_USER_ID" and business_identifier "Update Draft Account - Defendant"
 
-  @JIRA-STORY:PO-830 @JIRA-EPIC:PO-2220 @cleanUpData @JIRA-TEST-KEY:PO-5672
+  @JIRA-STORY:PO-830 @JIRA-EPIC:PO-2220 @cleanUpData @JIRA-NFR:PO-2507 @JIRA-TEST-KEY:PO-5672
   Scenario: Update draft account - user with no permissions
     Given I am testing as the "opal-test@dev.platform.hmcts.net" user
     And a draft account exists with the following details
@@ -55,7 +55,7 @@ Feature: Replace Draft Account Authorisation
       | account_snapshot.business_unit_name | West London |
 
 
-  @JIRA-STORY:PO-830 @JIRA-EPIC:PO-2220 @cleanUpData @JIRA-TEST-KEY:PO-5673
+  @JIRA-STORY:PO-830 @JIRA-EPIC:PO-2220 @cleanUpData @JIRA-NFR:PO-2507 @JIRA-TEST-KEY:PO-5673
   Scenario: Update draft account - user with permissions in different business unit - bu 73 to 26
     Given I am testing as the "opal-test@dev.platform.hmcts.net" user
     And a draft account exists with the following details
@@ -85,7 +85,7 @@ Feature: Replace Draft Account Authorisation
       | account_snapshot.business_unit_name | West London |
 
 
-  @JIRA-STORY:PO-830 @JIRA-EPIC:PO-2220 @cleanUpData @JIRA-TEST-KEY:PO-5674
+  @JIRA-STORY:PO-830 @JIRA-EPIC:PO-2220 @cleanUpData @JIRA-NFR:PO-2507 @JIRA-TEST-KEY:PO-5674
   Scenario: Update draft account - user with permissions in different business unit - bu 26 to 73
     Given I am testing as the "opal-test-3@dev.platform.hmcts.net" user
     And a draft account exists with the following details

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/update/UpdateDraftAccountAuthorisation.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/update/UpdateDraftAccountAuthorisation.feature
@@ -24,7 +24,7 @@ Feature: Update Draft Account Authorisation
     Then the request is rejected as unauthorized
 
 
-  @JIRA-STORY:PO-831 @JIRA-EPIC:PO-2220 @cleanUpData @JIRA-TEST-KEY:PO-5693
+  @JIRA-STORY:PO-831 @JIRA-EPIC:PO-2220 @cleanUpData @JIRA-NFR:PO-2507 @JIRA-TEST-KEY:PO-5693
   Scenario: Update draft account - user with no permissions
     Given I am testing as the "opal-test@dev.platform.hmcts.net" user
     And a draft account exists with the following details
@@ -54,7 +54,7 @@ Feature: Update Draft Account Authorisation
       | account_snapshot.business_unit_name | West London |
 
 
-  @JIRA-STORY:PO-831 @JIRA-EPIC:PO-2220 @cleanUpData @JIRA-TEST-KEY:PO-5694
+  @JIRA-STORY:PO-831 @JIRA-EPIC:PO-2220 @cleanUpData @JIRA-NFR:PO-2507 @JIRA-TEST-KEY:PO-5694
   Scenario: Update draft account - user with permissions in different business unit - bu 73 to 26
     Given I am testing as the "opal-test@dev.platform.hmcts.net" user
     And a draft account exists with the following details
@@ -84,7 +84,7 @@ Feature: Update Draft Account Authorisation
       | account_snapshot.business_unit_name | West London |
 
 
-  @JIRA-STORY:PO-831 @JIRA-EPIC:PO-2220 @cleanUpData @JIRA-TEST-KEY:PO-5695
+  @JIRA-STORY:PO-831 @JIRA-EPIC:PO-2220 @cleanUpData @JIRA-NFR:PO-2507 @JIRA-TEST-KEY:PO-5695
   Scenario: Update draft account - user with permissions in different business unit - bu 26 to 73
     Given I am testing as the "opal-test-3@dev.platform.hmcts.net" user
     And a draft account exists with the following details

--- a/src/functionalTest/resources/features/opalMode/majorCreditorAccounts/MajorCreditorAccountHeaderSummary.feature
+++ b/src/functionalTest/resources/features/opalMode/majorCreditorAccounts/MajorCreditorAccountHeaderSummary.feature
@@ -13,7 +13,7 @@ Feature: Major Creditor Account Header Summary
     When I request the major creditor account header summary for account 10770000000041 twice
     Then the repeated major creditor account header summary responses are identical
 
-  @JIRA-STORY:PO-2136 @JIRA-EPIC:PO-2136
+  @JIRA-STORY:PO-2136 @JIRA-EPIC:PO-2136 @JIRA-NFR:PO-2507
   Scenario: Major creditor account header summary is forbidden when the user has no account view permission
     When the "opal-test-2@dev.platform.hmcts.net" user requests the major creditor account header summary for account 10770000000041
     Then the request is rejected as forbidden

--- a/src/functionalTest/resources/features/opalMode/referenceData/CourtsBusinessUnitFiltering.feature
+++ b/src/functionalTest/resources/features/opalMode/referenceData/CourtsBusinessUnitFiltering.feature
@@ -11,7 +11,7 @@ Feature: Courts Business Unit Filtering
       | name             | magistrates |
       | business_unit_id | 43          |
 
-  @JIRA-STORY:PO-424 @JIRA-EPIC:PO-304 @JIRA-TEST-KEY:PO-5708
+  @JIRA-STORY:PO-424 @JIRA-EPIC:PO-304 @JIRA-NFR:PO-2507 @JIRA-TEST-KEY:PO-5708
   Scenario: Courts outside the requested business unit are excluded from a name search
     When I make a request to the court ref data api with a filter of "result" and a business unit of 48
     Then the response does not contain the below courts data
@@ -24,7 +24,7 @@ Feature: Courts Business Unit Filtering
     Then the response contains the below courts data
       | business_unit_id | 43 |
 
-  @JIRA-STORY:PO-424 @JIRA-EPIC:PO-304 @JIRA-TEST-KEY:PO-5710
+  @JIRA-STORY:PO-424 @JIRA-EPIC:PO-304 @JIRA-NFR:PO-2507 @JIRA-TEST-KEY:PO-5710
   Scenario: Courts from other business units are excluded
     When I make a request to the court ref data api with a business unit of 84
     Then the response does not contain the below courts data

--- a/src/functionalTest/resources/features/opalMode/referenceData/OffencesBusinessUnitScope.feature
+++ b/src/functionalTest/resources/features/opalMode/referenceData/OffencesBusinessUnitScope.feature
@@ -26,7 +26,7 @@ Feature: Offences Business Unit Scope
     Then the response contains the below offence data
       | business_unit_id | 12 |
 
-  @JIRA-STORY:PO-420 @JIRA-EPIC:PO-304 @JIRA-TEST-KEY:PO-5732
+  @JIRA-STORY:PO-420 @JIRA-EPIC:PO-304 @JIRA-NFR:PO-2507 @JIRA-TEST-KEY:PO-5732
   Scenario: Offences from other business units are excluded
     When I make a request to the offence ref data api filtering by business unit 12
     Then the response does not contain the below offence data


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Updates functional test coverage for PO-2507 NFR/GDPR compliance.

- Replaces `@JIRA-LABEL:gdpr-compliance` with `@JIRA-NFR:PO-2507` across relevant functional scenarios.
- Adds PDPO logging assertions to verify emitted logs do not expose personal field names or values.
- Adds logging-service polling and JSON inspection helpers in `LoggingSteps`.
- Adds JavaDoc for private helper methods and resolves IDE warnings in `LoggingSteps`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
