### PR TITLE
PO-3852: Align BACS Payments Entity with db enum

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/entity/BacsPaymentEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/BacsPaymentEntity.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -16,10 +17,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnTransformer;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import uk.gov.hmcts.opal.entity.converter.BacsStatusTypeConverter;
 
 @Entity
 @Table(name = "bacs_payments")
@@ -56,7 +59,9 @@ public class BacsPaymentEntity {
     @Column(name = "amount", precision = 18, scale = 2, nullable = false)
     private BigDecimal amount;
 
-    @Column(name = "status", length = 10, nullable = false)
-    private String status;
+    @Convert(converter = BacsStatusTypeConverter.class)
+    @ColumnTransformer(write = "?::t_bacs_status_enum")
+    @Column(name = "status", length = 10, nullable = false, columnDefinition = "t_bacs_status_enum")
+    private BacsStatusType status;
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/entity/BacsStatusType.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/BacsStatusType.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.opal.entity;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.stream.Stream;
+
+public enum BacsStatusType {
+    TRANSFERRED("T"),
+    REISSUED("R"),
+    CANCELLED_CHEQUE_WRITTEN("C"),
+    CANCELLED_POSTED_TO_SUSPENSE("S"),
+    CANCELLED_POSTED_TO_CENTRAL_FUND("F"),
+    CLEARED_AWAITING_DELETION("X"),
+    UNPROCESSED("U");
+
+    private final String label;
+
+    BacsStatusType(String label) {
+        this.label = label;
+    }
+
+    @JsonValue
+    public String getLabel() {
+        return label;
+    }
+
+    public static BacsStatusType getByLabel(String label) {
+        return Stream.of(BacsStatusType.values())
+            .filter(v -> v.getLabel().equals(label))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Unknown BACS Status Type: " + label));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/entity/converter/BacsStatusTypeConverter.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/converter/BacsStatusTypeConverter.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.opal.entity.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import uk.gov.hmcts.opal.entity.BacsStatusType;
+
+@Converter(autoApply = true)
+public class BacsStatusTypeConverter implements AttributeConverter<BacsStatusType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(BacsStatusType bacsStatusType) {
+        if (bacsStatusType == null) {
+            return null;
+        }
+        return bacsStatusType.getLabel();
+    }
+
+    @Override
+    public BacsStatusType convertToEntityAttribute(String label) {
+        if (label == null) {
+            return null;
+        }
+        return BacsStatusType.getByLabel(label);
+    }
+}

--- a/src/main/resources/db/migration/ddl/V1_110__alter_bacs_payments_status_to_enum.sql
+++ b/src/main/resources/db/migration/ddl/V1_110__alter_bacs_payments_status_to_enum.sql
@@ -1,0 +1,20 @@
+/**
+* OPAL Program
+*
+* MODULE      : alter_bacs_payments_status_to_enum.sql
+*
+* DESCRIPTION : Alter bacs_payments.status to use PostgreSQL enum
+*
+* VERSION HISTORY:
+*
+* Date          Author         Version     Nature of Change
+* ----------    -----------    --------    ----------------------------------------------------------------------------
+* 03/06/2026    TMc            1.0         PO-3620 - Update columns on BACS_PAYMENTS table to use PostgreSQL ENUM
+*
+**/
+
+ALTER TABLE bacs_payments
+    ALTER COLUMN status TYPE t_bacs_status_enum
+    USING status::t_bacs_status_enum;
+
+COMMENT ON COLUMN bacs_payments.status IS 'BACS status. Specific values can be found in the DB LLD on Confluence.';

--- a/src/test/java/uk/gov/hmcts/opal/entity/BacsStatusTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/entity/BacsStatusTypeTest.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.opal.entity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class BacsStatusTypeTest {
+
+    @Test
+    void getByLabel_shouldReturnEnum_forKnownLabel() {
+        assertEquals(BacsStatusType.TRANSFERRED, BacsStatusType.getByLabel("T"));
+        assertEquals(BacsStatusType.REISSUED, BacsStatusType.getByLabel("R"));
+        assertEquals(BacsStatusType.CANCELLED_CHEQUE_WRITTEN, BacsStatusType.getByLabel("C"));
+        assertEquals(BacsStatusType.CANCELLED_POSTED_TO_SUSPENSE, BacsStatusType.getByLabel("S"));
+        assertEquals(BacsStatusType.CANCELLED_POSTED_TO_CENTRAL_FUND, BacsStatusType.getByLabel("F"));
+        assertEquals(BacsStatusType.CLEARED_AWAITING_DELETION, BacsStatusType.getByLabel("X"));
+        assertEquals(BacsStatusType.UNPROCESSED, BacsStatusType.getByLabel("U"));
+    }
+
+    @Test
+    void getByLabel_shouldThrow_forUnknownLabel() {
+        assertThrows(IllegalArgumentException.class, () -> BacsStatusType.getByLabel("unknown"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/entity/converter/BacsStatusTypeConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/entity/converter/BacsStatusTypeConverterTest.java
@@ -1,0 +1,43 @@
+package uk.gov.hmcts.opal.entity.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import uk.gov.hmcts.opal.entity.BacsStatusType;
+
+class BacsStatusTypeConverterTest {
+
+    private final BacsStatusTypeConverter converter = new BacsStatusTypeConverter();
+
+    @ParameterizedTest
+    @EnumSource(BacsStatusType.class)
+    void givenBacsStatusType_whenConvertToDatabaseColumn_thenReturnLabel(BacsStatusType bacsStatusType) {
+        assertThat(converter.convertToDatabaseColumn(bacsStatusType)).isEqualTo(bacsStatusType.getLabel());
+    }
+
+    @Test
+    void givenNullBacsStatusType_whenConvertToDatabaseColumn_thenReturnNull() {
+        assertThat(converter.convertToDatabaseColumn(null)).isNull();
+    }
+
+    @ParameterizedTest
+    @EnumSource(BacsStatusType.class)
+    void givenDatabaseLabel_whenConvertToEntityAttribute_thenReturnBacsStatusType(BacsStatusType bacsStatusType) {
+        assertThat(converter.convertToEntityAttribute(bacsStatusType.getLabel())).isEqualTo(bacsStatusType);
+    }
+
+    @Test
+    void givenNullDatabaseLabel_whenConvertToEntityAttribute_thenReturnNull() {
+        assertThat(converter.convertToEntityAttribute(null)).isNull();
+    }
+
+    @Test
+    void givenUnknownDatabaseLabel_whenConvertToEntityAttribute_thenThrowException() {
+        assertThatThrownBy(() -> converter.convertToEntityAttribute("Unknown"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unknown BACS Status Type: Unknown");
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-3852
BE - Database enum alignment - BACSPaymentsEntity


### Change description ###
- Refactor `BacsPaymentEntity.status` to use the `BacsStatusType` enum instead of a `String`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
