### PR TITLE
Update nightly Jenkins pipeline for demo R1A functional coverage

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -7,6 +7,11 @@ def type = "java"
 def product = "opal"
 def component = "fines-service"
 
+def archiveZephyrReports = {
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'target/zephyr/**/*.json'
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'target/zephyr-reports/**/*.json'
+}
+
 def determineDevEnvironmentDeployment() {
   env.TEST_URL = "https://opal-fines-service-pr-${env.CHANGE_ID}.dev.platform.hmcts.net"
 
@@ -91,6 +96,7 @@ withPipeline(type, product, component) {
   afterAlways('test') {
     steps.junit '**/test-results/integration/*.xml'
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/integration/*.xml'
+    archiveZephyrReports()
 
     publishHTML target: [
         allowMissing         : true,
@@ -149,6 +155,7 @@ withPipeline(type, product, component) {
 
   afterAlways('functionalTest:dev') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-test-report/**/*'
+    archiveZephyrReports()
 
     publishHTML target: [
         allowMissing         : true,
@@ -170,6 +177,7 @@ withPipeline(type, product, component) {
 
   afterAlways('smoketest:dev') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-test-report/**/*'
+    archiveZephyrReports()
 
     publishHTML target: [
         allowMissing         : true,
@@ -183,6 +191,7 @@ withPipeline(type, product, component) {
 
   afterAlways('functionalTest:stg') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-test-report/**/*'
+    archiveZephyrReports()
 
     publishHTML target: [
         allowMissing         : true,
@@ -203,6 +212,7 @@ withPipeline(type, product, component) {
   }
   afterAlways('smoketest:stg') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-test-report/**/*'
+    archiveZephyrReports()
 
     publishHTML target: [
         allowMissing         : true,

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -6,6 +6,8 @@ properties([
   parameters([
     booleanParam(name: 'Integration', defaultValue: true, description: 'Run integration tests'),
     booleanParam(name: 'Functional', defaultValue: true, description: 'Run functional tests'),
+    booleanParam(name: 'Demo', defaultValue: true, description: 'Run R1A functional tests against demo'),
+    booleanParam(name: 'RunR1AOff', defaultValue: false, description: 'Run R1AOff functional tests against demo'),
     booleanParam(name: 'ZephyrExecution', defaultValue: false, description: 'Create Zephyr Execution'),
     choice(
       name: 'LEGACY_URL',
@@ -27,6 +29,28 @@ def component = "fines-service"
 
 GradleBuilder builder = new GradleBuilder(this, product)
 
+def r1ATagFilter = '@JIRA-LABEL:manual-account-creation and not @Ignore and ' +
+        'not (@R1AOff or @R1BOff or @R1COff or @R1CWriteOffOff or @R1CEnforcementOperationalReportingOff) and ' +
+        'not (@R1B or @R1C or @R1CFinance or @R1CWriteOff or @R1CEnforcementOperationalReporting or @R1CAdministration)'
+def r1AOffTagFilter = '@R1AOff and not @Ignore'
+
+def testEnvironments = [
+    staging: [
+        name                 : 'staging',
+        testUrl              : 'https://opal-fines-service.staging.platform.hmcts.net',
+        userServiceApiUrl    : 'https://opal-user-service.staging.platform.hmcts.net',
+        loggingServiceApiUrl : 'https://opal-logging-service.staging.platform.hmcts.net',
+        reportNameSuffix     : '',
+    ],
+    demo   : [
+        name                 : 'demo',
+        testUrl              : 'https://opal-fines-service.demo.platform.hmcts.net',
+        userServiceApiUrl    : 'https://opal-user-service.demo.platform.hmcts.net',
+        loggingServiceApiUrl : 'https://opal-logging-service.demo.platform.hmcts.net',
+        reportNameSuffix     : ' (Demo)',
+    ],
+]
+
 def secrets = [
     'opal-${env}': [
         secret('jiraAuthToken', 'JIRA_AUTH_TOKEN'),
@@ -42,69 +66,151 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
   ]
 }
 
+def configureTestEnvironment = { testEnvironment ->
+  env.ENVIRONMENT_NAME = testEnvironment.name
+  env.TEST_URL = testEnvironment.testUrl
+  env.OPAL_USER_SERVICE_API_URL = testEnvironment.userServiceApiUrl
+  env.OPAL_LOGGING_SERVICE_API_URL = testEnvironment.loggingServiceApiUrl
+
+  echo "Configured ${testEnvironment.name} test environment: TEST_URL=${env.TEST_URL}"
+}
+
+def configureZephyrExecution = { testEnvironment ->
+  env.EXECUTION_BUILD = env.GIT_COMMIT
+  env.EXECUTION_ENVIRONMENT = testEnvironment.name
+  env.EXECUTION_CYCLE_DESCRIPTION = "Nightly execution for commit ${env.GIT_COMMIT} on environment ${testEnvironment.name}.\n" +
+          "https://sds-build.hmcts.net/job/HMCTS_Nightly/job/opal-fines-service/job/master/${env.BUILD_NUMBER}/"
+  echo "Zephyr execution will be created with the following details:\n" +
+          "Build: ${env.EXECUTION_BUILD}\n" +
+          "Environment: ${env.EXECUTION_ENVIRONMENT}\n" +
+          "Description: ${env.EXECUTION_CYCLE_DESCRIPTION}"
+}
+
+def publishIntegrationResults = {
+  steps.junit '**/test-results/integration/*.xml'
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/integration/*.xml'
+}
+
+def publishFunctionalResults = { reportNameSuffix ->
+  steps.junit '**/test-results/functional/*.xml'
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/functional/*.xml'
+  publishHTML target: [
+    allowMissing         : true,
+    alwaysLinkToLastBuild: true,
+    keepAll              : true,
+    reportDir            : "functional-test-report/",
+    reportFiles          : "index.html",
+    reportName           : "Serenity Functional Test Report${reportNameSuffix}"
+  ]
+  publishHTML target: [
+    allowMissing         : true,
+    alwaysLinkToLastBuild: true,
+    keepAll              : true,
+    reportDir            : "functional-test-report/htmlReport/",
+    reportFiles          : "test-summary.html",
+    reportName           : "Test Summary Report${reportNameSuffix}"
+  ]
+}
+
+def runIntegrationStage = { stageName, gradleTask ->
+  if (params.Integration) {
+    stage(stageName) {
+      try {
+        builder.gradle(gradleTask)
+      } catch (error) {
+        steps.echo "${stageName} failed, but continuing with the pipeline. Error: " + error.message
+      } finally {
+        publishIntegrationResults()
+      }
+    }
+  }
+}
+
+def runFunctionalStage = { stageName, shouldRunWithZephyr, reportNameSuffix ->
+  if (params.Functional) {
+    stage(stageName) {
+      try {
+        if (shouldRunWithZephyr) {
+          builder.gradle('functionalWithZephyrExecution')
+        } else {
+          builder.gradle('functional')
+        }
+      } catch (error) {
+        steps.echo "${stageName} failed, but continuing with the pipeline. Error: " + error.message
+      } finally {
+        publishFunctionalResults(reportNameSuffix)
+      }
+    }
+  }
+}
+
+def runTaggedFunctionalStage = { enabled, stageName, shouldRunWithZephyr, reportNameSuffix, tagFilter ->
+  if (enabled) {
+    stage(stageName) {
+      try {
+        withEnv(["TAGS=${tagFilter}"]) {
+          if (shouldRunWithZephyr) {
+            builder.gradle('clearReports functionalOpalTagsWithZephyrExecution aggregate copyFunctionalReport mergeFunctionalResults generateTestSummary')
+          } else {
+            builder.gradle('clearReports functionalOpalTags aggregate copyFunctionalReport mergeFunctionalResults generateTestSummary')
+          }
+        }
+      } catch (error) {
+        steps.echo "${stageName} failed, but continuing with the pipeline. Error: " + error.message
+      } finally {
+        publishFunctionalResults(reportNameSuffix)
+      }
+    }
+  }
+}
+
 withNightlyPipeline(type, product, component) {
   loadVaultSecrets(secrets)
-  env.TEST_URL = "https://opal-fines-service.staging.platform.hmcts.net"
-  env.OPAL_USER_SERVICE_API_URL = "https://opal-user-service.staging.platform.hmcts.net"
-  env.OPAL_LOGGING_SERVICE_API_URL = "https://opal-logging-service.staging.platform.hmcts.net"
+  configureTestEnvironment(testEnvironments.staging)
   //enableFullFunctionalTest(600)
 
   afterAlways('DependencyCheckNightly') {
-   if (params.Integration) {
-     stage('Integration Tests') {
-       try {
-         builder.gradle('Integration')
-       } catch (Error) {
-         steps.echo "Integration tests failed, but continuing with the pipeline. Error" + Error.message
-       } finally {
-         steps.junit '**/test-results/integration/*.xml'
-         steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/integration/*.xml'
-       }
-     }
-   }
-      def today = ZonedDateTime.now().getDayOfWeek()
-      def shouldRunWithZephyr = params.ZephyrExecution || today == DayOfWeek.FRIDAY
+    echo 'Integration:' + params.Integration
+    echo 'Functional:' + params.Functional
+    echo 'Demo:' + params.Demo
+    echo 'RunR1AOff:' + params.RunR1AOff
+
+    def today = ZonedDateTime.now().getDayOfWeek()
+    def shouldRunWithZephyr = params.ZephyrExecution || today == DayOfWeek.FRIDAY
+
+    configureTestEnvironment(testEnvironments.staging)
+    if (shouldRunWithZephyr) {
+      configureZephyrExecution(testEnvironments.staging)
+    }
+    runIntegrationStage('Integration Tests', 'Integration')
+    runFunctionalStage('Functional Tests', shouldRunWithZephyr, testEnvironments.staging.reportNameSuffix)
+
+    if (params.Demo) {
+      configureTestEnvironment(testEnvironments.demo)
       if (shouldRunWithZephyr) {
-          env.EXECUTION_BUILD = env.GIT_COMMIT
-          env.EXECUTION_ENVIRONMENT = env.ENVIRONMENT_NAME
-          env.EXECUTION_CYCLE_DESCRIPTION = "Nightly execution for commit ${env.GIT_COMMIT} on environment ${env.ENVIRONMENT_NAME}.\n" +
-                  "https://sds-build.hmcts.net/job/HMCTS_Nightly/job/opal-fines-service/job/master/${env.BUILD_NUMBER}/"
-          echo "Zephyr execution will be created with the following details:\n" +
-                  "Build: ${env.EXECUTION_BUILD}\n" +
-                  "Environment: ${env.EXECUTION_ENVIRONMENT}\n" +
-                  "Description: ${env.EXECUTION_CYCLE_DESCRIPTION}"
+        configureZephyrExecution(testEnvironments.demo)
       }
-      if (params.Functional) {
-      stage('Functional Tests') {
-        try {
-            if (shouldRunWithZephyr) {
-                builder.gradle('functionalWithZephyrExecution')
-            } else {
-                builder.gradle('functional')
-            }
-        } catch (Error) {
-          steps.echo "Functional tests failed, but continuing with the pipeline. Error: " + Error.message
-        } finally {
-          steps.junit '**/test-results/functional/*.xml'
-          steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/functional/*.xml'
-          publishHTML target: [
-            allowMissing         : true,
-            alwaysLinkToLastBuild: true,
-            keepAll              : true,
-            reportDir            : "functional-test-report/",
-            reportFiles          : "index.html",
-            reportName           : "Serenity Functional Test Report"
-          ]
-          publishHTML target: [
-            allowMissing         : true,
-            alwaysLinkToLastBuild: true,
-            keepAll              : true,
-            reportDir            : "functional-test-report/htmlReport/",
-            reportFiles          : "test-summary.html",
-            reportName           : "Test Summary Report"
-          ]
-        }
+      runTaggedFunctionalStage(
+        params.Functional,
+        'Demo R1A Functional Tests',
+        shouldRunWithZephyr,
+        testEnvironments.demo.reportNameSuffix,
+        r1ATagFilter
+      )
+    }
+
+    if (params.RunR1AOff) {
+      configureTestEnvironment(testEnvironments.demo)
+      if (shouldRunWithZephyr) {
+        configureZephyrExecution(testEnvironments.demo)
       }
+      runTaggedFunctionalStage(
+        params.RunR1AOff,
+        'R1AOff Demo Functional Tests',
+        shouldRunWithZephyr,
+        ' (Demo R1AOff)',
+        r1AOffTagFilter
+      )
     }
   }
 }

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -89,11 +89,13 @@ def configureZephyrExecution = { testEnvironment ->
 def publishIntegrationResults = {
   steps.junit '**/test-results/integration/*.xml'
   steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/integration/*.xml'
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'target/zephyr-reports/**/*.json'
 }
 
 def publishFunctionalResults = { reportNameSuffix ->
   steps.junit '**/test-results/functional/*.xml'
   steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/functional/*.xml'
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'target/zephyr/**/*.json'
   publishHTML target: [
     allowMissing         : true,
     alwaysLinkToLastBuild: true,

--- a/README.md
+++ b/README.md
@@ -211,21 +211,20 @@ Use the standard functional suite for normal backend functional coverage:
   ./gradlew functional
 ```
 
-This runs the default Opal and Legacy functional suites, and the Opal portion excludes
-environment-specific scenarios tagged `@UAT-Technical`, including the `@R1AOff`,
-`@R1BOff`, and `@R1COff` feature-flag suites.
+This runs the default Opal and Legacy functional suites and publishes the Serenity
+functional report under `functional-test-report/`.
 
 Use the tagged Opal functional suite when you need to run only scenarios for a specific
-environment or feature-flag configuration:
+feature-flag or business-area configuration:
 
 ```bash / zsh
-  TAGS='@UAT-Technical and @R1BOff' ./gradlew functionalOpalTags
+  TAGS='@R1BOff and not @Ignore' ./gradlew functionalOpalTags
 ```
 
 You can also pass the tags as a Gradle property instead of an environment variable:
 
 ```bash / zsh
-  ./gradlew functionalOpalTags -Ptags='@UAT-Technical and @R1B and @R1C'
+  ./gradlew functionalOpalTags -Ptags='@R1B and @R1C and not @Ignore'
 ```
 
 Use the combined tagged wrapper when you want the default Opal suite and the tagged Opal
@@ -233,24 +232,65 @@ scenarios in one run, with the same Serenity report and merged JUnit summary flo
 the standard `functional` task:
 
 ```bash / zsh
-  TAGS='@UAT-Technical and @R1BOff' ./gradlew functionalWithTags
+  TAGS='@R1BOff and not @Ignore' ./gradlew functionalWithTags
 ```
 
 Use the Zephyr variant when you want the same combined tagged run and the tagged Opal
 execution recorded through the existing cucumber-report Zephyr flow:
 
 ```bash / zsh
-  TAGS='@UAT-Technical and @R1BOff' ./gradlew functionalWithTagsWithZephyrExecution
+  TAGS='@R1BOff and not @Ignore' ./gradlew functionalWithTagsWithZephyrExecution
 ```
 
 Common examples:
 
 ```bash / zsh
-  TAGS='@UAT-Technical and @R1B and @R1COff' ./gradlew functionalOpalTags
-  TAGS='@UAT-Technical and @R1B and @R1C' ./gradlew functionalOpalTags
-  TAGS='@UAT-Technical and @R1B and @R1C' ./gradlew functionalWithTags
-  TAGS='@UAT-Technical and @R1B and @R1C' ./gradlew functionalWithTagsWithZephyrExecution
+  TAGS='@R1AOff and not @Ignore' ./gradlew functionalOpalTags
+  TAGS='@R1BOff and not @Ignore' ./gradlew functionalOpalTags
+  TAGS='@R1B and @R1C and not @Ignore' ./gradlew functionalWithTags
+  TAGS='@JIRA-LABEL:manual-account-creation and not @Ignore' ./gradlew functionalOpalTags
 ```
+
+### Nightly Jenkins pipeline
+
+`Jenkinsfile_nightly` runs on weekdays using `H 08 * * 1-5`. It uses the HMCTS
+nightly pipeline wrapper for `opal/fines-service` and loads the Jira auth token from
+the Opal Key Vault for optional Zephyr reporting.
+
+Nightly parameters:
+
+| Parameter | Default | Purpose |
+|-----------|---------|---------|
+| `Integration` | `true` | Runs the staging integration-test stage. |
+| `Functional` | `true` | Runs the staging functional-test stage and enables the demo R1A functional stage when `Demo` is also enabled. |
+| `Demo` | `true` | Runs the demo R1A functional stage against the demo environment. |
+| `RunR1AOff` | `false` | Runs the optional demo R1A-off functional stage. |
+| `ZephyrExecution` | `false` | Creates Zephyr executions; this also runs automatically on Fridays. |
+| `LEGACY_URL` | `PRE-PROD` | Existing legacy URL selector retained for legacy-mode test configuration. |
+
+Nightly environments:
+
+| Environment | Fines service | User service | Logging service |
+|-------------|---------------|--------------|-----------------|
+| `staging` | `https://opal-fines-service.staging.platform.hmcts.net` | `https://opal-user-service.staging.platform.hmcts.net` | `https://opal-logging-service.staging.platform.hmcts.net` |
+| `demo` | `https://opal-fines-service.demo.platform.hmcts.net` | `https://opal-user-service.demo.platform.hmcts.net` | `https://opal-logging-service.demo.platform.hmcts.net` |
+
+Nightly stages:
+
+| Stage | Environment | Controlled by | Gradle task flow |
+|-------|-------------|---------------|------------------|
+| `Integration Tests` | `staging` | `Integration` | `Integration` |
+| `Functional Tests` | `staging` | `Functional` | `functional` or `functionalWithZephyrExecution` |
+| `Demo R1A Functional Tests` | `demo` | `Demo` and `Functional` | `functionalOpalTags` or `functionalOpalTagsWithZephyrExecution` with the R1A manual-account-creation tag filter |
+| `R1AOff Demo Functional Tests` | `demo` | `RunR1AOff` | `functionalOpalTags` or `functionalOpalTagsWithZephyrExecution` with `@R1AOff and not @Ignore` |
+
+The demo R1A stage is intentionally limited to manual-account-creation scenarios and
+excludes R1A-off, R1B, R1B-off, R1C, and R1C-off style release-tagged scenarios. It
+does not run the full backend functional suite.
+
+All functional stages publish JUnit XML from `build/test-results/functional`, archive the
+functional test XMLs, and publish the Serenity report plus the generated test-summary
+HTML. The integration stage publishes and archives JUnit XML from `build/test-results/integration`.
 
 ### Zephyr tasks
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ plugins {
   id 'application'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.7'
-  id 'org.springframework.boot' version '4.0.6'
+  id 'org.springframework.boot' version '4.1.0'
   id 'com.github.ben-manes.versions' version '0.54.0'
   id 'org.sonarqube' version '7.3.1.8318'
   id 'uk.gov.hmcts.java' version '0.12.70'
@@ -41,7 +41,6 @@ ext {
   serenityVersion = "5.3.10"
   cucumberVersion = "7.23.0" // Keep the forced Cucumber version stable while aligning Serenity with the Gradle plugin
   set('spring-framework.version', "7.0.8")
-  set('spring-security.version', "7.1.0")
 }
 
 //Should we fail fast on test failures?

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ ext {
   serenityVersion = "5.3.10"
   cucumberVersion = "7.23.0" // Keep the forced Cucumber version stable while aligning Serenity with the Gradle plugin
   set('spring-framework.version', "7.0.8")
+  set('spring-security.version', "7.1.0")
 }
 
 //Should we fail fast on test failures?

--- a/build.gradle
+++ b/build.gradle
@@ -321,7 +321,7 @@ tasks.register('functionalOpalTags', Test) {
 
     if (cucumberTags == null || cucumberTags.toString().trim().isEmpty()) {
       throw new GradleException(
-        "Set TAGS or -Ptags when running functionalOpalTags, for example TAGS='@UAT-Technical and @R1BOff'"
+        "Set TAGS or -Ptags when running functionalOpalTags, for example TAGS='@FeatureToggle and @R1BOff'"
       )
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,6 @@ ext {
   serenityVersion = "5.3.10"
   cucumberVersion = "7.23.0" // Keep the forced Cucumber version stable while aligning Serenity with the Gradle plugin
   set('spring-framework.version', "7.0.8")
-  set('spring-security.version', "7.1.0")
 }
 
 //Should we fail fast on test failures?

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ ext {
   serenityVersion = "5.3.10"
   cucumberVersion = "7.23.0" // Keep the forced Cucumber version stable while aligning Serenity with the Gradle plugin
   set('spring-framework.version', "7.0.8")
+  set('spring-security.version', "7.0.6")
 }
 
 //Should we fail fast on test failures?

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ plugins {
   id 'application'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.1.7'
-  id 'org.springframework.boot' version '4.1.0'
+  id 'org.springframework.boot' version '4.0.6'
   id 'com.github.ben-manes.versions' version '0.54.0'
   id 'org.sonarqube' version '7.3.1.8318'
   id 'uk.gov.hmcts.java' version '0.12.70'
@@ -41,6 +41,7 @@ ext {
   serenityVersion = "5.3.10"
   cucumberVersion = "7.23.0" // Keep the forced Cucumber version stable while aligning Serenity with the Gradle plugin
   set('spring-framework.version', "7.0.8")
+  set('spring-security.version', "7.1.0")
 }
 
 //Should we fail fast on test failures?

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,6 @@ ext {
   serenityVersion = "5.3.10"
   cucumberVersion = "7.23.0" // Keep the forced Cucumber version stable while aligning Serenity with the Gradle plugin
   set('spring-framework.version', "7.0.8")
-  set('spring-security.version', "7.0.6")
 }
 
 //Should we fail fast on test failures?

--- a/src/functionalTest/java/uk/gov/hmcts/opal/OpalTaggedTestRunner.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/OpalTaggedTestRunner.java
@@ -11,9 +11,9 @@ import uk.gov.hmcts.opal.steps.BaseStepDef;
  * Runs tagged Opal functional scenarios that must be selected deliberately at execution time.
  *
  * <p>This runner exists separately from {@link OpalTestRunner} because the default Opal suite
- * excludes environment-specific scenarios such as {@code @UAT-Technical}. Those scenarios are not
- * safe to include in the normal {@code functionalOpal} run because they depend on the target
- * environment being configured with a matching feature-flag combination.
+ * excludes feature-toggle scenarios tagged {@code @FeatureToggle}. Those scenarios are not safe
+ * to include in the normal {@code functionalOpal} run because they depend on the target environment
+ * being configured with a matching feature-flag combination.
  *
  * <p>The accompanying {@code functionalOpalTags} Gradle task supplies
  * {@code cucumber.filter.tags}, allowing a caller to run only the relevant tagged scenarios

--- a/src/functionalTest/java/uk/gov/hmcts/opal/OpalTestRunner.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/OpalTestRunner.java
@@ -15,7 +15,7 @@ import uk.gov.hmcts.opal.steps.BaseStepDef;
 @SelectClasspathResource("features/opalMode")
 @ConfigurationParameter(
     key = FILTER_TAGS_PROPERTY_NAME,
-    value = "@Opal and not @Smoke and not @Ignore and not @UAT-Technical"
+    value = "@Opal and not @Smoke and not @Ignore and not @FeatureToggle"
 )
 public class OpalTestRunner {
 

--- a/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountSearchFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountSearchFeatureToggles.feature
@@ -1,4 +1,4 @@
-@Opal @UAT-Technical @JIRA-LABEL:account-enquiry
+@Opal @FeatureToggle @JIRA-LABEL:account-enquiry
 Feature: Defendant Account Search Feature Toggles
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1aFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1aFeatureToggles.feature
@@ -1,4 +1,4 @@
-@Opal @UAT-Technical @JIRA-LABEL:reference-data @JIRA-LABEL:manual-account-creation
+@Opal @FeatureToggle @JIRA-LABEL:reference-data @JIRA-LABEL:manual-account-creation
 Feature: Fines Service Release 1a Feature Toggles
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1bFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1bFeatureToggles.feature
@@ -1,4 +1,4 @@
-@Opal @UAT-Technical @JIRA-LABEL:account-enquiry @JIRA-LABEL:reference-data
+@Opal @FeatureToggle @JIRA-LABEL:account-enquiry @JIRA-LABEL:reference-data
 Feature: Fines Service Release 1b Feature Toggles
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1cFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1cFeatureToggles.feature
@@ -1,4 +1,4 @@
-@Opal @UAT-Technical @Ignore @release-1c @JIRA-LABEL:account-enquiry @JIRA-LABEL:release-1c
+@Opal @FeatureToggle @Ignore @release-1c @JIRA-LABEL:account-enquiry @JIRA-LABEL:release-1c
 Feature: Fines Service Release 1c Feature Toggles
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/results/ResultsFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/results/ResultsFeatureToggles.feature
@@ -1,4 +1,4 @@
-@Opal @UAT-Technical @JIRA-LABEL:reference-data
+@Opal @FeatureToggle @JIRA-LABEL:reference-data
 Feature: Results Feature Toggles
 
   Background:


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Update the nightly Jenkins pipeline so demo functional coverage is limited to R1A manual-account-creation tests, with an optional on-demand R1AOff demo stage.

Changes

- Added demo environment configuration to Jenkinsfile_nightly.
- Added Demo R1A Functional Tests stage for demo-only R1A manual-account-creation coverage.
- Added optional RunR1AOff parameter, default false.
- Added R1AOff Demo Functional Tests stage, only run when RunR1AOff is enabled.
- Removed demo integration test execution.
- Replaced UAT-Technical tagging with repo-relevant FeatureToggle tagging.
- Updated README with nightly Jenkins pipeline parameters, environments, and stages.
- Updated pipelines to archive the Zephyr reports.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
