### PR TITLE
PO-2573_PO-2580_PO-2581 - Add new database columns to interface_files, tills, and interface_messages tables

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/service/report/CashTillReportGenerationIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/service/report/CashTillReportGenerationIntegrationTest.java
@@ -63,6 +63,7 @@ class CashTillReportGenerationIntegrationTest extends AbstractIntegrationTest {
             .businessUnit(businessUnit)
             .tillNumber((short) 17)
             .ownedBy("Jamie")
+            .createdDate(LocalDateTime.of(2026, 5, 1, 8, 0))
             .build());
         DefendantAccountEntity defendantAccount = defendantAccountRepository.findAll().stream().findFirst()
             .orElseThrow();

--- a/src/main/java/uk/gov/hmcts/opal/entity/TillEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/TillEntity.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -15,11 +17,18 @@ import jakarta.persistence.Table;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnTransformer;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
+import uk.gov.hmcts.opal.util.LocalDateTimeAdapter;
 
 @Entity
 @Table(name = "tills")
@@ -48,5 +57,33 @@ public class TillEntity {
 
     @Column(name = "owned_by", length = 20, nullable = false)
     private String ownedBy;
+
+    @ColumnTransformer(write = "?::t_interface_file_source_enum")
+    @Column(name = "source", columnDefinition = "t_interface_file_source_enum")
+    private String source;
+
+    @Column(name = "status", columnDefinition = "t_till_status_enum")
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    private TillStatusEnum status;
+
+    @Column(name = "total_amount", precision = 18, scale = 2)
+    private BigDecimal totalAmount;
+
+    @Column(name = "interface_file_id")
+    private Long interfaceFileId;
+
+    @Column(name = "payments_count")
+    private Short paymentsCount;
+
+    @Column(name = "owned_by_name", length = 100)
+    private String ownedByName;
+
+    @Column(name = "auto_payment", nullable = false)
+    private boolean autoPayment;
+
+    @Column(name = "created_date", nullable = false)
+    @XmlJavaTypeAdapter(LocalDateTimeAdapter.class)
+    private LocalDateTime createdDate;
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/entity/TillStatusEnum.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/TillStatusEnum.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.opal.entity;
+
+public enum TillStatusEnum {
+    Created,
+    Processing,
+    Failed,
+    Allocated
+}

--- a/src/main/resources/db/migration/ddl/V1_65__alter_interface_files_add_new_columns.sql
+++ b/src/main/resources/db/migration/ddl/V1_65__alter_interface_files_add_new_columns.sql
@@ -1,0 +1,25 @@
+/**
+* OPAL Program
+*
+* MODULE      : alter_interface_files_add_new_columns.sql
+*
+* DESCRIPTION : Add source, override inhibits, record count, and total amount to INTERFACE_FILES.
+*
+* VERSION HISTORY:
+*
+* Date          Author      Version     Nature of Change
+* ----------    -------     --------    -----------------------------------------------------------------------------------------------------------------
+* 10/06/2026    C Cho       1.0         PO-2573 Add summary columns to INTERFACE_FILES.
+*
+**/
+
+ALTER TABLE interface_files
+    ADD COLUMN source t_interface_file_source_enum,
+    ADD COLUMN override_inhibits BOOLEAN DEFAULT FALSE NOT NULL,
+    ADD COLUMN record_count SMALLINT,
+    ADD COLUMN total_amount DECIMAL(18,2);
+
+COMMENT ON COLUMN interface_files.source IS 'The party that sent the associated interface file. Specific values can be found in the DB LLD on Confluence, t_interface_file_source_enum.';
+COMMENT ON COLUMN interface_files.override_inhibits IS 'Determines whether or not to override inhibits. When it is FALSE then carry out the existing payment inhibit functionality.';
+COMMENT ON COLUMN interface_files.record_count IS 'To be populated by the external interface function that creates the data in the table, it is the number of records (payment entries) in the Interface File, to be displayed on the Till Summary Report / Interface File Summary screen.';
+COMMENT ON COLUMN interface_files.total_amount IS 'To be populated by the external interface function that creates the data in the table, it is the sum of all the records (payment entries) in the Interface File, to be displayed on the Till Summary Report / Interface File Summary screen.';

--- a/src/main/resources/db/migration/ddl/V1_70__alter_tills_add_new_columns.sql
+++ b/src/main/resources/db/migration/ddl/V1_70__alter_tills_add_new_columns.sql
@@ -1,0 +1,38 @@
+/**
+* OPAL Program
+*
+* MODULE      : alter_tills_add_new_columns.sql
+*
+* DESCRIPTION : Add source, status, totals, ownership, interface file, and creation details to TILLS.
+*
+* VERSION HISTORY:
+*
+* Date          Author      Version     Nature of Change
+* ----------    -------     --------    -----------------------------------------------------------------------------------------------------------------
+* 10/06/2026    C Cho       1.0         PO-2580 Add summary columns to TILLS.
+*
+**/
+
+CREATE TYPE t_till_status_enum AS ENUM ('Created', 'Processing', 'Failed', 'Allocated');
+
+ALTER TABLE tills
+    ADD COLUMN source t_interface_file_source_enum,
+    ADD COLUMN status t_till_status_enum,
+    ADD COLUMN total_amount DECIMAL(18,2),
+    ADD COLUMN interface_file_id BIGINT,
+    ADD COLUMN payments_count SMALLINT,
+    ADD COLUMN owned_by_name VARCHAR(100),
+    ADD COLUMN auto_payment BOOLEAN DEFAULT FALSE NOT NULL,
+    ADD COLUMN created_date TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL;
+
+COMMENT ON COLUMN tills.source IS 'The party that sent the associated interface file or manual payments in which will be passed on to Tills. Specific values can be found in the DB LLD on Confluence.';
+COMMENT ON COLUMN tills.status IS 'Confirmation if the till has been created. Set to: Created when first created. Then Allocated once allocated by the functionality that allocates Tills.';
+COMMENT ON COLUMN tills.total_amount IS 'As payments in are created for a till, the payment amounts are added up and the total is then used to update this total_amount column.';
+COMMENT ON COLUMN tills.interface_file_id IS 'If it has a value then it enables one to tell the Interface File that was processed in order for the Till to created. Foreign key to INTERFACE_FILES tables.';
+COMMENT ON COLUMN tills.payments_count IS 'As payments in are created for a till, the number of payments in records are added up and the total is then used to update this payments_count column. The backend will not have to compute this value and this column will also be used during Manual Payments In.';
+COMMENT ON COLUMN tills.owned_by_name IS 'The name of the till owner.';
+COMMENT ON COLUMN tills.auto_payment IS 'When the till by Auto Payments In then True, else false.';
+COMMENT ON COLUMN tills.created_date IS 'The Till creation datetime.';
+
+ALTER TABLE ONLY tills
+    ADD CONSTRAINT till_interface_file_id_fk FOREIGN KEY (interface_file_id) REFERENCES interface_files(interface_file_id);

--- a/src/main/resources/db/migration/ddl/V1_75__alter_interface_messages_add_message_data.sql
+++ b/src/main/resources/db/migration/ddl/V1_75__alter_interface_messages_add_message_data.sql
@@ -1,0 +1,19 @@
+/**
+* OPAL Program
+*
+* MODULE      : alter_interface_messages_add_message_data.sql
+*
+* DESCRIPTION : Add message data JSON to INTERFACE_MESSAGES.
+*
+* VERSION HISTORY:
+*
+* Date          Author      Version     Nature of Change
+* ----------    -------     --------    -----------------------------------------------------------------------------------------------------------------
+* 10/06/2026    C Cho       1.0         PO-2581 Add MESSAGE_DATA to INTERFACE_MESSAGES.
+*
+**/
+
+ALTER TABLE interface_messages
+    ADD COLUMN message_data JSON;
+
+COMMENT ON COLUMN interface_messages.message_data IS 'This will hold the data, in the form a json, for the fields required to create the Till Summary screen.';


### PR DESCRIPTION
JIRA link (if applicable)

https://tools.hmcts.net/jira/browse/PO-2573
https://tools.hmcts.net/jira/browse/PO-2580
https://tools.hmcts.net/jira/browse/PO-2581

Change description

PO-2573 - Added new columns to the interface_files table.

PO-2580 - Added new columns to the tills table.

PO-2581 - Added a new column to the interface_messages table.

Does this PR introduce a breaking change?** (check one with "x")

[ ] Yes
[x] No