### PR TITLE
PO-3850: Align AllocationsEntity with DB enum

### DIFF
--- a/src/integrationTest/resources/db/insertData/insert_into_defendants_for_deletion_test.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_defendants_for_deletion_test.sql
@@ -126,12 +126,12 @@ VALUES (9105, 1001, '2023-11-03 16:05:10', '01000000A', 'User9100',
 -- Insert allocations (Level 3 - references both imposition and defendant_transaction)
 INSERT INTO allocations (allocation_id, imposition_id, defendant_transaction_id,
                          allocated_date, allocated_amount, transaction_type, allocation_function)
-VALUES (9106, 9105, 9104, '2023-11-04 10:00:00', 100.00, 'Payment', 'Auto');
+VALUES (9106, 9105, 9104, '2023-11-04 10:00:00', 100.00, 'PAYMNT', 'Auto');
 
 -- Insert another allocation (Level 3 - only references imposition)
 INSERT INTO allocations (allocation_id, imposition_id, allocated_date, allocated_amount,
                          transaction_type, allocation_function)
-VALUES (9108, 9105, '2023-11-05 10:00:00', 50.00, 'Adjustment', 'Manual');
+VALUES (9108, 9105, '2023-11-05 10:00:00', 50.00, 'MADJ', 'Manual');
 
 -- Insert cheque (Level 3 - references defendant_transaction)
 INSERT INTO cheques (cheque_id, business_unit_id, cheque_number, issue_date,

--- a/src/main/java/uk/gov/hmcts/opal/entity/AllocationEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/AllocationEntity.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.opal.entity;
 
+import jakarta.persistence.Convert;
+import org.hibernate.annotations.ColumnTransformer;
+import uk.gov.hmcts.opal.entity.converter.TransactionTypeConverter;
 import uk.gov.hmcts.opal.entity.defendanttransaction.DefendantTransactionEntity;
 import uk.gov.hmcts.opal.entity.imposition.ImpositionEntity;
 
@@ -39,8 +42,11 @@ public class AllocationEntity {
     @Column(name = "allocated_amount", nullable = false, precision = 18, scale = 2)
     private BigDecimal allocatedAmount;
 
-    @Column(name = "transaction_type", nullable = false, length = 10)
-    private String transactionType;
+    @Convert(converter = TransactionTypeConverter.class)
+    @ColumnTransformer(write = "?::t_allocation_transaction_type_enum")
+    @Column(name = "transaction_type", nullable = false, length = 10,
+        columnDefinition = "t_allocation_transaction_type_enum")
+    private TransactionType transactionType;
 
     @Column(name = "allocation_function", nullable = false, length = 30)
     private String allocationFunction;

--- a/src/main/java/uk/gov/hmcts/opal/entity/TransactionType.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/TransactionType.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.opal.entity;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.stream.Stream;
+
+public enum TransactionType {
+    DISHONOURED_CHEQUE("DISHCQ"),
+    TRANSFER_FROM_SUSPENSE("FR_SUS"),
+    MONIES_MANUALLY_ADJUSTED_TO_SUSPENSE("MADJ"),
+    PAYMENT("PAYMNT"),
+    REVERSED_PAYMENT("REVPAY"),
+    REVERSED_WRITE_OFF("RVWOFF"),
+    TRANSFERRED_OUT("TFO"),
+    TRANSFERRED_IN("TFO_IN"),
+    WRITE_OFF("WRTOFF");
+
+    private final String label;
+
+    TransactionType(String label) {
+        this.label = label;
+    }
+
+    @JsonValue
+    public String getLabel() {
+        return label;
+    }
+
+    public static TransactionType getByLabel(String label) {
+        return Stream.of(TransactionType.values())
+            .filter(v -> v.getLabel().equals(label))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Unknown TransactionType: " + label));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/entity/converter/TransactionTypeConverter.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/converter/TransactionTypeConverter.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.opal.entity.converter;
+
+import jakarta.persistence.AttributeConverter;
+import uk.gov.hmcts.opal.entity.TransactionType;
+
+public class TransactionTypeConverter implements AttributeConverter<TransactionType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(TransactionType transactionType) {
+        if (transactionType == null) {
+            return null;
+        }
+        return transactionType.getLabel();
+    }
+
+    @Override
+    public TransactionType convertToEntityAttribute(String label) {
+        if (label == null) {
+            return null;
+        }
+        return TransactionType.getByLabel(label);
+    }
+}

--- a/src/main/resources/db/migration/data/dev/V1_95__update_allocations_dev_test_data_for_r1b_enums.sql
+++ b/src/main/resources/db/migration/data/dev/V1_95__update_allocations_dev_test_data_for_r1b_enums.sql
@@ -1,0 +1,18 @@
+/**
+* OPAL Program
+*
+* MODULE      : update_allocations_dev_test_data_for_r1b_enums.sql
+*
+* DESCRIPTION : Update allocations dev test data for R1b enum values
+*
+* VERSION HISTORY:
+*
+* Date          Author    Version     Nature of Change
+* ----------    ------    --------    ----------------------------------------------------------------------------
+* 03/06/2026    TMc       1.0         PO-3618 - Update columns on ALLOCATIONS table to use PostgreSQL ENUM
+*
+**/
+
+UPDATE allocations
+SET transaction_type = 'PAYMNT'
+WHERE transaction_type = 'PAYMENT';

--- a/src/main/resources/db/migration/ddl/V1_100__alter_allocations_transaction_type_to_enum.sql
+++ b/src/main/resources/db/migration/ddl/V1_100__alter_allocations_transaction_type_to_enum.sql
@@ -1,0 +1,20 @@
+/**
+* OPAL Program
+*
+* MODULE      : alter_allocations_transaction_type_to_enum.sql
+*
+* DESCRIPTION : Alter allocations.transaction_type to use PostgreSQL enum
+*
+* VERSION HISTORY:
+*
+* Date          Author         Version     Nature of Change
+* ----------    -----------    --------    ----------------------------------------------------------------------------
+* 03/06/2026    TMc            1.0         PO-3618 - Update columns on ALLOCATIONS table to use PostgreSQL ENUM
+*
+**/
+
+ALTER TABLE allocations
+    ALTER COLUMN transaction_type TYPE t_allocation_transaction_type_enum
+    USING transaction_type::t_allocation_transaction_type_enum;
+
+COMMENT ON COLUMN allocations.transaction_type IS 'The type of transaction this allocation is associated with. Specific values can be found in the DB LLD on Confluence.';

--- a/src/test/java/uk/gov/hmcts/opal/entity/TransactionTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/entity/TransactionTypeTest.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.opal.entity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class TransactionTypeTest {
+
+    @Test
+    void getByLabel_shouldReturnEnum_forKnownLabel() {
+        assertEquals(TransactionType.DISHONOURED_CHEQUE, TransactionType.getByLabel("DISHCQ"));
+        assertEquals(TransactionType.TRANSFER_FROM_SUSPENSE, TransactionType.getByLabel("FR_SUS"));
+        assertEquals(TransactionType.MONIES_MANUALLY_ADJUSTED_TO_SUSPENSE, TransactionType.getByLabel("MADJ"));
+        assertEquals(TransactionType.PAYMENT, TransactionType.getByLabel("PAYMNT"));
+        assertEquals(TransactionType.REVERSED_PAYMENT, TransactionType.getByLabel("REVPAY"));
+        assertEquals(TransactionType.REVERSED_WRITE_OFF, TransactionType.getByLabel("RVWOFF"));
+        assertEquals(TransactionType.TRANSFERRED_OUT, TransactionType.getByLabel("TFO"));
+        assertEquals(TransactionType.TRANSFERRED_IN, TransactionType.getByLabel("TFO_IN"));
+        assertEquals(TransactionType.WRITE_OFF, TransactionType.getByLabel("WRTOFF"));
+    }
+
+    @Test
+    void getByLabel_shouldThrow_forUnknownLabel() {
+        assertThrows(IllegalArgumentException.class, () -> TransactionType.getByLabel("unknown"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/entity/converter/TransactionTypeConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/entity/converter/TransactionTypeConverterTest.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.opal.entity.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import uk.gov.hmcts.opal.entity.TransactionType;
+
+class TransactionTypeConverterTest {
+
+    private final TransactionTypeConverter converter = new TransactionTypeConverter();
+
+    @ParameterizedTest
+    @EnumSource(TransactionType.class)
+    void givenTransactionType_whenConvertToDatabaseColumn_thenReturnLabel(TransactionType transactionType) {
+        assertThat(converter.convertToDatabaseColumn(transactionType)).isEqualTo(transactionType.getLabel());
+    }
+
+    @Test
+    void givenNullTransactionType_whenConvertToDatabaseColumn_thenReturnNull() {
+        assertThat(converter.convertToDatabaseColumn(null)).isNull();
+    }
+
+    @ParameterizedTest
+    @EnumSource(TransactionType.class)
+    void givenDatabaseLabel_whenConvertToEntityAttribute_thenReturnTransactionType(TransactionType transactionType) {
+        assertThat(converter.convertToEntityAttribute(transactionType.getLabel())).isEqualTo(transactionType);
+    }
+
+    @Test
+    void givenNullDatabaseLabel_whenConvertToEntityAttribute_thenReturnNull() {
+        assertThat(converter.convertToEntityAttribute(null)).isNull();
+    }
+
+    @Test
+    void givenUnknownDatabaseLabel_whenConvertToEntityAttribute_thenThrowException() {
+        assertThatThrownBy(() -> converter.convertToEntityAttribute("Unknown"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unknown TransactionType: Unknown");
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-3850
BE - Database enum alignment - AllocationsEntity
https://tools.hmcts.net/jira/browse/PO-3618 (DB)


### Change description ###
- Refactor `AllocationEntity.transactionType` to use the `TransactionType` enum instead of a String


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
