### PR TITLE
PO-7199: Updated cache logic to use SSL correctly

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/config/CacheConfig.java
+++ b/src/main/java/uk/gov/hmcts/opal/config/CacheConfig.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.config;
 
+import io.lettuce.core.RedisURI;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -20,7 +21,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration.LettuceClientConfigurationBuilder;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJacksonJsonRedisSerializer;
@@ -44,7 +48,15 @@ public class CacheConfig {
     @Bean
     @ConditionalOnProperty(name = "opal.redis.enabled", havingValue = "true")
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(LettuceConnectionFactory.createRedisConfiguration(redisUrl));
+        RedisURI redisURI = RedisURI.create(redisUrl);
+
+        RedisConfiguration redisConfiguration = LettuceConnectionFactory.createRedisConfiguration(redisURI);
+        LettuceClientConfigurationBuilder clientConfigurationBuilder = LettuceClientConfiguration.builder();
+        if (redisURI.isSsl()) {
+            clientConfigurationBuilder.useSsl();
+        }
+        return new LettuceConnectionFactory(redisConfiguration, clientConfigurationBuilder.build());
+
     }
 
     @Bean

--- a/src/test/java/uk/gov/hmcts/opal/config/CacheConfigTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/config/CacheConfigTest.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.opal.config;
 
+import java.lang.reflect.Field;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,9 +13,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -65,5 +69,34 @@ class CacheConfigTest {
         public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
             return RedisCacheManager.builder(redisConnectionFactory).build();
         }
+    }
+    @Test
+    void redisConnectionFactory_shouldEnableSsl_whenUsingRedissUrl() throws Exception {
+        CacheConfig config = new CacheConfig();
+        setField(config, "redisUrl", "rediss://:password@opal-stg.redis.cache.windows.net:6380?tls=true");
+        setField(config, "redisEnabled", true);
+        setField(config, "redisTtlDuration", Duration.ofMinutes(5));
+
+        LettuceConnectionFactory factory = (LettuceConnectionFactory) config.redisConnectionFactory();
+
+        assertThat(factory.isUseSsl()).isTrue();
+    }
+
+    @Test
+    void redisConnectionFactory_shouldDisableSsl_whenUsingRedisUrl() throws Exception {
+        CacheConfig config = new CacheConfig();
+        setField(config, "redisUrl", "redis://localhost:6379");
+        setField(config, "redisEnabled", true);
+        setField(config, "redisTtlDuration", Duration.ofMinutes(5));
+
+        LettuceConnectionFactory factory = (LettuceConnectionFactory) config.redisConnectionFactory();
+
+        assertThat(factory.isUseSsl()).isFalse();
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/config/CacheConfigTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/config/CacheConfigTest.java
@@ -1,5 +1,10 @@
 package uk.gov.hmcts.opal.config;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
 import java.lang.reflect.Field;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
@@ -16,11 +21,6 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
 @SpringBootTest(classes = {CacheConfig.class, CacheConfigTest.TestConfig.class})
 @Isolated
@@ -58,6 +58,7 @@ class CacheConfigTest {
 
     @TestConfiguration
     static class TestConfig {
+
         @Bean
         @Primary
         public RedisConnectionFactory redisConnectionFactory() {
@@ -70,6 +71,7 @@ class CacheConfigTest {
             return RedisCacheManager.builder(redisConnectionFactory).build();
         }
     }
+
     @Test
     void redisConnectionFactory_shouldEnableSsl_whenUsingRedissUrl() throws Exception {
         CacheConfig config = new CacheConfig();


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-7199


### Change description ###
Updated Redis cache to take into account SSL


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
