### PR TITLE
PO-7193 Preserve last enforcement and return result responses in enforcement flow

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantEnforcementIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantEnforcementIntegrationTest.java
@@ -24,7 +24,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-
 abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTest {
 
     protected static final String URL_BASE = "/defendant-accounts";

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantEnforcementIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantEnforcementIntegrationTest.java
@@ -1,10 +1,5 @@
 package uk.gov.hmcts.opal.controllers;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Collections;
@@ -13,6 +8,7 @@ import org.slf4j.Logger;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
+import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.dto.AddDefendantAccountEnforcementRequest;
 import uk.gov.hmcts.opal.dto.PaymentTerms;
 import uk.gov.hmcts.opal.dto.PostedDetails;
@@ -22,14 +18,6 @@ import uk.gov.hmcts.opal.dto.ToJsonString;
 import uk.gov.hmcts.opal.dto.common.InstalmentPeriod;
 import uk.gov.hmcts.opal.dto.common.PaymentTermsType;
 
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.util.Collections;
-import java.util.List;
-import uk.gov.hmcts.opal.service.UserStateService;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -42,6 +30,8 @@ abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTe
     protected static final String URL_BASE = "/defendant-accounts";
     protected static final Long BUSINESS_UNIT_ID = 77L;
     protected static final Long DEFENDANT_ACCOUNT_ID = 99000000000006L;
+    protected static final Long COLLO_BUSINESS_UNIT_ID = 77L;
+    protected static final Long COLLO_DEFENDANT_ACCOUNT_ID = 99000000000007L;
     protected static final Long INVALID_DEFENDANT_ACCOUNT_ID = 404L;
 
     protected static final List<ResultResponse> fullResponses = List.of(
@@ -81,7 +71,7 @@ abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTe
             .paymentTerms(paymentTerms)
             .build();
 
-        String version = getCurrentDefendantAccountVersion().toString();
+        String version = getCurrentDefendantAccountVersion(DEFENDANT_ACCOUNT_ID).toString();
 
         ResultActions resultActions = mockMvc.perform(
             post(URL_BASE + "/" + DEFENDANT_ACCOUNT_ID + "/enforcements")
@@ -111,7 +101,7 @@ abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTe
             .paymentTerms(paymentTerms)
             .build();
 
-        String version = getCurrentDefendantAccountVersion().toString();
+        String version = getCurrentDefendantAccountVersion(DEFENDANT_ACCOUNT_ID).toString();
 
         ResultActions resultActions = mockMvc.perform(
             post(URL_BASE + "/" + DEFENDANT_ACCOUNT_ID + "/enforcements")
@@ -140,7 +130,7 @@ abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTe
             .paymentTerms(paymentTerms)
             .build();
 
-        String version = getCurrentDefendantAccountVersion().toString();
+        String version = getCurrentDefendantAccountVersion(DEFENDANT_ACCOUNT_ID).toString();
 
         ResultActions resultActions = mockMvc.perform(
             post(URL_BASE + "/" + INVALID_DEFENDANT_ACCOUNT_ID + "/enforcements")
@@ -159,45 +149,57 @@ abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTe
             .andExpect(jsonPath("title").value("Entity Not Found"));
     }
 
-    void postEnforcementImpl_colloResponses_AreReturnedByEnforcementStatus(Logger log) throws Exception {
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(buildEnterEnforcementUserState());
+    void postEnforcementImpl_colloWithPaymentTerms_preservesLastEnforcementAndReturnsResponses(Logger log)
+        throws Exception {
+        userStateStub.setupWithNoPermissions();
+        userStateStub.addPermissions(
+            (short) 77,
+            FinesPermission.ENTER_ENFORCEMENT,
+            FinesPermission.SEARCH_AND_VIEW_ACCOUNTS
+        );
 
         AddDefendantAccountEnforcementRequest request = AddDefendantAccountEnforcementRequest.builder()
             .resultId(ResultId.COLLO)
             .enforcementResultResponses(colloResponses)
+            .paymentTerms(paymentTerms)
             .build();
 
-        String version = getCurrentDefendantAccountVersion().toString();
+        String version = getCurrentDefendantAccountVersion(COLLO_DEFENDANT_ACCOUNT_ID).toString();
 
         ResultActions postResult = mockMvc.perform(
-            post(URL_BASE + "/" + DEFENDANT_ACCOUNT_ID + "/enforcements")
-                .header("Authorization", AUTH_HEADER)
-                .header("Business-Unit-ID", BUSINESS_UNIT_ID.toString())
+            post(URL_BASE + "/" + COLLO_DEFENDANT_ACCOUNT_ID + "/enforcements")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("Authorization", userStateStub.getBearerToken())
+                .header("Business-Unit-ID", COLLO_BUSINESS_UNIT_ID.toString())
                 .header("IF-MATCH", version)
                 .content(objectMapper.writeValueAsString(request))
                 .contentType(MediaType.APPLICATION_JSON)
         );
 
         String postBody = postResult.andReturn().getResponse().getContentAsString();
-        log.info(":postEnforcementImpl_colloResponses_AreReturnedByEnforcementStatus: POST response body:\n{}",
+        log.info(":postEnforcementImpl_colloWithPaymentTerms_preservesLastEnforcementAndReturnsResponses:"
+                + " POST response body:\n{}",
             ToJsonString.toPrettyJson(postBody));
 
         postResult.andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("defendant_account_id").value(String.valueOf(DEFENDANT_ACCOUNT_ID)))
+            .andExpect(jsonPath("defendant_account_id").value(String.valueOf(COLLO_DEFENDANT_ACCOUNT_ID)))
             .andExpect(jsonPath("enforcement_id").exists());
 
         ResultActions getResult = mockMvc.perform(
-            get(URL_BASE + "/" + DEFENDANT_ACCOUNT_ID + "/enforcement-status")
-                .header("Authorization", AUTH_HEADER)
+            get(URL_BASE + "/" + COLLO_DEFENDANT_ACCOUNT_ID + "/enforcement-status")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("Authorization", userStateStub.getBearerToken())
         );
 
         String getBody = getResult.andReturn().getResponse().getContentAsString();
-        log.info(":postEnforcementImpl_colloResponses_AreReturnedByEnforcementStatus: GET response body:\n{}",
+        log.info(":postEnforcementImpl_colloWithPaymentTerms_preservesLastEnforcementAndReturnsResponses:"
+                + " GET response body:\n{}",
             ToJsonString.toPrettyJson(getBody));
 
         getResult.andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.enforcement_overview.collection_order.collection_order_flag").value(true))
             .andExpect(jsonPath("$.last_enforcement_action.enforcement_action.result_id").value("COLLO"))
             .andExpect(jsonPath("$.last_enforcement_action.reason").value("a"))
             .andExpect(jsonPath("$.last_enforcement_action.result_responses[0].parameter_name").value("reason"))
@@ -210,32 +212,11 @@ abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTe
             .andExpect(jsonPath("$.last_enforcement_action.result_responses[2].response").value("aa"));
     }
 
-    private Integer getCurrentDefendantAccountVersion() {
+    private Integer getCurrentDefendantAccountVersion(Long defendantAccountId) {
         return jdbcTemplate.queryForObject(
             "SELECT version_number FROM defendant_accounts WHERE defendant_account_id = ?",
             Integer.class,
-            DEFENDANT_ACCOUNT_ID
+            defendantAccountId
         );
-    }
-
-    private UserState buildEnterEnforcementUserState() {
-        return UserState.builder()
-            .userId(1L)
-            .userName("testUser")
-            .businessUnitUser(Set.of(BusinessUnitUser.builder()
-                .businessUnitUserId("testUserId")
-                .businessUnitId((short) 77)
-                .permissions(Set.of(
-                    Permission.builder()
-                        .permissionId(10L)
-                        .permissionName("Enter Enforcement")
-                        .build(),
-                    Permission.builder()
-                        .permissionId(11L)
-                        .permissionName("Search and View Accounts")
-                        .build()
-                ))
-                .build()))
-            .build();
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantEnforcementIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantEnforcementIntegrationTest.java
@@ -225,10 +225,16 @@ abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTe
             .businessUnitUser(Set.of(BusinessUnitUser.builder()
                 .businessUnitUserId("testUserId")
                 .businessUnitId((short) 77)
-                .permissions(Set.of(Permission.builder()
-                    .permissionId(10L)
-                    .permissionName("Enter Enforcement")
-                    .build()))
+                .permissions(Set.of(
+                    Permission.builder()
+                        .permissionId(10L)
+                        .permissionName("Enter Enforcement")
+                        .build(),
+                    Permission.builder()
+                        .permissionId(11L)
+                        .permissionName("Search and View Accounts")
+                        .build()
+                ))
                 .build()))
             .build();
     }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantEnforcementIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantEnforcementIntegrationTest.java
@@ -22,6 +22,20 @@ import uk.gov.hmcts.opal.dto.ToJsonString;
 import uk.gov.hmcts.opal.dto.common.InstalmentPeriod;
 import uk.gov.hmcts.opal.dto.common.PaymentTermsType;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import uk.gov.hmcts.opal.service.UserStateService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 
 abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTest {
 
@@ -35,6 +49,12 @@ abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTe
         ResultResponse.builder().parameterName("jail_days").response("14").build(),
         ResultResponse.builder().parameterName("enforcer_id").response("50000000001").build(),
         ResultResponse.builder().parameterName("earliest_release_date").response("2026-05-01T00:00:00").build()
+    );
+
+    protected static final List<ResultResponse> colloResponses = List.of(
+        ResultResponse.builder().parameterName("reason").response("a").build(),
+        ResultResponse.builder().parameterName("collectiontype").response("Wages").build(),
+        ResultResponse.builder().parameterName("reserveterms").response("aa").build()
     );
 
     protected static final PaymentTerms paymentTerms = PaymentTerms.builder()
@@ -139,11 +159,77 @@ abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTe
             .andExpect(jsonPath("title").value("Entity Not Found"));
     }
 
+    void postEnforcementImpl_colloResponses_AreReturnedByEnforcementStatus(Logger log) throws Exception {
+        when(userStateService.checkForAuthorisedUser(any())).thenReturn(buildEnterEnforcementUserState());
+
+        AddDefendantAccountEnforcementRequest request = AddDefendantAccountEnforcementRequest.builder()
+            .resultId(ResultId.COLLO)
+            .enforcementResultResponses(colloResponses)
+            .build();
+
+        String version = getCurrentDefendantAccountVersion().toString();
+
+        ResultActions postResult = mockMvc.perform(
+            post(URL_BASE + "/" + DEFENDANT_ACCOUNT_ID + "/enforcements")
+                .header("Authorization", AUTH_HEADER)
+                .header("Business-Unit-ID", BUSINESS_UNIT_ID.toString())
+                .header("IF-MATCH", version)
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        String postBody = postResult.andReturn().getResponse().getContentAsString();
+        log.info(":postEnforcementImpl_colloResponses_AreReturnedByEnforcementStatus: POST response body:\n{}",
+            ToJsonString.toPrettyJson(postBody));
+
+        postResult.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("defendant_account_id").value(String.valueOf(DEFENDANT_ACCOUNT_ID)))
+            .andExpect(jsonPath("enforcement_id").exists());
+
+        ResultActions getResult = mockMvc.perform(
+            get(URL_BASE + "/" + DEFENDANT_ACCOUNT_ID + "/enforcement-status")
+                .header("Authorization", AUTH_HEADER)
+        );
+
+        String getBody = getResult.andReturn().getResponse().getContentAsString();
+        log.info(":postEnforcementImpl_colloResponses_AreReturnedByEnforcementStatus: GET response body:\n{}",
+            ToJsonString.toPrettyJson(getBody));
+
+        getResult.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.last_enforcement_action.enforcement_action.result_id").value("COLLO"))
+            .andExpect(jsonPath("$.last_enforcement_action.reason").value("a"))
+            .andExpect(jsonPath("$.last_enforcement_action.result_responses[0].parameter_name").value("reason"))
+            .andExpect(jsonPath("$.last_enforcement_action.result_responses[0].response").value("a"))
+            .andExpect(jsonPath("$.last_enforcement_action.result_responses[1].parameter_name")
+                .value("collectiontype"))
+            .andExpect(jsonPath("$.last_enforcement_action.result_responses[1].response").value("Wages"))
+            .andExpect(jsonPath("$.last_enforcement_action.result_responses[2].parameter_name")
+                .value("reserveterms"))
+            .andExpect(jsonPath("$.last_enforcement_action.result_responses[2].response").value("aa"));
+    }
+
     private Integer getCurrentDefendantAccountVersion() {
         return jdbcTemplate.queryForObject(
             "SELECT version_number FROM defendant_accounts WHERE defendant_account_id = ?",
             Integer.class,
             DEFENDANT_ACCOUNT_ID
         );
+    }
+
+    private UserState buildEnterEnforcementUserState() {
+        return UserState.builder()
+            .userId(1L)
+            .userName("testUser")
+            .businessUnitUser(Set.of(BusinessUnitUser.builder()
+                .businessUnitUserId("testUserId")
+                .businessUnitId((short) 77)
+                .permissions(Set.of(Permission.builder()
+                    .permissionId(10L)
+                    .permissionName("Enter Enforcement")
+                    .build()))
+                .build()))
+            .build();
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantEnforcementIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantEnforcementIntegrationTest.java
@@ -34,5 +34,11 @@ public class OpalDefendantEnforcementIntegrationTest extends DefendantEnforcemen
     public void testAddEnforcement_whenGivenInvalidDefendant_Fails() throws Exception {
         super.postEnforcementImpl_invalidDefendant_Failure(log);
     }
-}
 
+    @Test
+    @JiraStory("PO-7193")
+    @JiraEpic("PO-1675")
+    public void testAddEnforcement_whenGivenColloResponses_enforcementStatusReturnsPersistedValues() throws Exception {
+        super.postEnforcementImpl_colloResponses_AreReturnedByEnforcementStatus(log);
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantEnforcementIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantEnforcementIntegrationTest.java
@@ -38,7 +38,8 @@ public class OpalDefendantEnforcementIntegrationTest extends DefendantEnforcemen
     @Test
     @JiraStory("PO-7193")
     @JiraEpic("PO-1675")
-    public void testAddEnforcement_whenGivenColloResponses_enforcementStatusReturnsPersistedValues() throws Exception {
-        super.postEnforcementImpl_colloResponses_AreReturnedByEnforcementStatus(log);
+    public void testAddEnforcement_whenGivenColloWithPaymentTerms_preservesLastEnforcementAndReturnsResponses()
+        throws Exception {
+        super.postEnforcementImpl_colloWithPaymentTerms_preservesLastEnforcementAndReturnsResponses(log);
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementService.java
@@ -132,15 +132,17 @@ public class OpalDefendantAccountEnforcementService
 
         if (request.getPaymentTerms() != null) {
             DefendantAccountEntity defendantEntity = defendantAccountRepositoryService.findById(defendantAccountId);
-            opalDefendantAccountService.addPaymentTerms(defendantAccountId,
-                                                        businessUnitId.toString(),
-                                                        businessUnitUserId,
-                                                        defendantEntity.getVersion().toString(),
-                                                        AddDefendantAccountPaymentTermsRequest.builder()
-                                                            .paymentTerms(request.getPaymentTerms())
-                                                            .requestPaymentCard(false)
-                                                            .generatePaymentTermsChangeLetter(false)
-                                                            .build()
+            opalDefendantAccountService.addPaymentTermsPreservingLastEnforcement(
+                defendantAccountId,
+                businessUnitId.toString(),
+                businessUnitUserId,
+                defendantEntity.getVersion().toString(),
+                null,
+                AddDefendantAccountPaymentTermsRequest.builder()
+                    .paymentTerms(request.getPaymentTerms())
+                    .requestPaymentCard(false)
+                    .generatePaymentTermsChangeLetter(false)
+                    .build()
             );
         }
 

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementService.java
@@ -4,6 +4,10 @@ import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -34,8 +38,6 @@ import uk.gov.hmcts.opal.service.persistence.LocalJusticeAreaRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.ResultRepositoryService;
 import uk.gov.hmcts.opal.service.proxy.NotesProxy;
 import uk.gov.hmcts.opal.util.VersionUtils;
-
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 import static uk.gov.hmcts.opal.service.opal.OpalDefendantAccountBuilders.buildEnforcementAction;
@@ -87,8 +89,12 @@ public class OpalDefendantAccountEnforcementService
         Integer jailDays = null;
         Long enforcerId = null;
         LocalDateTime earliestReleaseDate = null;
+        List<ResultResponse> enforcementResultResponses =
+            request != null && request.getEnforcementResultResponses() != null
+                ? request.getEnforcementResultResponses()
+                : List.of();
 
-        for (ResultResponse result : request.getEnforcementResultResponses()) {
+        for (ResultResponse result : enforcementResultResponses) {
             if (Objects.equals(result.getParameterName(), "reason")) {
                 reason = result.getResponse();
             }
@@ -103,7 +109,7 @@ public class OpalDefendantAccountEnforcementService
             }
         }
 
-        String resultResponses = objectMapper.writeValueAsString(request.getEnforcementResultResponses());
+        String resultResponses = objectMapper.writeValueAsString(toResultResponsesMap(enforcementResultResponses));
 
         UserState userState = userStateService.getUserStateV1FromSecurityContext();
         DefendantAccountEntity defendant = defendantAccountRepositoryService.findById(defendantAccountId);
@@ -145,6 +151,22 @@ public class OpalDefendantAccountEnforcementService
             .version(Math.toIntExact(latestDefendant.getVersionNumber()))
             .enforcementId(String.valueOf(enforcementId))
             .build();
+    }
+
+    private Map<String, String> toResultResponsesMap(List<ResultResponse> responses) {
+        Map<String, String> resultResponsesMap = new LinkedHashMap<>();
+        if (responses == null) {
+            return resultResponsesMap;
+        }
+
+        for (ResultResponse response : responses) {
+            if (response == null || response.getParameterName() == null) {
+                continue;
+            }
+            resultResponsesMap.put(response.getParameterName(), response.getResponse());
+        }
+
+        return resultResponsesMap;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
@@ -1062,7 +1062,6 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
         String businessUnitUserId,
         String ifMatch,
         AddDefendantAccountPaymentTermsRequest addPaymentTermsRequest) {
-
         log.debug(":addPaymentTerms (Opal): accountId={}, bu={}", defendantAccountId, businessUnitId);
 
         // Look up the defendant account
@@ -1099,7 +1098,6 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
         // Update defendant account with any payment term related attributes
         addPaymentTerm(defAccount, addPaymentTermsRequest);
 
-        // Clear last_enforcement on the defendant account, if applicable
         clearLastEnforcementAction(defAccount);
 
         defendantAccountRepository.save(defAccount);
@@ -1127,6 +1125,78 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
             defAccount.getBusinessUnit().getBusinessUnitId());
 
         log.debug(":addPaymentTerms: saved payment terms id={} for account {}",
+            savedPaymentTerms.getPaymentTermsId(), defAccount.getDefendantAccountId());
+
+        amendmentService.auditFinaliseStoredProc(
+            defAccount.getDefendantAccountId(),
+            RecordType.DEFENDANT_ACCOUNTS,
+            Short.parseShort(businessUnitId),
+            businessUnitUserId,
+            savedPaymentTerms.getPostedByUsername(),
+            defAccount.getProsecutorCaseReference(),
+            "ACCOUNT_ENQUIRY"
+        );
+
+        return OpalDefendantAccountBuilders.buildPaymentTermsResponse(savedPaymentTerms);
+    }
+
+    @Transactional
+    public GetDefendantAccountPaymentTermsResponse addPaymentTermsPreservingLastEnforcement(Long defendantAccountId,
+        String businessUnitId,
+        String businessUnitUserId,
+        String ifMatch,
+        String authHeader,
+        AddDefendantAccountPaymentTermsRequest addPaymentTermsRequest) {
+
+        log.debug(":addPaymentTermsPreservingLastEnforcement (Opal): accountId={}, bu={}",
+            defendantAccountId, businessUnitId);
+
+        DefendantAccountEntity defAccount = getDefendantAccountByIdForUpdate(defendantAccountId);
+
+        if (defAccount.getBusinessUnit() == null
+            || defAccount.getBusinessUnit().getBusinessUnitId() == null
+            || !String.valueOf(defAccount.getBusinessUnit().getBusinessUnitId()).equals(businessUnitId)) {
+            throw new EntityNotFoundException("Defendant Account not found in business unit " + businessUnitId);
+        }
+
+        VersionUtils.verifyIfMatch(defAccount, ifMatch, defendantAccountId, "addPaymentTerms");
+
+        amendmentService.auditInitialiseStoredProc(defendantAccountId, RecordType.DEFENDANT_ACCOUNTS);
+
+        paymentTermsService.deactivateExistingActivePaymentTerms(defAccount.getDefendantAccountId());
+
+        PaymentTermsEntity paymentTermsEntity = paymentTermsMapper.toEntity(addPaymentTermsRequest.getPaymentTerms());
+        paymentTermsEntity.setDefendantAccount(defAccount);
+        if (paymentTermsEntity.getPostedByUsername() == null) {
+            paymentTermsEntity.setPostedByUsername(businessUnitUserId);
+        }
+        if (paymentTermsEntity.getPostedBy() == null) {
+            paymentTermsEntity.setPostedBy(businessUnitUserId);
+        }
+
+        final PaymentTermsEntity savedPaymentTerms = paymentTermsService.addPaymentTerm(paymentTermsEntity);
+
+        addPaymentTerm(defAccount, addPaymentTermsRequest);
+        defendantAccountRepository.save(defAccount);
+
+        if (Boolean.TRUE.equals(addPaymentTermsRequest.getRequestPaymentCard())) {
+            log.debug(":addPaymentTermsPreservingLastEnforcement: Request Payment Card flag is TRUE for account {}",
+                defAccount.getDefendantAccountId());
+            addPaymentCard(defendantAccountId, businessUnitId, businessUnitUserId, ifMatch, authHeader);
+        }
+
+        if (Boolean.TRUE.equals(addPaymentTermsRequest.getGeneratePaymentTermsChangeLetter())) {
+            log.debug(":addPaymentTermsPreservingLastEnforcement: Generate Payment Terms Change Letter flag is TRUE "
+                    + "for account {}",
+                defAccount.getDefendantAccountId());
+            documentService.createDocumentInstance(defendantAccountId,
+                defAccount.getBusinessUnit().getBusinessUnitId());
+        }
+
+        reportEntryService.createExtendTtpReportEntry(savedPaymentTerms.getPaymentTermsId(),
+            defAccount.getBusinessUnit().getBusinessUnitId());
+
+        log.debug(":addPaymentTermsPreservingLastEnforcement: saved payment terms id={} for account {}",
             savedPaymentTerms.getPaymentTermsId(), defAccount.getDefendantAccountId());
 
         amendmentService.auditFinaliseStoredProc(

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountBuildersTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountBuildersTest.java
@@ -12,6 +12,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.Month;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -90,7 +91,7 @@ class OpalDefendantAccountBuildersTest {
                   "reserveterms":"aa"
                 }
                 """)
-            .postedDate(LocalDateTime.of(2026, 6, 11, 10, 0))
+            .postedDate(LocalDateTime.of(2026, Month.JUNE, 11, 10, 0))
             .build();
 
         EnforcementActionDefendantAccount action =

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountBuildersTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountBuildersTest.java
@@ -28,12 +28,16 @@ import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountHeaderViewEntit
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountSummaryViewEntity;
 import uk.gov.hmcts.opal.entity.debtordetail.DebtorDetailEntity;
 import uk.gov.hmcts.opal.entity.debtordetail.Language;
+import uk.gov.hmcts.opal.entity.enforcement.EnforcementEntity;
 import uk.gov.hmcts.opal.entity.FixedPenaltyOffenceEntity;
+import uk.gov.hmcts.opal.entity.result.ResultEntity;
 import uk.gov.hmcts.opal.generated.model.EnforcementOverrideDefendantAccount;
 import uk.gov.hmcts.opal.generated.model.EnforcementOverrideResultDefendantAccount;
 import uk.gov.hmcts.opal.generated.model.EnforcerDefendantAccount;
 import uk.gov.hmcts.opal.generated.model.AccountStatusReferenceCommon;
+import uk.gov.hmcts.opal.generated.model.EnforcementActionDefendantAccount;
 import uk.gov.hmcts.opal.generated.model.LocalJusticeAreaDefendantAccount;
+import uk.gov.hmcts.opal.generated.model.ResultResponsesCommon;
 
 @ExtendWith(MockitoExtension.class)
 class OpalDefendantAccountBuildersTest {
@@ -59,6 +63,54 @@ class OpalDefendantAccountBuildersTest {
         assertNotNull(reference);
         assertEquals("L", reference.getAccountStatusCode());
         assertEquals("Live", reference.getAccountStatusDisplayName());
+    }
+
+    @Test
+    void buildEnforcementAction_mapsResultResponsesFromKeyedJson() {
+        ResultEntity result = ResultEntity.builder()
+            .resultId("FE")
+            .resultTitle("Further Enforcement")
+            .resultParameters("""
+                [
+                  {"name":"reason"},
+                  {"name":"collectiontype"},
+                  {"name":"reserveterms"}
+                ]
+                """)
+            .build();
+
+        EnforcementEntity enforcement = EnforcementEntity.builder()
+            .resultId("FE")
+            .result(result)
+            .reason("a")
+            .resultResponses("""
+                {
+                  "reason":"a",
+                  "collectiontype":"Wages",
+                  "reserveterms":"aa"
+                }
+                """)
+            .postedDate(LocalDateTime.of(2026, 6, 11, 10, 0))
+            .build();
+
+        EnforcementActionDefendantAccount action =
+            OpalDefendantAccountBuilders.buildEnforcementAction(enforcement, null);
+
+        assertNotNull(action);
+        assertNotNull(action.getResultResponses());
+        assertEquals(3, action.getResultResponses().size());
+
+        ResultResponsesCommon reason = action.getResultResponses().get(0);
+        assertEquals("reason", reason.getParameterName());
+        assertEquals("a", reason.getResponse());
+
+        ResultResponsesCommon collectionType = action.getResultResponses().get(1);
+        assertEquals("collectiontype", collectionType.getParameterName());
+        assertEquals("Wages", collectionType.getResponse());
+
+        ResultResponsesCommon reserveTerms = action.getResultResponses().get(2);
+        assertEquals("reserveterms", reserveTerms.getParameterName());
+        assertEquals("aa", reserveTerms.getResponse());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
@@ -206,7 +206,6 @@ public class OpalDefendantAccountEnforcementServiceTest {
             BUSINESS_UNIT_ID,
             BUSINESS_UNIT_USER_ID,
             IF_MATCH,
-            AUTH_HEADER,
             request
         );
 

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
@@ -2,6 +2,9 @@ package uk.gov.hmcts.opal.service.opal;
 
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
@@ -15,6 +18,7 @@ import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddDefendantAccountEnforcementRequest;
 import uk.gov.hmcts.opal.dto.AddEnforcementResponse;
+import uk.gov.hmcts.opal.dto.EnforcementStatus;
 import uk.gov.hmcts.opal.dto.common.EnforcementOverride;
 import uk.gov.hmcts.opal.dto.PaymentTerms;
 import uk.gov.hmcts.opal.dto.ResultId;
@@ -28,10 +32,16 @@ import uk.gov.hmcts.opal.dto.RemoveDefendantAccountEnforcementHoldResponse;
 import uk.gov.hmcts.opal.dto.request.AddDefendantAccountPaymentTermsRequest;
 import uk.gov.hmcts.opal.entity.EnforcerEntity;
 import uk.gov.hmcts.opal.entity.LocalJusticeAreaEntity;
+import uk.gov.hmcts.opal.entity.PartyEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
+import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountPartiesEntity;
+import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountStatus;
+import uk.gov.hmcts.opal.entity.defendantaccount.AssociationType;
+import uk.gov.hmcts.opal.entity.debtordetail.DebtorDetailEntity;
 import uk.gov.hmcts.opal.entity.result.ResultEntity;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.opal.service.UserStateService;
+import uk.gov.hmcts.opal.service.persistence.DebtorDetailRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.EnforcementRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.EnforcerRepositoryService;
@@ -47,6 +57,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -57,6 +68,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -92,6 +104,9 @@ public class OpalDefendantAccountEnforcementServiceTest {
 
     @Mock
     private EnforcementRepositoryService enforcementRepositoryService;
+
+    @Mock
+    private DebtorDetailRepositoryService debtorDetailRepositoryService;
 
     @Mock
     private ResultRepositoryService resultRepositoryService;
@@ -163,6 +178,77 @@ public class OpalDefendantAccountEnforcementServiceTest {
         assertEquals(55L, override.getEnforcer().getEnforcerId());
         assertNotNull(override.getLja());
         assertEquals((short) 66, override.getLja().getLjaId());
+    }
+
+    @Test
+    void buildEnforcementOverride_whenAllOverrideIdsNull_returnsNull() {
+        DefendantAccountEntity entity = DefendantAccountEntity.builder().build();
+
+        EnforcementOverride override = service.buildEnforcementOverride(entity);
+
+        assertNull(override);
+        verifyNoInteractions(resultRepositoryService, enforcerRepositoryService, localJusticeAreaRepositoryService);
+    }
+
+    @Test
+    void addEnforcement_whenResultResponsesAreNull_persistsEmptyResultResponses() throws JsonProcessingException {
+        mockAuthorisedUser();
+        mockDefendantAccount();
+        mockCreatedEnforcement();
+
+        AddDefendantAccountEnforcementRequest request = AddDefendantAccountEnforcementRequest.builder()
+            .resultId(ResultId.ABDC)
+            .enforcementResultResponses(null)
+            .paymentTerms(null)
+            .build();
+
+        AddEnforcementResponse response = service.addEnforcement(
+            DEFENDANT_ACCOUNT_ID,
+            BUSINESS_UNIT_ID,
+            BUSINESS_UNIT_USER_ID,
+            IF_MATCH,
+            AUTH_HEADER,
+            request
+        );
+
+        verify(enforcementRepositoryService).addDefendantAccountEnforcement(
+            eq(RESULT_ID_AS_STRING),
+            eq(DEFENDANT_ACCOUNT_ID),
+            eq(BUSINESS_UNIT_ID),
+            eq(PROSECUTOR_CASE_REFERENCE),
+            eq("ACCOUNT_ENQUIRY"),
+            eq(null),
+            eq(BUSINESS_UNIT_USER_ID),
+            eq(USER_DISPLAY_NAME),
+            eq(null),
+            eq(null),
+            eq("{}"),
+            eq(null),
+            eq(VersionUtils.extractBigInteger(IF_MATCH).longValue())
+        );
+
+        assertCommonResponse(response);
+    }
+
+    @Test
+    void toResultResponsesMap_whenResponsesNull_returnsEmptyMap() throws Exception {
+        Map<String, String> result = invokeToResultResponsesMap(null);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void toResultResponsesMap_skipsNullEntriesAndEntriesWithoutParameterName() throws Exception {
+        List<ResultResponse> responses = new ArrayList<>();
+        responses.add(null);
+        responses.add(ResultResponse.builder().parameterName(null).response("ignored").build());
+        responses.add(ResultResponse.builder().parameterName("reason").response("a").build());
+
+        Map<String, String> result = invokeToResultResponsesMap(responses);
+
+        assertEquals(1, result.size());
+        assertEquals("a", result.get("reason"));
     }
 
     @Test
@@ -829,6 +915,43 @@ public class OpalDefendantAccountEnforcementServiceTest {
         }
     }
 
+    @Test
+    void getEnforcementStatus_whenNoRecentEnforcement_returnsStatusWithoutLastEnforcementAction() {
+        Long defendantAccountId = 77L;
+
+        PartyEntity party = PartyEntity.builder()
+            .partyId(88L)
+            .organisation(false)
+            .birthDate(LocalDate.of(1990, 1, 1))
+            .build();
+
+        DefendantAccountPartiesEntity defendantParty = DefendantAccountPartiesEntity.builder()
+            .party(party)
+            .associationType(AssociationType.DEFENDANT)
+            .build();
+
+        DefendantAccountEntity defendantEntity = DefendantAccountEntity.builder()
+            .defendantAccountId(defendantAccountId)
+            .accountStatus(DefendantAccountStatus.LIVE)
+            .jailDays(12)
+            .parties(List.of(defendantParty))
+            .build();
+
+        when(defendantAccountRepositoryService.findById(defendantAccountId)).thenReturn(defendantEntity);
+        when(enforcementRepositoryService.getEnforcementMostRecent(defendantAccountId, null))
+            .thenReturn(java.util.Optional.empty());
+        when(debtorDetailRepositoryService.findByPartyId(88L)).thenReturn(java.util.Optional.of(
+            DebtorDetailEntity.builder().partyId(88L).build()
+        ));
+
+        EnforcementStatus status = service.getEnforcementStatus(defendantAccountId);
+
+        assertNotNull(status);
+        assertNull(status.getLastEnforcementAction());
+        assertNull(status.getEnforcementOverride());
+        assertNull(status.getNextEnforcementActionData());
+    }
+
     private void assertCommonResponse(AddEnforcementResponse response) {
         assertEquals(String.valueOf(DEFENDANT_ACCOUNT_ID), response.getDefendantAccountId());
         assertEquals(0, response.getVersion());
@@ -871,6 +994,14 @@ public class OpalDefendantAccountEnforcementServiceTest {
             resultResponses.put(keyValues[i], keyValues[i + 1]);
         }
         return resultResponses;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> invokeToResultResponsesMap(List<ResultResponse> responses) throws Exception {
+        Method method = OpalDefendantAccountEnforcementService.class
+            .getDeclaredMethod("toResultResponsesMap", List.class);
+        method.setAccessible(true);
+        return (Map<String, String>) method.invoke(service, responses);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
@@ -40,7 +40,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -134,7 +136,12 @@ public class OpalDefendantAccountEnforcementServiceTest {
             request
         );
 
-        String responsesJson = objectMapper.writeValueAsString(responses);
+        String responsesJson = objectMapper.writeValueAsString(resultResponsesMap(
+            "reason", "test reason",
+            "jail_days", "14",
+            "enforcer_id", "55",
+            "earliest_release_date", "2026-05-01T00:00:00"
+        ));
 
         verify(enforcementRepositoryService).addDefendantAccountEnforcement(
             eq(RESULT_ID_AS_STRING),
@@ -199,7 +206,9 @@ public class OpalDefendantAccountEnforcementServiceTest {
             request
         );
 
-        String responsesJson = objectMapper.writeValueAsString(responses);
+        String responsesJson = objectMapper.writeValueAsString(resultResponsesMap(
+            "reason", "test reason"
+        ));
 
         verify(enforcementRepositoryService).addDefendantAccountEnforcement(
             eq(RESULT_ID_AS_STRING),
@@ -264,7 +273,9 @@ public class OpalDefendantAccountEnforcementServiceTest {
             request
         );
 
-        String responsesJson = objectMapper.writeValueAsString(responses);
+        String responsesJson = objectMapper.writeValueAsString(resultResponsesMap(
+            "jail_days", "14"
+        ));
 
         verify(enforcementRepositoryService).addDefendantAccountEnforcement(
             eq(RESULT_ID_AS_STRING),
@@ -329,7 +340,9 @@ public class OpalDefendantAccountEnforcementServiceTest {
             request
         );
 
-        String responsesJson = objectMapper.writeValueAsString(responses);
+        String responsesJson = objectMapper.writeValueAsString(resultResponsesMap(
+            "enforcer_id", "55"
+        ));
 
         verify(enforcementRepositoryService).addDefendantAccountEnforcement(
             eq(RESULT_ID_AS_STRING),
@@ -394,7 +407,9 @@ public class OpalDefendantAccountEnforcementServiceTest {
             request
         );
 
-        String responsesJson = objectMapper.writeValueAsString(responses);
+        String responsesJson = objectMapper.writeValueAsString(resultResponsesMap(
+            "earliest_release_date", "2026-05-01T00:00:00"
+        ));
 
         verify(enforcementRepositoryService).addDefendantAccountEnforcement(
             eq(RESULT_ID_AS_STRING),
@@ -483,7 +498,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
             eq(USER_DISPLAY_NAME),
             eq(null),
             eq(null),
-            eq("[]"),
+            eq("{}"),
             eq(null),
             eq(VersionUtils.extractBigInteger(IF_MATCH).longValue())
         );
@@ -791,6 +806,14 @@ public class OpalDefendantAccountEnforcementServiceTest {
             nullable(LocalDateTime.class),
             anyLong()
         )).thenReturn(ENFORCEMENT_ID);
+    }
+
+    private Map<String, String> resultResponsesMap(String... keyValues) {
+        Map<String, String> resultResponses = new LinkedHashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            resultResponses.put(keyValues[i], keyValues[i + 1]);
+        }
+        return resultResponses;
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.opal.service.opal;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
@@ -4,6 +4,7 @@ import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -505,12 +506,13 @@ public class OpalDefendantAccountEnforcementServiceTest {
 
         assertCommonResponse(response);
 
-        verify(opalDefendantAccountService).addPaymentTerms(
+        verify(opalDefendantAccountService).addPaymentTermsPreservingLastEnforcement(
             eq(DEFENDANT_ACCOUNT_ID),
             eq(BUSINESS_UNIT_ID.toString()),
             eq(BUSINESS_UNIT_USER_ID),
             eq(IF_MATCH),
-            org.mockito.ArgumentMatchers.any(AddDefendantAccountPaymentTermsRequest.class)
+            isNull(),
+            ArgumentMatchers.any(AddDefendantAccountPaymentTermsRequest.class)
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
@@ -15,6 +15,7 @@ import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddDefendantAccountEnforcementRequest;
 import uk.gov.hmcts.opal.dto.AddEnforcementResponse;
+import uk.gov.hmcts.opal.dto.common.EnforcementOverride;
 import uk.gov.hmcts.opal.dto.PaymentTerms;
 import uk.gov.hmcts.opal.dto.ResultId;
 import uk.gov.hmcts.opal.dto.ResultResponse;
@@ -25,11 +26,17 @@ import uk.gov.hmcts.opal.dto.Note;
 import uk.gov.hmcts.opal.dto.RemoveDefendantAccountEnforcementHoldRequest;
 import uk.gov.hmcts.opal.dto.RemoveDefendantAccountEnforcementHoldResponse;
 import uk.gov.hmcts.opal.dto.request.AddDefendantAccountPaymentTermsRequest;
+import uk.gov.hmcts.opal.entity.EnforcerEntity;
+import uk.gov.hmcts.opal.entity.LocalJusticeAreaEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
+import uk.gov.hmcts.opal.entity.result.ResultEntity;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.opal.service.UserStateService;
 import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.EnforcementRepositoryService;
+import uk.gov.hmcts.opal.service.persistence.EnforcerRepositoryService;
+import uk.gov.hmcts.opal.service.persistence.LocalJusticeAreaRepositoryService;
+import uk.gov.hmcts.opal.service.persistence.ResultRepositoryService;
 import uk.gov.hmcts.opal.service.proxy.NotesProxy;
 import uk.gov.hmcts.opal.util.VersionUtils;
 
@@ -87,6 +94,15 @@ public class OpalDefendantAccountEnforcementServiceTest {
     private EnforcementRepositoryService enforcementRepositoryService;
 
     @Mock
+    private ResultRepositoryService resultRepositoryService;
+
+    @Mock
+    private EnforcerRepositoryService enforcerRepositoryService;
+
+    @Mock
+    private LocalJusticeAreaRepositoryService localJusticeAreaRepositoryService;
+
+    @Mock
     private NotesProxy notesProxy;
 
     @Mock
@@ -109,6 +125,45 @@ public class OpalDefendantAccountEnforcementServiceTest {
 
     @InjectMocks
     private OpalDefendantAccountEnforcementService service;
+
+    @Test
+    void buildEnforcementOverride_whenOverrideIdsPresent_buildsMappedOverride() {
+        DefendantAccountEntity entity = DefendantAccountEntity.builder()
+            .enforcementOverrideResultId("FWEC")
+            .enforcementOverrideEnforcerId(55L)
+            .enforcementOverrideTfoLjaId((short) 66)
+            .build();
+
+        ResultEntity result = ResultEntity.builder()
+            .resultId("FWEC")
+            .resultTitle("Witness Expenses")
+            .build();
+
+        EnforcerEntity enforcer = EnforcerEntity.builder()
+            .enforcerId(55L)
+            .name("North East Enforcement")
+            .build();
+
+        LocalJusticeAreaEntity lja = LocalJusticeAreaEntity.builder()
+            .localJusticeAreaId((short) 66)
+            .ljaCode("L066")
+            .name("Tyne & Wear LJA")
+            .build();
+
+        when(resultRepositoryService.getResultById("FWEC")).thenReturn(java.util.Optional.of(result));
+        when(enforcerRepositoryService.findById(55L)).thenReturn(java.util.Optional.of(enforcer));
+        when(localJusticeAreaRepositoryService.getLjaById((short) 66)).thenReturn(java.util.Optional.of(lja));
+
+        EnforcementOverride override = service.buildEnforcementOverride(entity);
+
+        assertNotNull(override);
+        assertNotNull(override.getEnforcementOverrideResult());
+        assertEquals("FWEC", override.getEnforcementOverrideResult().getEnforcementOverrideId());
+        assertNotNull(override.getEnforcer());
+        assertEquals(55L, override.getEnforcer().getEnforcerId());
+        assertNotNull(override.getLja());
+        assertEquals((short) 66, override.getLja().getLjaId());
+    }
 
     @Test
     public void testAddEnforcement_whenGivenAllFields_createsEnforcement() throws JacksonException {

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceAddPaymentTermsTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceAddPaymentTermsTest.java
@@ -37,6 +37,8 @@ import uk.gov.hmcts.opal.service.UserStateService;
 
 @ExtendWith(MockitoExtension.class)
 public class OpalDefendantAccountServiceAddPaymentTermsTest {
+    private static final LocalDateTime TEST_POSTED_DATE = LocalDateTime.of(2026, 6, 11, 10, 0);
+
     @Mock
     private DefendantAccountPaymentTermsRepository paymentTermsRepository;
 
@@ -121,7 +123,7 @@ public class OpalDefendantAccountServiceAddPaymentTermsTest {
 
         PaymentTermsEntity paymentTerms = PaymentTermsEntity.builder()
             .active(Boolean.TRUE)
-            .postedDate(LocalDateTime.now())
+            .postedDate(TEST_POSTED_DATE)
             .postedBy(postedBy)
             .postedByUsername(postedBy)
             .build();
@@ -131,7 +133,7 @@ public class OpalDefendantAccountServiceAddPaymentTermsTest {
         EnforcementEntity enforcementLite = new EnforcementEntity();
         enforcementLite.setEnforcementId(300L);
         enforcementLite.setDefendantAccountId(defendantAccountId);
-        enforcementLite.setPostedDate(LocalDateTime.now());
+        enforcementLite.setPostedDate(TEST_POSTED_DATE);
         enforcementLite.setPostedBy("enf_tester");
         enforcementLite.setResultId("55");
 
@@ -241,7 +243,7 @@ public class OpalDefendantAccountServiceAddPaymentTermsTest {
 
         PaymentTermsEntity paymentTerms = PaymentTermsEntity.builder()
             .active(Boolean.TRUE)
-            .postedDate(LocalDateTime.now())
+            .postedDate(TEST_POSTED_DATE)
             .postedBy(businessUnitUserId)
             .postedByUsername(businessUnitUserId)
             .build();

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceAddPaymentTermsTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceAddPaymentTermsTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,7 +38,7 @@ import uk.gov.hmcts.opal.service.UserStateService;
 
 @ExtendWith(MockitoExtension.class)
 public class OpalDefendantAccountServiceAddPaymentTermsTest {
-    private static final LocalDateTime TEST_POSTED_DATE = LocalDateTime.of(2026, 6, 11, 10, 0);
+    private static final LocalDateTime TEST_POSTED_DATE = LocalDateTime.of(2026, Month.JUNE, 11, 10, 0);
 
     @Mock
     private DefendantAccountPaymentTermsRepository paymentTermsRepository;

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceAddPaymentTermsTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceAddPaymentTermsTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.opal.service.opal;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
@@ -212,5 +213,64 @@ public class OpalDefendantAccountServiceAddPaymentTermsTest {
             businessUnitUserId.equals(entity.getPostedBy())
                 && businessUnitUserId.equals(entity.getPostedByUsername())
         ));
+    }
+
+    @Test
+    void addPaymentTerms_preservesLastEnforcement_whenRequestedByEnforcementFlow() {
+        final Long defendantAccountId = 77L;
+        final String businessUnitId = "10";
+        final String ifMatch = "\"1\"";
+        final String businessUnitUserId = "tester";
+
+        BusinessUnitEntity bu = BusinessUnitEntity.builder()
+            .businessUnitId((short) 10)
+            .build();
+
+        DefendantAccountEntity account = new DefendantAccountEntity();
+        account.setDefendantAccountId(defendantAccountId);
+        account.setBusinessUnit(bu);
+        account.setLastEnforcement("55");
+        account.setVersionNumber(1L);
+
+        PaymentTerms paymentTermsDto = new PaymentTerms();
+        AddDefendantAccountPaymentTermsRequest request = new AddDefendantAccountPaymentTermsRequest();
+        request.setPaymentTerms(paymentTermsDto);
+
+        when(defendantAccountRepository.findByDefendantAccountIdForUpdate(defendantAccountId))
+            .thenReturn(Optional.of(account));
+
+        PaymentTermsEntity paymentTerms = PaymentTermsEntity.builder()
+            .active(Boolean.TRUE)
+            .postedDate(LocalDateTime.now())
+            .postedBy(businessUnitUserId)
+            .postedByUsername(businessUnitUserId)
+            .build();
+
+        when(paymentTermsMapper.toEntity(any(PaymentTerms.class))).thenReturn(paymentTerms);
+
+        PaymentTermsEntity savedPaymentTermsEntity = PaymentTermsEntity.builder()
+            .paymentTermsId(200L)
+            .active(Boolean.TRUE)
+            .defendantAccount(account)
+            .extension(Boolean.TRUE)
+            .build();
+
+        when(paymentTermsService.addPaymentTerm(any(PaymentTermsEntity.class))).thenReturn(savedPaymentTermsEntity);
+
+        defendantAccountService.addPaymentTermsPreservingLastEnforcement(
+            defendantAccountId,
+            businessUnitId,
+            businessUnitUserId,
+            ifMatch,
+            businessUnitUserId,
+            request
+        );
+
+        verify(defendantAccountRepository).save(accountCaptor.capture());
+        DefendantAccountEntity savedAccount = accountCaptor.getValue();
+        assertNotNull(savedAccount);
+        assertEquals("55", savedAccount.getLastEnforcement(),
+            "Expected lastEnforcement to be preserved for enforcement-driven payment terms");
+        verify(reportEntryService).createExtendTtpReportEntry(any(Long.class), any(short.class));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PO-7193


### Change description ###

- persist enforcement result_responses in the keyed format expected by enforcement status mapping
- preserve last_enforcement_action when payment_terms is included in POST /defendant-accounts/{id}/enforcements
- keep standalone addPaymentTerms behaviour unchanged and use an enforcement-specific path for the preserve case
- add unit and integration coverage for the merged enforcement + payment terms flow


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
