### PR TITLE
PO-3853: align ChequesEntity with DB enum

### DIFF
--- a/src/integrationTest/resources/db/insertData/insert_into_defendants_for_deletion_test.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_defendants_for_deletion_test.sql
@@ -137,7 +137,7 @@ VALUES (9108, 9105, '2023-11-05 10:00:00', 50.00, 'MADJ', 'Manual');
 INSERT INTO cheques (cheque_id, business_unit_id, cheque_number, issue_date,
                      defendant_transaction_id, amount, status)
 VALUES (9107, 78, 123456, '2023-11-04 10:00:00',
-        9104, 100.00, 'C');
+        9104, 100.00, 'P');
 
 INSERT INTO notes(note_id, note_type, associated_record_type,
                          associated_record_id, note_text, posted_date,

--- a/src/main/java/uk/gov/hmcts/opal/entity/ChequeAllocationType.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/ChequeAllocationType.java
@@ -1,6 +1,27 @@
 package uk.gov.hmcts.opal.entity;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.stream.Stream;
+
 public enum ChequeAllocationType {
-    COMP,
-    REPAYW
+    COMPENSATION("COMP"),
+    REPAY_WITNESS_EXPENSES("REPAYW");
+
+    private final String label;
+
+    ChequeAllocationType(String label) {
+        this.label = label;
+    }
+
+    @JsonValue
+    public String getLabel() {
+        return label;
+    }
+
+    public static ChequeAllocationType getByLabel(String label) {
+        return Stream.of(ChequeAllocationType.values())
+            .filter(v -> v.getLabel().equals(label))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Unknown ChequeAllocationType: " + label));
+    }
 }

--- a/src/main/java/uk/gov/hmcts/opal/entity/ChequeAllocationType.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/ChequeAllocationType.java
@@ -1,0 +1,6 @@
+package uk.gov.hmcts.opal.entity;
+
+public enum ChequeAllocationType {
+    COMP,
+    REPAYW
+}

--- a/src/main/java/uk/gov/hmcts/opal/entity/ChequeEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/ChequeEntity.java
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -20,9 +18,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnTransformer;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
+import uk.gov.hmcts.opal.entity.converter.ChequeAllocationTypeConverter;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -63,8 +60,8 @@ public class ChequeEntity {
     @Column(name = "amount", precision = 18, scale = 2, nullable = false)
     private BigDecimal amount;
 
-    @Enumerated(EnumType.STRING)
-    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Convert(converter = ChequeAllocationTypeConverter.class)
+    @ColumnTransformer(write = "?::t_cheque_allocation_type_enum")
     @Column(name = "allocation_type", length = 10, columnDefinition = "t_cheque_allocation_type_enum")
     private ChequeAllocationType allocationType;
 

--- a/src/main/java/uk/gov/hmcts/opal/entity/ChequeEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/ChequeEntity.java
@@ -4,7 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -16,10 +19,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnTransformer;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import uk.gov.hmcts.opal.entity.converter.ChequeStatusTypeConverter;
 
 @Entity
 @Table(name = "cheques")
@@ -56,13 +63,17 @@ public class ChequeEntity {
     @Column(name = "amount", precision = 18, scale = 2, nullable = false)
     private BigDecimal amount;
 
-    @Column(name = "allocation_type", length = 10)
-    private String allocationType;
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "allocation_type", length = 10, columnDefinition = "t_cheque_allocation_type_enum")
+    private ChequeAllocationType allocationType;
 
     @Column(name = "reminder_date")
     private LocalDate reminderDate;
 
-    @Column(name = "status", length = 1, nullable = false)
-    private String status;
+    @Convert(converter = ChequeStatusTypeConverter.class)
+    @ColumnTransformer(write = "?::t_cheque_status_enum")
+    @Column(name = "status", length = 1, nullable = false, columnDefinition = "t_cheque_status_enum")
+    private ChequeStatusType status;
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/entity/ChequeStatusType.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/ChequeStatusType.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.opal.entity;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.stream.Stream;
+
+public enum ChequeStatusType {
+    DESTROYED("D"),
+    NEW("N"),
+    PRESENTED("P"),
+    QUERY("Q"),
+    WITHDRAWN("W"),
+    AWAITING_DELETION("X");
+
+    private final String label;
+
+    ChequeStatusType(String label) {
+        this.label = label;
+    }
+
+    @JsonValue
+    public String getLabel() {
+        return label;
+    }
+
+    public static ChequeStatusType getByLabel(String label) {
+        return Stream.of(ChequeStatusType.values())
+            .filter(v -> v.getLabel().equals(label))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Unknown ChequeStatusType: " + label));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/entity/converter/ChequeAllocationTypeConverter.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/converter/ChequeAllocationTypeConverter.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.opal.entity.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.apache.logging.log4j.util.Strings;
+import uk.gov.hmcts.opal.entity.ChequeAllocationType;
+
+@Converter(autoApply = true)
+public class ChequeAllocationTypeConverter implements AttributeConverter<ChequeAllocationType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(ChequeAllocationType chequeAllocationType) {
+        return chequeAllocationType == null ? null : chequeAllocationType.getLabel();
+    }
+
+    @Override
+    public ChequeAllocationType convertToEntityAttribute(String label) {
+        return Strings.isBlank(label) ? null : ChequeAllocationType.getByLabel(label);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/entity/converter/ChequeStatusTypeConverter.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/converter/ChequeStatusTypeConverter.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.opal.entity.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.apache.logging.log4j.util.Strings;
+import uk.gov.hmcts.opal.entity.ChequeStatusType;
+
+@Converter(autoApply = true)
+public class ChequeStatusTypeConverter implements AttributeConverter<ChequeStatusType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(ChequeStatusType chequeStatusType) {
+        return chequeStatusType == null ? null : chequeStatusType.getLabel();
+    }
+
+    @Override
+    public ChequeStatusType convertToEntityAttribute(String label) {
+        return Strings.isBlank(label) ? null : ChequeStatusType.getByLabel(label);
+    }
+}

--- a/src/main/resources/db/migration/ddl/V1_125__alter_cheques_columns_to_enums.sql
+++ b/src/main/resources/db/migration/ddl/V1_125__alter_cheques_columns_to_enums.sql
@@ -1,0 +1,23 @@
+/**
+* OPAL Program
+*
+* MODULE      : alter_cheques_columns_to_enums.sql
+*
+* DESCRIPTION : Alter cheques, allocation_type and status, columns to enums
+*
+* VERSION HISTORY:
+*
+* Date          Author         Version     Nature of Change
+* ----------    -----------    --------    ----------------------------------------------------------------------------
+* 03/06/2026    TMc            1.0         PO-3621 - Update columns on CHEQUES table to use PostgreSQL ENUM
+*
+**/
+
+ALTER TABLE cheques
+    ALTER COLUMN allocation_type TYPE t_cheque_allocation_type_enum
+        USING allocation_type::t_cheque_allocation_type_enum,
+    ALTER COLUMN status TYPE t_cheque_status_enum
+        USING status::t_cheque_status_enum;
+
+COMMENT ON COLUMN cheques.allocation_type IS 'Indicates what this cheque payment is in respect of, for example, COMP or REPAYW. Specific values can be found in the DB LLD on Confluence.';
+COMMENT ON COLUMN cheques.status IS 'The cheque status. Specific values can be found in the DB LLD on Confluence.';

--- a/src/main/resources/db/migration/ddl/V1_130__recreate_p_update_cheque_status.sql
+++ b/src/main/resources/db/migration/ddl/V1_130__recreate_p_update_cheque_status.sql
@@ -1,0 +1,31 @@
+--Update signature for p_update_cheque_status
+DROP PROCEDURE IF EXISTS p_update_cheque_status;
+
+CREATE OR REPLACE PROCEDURE p_update_cheque_status(
+    IN pi_cheque_id cheques.cheque_id%TYPE,
+    IN pi_status cheques.status%TYPE)
+LANGUAGE 'plpgsql'
+AS $$
+/**
+* OPAL Program
+*
+* MODULE      : p_update_cheque_status.sql
+*
+* DESCRIPTION : This procedure was written by Capita required for interface files
+*
+* VERSION HISTORY:
+*
+* Date          Author      Version     Nature of Change
+* ----------    -------     --------    ------------------------------------------------------------------------
+* 25/11/2024    Capita      1.0         PO-1010 This procedure was written by Capita required for interface files
+* 03/06/2025    TMc         2.0         PO-3621 - Update columns on CHEQUES table to use PostgreSQL ENUM
+*                                       Dropped and recreated SP as signature has changed. No other changes made.
+*
+**/
+DECLARE
+BEGIN
+    UPDATE  cheques
+    SET     status = pi_status
+    WHERE   cheque_id = pi_cheque_id;
+END;
+$$;

--- a/src/test/java/uk/gov/hmcts/opal/entity/ChequeAllocationTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/entity/ChequeAllocationTypeTest.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.opal.entity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class ChequeAllocationTypeTest {
+
+    @Test
+    void getByLabel_shouldReturnEnum_forKnownLabel() {
+        assertEquals(ChequeAllocationType.COMPENSATION, ChequeAllocationType.getByLabel("COMP"));
+        assertEquals(ChequeAllocationType.REPAY_WITNESS_EXPENSES, ChequeAllocationType.getByLabel("REPAYW"));
+    }
+
+    @Test
+    void getByLabel_shouldThrow_forUnknownLabel() {
+        assertThrows(IllegalArgumentException.class, () -> ChequeAllocationType.getByLabel("unknown"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/entity/ChequeStatusTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/entity/ChequeStatusTypeTest.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.opal.entity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class ChequeStatusTypeTest {
+
+    @Test
+    void getByLabel_shouldReturnEnum_forKnownLabel() {
+        assertEquals(ChequeStatusType.DESTROYED, ChequeStatusType.getByLabel("D"));
+        assertEquals(ChequeStatusType.NEW, ChequeStatusType.getByLabel("N"));
+        assertEquals(ChequeStatusType.PRESENTED, ChequeStatusType.getByLabel("P"));
+        assertEquals(ChequeStatusType.QUERY, ChequeStatusType.getByLabel("Q"));
+        assertEquals(ChequeStatusType.WITHDRAWN, ChequeStatusType.getByLabel("W"));
+        assertEquals(ChequeStatusType.AWAITING_DELETION, ChequeStatusType.getByLabel("X"));
+    }
+
+    @Test
+    void getByLabel_shouldThrow_forUnknownLabel() {
+        assertThrows(IllegalArgumentException.class, () -> ChequeStatusType.getByLabel("unknown"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/entity/converter/ChequeAllocationTypeConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/entity/converter/ChequeAllocationTypeConverterTest.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.opal.entity.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.hmcts.opal.entity.ChequeAllocationType;
+
+class ChequeAllocationTypeConverterTest {
+
+    private final ChequeAllocationTypeConverter converter = new ChequeAllocationTypeConverter();
+
+    @ParameterizedTest
+    @EnumSource(ChequeAllocationType.class)
+    void givenChequeAllocationType_whenConvertToDatabaseColumn_thenReturnLabel(
+        ChequeAllocationType chequeAllocationType) {
+        assertThat(converter.convertToDatabaseColumn(chequeAllocationType)).isEqualTo(chequeAllocationType.getLabel());
+    }
+
+    @Test
+    void givenNullChequeAllocationType_whenConvertToDatabaseColumn_thenReturnNull() {
+        assertThat(converter.convertToDatabaseColumn(null)).isNull();
+    }
+
+    @ParameterizedTest
+    @EnumSource(ChequeAllocationType.class)
+    void givenDatabaseLabel_whenConvertToEntityAttribute_thenReturnChequeAllocationType(
+        ChequeAllocationType chequeAllocationType) {
+        assertThat(converter.convertToEntityAttribute(chequeAllocationType.getLabel())).isEqualTo(chequeAllocationType);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "   ", "\t", "\n"})
+    void givenBlankDatabaseLabel_whenConvertToEntityAttribute_thenReturnNull(String databaseLabel) {
+        assertThat(converter.convertToEntityAttribute(databaseLabel)).isNull();
+    }
+
+    @Test
+    void givenUnknownDatabaseLabel_whenConvertToEntityAttribute_thenThrowException() {
+        assertThatThrownBy(() -> converter.convertToEntityAttribute("Unknown"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unknown ChequeAllocationType: Unknown");
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/entity/converter/ChequeStatusTypeConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/entity/converter/ChequeStatusTypeConverterTest.java
@@ -1,0 +1,48 @@
+package uk.gov.hmcts.opal.entity.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.hmcts.opal.entity.ChequeStatusType;
+
+class ChequeStatusTypeConverterTest {
+
+    private final ChequeStatusTypeConverter converter = new ChequeStatusTypeConverter();
+
+    @ParameterizedTest
+    @EnumSource(ChequeStatusType.class)
+    void givenChequeStatusType_whenConvertToDatabaseColumn_thenReturnLabel(ChequeStatusType chequeStatusType) {
+        assertThat(converter.convertToDatabaseColumn(chequeStatusType)).isEqualTo(chequeStatusType.getLabel());
+    }
+
+    @Test
+    void givenNullChequeStatusType_whenConvertToDatabaseColumn_thenReturnNull() {
+        assertThat(converter.convertToDatabaseColumn(null)).isNull();
+    }
+
+    @ParameterizedTest
+    @EnumSource(ChequeStatusType.class)
+    void givenDatabaseLabel_whenConvertToEntityAttribute_thenReturnChequeStatusType(
+        ChequeStatusType chequeStatusType) {
+        assertThat(converter.convertToEntityAttribute(chequeStatusType.getLabel())).isEqualTo(chequeStatusType);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "   ", "\t", "\n"})
+    void givenBlankDatabaseLabel_whenConvertToEntityAttribute_thenReturnNull(String databaseLabel) {
+        assertThat(converter.convertToEntityAttribute(databaseLabel)).isNull();
+    }
+
+    @Test
+    void givenUnknownDatabaseLabel_whenConvertToEntityAttribute_thenThrowException() {
+        assertThatThrownBy(() -> converter.convertToEntityAttribute("Unknown"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Unknown ChequeStatusType: Unknown");
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-3853
BE - Database enum alignment - ChequesEntity


### Change description ###
- Refactor `ChequeEntity.allocationType` to use the `ChequeAllocationType` enum instead of a `String`
- Refactor `ChequeEntity.status` to use the `ChequeStatusType` enum instead of a `String`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
