### PR TITLE
PO-7246 : auth header not passed down

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,10 @@
 #!groovy
 import uk.gov.hmcts.contino.GithubAPI
-
+properties([
+        parameters([
+                booleanParam(name: 'SKIP_SONAR', defaultValue: false, description: 'Skip sonar'),
+        ])
+])
 @Library("Infrastructure@master")
 
 def type = "java"
@@ -24,7 +28,7 @@ def determineDevEnvironmentDeployment() {
   env.OPAL_LOGGING_SERVICE_API_URL = "https://opal-logging-service.staging.platform.hmcts.net"
   env.DEV_OPAL_LOGGING_SERVICE_IMAGE_SUFFIX = "latest"
 
-
+  env.SKIP_SONAR = params.SKIP_SONAR
   env.APP_MODE = "opal"
 
   def githubApi = new GithubAPI(this)
@@ -130,6 +134,13 @@ withPipeline(type, product, component) {
     steps.sh './gradlew checkTestJiraAnnotations'
   }
 
+  afterAlways("helmReleaseUninstall:${params.environment}") {
+    if(params.SKIP_SONAR) {
+      stage('SKIP_SONAR IS TRUE') {
+        error("Build can not fully complete when SKIP_SONAR is set to true")
+      }
+    }
+  }
   afterAlways('test') {
     steps.junit '**/test-results/integration/*.xml'
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/integration/*.xml'

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ ext {
 //Should we fail fast on test failures?
 //Defaults to true if env is not present
 var failFast = System.getenv('FAIL_FAST') == null || System.getenv('FAIL_FAST').toBoolean()
+var skipSonar = System.getenv('SKIP_SONAR') != null && System.getenv('SKIP_SONAR').toBoolean();
 def defaultLegacyStubImage = 'hmctsprod.azurecr.io/opal/legacy-db-stub:latest'
 def legacyStubImage = System.getenv('OPAL_LEGACY_STUB_IMAGE') ?: defaultLegacyStubImage
 def legacyStubPort = 4553
@@ -572,6 +573,9 @@ sonarqube {
     property "sonar.exclusions", coverageExclusions.join(', ')
     property 'sonar.coverage.exclusions', "**/entity/**,**/model/*,**/exception/*,**/config/**,**/repository/jpa/*,**/opal/dto/*"
     property 'sonar.cpd.exclusions', "**/entity/**,**/opal/dto/**,**/service/DefendantAccountService.java,**/service/legacy/LegacyDefendantAccountService.java,**/service/opal/OpalDefendantAccountService.java"
+    if (skipSonar) {
+      property 'sonar.exclusions', "**/**"
+    }
   }
 }
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountSearchRelease1cDisabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountSearchRelease1cDisabledIntegrationTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.opal.controllers;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -47,7 +46,7 @@ class DefendantAccountSearchRelease1cDisabledIntegrationTest extends AbstractInt
             .defendantAccounts(List.of())
             .build();
 
-        when(defendantAccountService.searchDefendantAccounts(any(AccountSearchDto.class), anyString()))
+        when(defendantAccountService.searchDefendantAccounts(any(AccountSearchDto.class)))
             .thenReturn(response);
 
         mockMvc.perform(post(DEFENDANTS_SEARCH_URL)
@@ -59,7 +58,7 @@ class DefendantAccountSearchRelease1cDisabledIntegrationTest extends AbstractInt
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.count").value(0));
 
-        verify(defendantAccountService).searchDefendantAccounts(any(AccountSearchDto.class), anyString());
+        verify(defendantAccountService).searchDefendantAccounts(any(AccountSearchDto.class));
         verifyNoMoreInteractions(defendantAccountService);
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerTransientErrorsIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerTransientErrorsIntegrationTest.java
@@ -61,7 +61,7 @@ class DraftAccountControllerTransientErrorsIntegrationTest extends AbstractInteg
             .account(validAccountJson())
             .timelineData(validTimelineDataJson())
             .build();
-        when(draftAccountService.updateDraftAccount(any(), any(), any(), any())).thenReturn(dto);
+        when(draftAccountService.updateDraftAccount(any(), any(), any())).thenReturn(dto);
         shouldReturn406WhenResponseContentTypeNotSupported(
             patch(URL_BASE + "/1").contentType(MediaType.APPLICATION_JSON).content(validUpdateRequestBody())
         );
@@ -78,7 +78,7 @@ class DraftAccountControllerTransientErrorsIntegrationTest extends AbstractInteg
                 .header("If-Match", "0")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(validUpdateRequestBody()),
-            when(draftAccountService.updateDraftAccount(any(), any(), any(), any()))
+            when(draftAccountService.updateDraftAccount(any(), any(), any()))
         );
     }
 
@@ -93,7 +93,7 @@ class DraftAccountControllerTransientErrorsIntegrationTest extends AbstractInteg
                 .header("If-Match", "0")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(validUpdateRequestBody()),
-            when(draftAccountService.updateDraftAccount(any(), any(), any(), any()))
+            when(draftAccountService.updateDraftAccount(any(), any(), any()))
         );
     }
 
@@ -118,7 +118,7 @@ class DraftAccountControllerTransientErrorsIntegrationTest extends AbstractInteg
         String validRequestBody = validCreateRequestBody();
         shouldReturn408WhenTimeout(
             post(URL_BASE).contentType(MediaType.APPLICATION_JSON).content(validRequestBody),
-            when(draftAccountService.submitDraftAccount(any(), any())));
+            when(draftAccountService.submitDraftAccount(any())));
     }
 
     @Test
@@ -130,7 +130,7 @@ class DraftAccountControllerTransientErrorsIntegrationTest extends AbstractInteg
         String validRequestBody = validCreateRequestBody();
         shouldReturn503WhenDownstreamServiceIsUnavailable(
             post(URL_BASE).contentType(MediaType.APPLICATION_JSON).content(validRequestBody),
-            when(draftAccountService.submitDraftAccount(any(), any()))
+            when(draftAccountService.submitDraftAccount(any()))
         );
 
     }
@@ -142,8 +142,7 @@ class DraftAccountControllerTransientErrorsIntegrationTest extends AbstractInteg
     @JiraTestKey("PO-5877")
     void testGetDraftAccountById_trap408Response() throws Exception {
         shouldReturn408WhenTimeout(
-            get(URL_BASE + "/1"), when(
-                draftAccountService.getDraftAccount(1L, "Bearer some_value")));
+            get(URL_BASE + "/1"), when(draftAccountService.getDraftAccount(1L)));
     }
 
     @Test
@@ -153,8 +152,7 @@ class DraftAccountControllerTransientErrorsIntegrationTest extends AbstractInteg
     @JiraTestKey("PO-5885")
     void testGetDraftAccountById_trap503Response() throws Exception {
         shouldReturn503WhenDownstreamServiceIsUnavailable(
-            get(URL_BASE + "/1"), when(
-                draftAccountService.getDraftAccount(1L, "Bearer some_value")));
+            get(URL_BASE + "/1"), when(draftAccountService.getDraftAccount(1L)));
     }
 
 
@@ -177,7 +175,7 @@ class DraftAccountControllerTransientErrorsIntegrationTest extends AbstractInteg
     void testGetDraftAccountsSummaries_trap408Response() throws Exception {
         shouldReturn408WhenTimeout(
             get(URL_BASE), when(draftAccountService
-                                    .getDraftAccounts(any(), any(), any(), any(), any(), any(), any())));
+                                    .getDraftAccounts(any(), any(), any(), any(), any(), any())));
     }
 
     @Test
@@ -188,7 +186,7 @@ class DraftAccountControllerTransientErrorsIntegrationTest extends AbstractInteg
     void testGetDraftAccountsSummaries_trap503Response() throws Exception {
         shouldReturn503WhenDownstreamServiceIsUnavailable(
             get(URL_BASE), when(draftAccountService
-                                    .getDraftAccounts(any(), any(), any(), any(), any(), any(), any())));
+                                    .getDraftAccounts(any(), any(), any(), any(), any(), any())));
     }
 
     void shouldReturn406WhenResponseContentTypeNotSupported(MockHttpServletRequestBuilder reqBuilder) throws Exception {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsPatchIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsPatchIntegrationTest.java
@@ -437,7 +437,7 @@ class OpalDefendantsPatchIntegrationTest extends AbstractOpalDefendantsIntegrati
             ).andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/missing-header"))
             .andExpect(jsonPath("$.title").value("Missing Required Header"))
-            .andExpect(jsonPath("$.detail").value("Required request header \"Authorization\" is missing"))
+            .andExpect(jsonPath("$.detail").value("Required request header \"Business-Unit-Id\" is missing"))
             .andExpect(jsonPath("$.instance").isNotEmpty())
             .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
             .andExpect(jsonPath("$.retriable").value(false));

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMajorCreditorAccountAtAGlanceIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMajorCreditorAccountAtAGlanceIntegrationTest.java
@@ -96,7 +96,7 @@ class OpalMajorCreditorAccountAtAGlanceIntegrationTest extends AbstractIntegrati
     @JiraStory("PO-2132")
     @JiraEpic("PO-1286")
     void getAtAGlance_majorCreditorSuccessReturnsMappedResponseAndEtag() throws Exception {
-        when(userStateService.checkForAuthorisedUser())
+        when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(UserStateUtil.permissionUser((short) 77, SEARCH_AND_VIEW_ACCOUNTS));
 
         Map<String, Object> account = getAtAGlanceRow(MJ_ACCOUNT_ID);
@@ -141,7 +141,7 @@ class OpalMajorCreditorAccountAtAGlanceIntegrationTest extends AbstractIntegrati
     @JiraStory("PO-2132")
     @JiraEpic("PO-1286")
     void getAtAGlance_centralFundSuccessReturnsMappedResponseAndEtag() throws Exception {
-        when(userStateService.checkForAuthorisedUser())
+        when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(UserStateUtil.permissionUser((short) 77, SEARCH_AND_VIEW_ACCOUNTS));
 
         Map<String, Object> account = getAtAGlanceRow(CF_ACCOUNT_ID);
@@ -179,7 +179,7 @@ class OpalMajorCreditorAccountAtAGlanceIntegrationTest extends AbstractIntegrati
     @JiraStory("PO-2132")
     @JiraEpic("PO-1286")
     void getAtAGlance_repeatedGetReturnsSamePayloadAndHeaders() throws Exception {
-        when(userStateService.checkForAuthorisedUser())
+        when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(UserStateUtil.permissionUser((short) 77, SEARCH_AND_VIEW_ACCOUNTS));
 
         ResultActions first = mockMvc.perform(get(URL, MJ_ACCOUNT_ID).header(HttpHeaders.AUTHORIZATION, AUTH_HEADER));
@@ -198,7 +198,7 @@ class OpalMajorCreditorAccountAtAGlanceIntegrationTest extends AbstractIntegrati
     @JiraStory("PO-2132")
     @JiraEpic("PO-1286")
     void getAtAGlance_sameBusinessUnitPermissionReturns200() throws Exception {
-        when(userStateService.checkForAuthorisedUser())
+        when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(UserStateUtil.permissionUser((short) 77, SEARCH_AND_VIEW_ACCOUNTS));
 
         mockMvc.perform(get(URL, MJ_ACCOUNT_ID).header(HttpHeaders.AUTHORIZATION, AUTH_HEADER))
@@ -210,7 +210,7 @@ class OpalMajorCreditorAccountAtAGlanceIntegrationTest extends AbstractIntegrati
     @JiraStory("PO-2132")
     @JiraEpic("PO-1286")
     void getAtAGlance_differentBusinessUnitPermissionReturns200() throws Exception {
-        when(userStateService.checkForAuthorisedUser())
+        when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(UserStateUtil.permissionUser((short) 73, SEARCH_AND_VIEW_ACCOUNTS));
 
         mockMvc.perform(get(URL, MJ_ACCOUNT_ID).header(HttpHeaders.AUTHORIZATION, AUTH_HEADER))
@@ -222,7 +222,7 @@ class OpalMajorCreditorAccountAtAGlanceIntegrationTest extends AbstractIntegrati
     @JiraStory("PO-2132")
     @JiraEpic("PO-1286")
     void getAtAGlance_notFoundReturns404() throws Exception {
-        when(userStateService.checkForAuthorisedUser())
+        when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(UserStateUtil.permissionUser((short) 77, SEARCH_AND_VIEW_ACCOUNTS));
 
         ResultActions actions = mockMvc.perform(get(URL, 999999L)
@@ -253,7 +253,7 @@ class OpalMajorCreditorAccountAtAGlanceIntegrationTest extends AbstractIntegrati
     @JiraEpic("PO-1286")
     void getAtAGlance_missingAuthReturns401() throws Exception {
         doThrow(new ResponseStatusException(UNAUTHORIZED, "Unauthorized"))
-            .when(userStateService).checkForAuthorisedUser();
+            .when(userStateService).getUserStateV1FromSecurityContext();
 
         mockMvc.perform(get(URL, MJ_ACCOUNT_ID))
             .andExpect(status().isUnauthorized())
@@ -267,7 +267,7 @@ class OpalMajorCreditorAccountAtAGlanceIntegrationTest extends AbstractIntegrati
     @JiraStory("PO-2132")
     @JiraEpic("PO-1286")
     void getAtAGlance_missingPermissionReturns403() throws Exception {
-        when(userStateService.checkForAuthorisedUser()).thenReturn(UserStateUtil.noPermissionsUser());
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(UserStateUtil.noPermissionsUser());
 
         mockMvc.perform(get(URL, MJ_ACCOUNT_ID).header(HttpHeaders.AUTHORIZATION, AUTH_HEADER))
             .andExpect(status().isForbidden())
@@ -281,10 +281,10 @@ class OpalMajorCreditorAccountAtAGlanceIntegrationTest extends AbstractIntegrati
     @JiraStory("PO-2132")
     @JiraEpic("PO-1286")
     void getAtAGlance_queryTimeoutReturns408() throws Exception {
-        when(userStateService.checkForAuthorisedUser())
+        when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(UserStateUtil.permissionUser((short) 77, SEARCH_AND_VIEW_ACCOUNTS));
         doThrow(new QueryTimeoutException("timeout", null, null))
-            .when(userStateService).checkForAuthorisedUser();
+            .when(userStateService).getUserStateV1FromSecurityContext();
 
         mockMvc.perform(get(URL, MJ_ACCOUNT_ID).header(HttpHeaders.AUTHORIZATION, AUTH_HEADER))
             .andExpect(status().isRequestTimeout())
@@ -297,7 +297,7 @@ class OpalMajorCreditorAccountAtAGlanceIntegrationTest extends AbstractIntegrati
     @JiraStory("PO-2132")
     @JiraEpic("PO-1286")
     void getAtAGlance_dataAccessFailureReturns503() throws Exception {
-        when(userStateService.checkForAuthorisedUser())
+        when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(UserStateUtil.permissionUser((short) 77, SEARCH_AND_VIEW_ACCOUNTS));
         doThrow(new DataAccessResourceFailureException("db unavailable"))
             .when(majorCreditorAccountAtAGlanceRepository).findById(MJ_ACCOUNT_ID);
@@ -313,7 +313,7 @@ class OpalMajorCreditorAccountAtAGlanceIntegrationTest extends AbstractIntegrati
     @JiraStory("PO-2132")
     @JiraEpic("PO-1286")
     void getAtAGlance_internalServerErrorReturns500() throws Exception {
-        when(userStateService.checkForAuthorisedUser())
+        when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(UserStateUtil.permissionUser((short) 77, SEARCH_AND_VIEW_ACCOUNTS));
         doThrow(HttpServerErrorException.create(
             org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR,

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportInstancesControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportInstancesControllerIntegrationTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.opal.controllers;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -77,7 +76,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraStory("PO-2252")
     @JiraEpic("PO-2248")
     void createReportInstance_singleBU() throws Exception {
-        when(userStateService.checkForAuthorisedUser(anyString())).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
         when(userState.getUserId()).thenReturn(USER_ID);
         when(userState.getUserName()).thenReturn(USER_NAME);
@@ -141,7 +140,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraStory("PO-2252")
     @JiraEpic("PO-2248")
     void createReportInstance_multiBUs() throws Exception {
-        when(userStateService.checkForAuthorisedUser(anyString())).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1, businessUnitUser2));
         when(userState.getUserId()).thenReturn(USER_ID);
         when(userState.getUserName()).thenReturn(USER_NAME);
@@ -173,7 +172,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraStory("PO-2252")
     @JiraEpic("PO-2248")
     void createReportInstance_singleBU_fail2BUs_422() throws Exception {
-        when(userStateService.checkForAuthorisedUser(anyString())).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1, businessUnitUser2));
         when(businessUnitUser1.getBusinessUnitId()).thenReturn((short)1);
         when(businessUnitUser2.getBusinessUnitId()).thenReturn((short)2);
@@ -198,7 +197,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraStory("PO-2252")
     @JiraEpic("PO-2248")
     void createReportInstance_cannotManuallyCreate_422() throws Exception {
-        when(userStateService.checkForAuthorisedUser(anyString())).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
         when(businessUnitUser1.getBusinessUnitId()).thenReturn((short)1);
 
@@ -222,7 +221,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraStory("PO-2252")
     @JiraEpic("PO-2248")
     void createReportInstance_wrongBU_403() throws Exception {
-        when(userStateService.checkForAuthorisedUser(anyString())).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
         when(businessUnitUser1.getBusinessUnitId()).thenReturn((short)1);
 
@@ -245,7 +244,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraStory("PO-2252")
     @JiraEpic("PO-2248")
     void createReportInstance_notAllBUs_403() throws Exception {
-        when(userStateService.checkForAuthorisedUser(anyString())).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
         when(businessUnitUser1.getBusinessUnitId()).thenReturn((short)1);
 
@@ -354,7 +353,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
         doThrow(new IllegalArgumentException("Unable to publish report queue message"))
             .when(reportQueuePublisher).publish(anyLong());
 
-        when(userStateService.checkForAuthorisedUser(anyString())).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
         when(userState.getUserId()).thenReturn(USER_ID);
         when(userState.getUserName()).thenReturn(USER_NAME);
@@ -399,7 +398,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraStory("PO-2252")
     @JiraEpic("PO-2248")
     void createReportInstance_reportParameterValidation_mandatoryFieldsNotSuppliedFail() throws Exception {
-        when(userStateService.checkForAuthorisedUser(anyString())).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
         when(userState.getUserId()).thenReturn(USER_ID);
         when(userState.getUserName()).thenReturn(USER_NAME);
@@ -430,7 +429,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraStory("PO-2252")
     @JiraEpic("PO-2248")
     void createReportInstance_reportParameterValidation_unknownParameterFail() throws Exception {
-        when(userStateService.checkForAuthorisedUser(anyString())).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
         when(userState.getUserId()).thenReturn(USER_ID);
         when(userState.getUserName()).thenReturn(USER_NAME);
@@ -471,7 +470,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraStory("PO-2252")
     @JiraEpic("PO-2248")
     void createReportInstance_reportParameterValidation_parameterTypeMismatchFail() throws Exception {
-        when(userStateService.checkForAuthorisedUser(anyString())).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
         when(userState.getUserId()).thenReturn(USER_ID);
         when(userState.getUserName()).thenReturn(USER_NAME);
@@ -512,7 +511,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraStory("PO-2252")
     @JiraEpic("PO-2248")
     void createReportInstance_repeatSuccess() throws Exception {
-        when(userStateService.checkForAuthorisedUser(anyString())).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
         when(userState.getUserId()).thenReturn(USER_ID);
         when(userState.getUserName()).thenReturn(USER_NAME);

--- a/src/main/java/uk/gov/hmcts/opal/controllers/BusinessUnitController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/BusinessUnitController.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -71,13 +70,12 @@ public class BusinessUnitController {
     @Operation(summary = "Returns Business Units as reference data with an optional filter applied")
     @FeatureToggle(feature = FeatureFlags.RELEASE_1A, defaultValueProperty = FeatureFlags.RELEASE_1A_ENABLED_PROPERTY)
     public ResponseEntity<BusinessUnitReferenceDataResults> getBusinessUnitRefData(
-        @RequestParam("q") Optional<String> filter, @RequestParam Optional<FinesPermission> permission,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
+        @RequestParam("q") Optional<String> filter, @RequestParam Optional<FinesPermission> permission) {
 
         log.debug(":GET:getBusinessUnitRefData: permission: {}, query: \n{}", permission, filter);
 
         List<BusinessUnitReferenceData> refData = filterBusinessUnitsByPermission(
-            userStateService, businessUnitService.getReferenceData(filter), permission, authHeaderValue);
+            userStateService, businessUnitService.getReferenceData(filter), permission);
 
         log.debug(":GET:getBusinessUnitRefData: business unit reference data count: {}", refData.size());
         return ResponseEntity.ok(BusinessUnitReferenceDataResults.builder().refData(refData).build());

--- a/src/main/java/uk/gov/hmcts/opal/controllers/CourtController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/CourtController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,10 +22,8 @@ import uk.gov.hmcts.opal.dto.reference.CourtReferenceDataResults;
 import uk.gov.hmcts.opal.dto.response.SearchDataResponse;
 import uk.gov.hmcts.opal.dto.search.CourtSearchDto;
 import uk.gov.hmcts.opal.entity.court.CourtEntity;
-import uk.gov.hmcts.opal.service.UserStateService;
 import uk.gov.hmcts.opal.service.opal.CourtService;
 import uk.gov.hmcts.opal.util.FeatureFlags;
-
 
 @RestController
 @RequestMapping("/courts")
@@ -36,10 +33,7 @@ public class CourtController {
 
     private final CourtService courtService;
 
-    private final UserStateService userStateService;
-
-    public CourtController(UserStateService userStateService, CourtService courtService) {
-        this.userStateService = userStateService;
+    public CourtController(CourtService courtService) {
         this.courtService = courtService;
     }
 
@@ -47,11 +41,9 @@ public class CourtController {
     @Operation(summary = "Returns the court for the given courtId.")
     @FeatureToggle(feature = FeatureFlags.RELEASE_1A, defaultValueProperty = FeatureFlags.RELEASE_1A_ENABLED_PROPERTY)
     public ResponseEntity<CourtEntity> getCourtById(
-        @PathVariable Long courtId, @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
+        @PathVariable Long courtId) {
 
         log.debug(":GET:getCourtById: courtId: {}", courtId);
-
-        userStateService.checkForAuthorisedUser(authHeaderValue);
 
         CourtEntity response = courtService.getCourtById(courtId);
 
@@ -62,12 +54,9 @@ public class CourtController {
     @Operation(summary = "Searches courts based upon criteria in request body")
     @FeatureToggle(feature = FeatureFlags.RELEASE_1A, defaultValueProperty = FeatureFlags.RELEASE_1A_ENABLED_PROPERTY)
     public ResponseEntity<SearchDataResponse<CourtEntity>> postCourtsSearch(
-        @RequestBody CourtSearchDto criteria,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
+        @RequestBody CourtSearchDto criteria) {
 
         log.debug(":POST:postCourtsSearch: query: \n{}", criteria);
-
-        userStateService.checkForAuthorisedUser(authHeaderValue);
 
         List<CourtEntity> results = courtService.searchCourts(criteria);
 

--- a/src/main/java/uk/gov/hmcts/opal/controllers/DefendantAccountApiController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/DefendantAccountApiController.java
@@ -36,31 +36,30 @@ public class DefendantAccountApiController implements DefendantAccountApi {
 
     @FeatureToggle(feature = RELEASE_1B, defaultValueProperty = RELEASE_1B_ENABLED_PROPERTY)
     @Override
-    public ResponseEntity<DefendantAccountImpositionsResponseCommon> getImpositions(Long id, String authHeaderValue) {
+    public ResponseEntity<DefendantAccountImpositionsResponseCommon> getImpositions(Long id) {
         log.debug(":GET:getImpositions: for defendant account id: {}", id);
 
-        GetDefendantAccountImpositionsResponse response = impositionService.getImpositions(id, authHeaderValue);
+        GetDefendantAccountImpositionsResponse response = impositionService.getImpositions(id);
 
         return ResponseEntity.ok().eTag(VersionUtils.createETag(response)).body(response.getPayload());
     }
 
     @Override
     @FeatureToggle(feature = RELEASE_1B, defaultValueProperty = RELEASE_1B_ENABLED_PROPERTY)
-    public ResponseEntity<GetEnforcementStatusResponse> getEnforcementStatus(Long id, String authHeaderValue) {
+    public ResponseEntity<GetEnforcementStatusResponse> getEnforcementStatus(Long id) {
         log.debug(":GET:getDefendantAccountEnforcementStatus: for defendant id: {}", id);
 
-        return buildResponse(defendantAccountService.getEnforcementStatus(id, authHeaderValue));
+        return buildResponse(defendantAccountService.getEnforcementStatus(id));
     }
 
     @Override
     @FeatureToggle(feature = RELEASE_1B, defaultValueProperty = RELEASE_1B_ENABLED_PROPERTY)
     public ResponseEntity<UpdateDefendantAccountResponsePayload> updateDefendantAccount(Long defendantAccountId,
-        String authHeaderValue, String businessUnitId, UpdateDefendantAccountRequestPayload request, String ifMatch) {
+        String businessUnitId, UpdateDefendantAccountRequestPayload request, String ifMatch) {
         log.debug(":PATCH:updateDefendantAccount: id={}", defendantAccountId);
 
         UpdateDefendantAccountResponse response =
-            defendantAccountService.updateDefendantAccount(defendantAccountId, businessUnitId, request, authHeaderValue,
-                ifMatch);
+            defendantAccountService.updateDefendantAccount(defendantAccountId, businessUnitId, request, ifMatch);
 
         return ResponseEntity.ok().eTag(VersionUtils.createETag(response)).body(response.getPayload());
     }

--- a/src/main/java/uk/gov/hmcts/opal/controllers/DefendantAccountApiController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/DefendantAccountApiController.java
@@ -70,13 +70,12 @@ public class DefendantAccountApiController implements DefendantAccountApi {
         Long id,
         LocalDate dateFrom,
         LocalDate dateTo,
-        List<String> itemTypes,
-        String authorization) {
+        List<String> itemTypes) {
 
         log.debug(":GET:getDefendantAccountHistory: for defendant id: {}", id);
 
         DefendantAccountHistoryResponse response =
-            defendantAccountService.getHistory(id, dateFrom, dateTo, itemTypes, authorization);
+            defendantAccountService.getHistory(id, dateFrom, dateTo, itemTypes);
 
         GetDefendantAccountHistoryResponse generatedResponse =
             defendantAccountHistoryResponseMapper.toGeneratedResponse(response);

--- a/src/main/java/uk/gov/hmcts/opal/controllers/DefendantAccountController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/DefendantAccountController.java
@@ -80,13 +80,11 @@ public class DefendantAccountController {
     @Operation(summary = "Get defendant account details by providing the defendant account summary")
     @FeatureToggle(feature = RELEASE_1B, defaultValueProperty = RELEASE_1B_ENABLED_PROPERTY)
     public ResponseEntity<DefendantAccountHeaderSummary> getHeaderSummary(
-        @PathVariable Long defendantAccountId,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
+        @PathVariable Long defendantAccountId) {
 
         log.debug(":GET:getHeaderSummary: for defendant id: {}", defendantAccountId);
 
-        return buildResponse(
-            defendantAccountService.getHeaderSummary(defendantAccountId, authHeaderValue));
+        return buildResponse(defendantAccountService.getHeaderSummary(defendantAccountId));
     }
 
     @GetMapping(value = "/{defendantAccountId}/defendant-account-parties/{defendantAccountPartyId}")
@@ -94,15 +92,13 @@ public class DefendantAccountController {
     @FeatureToggle(feature = RELEASE_1B, defaultValueProperty = RELEASE_1B_ENABLED_PROPERTY)
     public ResponseEntity<GetDefendantAccountPartyResponse> getDefendantAccountParty(
         @PathVariable Long defendantAccountId,
-        @PathVariable Long defendantAccountPartyId,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
+        @PathVariable Long defendantAccountPartyId) {
 
         log.debug(":GET:getDefendantAccountParty: for accountId={}, partyId={}", defendantAccountId,
             defendantAccountPartyId);
 
         GetDefendantAccountPartyResponse response =
-            defendantAccountPartyService.getDefendantAccountParty(defendantAccountId, defendantAccountPartyId,
-                authHeaderValue);
+            defendantAccountPartyService.getDefendantAccountParty(defendantAccountId, defendantAccountPartyId);
 
         return buildResponse(response);
     }
@@ -113,14 +109,13 @@ public class DefendantAccountController {
     public ResponseEntity<DefendantAccountSearchResultsDto> postDefendantAccountSearch(
         @JsonSchemaValidated(schemaPath = SchemaPaths.POST_DEFENDANT_ACCOUNT_SEARCH_REQUEST)
             @RequestBody
-           AccountSearchDto accountSearchDto,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
+           AccountSearchDto accountSearchDto) {
         log.debug(":POST:postDefendantAccountSearch: query: \n{}", accountSearchDto.toPrettyJson());
 
         rejectConsolidatedSearchWhenDisabled(accountSearchDto);
 
         DefendantAccountSearchResultsDto response =
-            defendantAccountService.searchDefendantAccounts(accountSearchDto, authHeaderValue);
+            defendantAccountService.searchDefendantAccounts(accountSearchDto);
 
         return buildResponse(response);
     }
@@ -144,7 +139,6 @@ public class DefendantAccountController {
         @PathVariable Long defendantAccountId,
         @RequestHeader("Business-Unit-Id") String businessUnitId,
         @RequestHeader(value = "If-Match", required = false) String ifMatch,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue,
         @JsonSchemaValidated(schemaPath = SchemaPaths.POST_DEFENDANT_ACCOUNT_ADD_PAYMENT_TERMS)
         @RequestBody AddDefendantAccountPaymentTermsRequest addPaymentTermsRequest) {
 
@@ -154,7 +148,6 @@ public class DefendantAccountController {
             defendantAccountService.addPaymentTerms(defendantAccountId,
                 businessUnitId,
                 ifMatch,
-                authHeaderValue,
                 addPaymentTermsRequest));
     }
 
@@ -162,13 +155,12 @@ public class DefendantAccountController {
     @Operation(summary = "Get defendant account details by providing the defendant account summary")
     @FeatureToggle(feature = RELEASE_1B, defaultValueProperty = RELEASE_1B_ENABLED_PROPERTY)
     public ResponseEntity<GetDefendantAccountPaymentTermsResponse> defendantAccountPaymentTerms(
-        @PathVariable Long defendantAccountId,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
+        @PathVariable Long defendantAccountId) {
 
         log.debug(":GET:DefendantAccountPaymentTerms: for defendant id: {}", defendantAccountId);
 
         return buildResponse(
-            defendantAccountPaymentTermsService.getPaymentTerms(defendantAccountId, authHeaderValue));
+            defendantAccountPaymentTermsService.getPaymentTerms(defendantAccountId));
     }
 
     @PostMapping("/{defendantAccountId}/payment-card-request")
@@ -176,7 +168,6 @@ public class DefendantAccountController {
     @FeatureToggle(feature = RELEASE_1B, defaultValueProperty = RELEASE_1B_ENABLED_PROPERTY)
     public ResponseEntity<AddPaymentCardRequestResponse> addPaymentCardRequest(
         @PathVariable Long defendantAccountId,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue,
         @RequestHeader("Business-Unit-Id") String businessUnitId,
         @RequestHeader(value = "Business-Unit-User-Id", required = false) String businessUnitUserId,
         @RequestHeader(value = "If-Match", required = false) String ifMatch
@@ -187,8 +178,7 @@ public class DefendantAccountController {
             defendantAccountId,
             businessUnitId,
             businessUnitUserId,
-            ifMatch,
-            authHeaderValue
+            ifMatch
         );
 
         return buildResponse(response);
@@ -198,22 +188,20 @@ public class DefendantAccountController {
     @GetMapping(value = "/{defendantAccountId}/at-a-glance")
     @Operation(summary = "Get At A Glance details for a given defendant account")
     @FeatureToggle(feature = RELEASE_1B, defaultValueProperty = RELEASE_1B_ENABLED_PROPERTY)
-    public ResponseEntity<DefendantAccountAtAGlanceResponse> getAtAGlance(@PathVariable Long defendantAccountId,
-              @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
+    public ResponseEntity<DefendantAccountAtAGlanceResponse> getAtAGlance(@PathVariable Long defendantAccountId) {
 
-        return buildResponse(defendantAccountService.getAtAGlance(defendantAccountId, authHeaderValue));
+        return buildResponse(defendantAccountService.getAtAGlance(defendantAccountId));
     }
 
     @GetMapping("/{defendantAccountId}/fixed-penalty")
     @Operation(summary = "Retrieve Fixed Penalty Offence details for a given Defendant Account")
     @FeatureToggle(feature = RELEASE_1B, defaultValueProperty = RELEASE_1B_ENABLED_PROPERTY)
     public ResponseEntity<GetDefendantAccountFixedPenaltyResponse> getDefendantAccountFixedPenalty(
-        @PathVariable Long defendantAccountId,
-        @RequestHeader("Authorization") String authHeaderValue) {
+        @PathVariable Long defendantAccountId) {
         log.debug(":GET:getDefendantAccountFixedPenalty: for defendantAccountId={}", defendantAccountId);
 
         GetDefendantAccountFixedPenaltyResponse response =
-            defendantAccountFixedPenaltyService.getDefendantAccountFixedPenalty(defendantAccountId, authHeaderValue);
+            defendantAccountFixedPenaltyService.getDefendantAccountFixedPenalty(defendantAccountId);
 
         return buildResponse(response);
     }
@@ -224,7 +212,6 @@ public class DefendantAccountController {
         @PathVariable Long defendantAccountId,
         @RequestHeader("Business-Unit-Id") String businessUnitId,
         @RequestHeader(value = "If-Match", required = false) String ifMatch,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue,
         @JsonSchemaValidated(schemaPath = SchemaPaths.POST_DEFENDANT_ACCOUNT_ADD_PARTY)
         @RequestBody AddDefendantAccountPartyRequest request) {
 
@@ -236,7 +223,7 @@ public class DefendantAccountController {
         return buildResponse(
             defendantAccountPartyService.addDefendantAccountParty(
                 defendantAccountId,
-                authHeaderValue, ifMatch, businessUnitId, request
+                ifMatch, businessUnitId, request
             ));
     }
 
@@ -248,7 +235,6 @@ public class DefendantAccountController {
         @PathVariable Long defendantAccountPartyId,
         @RequestHeader("Business-Unit-Id") String businessUnitId,
         @RequestHeader(value = "If-Match", required = false) String ifMatch,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue,
         @RequestBody DefendantAccountParty request
     ) {
 
@@ -257,7 +243,7 @@ public class DefendantAccountController {
 
         return buildResponse(
             defendantAccountPartyService.replaceDefendantAccountParty(defendantAccountId,
-                defendantAccountPartyId, authHeaderValue, ifMatch, businessUnitId, request));
+                defendantAccountPartyId, ifMatch, businessUnitId, request));
     }
 
     @DeleteMapping(value = "/{defendantAccountId}/defendant-account-parties/{defendantAccountPartyId}",
@@ -270,7 +256,6 @@ public class DefendantAccountController {
         @PathVariable Long defendantAccountPartyId,
         @RequestHeader("Business-Unit-Id") Short businessUnitId,
         @RequestHeader(value = "If-Match", required = false) String ifMatch,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue,
         @RequestBody RemoveDefendantAccountPartyRequest request
     ) {
         log.debug(":DELETE:removeDefendantAccountParty: for defendant id: {} and defendantAccountPartyId: {}",
@@ -278,7 +263,7 @@ public class DefendantAccountController {
 
         return buildResponse(
             defendantAccountPartyService.removeDefendantAccountParty(defendantAccountId,
-                defendantAccountPartyId, businessUnitId, ifMatch, authHeaderValue, request));
+                defendantAccountPartyId, businessUnitId, ifMatch, request));
     }
 
     @PostMapping("/{defendantAccountId}/enforcements")
@@ -286,7 +271,6 @@ public class DefendantAccountController {
     @FeatureToggle(feature = RELEASE_1B, defaultValueProperty = RELEASE_1B_ENABLED_PROPERTY)
     public ResponseEntity<AddEnforcementResponse> addEnforcement(
         @PathVariable Long defendantAccountId,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue,
         @RequestHeader("Business-Unit-Id") Short businessUnitId,
         @RequestHeader(value = "If-Match", required = false) String ifMatch,
         @RequestBody AddDefendantAccountEnforcementRequest request
@@ -295,7 +279,7 @@ public class DefendantAccountController {
         log.debug(":POST:addEnforcement: for defendantAccountId={}", defendantAccountId);
 
         AddEnforcementResponse response = defendantAccountEnforcementService.addEnforcement(
-            defendantAccountId, businessUnitId, ifMatch, authHeaderValue, request
+            defendantAccountId, businessUnitId, ifMatch, request
         );
 
         return buildResponse(response);
@@ -308,7 +292,6 @@ public class DefendantAccountController {
         @PathVariable Long defendantAccountId,
         @RequestHeader("Business-Unit-Id") Short businessUnitId,
         @RequestHeader(value = "If-Match", required = false) String ifMatch,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue,
         @RequestBody RemoveDefendantAccountEnforcementHoldRequest request
     ) {
         log.debug(":PATCH:removeEnforcementHold: for defendantAccountId={}", defendantAccountId);
@@ -318,7 +301,6 @@ public class DefendantAccountController {
                 defendantAccountId,
                 businessUnitId,
                 ifMatch,
-                authHeaderValue,
                 request
             )
         );

--- a/src/main/java/uk/gov/hmcts/opal/controllers/DraftAccountController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/DraftAccountController.java
@@ -57,12 +57,11 @@ public class DraftAccountController {
     @FeatureToggle(feature = FeatureFlags.RELEASE_1A,
         defaultValueProperty = FeatureFlags.RELEASE_1A_ENABLED_PROPERTY)
     public ResponseEntity<DraftAccountResponseDto> getDraftAccountById(
-        @PathVariable Long draftAccountId,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
+        @PathVariable Long draftAccountId) {
 
         log.debug(":GET:getDraftAccountById: draftAccountId: {}", draftAccountId);
 
-        return buildResponse(draftAccountService.getDraftAccount(draftAccountId, authHeaderValue));
+        return buildResponse(draftAccountService.getDraftAccount(draftAccountId));
     }
 
     @GetMapping()
@@ -76,25 +75,23 @@ public class DraftAccountController {
         @RequestParam(value = "submitted_by") Optional<List<String>> optionalSubmittedBys,
         @RequestParam(value = "not_submitted_by") Optional<List<String>> optionalNotSubmittedBys,
         @RequestParam(value = "account_status_date_from") Optional<LocalDate> accountStatusDateFrom,
-        @RequestParam(value = "account_status_date_to") Optional<LocalDate> accountStatusDateTo,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
+        @RequestParam(value = "account_status_date_to") Optional<LocalDate> accountStatusDateTo) {
 
         log.debug(":GET:getDraftAccountSummaries:");
 
         return buildResponse(
             draftAccountService.getDraftAccounts(optionalBusinessUnitIds, optionalStatus, optionalSubmittedBys,
-                optionalNotSubmittedBys, accountStatusDateFrom, accountStatusDateTo, authHeaderValue));
+                optionalNotSubmittedBys, accountStatusDateFrom, accountStatusDateTo));
     }
 
     @PostMapping(value = "/search", consumes = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Searches Draft Accounts based upon criteria in request body")
     public ResponseEntity<List<DraftAccountResponseDto>> postDraftAccountsSearch(
-        @RequestBody DraftAccountSearchDto criteria,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
+        @RequestBody DraftAccountSearchDto criteria) {
 
         log.debug(":POST:postDraftAccountsSearch: query: \n{}", criteria);
 
-        return buildResponse(draftAccountService.searchDraftAccounts(criteria, authHeaderValue));
+        return buildResponse(draftAccountService.searchDraftAccounts(criteria));
     }
 
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
@@ -104,13 +101,12 @@ public class DraftAccountController {
         defaultValueProperty = FeatureFlags.RELEASE_1A_ENABLED_PROPERTY)
     public ResponseEntity<DraftAccountResponseDto> postDraftAccount(
         @JsonSchemaValidated(schemaPath = SchemaPaths.DRAFT_ACCOUNT + "/addDraftAccountRequest.json")
-        @RequestBody AddDraftAccountRequestDto dto,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
+        @RequestBody AddDraftAccountRequestDto dto) {
         rejectTimelineDataIfSupplied(dto.getTimelineData());
 
         log.debug(":POST:postDraftAccount: creating a new draft account entity: \n{}", dto.toPrettyJson());
 
-        return buildCreatedResponse(draftAccountService.submitDraftAccount(dto, authHeaderValue));
+        return buildCreatedResponse(draftAccountService.submitDraftAccount(dto));
     }
 
     @Hidden
@@ -119,7 +115,6 @@ public class DraftAccountController {
     @ConditionalOnProperty(prefix = "opal.testing-support-endpoints", name = "enabled", havingValue = "true")
     public ResponseEntity<String> deleteDraftAccountById(
         @PathVariable Long draftAccountId,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue,
         @RequestHeader(value = "If-Match", required = false) String ifMatch,
         @RequestParam("ignore_missing") Optional<Boolean> ignoreMissing) {
 
@@ -129,7 +124,7 @@ public class DraftAccountController {
         log.debug(":DELETE:deleteDraftAccountById: Delete Draft Account: {}{}", draftAccountId,
             checkExisted ? "" : ", ignore if missing");
 
-        return buildResponse(draftAccountService.deleteDraftAccount((draftAccountId), checkExisted, authHeaderValue));
+        return buildResponse(draftAccountService.deleteDraftAccount((draftAccountId), checkExisted));
 
     }
 
@@ -142,13 +137,12 @@ public class DraftAccountController {
         @PathVariable Long draftAccountId,
         @JsonSchemaValidated(schemaPath = SchemaPaths.DRAFT_ACCOUNT + "/replaceDraftAccountRequest.json")
         @RequestBody ReplaceDraftAccountRequestDto dto,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue,
         @RequestHeader(value = "If-Match") String ifMatch) {
         rejectTimelineDataIfSupplied(dto.getTimelineData());
 
         log.debug(":PUT:putDraftAccount: replacing draft account '{}' with: \n{}", draftAccountId, dto.toPrettyJson());
 
-        return buildResponse(draftAccountService.replaceDraftAccount(draftAccountId, dto, authHeaderValue, ifMatch));
+        return buildResponse(draftAccountService.replaceDraftAccount(draftAccountId, dto, ifMatch));
     }
 
     @PatchMapping(value = "/{draftAccountId}", consumes = MediaType.APPLICATION_JSON_VALUE)
@@ -160,13 +154,12 @@ public class DraftAccountController {
         @PathVariable Long draftAccountId,
         @JsonSchemaValidated(schemaPath = SchemaPaths.DRAFT_ACCOUNT + "/updateDraftAccountRequest.json")
         @RequestBody UpdateDraftAccountRequestDto dto,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue,
         @RequestHeader(value = "If-Match") String ifMatch) {
         rejectTimelineDataIfSupplied(dto.getTimelineData());
 
         log.info(":PATCH:patchDraftAccount: updating draft account entity: {}", draftAccountId);
 
-        return buildResponse(draftAccountService.updateDraftAccount(draftAccountId, dto, authHeaderValue, ifMatch));
+        return buildResponse(draftAccountService.updateDraftAccount(draftAccountId, dto, ifMatch));
     }
 
     private static void rejectTimelineDataIfSupplied(Object timelineData) {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/MajorCreditorApiController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/MajorCreditorApiController.java
@@ -41,12 +41,11 @@ public class MajorCreditorApiController implements MajorCreditorApi {
         defaultValueProperty = FeatureFlags.RELEASE_1B_ENABLED_PROPERTY
     )
     public ResponseEntity<GetCentralFundResponse> getCentralFundByBusinessUnit(
-        Integer id,
-        @Nullable String authorization) {
+        Integer id) {
 
         log.debug(":GET:getCentralFundByBusinessUnit: businessUnitId={}", id);
 
-        CentralFundResponse response = centralFundService.getCentralFundByBusinessUnit(id, authorization);
+        CentralFundResponse response = centralFundService.getCentralFundByBusinessUnit(id);
 
         return ResponseEntity.ok()
             .eTag(createETag(response))

--- a/src/main/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiController.java
@@ -39,7 +39,6 @@ public class MinorCreditorApiController implements MinorCreditorApi {
         Long id,
         String businessUnitId,
         String ifMatch,
-        String authHeaderValue,
         PatchMinorCreditorAccountRequest patchMinorCreditorAccountRequest) {
 
         log.debug(":PATCH:patchMinorCreditorAccount: id={}", id);
@@ -47,7 +46,7 @@ public class MinorCreditorApiController implements MinorCreditorApi {
         MinorCreditorAccountResponse result =
             minorCreditorService.updateMinorCreditorAccount(id, patchMinorCreditorAccountRequest,
                 extractOptionalBigInteger(ifMatch).orElse(null),
-                authHeaderValue, businessUnitId);
+                businessUnitId);
 
         return buildResponse(result);
     }

--- a/src/main/java/uk/gov/hmcts/opal/controllers/MinorCreditorController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/MinorCreditorController.java
@@ -50,12 +50,11 @@ public class MinorCreditorController {
     @Operation(summary = "Searches MinorCreditors based upon criteria in request body")
     @FeatureToggle(feature = RELEASE_1B, defaultValueProperty = RELEASE_1B_ENABLED_PROPERTY)
     public ResponseEntity<PostMinorCreditorAccountsSearchResponse> postMinorCreditorsSearch(
-        @RequestBody MinorCreditorSearch criteria,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
+        @RequestBody MinorCreditorSearch criteria) {
         log.debug(":POST:postMinorCreditorsSearch: query: \n{}", criteria);
 
         PostMinorCreditorAccountsSearchResponse response = minorCreditorService
-            .searchMinorCreditors(criteria, authHeaderValue);
+            .searchMinorCreditors(criteria);
 
         return buildResponse(response);
     }
@@ -64,12 +63,11 @@ public class MinorCreditorController {
     @Operation(summary = "Get Minor Creditor Account At A Glance")
     @FeatureToggle(feature = RELEASE_1B, defaultValueProperty = RELEASE_1B_ENABLED_PROPERTY)
     public ResponseEntity<GetMinorCreditorAccountAtAGlanceResponse> getMinorCreditorsAtAGlance(
-        @PathVariable Long minorCreditorId,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
+        @PathVariable Long minorCreditorId) {
         log.debug(":GET:getMinorCreditorsAtAGlance: query: \n{}", minorCreditorId);
 
         GetMinorCreditorAccountAtAGlanceResponse response = minorCreditorService
-            .getMinorCreditorAtAGlance(minorCreditorId, authHeaderValue);
+            .getMinorCreditorAtAGlance(minorCreditorId);
 
         return buildResponse(response);
     }
@@ -80,7 +78,6 @@ public class MinorCreditorController {
     @ConditionalOnProperty(prefix = "opal.testing-support-endpoints", name = "enabled", havingValue = "true")
     public ResponseEntity<String> deleteMinorCreditorById(
         @PathVariable Long minorCreditorId,
-        @RequestHeader(value = "Authorization", required = false)  String authHeaderValue,
         @RequestHeader(value = "If-Match") String ifMatch,
         @RequestParam("ignore_missing") Optional<Boolean> ignoreMissing) {
         log.warn("TEST ENDPOINT: Request to delete creditor account {} and all associated data", minorCreditorId);
@@ -91,20 +88,19 @@ public class MinorCreditorController {
                   checkExisted ? "" : ", ignore if missing");
 
         return buildResponse(opalCreditorAccountService
-                                 .deleteCreditorAccount((minorCreditorId), checkExisted, authHeaderValue));
+                                 .deleteCreditorAccount((minorCreditorId), checkExisted));
     }
 
     @GetMapping(value = "/{minorCreditorId}/header-summary", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Gets Minor Creditor account header summary for the given minorCreditorId")
     @FeatureToggle(feature = RELEASE_1B, defaultValueProperty = RELEASE_1B_ENABLED_PROPERTY)
     public ResponseEntity<GetMinorCreditorAccountHeaderSummaryResponse> getMinorCreditorAccountHeaderSummary(
-        @PathVariable Long minorCreditorId,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue) {
+        @PathVariable Long minorCreditorId) {
 
         log.debug(":GET:getMinorCreditorAccountHeaderSummary: minorCreditorId: {}", minorCreditorId);
 
         GetMinorCreditorAccountHeaderSummaryResponse response =
-            minorCreditorService.getMinorCreditorAccountHeaderSummary(minorCreditorId, authHeaderValue);
+            minorCreditorService.getMinorCreditorAccountHeaderSummary(minorCreditorId);
 
         return buildResponse(response);
     }

--- a/src/main/java/uk/gov/hmcts/opal/controllers/NotesController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/NotesController.java
@@ -34,13 +34,12 @@ public class NotesController {
     public ResponseEntity<String> addNote(
         @RequestBody
         AddNoteRequest request,
-        @RequestHeader(value = "Authorization", required = false) String authHeaderValue,
         @RequestHeader("If-Match") String ifMatch) {
 
         log.debug(":POST:postDefendantAccountSearch: query: \n{}", request.toPrettyJson());
 
         String response =
-            notesService.addNote(request, ifMatch, authHeaderValue);
+            notesService.addNote(request, ifMatch);
 
         return buildCreatedResponse(response);
     }

--- a/src/main/java/uk/gov/hmcts/opal/service/CentralFundService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/CentralFundService.java
@@ -26,7 +26,7 @@ public class CentralFundService {
     public CentralFundResponse getCentralFundByBusinessUnit(int businessUnitId) {
         log.debug(":getCentralFundByBusinessUnit: businessUnitId={}", businessUnitId);
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
         if (!userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         }

--- a/src/main/java/uk/gov/hmcts/opal/service/CentralFundService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/CentralFundService.java
@@ -23,10 +23,10 @@ public class CentralFundService {
     private final CentralFundMapper centralFundMapper;
 
     @Transactional(readOnly = true)
-    public CentralFundResponse getCentralFundByBusinessUnit(int businessUnitId, String authHeaderValue) {
+    public CentralFundResponse getCentralFundByBusinessUnit(int businessUnitId) {
         log.debug(":getCentralFundByBusinessUnit: businessUnitId={}", businessUnitId);
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
         if (!userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         }

--- a/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountEnforcementService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountEnforcementService.java
@@ -24,11 +24,11 @@ public class DefendantAccountEnforcementService {
 
     private final UserStateService userStateService;
 
-    public EnforcementStatus getEnforcementStatus(Long defendantAccountId, String authHeaderValue) {
+    public EnforcementStatus getEnforcementStatus(Long defendantAccountId) {
 
         log.debug(":getEnforcementStatus:");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             return defendantAccountEnforcementServiceProxy.getEnforcementStatus(defendantAccountId);
@@ -40,12 +40,11 @@ public class DefendantAccountEnforcementService {
     public AddEnforcementResponse addEnforcement(Long defendantAccountId,
         Short businessUnitId,
         String ifMatch,
-        String authHeaderValue,
         AddDefendantAccountEnforcementRequest request) throws JacksonException {
 
         log.debug(":addEnforcement:");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         String businessUnitUserId = userState.getBusinessUnitUserForBusinessUnit(businessUnitId)
             .map(BusinessUnitUser::getBusinessUnitUserId)
@@ -55,7 +54,7 @@ public class DefendantAccountEnforcementService {
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT)) {
 
             return defendantAccountEnforcementServiceProxy.addEnforcement(
-                defendantAccountId, businessUnitId, businessUnitUserId, ifMatch, authHeaderValue, request
+                defendantAccountId, businessUnitId, businessUnitUserId, ifMatch, request
             );
         } else {
             throw new PermissionNotAllowedException(FinesPermission.ENTER_ENFORCEMENT);
@@ -66,12 +65,11 @@ public class DefendantAccountEnforcementService {
         Long defendantAccountId,
         Short businessUnitId,
         String ifMatch,
-        String authHeaderValue,
         RemoveDefendantAccountEnforcementHoldRequest request) {
 
         log.debug(":removeEnforcementHold:");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         String businessUnitUserId = userState.getBusinessUnitUserForBusinessUnit(businessUnitId)
             .map(BusinessUnitUser::getBusinessUnitUserId)
@@ -84,7 +82,6 @@ public class DefendantAccountEnforcementService {
                 businessUnitId,
                 businessUnitUserId,
                 ifMatch,
-                authHeaderValue,
                 request
             );
         }

--- a/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountEnforcementService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountEnforcementService.java
@@ -28,7 +28,7 @@ public class DefendantAccountEnforcementService {
 
         log.debug(":getEnforcementStatus:");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             return defendantAccountEnforcementServiceProxy.getEnforcementStatus(defendantAccountId);
@@ -44,7 +44,7 @@ public class DefendantAccountEnforcementService {
 
         log.debug(":addEnforcement:");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         String businessUnitUserId = userState.getBusinessUnitUserForBusinessUnit(businessUnitId)
             .map(BusinessUnitUser::getBusinessUnitUserId)
@@ -69,7 +69,7 @@ public class DefendantAccountEnforcementService {
 
         log.debug(":removeEnforcementHold:");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         String businessUnitUserId = userState.getBusinessUnitUserForBusinessUnit(businessUnitId)
             .map(BusinessUnitUser::getBusinessUnitUserId)

--- a/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountFixedPenaltyService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountFixedPenaltyService.java
@@ -21,7 +21,7 @@ public class DefendantAccountFixedPenaltyService {
     public GetDefendantAccountFixedPenaltyResponse getDefendantAccountFixedPenalty(
         Long defendantAccountId) {
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (!userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);

--- a/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountFixedPenaltyService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountFixedPenaltyService.java
@@ -19,10 +19,9 @@ public class DefendantAccountFixedPenaltyService {
     private final UserStateService userStateService;
 
     public GetDefendantAccountFixedPenaltyResponse getDefendantAccountFixedPenalty(
-        Long defendantAccountId,
-        String authHeaderValue) {
+        Long defendantAccountId) {
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (!userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);

--- a/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountPartyService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountPartyService.java
@@ -30,7 +30,7 @@ public class DefendantAccountPartyService {
 
         log.debug(":getDefendantAccountParty:");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
 
@@ -47,7 +47,7 @@ public class DefendantAccountPartyService {
 
         log.debug(":addDefendantAccountParty: buId: {},  request: \n{}", businessUnitId, request);
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         short buId = Short.parseShort(businessUnitId);
 
@@ -77,7 +77,7 @@ public class DefendantAccountPartyService {
 
         log.debug(":replaceDefendantAccountParty: buId: {},  request: \n{}", businessUnitId, request.toPrettyJson());
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         short buId = Short.parseShort(businessUnitId);
 
@@ -102,7 +102,7 @@ public class DefendantAccountPartyService {
 
         log.debug(":removeDefendantAccountParty: buId: {},  request: \n{}", businessUnitId, request.toPrettyJson());
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         String postedBy = userState.getBusinessUnitUserForBusinessUnit(businessUnitId)
             .map(BusinessUnitUser::getBusinessUnitUserId)

--- a/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountPartyService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountPartyService.java
@@ -26,12 +26,11 @@ public class DefendantAccountPartyService {
 
     public GetDefendantAccountPartyResponse getDefendantAccountParty(
         Long defendantAccountId,
-        Long defendantAccountPartyId,
-        String authHeaderValue) {
+        Long defendantAccountPartyId) {
 
         log.debug(":getDefendantAccountParty:");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
 
@@ -43,12 +42,12 @@ public class DefendantAccountPartyService {
     }
 
     public GetDefendantAccountPartyResponse addDefendantAccountParty(
-        Long defendantAccountId, String authHeaderValue, String ifMatch,
+        Long defendantAccountId, String ifMatch,
         String businessUnitId, AddDefendantAccountPartyRequest request) {
 
         log.debug(":addDefendantAccountParty: buId: {},  request: \n{}", businessUnitId, request);
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         short buId = Short.parseShort(businessUnitId);
 
@@ -73,12 +72,12 @@ public class DefendantAccountPartyService {
 
 
     public GetDefendantAccountPartyResponse replaceDefendantAccountParty(
-        Long defendantAccountId, Long defendantAccountPartyId, String authHeaderValue, String ifMatch,
+        Long defendantAccountId, Long defendantAccountPartyId, String ifMatch,
         String businessUnitId, DefendantAccountParty request) {
 
         log.debug(":replaceDefendantAccountParty: buId: {},  request: \n{}", businessUnitId, request.toPrettyJson());
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         short buId = Short.parseShort(businessUnitId);
 
@@ -98,12 +97,12 @@ public class DefendantAccountPartyService {
     }
 
     public RemoveDefendantAccountPartyResponse removeDefendantAccountParty(Long defendantAccountId,
-        Long defendantAccountPartyId, Short businessUnitId, String ifMatch, String authHeaderValue,
+        Long defendantAccountPartyId, Short businessUnitId, String ifMatch,
         RemoveDefendantAccountPartyRequest request) {
 
         log.debug(":removeDefendantAccountParty: buId: {},  request: \n{}", businessUnitId, request.toPrettyJson());
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         String postedBy = userState.getBusinessUnitUserForBusinessUnit(businessUnitId)
             .map(BusinessUnitUser::getBusinessUnitUserId)

--- a/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountPaymentTermsService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountPaymentTermsService.java
@@ -24,7 +24,7 @@ public class DefendantAccountPaymentTermsService {
 
         log.debug(":getPaymentTerms:");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             return defendantAccountPaymentTermsServiceProxy.getPaymentTerms(defendantAccountId);
@@ -41,7 +41,7 @@ public class DefendantAccountPaymentTermsService {
     ) {
         log.debug(":addPaymentCardRequest:");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.AMEND_PAYMENT_TERMS)) {
             return defendantAccountPaymentTermsServiceProxy.addPaymentCardRequest(

--- a/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountPaymentTermsService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountPaymentTermsService.java
@@ -20,11 +20,11 @@ public class DefendantAccountPaymentTermsService {
     private final UserStateService userStateService;
 
 
-    public GetDefendantAccountPaymentTermsResponse getPaymentTerms(Long defendantAccountId, String authHeaderValue) {
+    public GetDefendantAccountPaymentTermsResponse getPaymentTerms(Long defendantAccountId) {
 
         log.debug(":getPaymentTerms:");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             return defendantAccountPaymentTermsServiceProxy.getPaymentTerms(defendantAccountId);
@@ -37,20 +37,18 @@ public class DefendantAccountPaymentTermsService {
         Long defendantAccountId,
         String businessUnitId,
         String businessUnitUserId,
-        String ifMatch,
-        String authHeaderValue
+        String ifMatch
     ) {
         log.debug(":addPaymentCardRequest:");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.AMEND_PAYMENT_TERMS)) {
             return defendantAccountPaymentTermsServiceProxy.addPaymentCardRequest(
                 defendantAccountId,
                 businessUnitId,
                 businessUnitUserId,
-                ifMatch,
-                authHeaderValue
+                ifMatch
             );
         } else {
             throw new PermissionNotAllowedException(FinesPermission.AMEND_PAYMENT_TERMS);

--- a/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountService.java
@@ -43,10 +43,10 @@ public class DefendantAccountService {
 
     private final UserStateService userStateService;
 
-    public DefendantAccountHeaderSummary getHeaderSummary(Long defendantAccountId, String authHeaderValue) {
+    public DefendantAccountHeaderSummary getHeaderSummary(Long defendantAccountId) {
         log.debug(":getHeaderSummary:");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (!userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
@@ -86,11 +86,10 @@ public class DefendantAccountService {
             .toList();
     }
 
-    public DefendantAccountSearchResultsDto searchDefendantAccounts(AccountSearchDto accountSearchDto,
-                                                                    String authHeaderValue) {
+    public DefendantAccountSearchResultsDto searchDefendantAccounts(AccountSearchDto accountSearchDto) {
         log.debug(":searchDefendantAccounts:");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
 
@@ -102,12 +101,11 @@ public class DefendantAccountService {
 
     public GetDefendantAccountPartyResponse getDefendantAccountParty(
         Long defendantAccountId,
-        Long defendantAccountPartyId,
-        String authHeaderValue) {
+        Long defendantAccountPartyId) {
 
         log.debug(":getDefendantAccountParty:");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
 
@@ -117,11 +115,11 @@ public class DefendantAccountService {
         }
     }
 
-    public GetDefendantAccountPaymentTermsResponse getPaymentTerms(Long defendantAccountId, String authHeaderValue) {
+    public GetDefendantAccountPaymentTermsResponse getPaymentTerms(Long defendantAccountId) {
 
         log.debug(":getPaymentTerms:");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             return defendantAccountServiceProxy.getPaymentTerms(defendantAccountId);
@@ -130,10 +128,10 @@ public class DefendantAccountService {
         }
     }
 
-    public DefendantAccountAtAGlanceResponse getAtAGlance(Long defendantAccountId, String authHeaderValue) {
+    public DefendantAccountAtAGlanceResponse getAtAGlance(Long defendantAccountId) {
         log.debug(":getAtAGlance");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             return defendantAccountServiceProxy.getAtAGlance(defendantAccountId);
@@ -143,10 +141,9 @@ public class DefendantAccountService {
     }
 
     public GetDefendantAccountFixedPenaltyResponse getDefendantAccountFixedPenalty(
-        Long defendantAccountId,
-        String authHeaderValue) {
+        Long defendantAccountId) {
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (!userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
@@ -158,7 +155,7 @@ public class DefendantAccountService {
     public UpdateDefendantAccountResponse updateDefendantAccount(Long defendantAccountId,
                                                            String businessUnitId,
                                                            UpdateDefendantAccountRequestPayload request,
-                                                           String authHeaderValue, String ifMatch) {
+                                                           String ifMatch) {
         log.debug(":updateDefendantAccount:");
 
         if (ifMatch == null) {
@@ -166,7 +163,7 @@ public class DefendantAccountService {
                 "Defendant Account", defendantAccountId, "If-Match header is required", null);
         }
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.ACCOUNT_MAINTENANCE)) {
 
@@ -210,11 +207,11 @@ public class DefendantAccountService {
         }
     }
 
-    public EnforcementStatus getEnforcementStatus(Long defendantAccountId, String authHeaderValue) {
+    public EnforcementStatus getEnforcementStatus(Long defendantAccountId) {
 
         log.debug(":getEnforcementStatus:");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             return defendantAccountServiceProxy.getEnforcementStatus(defendantAccountId);
@@ -225,10 +222,10 @@ public class DefendantAccountService {
 
     public GetDefendantAccountPartyResponse replaceDefendantAccountParty(Long defendantAccountId,
         Long defendantAccountPartyId,
-        String authHeaderValue, String ifMatch, String businessUnitId, DefendantAccountParty request) {
+        String ifMatch, String businessUnitId, DefendantAccountParty request) {
         log.debug(":replaceDefendantAccountParty");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         short buId = Short.parseShort(businessUnitId);
 
@@ -259,20 +256,18 @@ public class DefendantAccountService {
         Long defendantAccountId,
         String businessUnitId,
         String businessUnitUserId,
-        String ifMatch,
-        String authHeaderValue
+        String ifMatch
     ) {
         log.debug(":addPaymentCardRequest:");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.AMEND_PAYMENT_TERMS)) {
             return defendantAccountServiceProxy.addPaymentCardRequest(
                 defendantAccountId,
                 businessUnitId,
                 businessUnitUserId,
-                ifMatch,
-                authHeaderValue
+                ifMatch
             );
         } else {
             throw new PermissionNotAllowedException(FinesPermission.AMEND_PAYMENT_TERMS);
@@ -282,12 +277,11 @@ public class DefendantAccountService {
     public AddEnforcementResponse addEnforcement(Long defendantAccountId,
         String businessUnitId,
         String ifMatch,
-        String authHeaderValue,
         AddDefendantAccountEnforcementRequest request) {
 
         log.debug(":addEnforcement:");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         String businessUnitUserId = userState.getBusinessUnitUserForBusinessUnit(Short.parseShort(businessUnitId))
             .map(uk.gov.hmcts.opal.common.user.authorisation.model.BusinessUnitUser::getBusinessUnitUserId)
@@ -296,7 +290,7 @@ public class DefendantAccountService {
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT)) {
             return defendantAccountServiceProxy.addEnforcement(
-                defendantAccountId, businessUnitId, businessUnitUserId, ifMatch, authHeaderValue, request
+                defendantAccountId, businessUnitId, businessUnitUserId, ifMatch, request
             );
         } else {
             throw new PermissionNotAllowedException(FinesPermission.ENTER_ENFORCEMENT);
@@ -306,12 +300,11 @@ public class DefendantAccountService {
     public GetDefendantAccountPaymentTermsResponse addPaymentTerms(Long defendantAccountId,
         String businessUnitId,
         String ifMatch,
-        String authHeaderValue,
         AddDefendantAccountPaymentTermsRequest addPaymentTermsRequest) {
 
         log.debug(":addPaymentTerms:");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         short buId = Short.parseShort(businessUnitId);
         String businessUnitUserId = userState.getBusinessUnitUserForBusinessUnit(buId)
@@ -332,7 +325,6 @@ public class DefendantAccountService {
                 businessUnitId,
                 businessUnitUserId,
                 ifMatch,
-                authHeaderValue,
                 addPaymentTermsRequest);
         } else {
             throw new PermissionNotAllowedException(buId, FinesPermission.AMEND_PAYMENT_TERMS);

--- a/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountService.java
@@ -58,11 +58,10 @@ public class DefendantAccountService {
     public DefendantAccountHistoryResponse getHistory(Long defendantAccountId,
                                                       LocalDate dateFrom,
                                                       LocalDate dateTo,
-                                                      List<String> itemTypes,
-                                                      String authHeaderValue) {
+                                                      List<String> itemTypes) {
         log.debug(":getHistory:");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (!userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);

--- a/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DefendantAccountService.java
@@ -46,7 +46,7 @@ public class DefendantAccountService {
     public DefendantAccountHeaderSummary getHeaderSummary(Long defendantAccountId) {
         log.debug(":getHeaderSummary:");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (!userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
@@ -89,7 +89,7 @@ public class DefendantAccountService {
     public DefendantAccountSearchResultsDto searchDefendantAccounts(AccountSearchDto accountSearchDto) {
         log.debug(":searchDefendantAccounts:");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
 
@@ -105,7 +105,7 @@ public class DefendantAccountService {
 
         log.debug(":getDefendantAccountParty:");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
 
@@ -119,7 +119,7 @@ public class DefendantAccountService {
 
         log.debug(":getPaymentTerms:");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             return defendantAccountServiceProxy.getPaymentTerms(defendantAccountId);
@@ -131,7 +131,7 @@ public class DefendantAccountService {
     public DefendantAccountAtAGlanceResponse getAtAGlance(Long defendantAccountId) {
         log.debug(":getAtAGlance");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             return defendantAccountServiceProxy.getAtAGlance(defendantAccountId);
@@ -143,7 +143,7 @@ public class DefendantAccountService {
     public GetDefendantAccountFixedPenaltyResponse getDefendantAccountFixedPenalty(
         Long defendantAccountId) {
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (!userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
@@ -163,7 +163,7 @@ public class DefendantAccountService {
                 "Defendant Account", defendantAccountId, "If-Match header is required", null);
         }
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.ACCOUNT_MAINTENANCE)) {
 
@@ -211,7 +211,7 @@ public class DefendantAccountService {
 
         log.debug(":getEnforcementStatus:");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             return defendantAccountServiceProxy.getEnforcementStatus(defendantAccountId);
@@ -225,7 +225,7 @@ public class DefendantAccountService {
         String ifMatch, String businessUnitId, DefendantAccountParty request) {
         log.debug(":replaceDefendantAccountParty");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         short buId = Short.parseShort(businessUnitId);
 
@@ -260,7 +260,7 @@ public class DefendantAccountService {
     ) {
         log.debug(":addPaymentCardRequest:");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.AMEND_PAYMENT_TERMS)) {
             return defendantAccountServiceProxy.addPaymentCardRequest(
@@ -281,7 +281,7 @@ public class DefendantAccountService {
 
         log.debug(":addEnforcement:");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         String businessUnitUserId = userState.getBusinessUnitUserForBusinessUnit(Short.parseShort(businessUnitId))
             .map(uk.gov.hmcts.opal.common.user.authorisation.model.BusinessUnitUser::getBusinessUnitUserId)
@@ -304,7 +304,7 @@ public class DefendantAccountService {
 
         log.debug(":addPaymentTerms:");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         short buId = Short.parseShort(businessUnitId);
         String businessUnitUserId = userState.getBusinessUnitUserForBusinessUnit(buId)

--- a/src/main/java/uk/gov/hmcts/opal/service/DraftAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DraftAccountService.java
@@ -72,7 +72,7 @@ public class DraftAccountService {
 
     public DraftAccountResponseDto getDraftAccount(long draftAccountId) {
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (userState.anyBusinessUnitUserHasAnyPermission(FinesPermission.DRAFT_ACCOUNT_PERMISSIONS)) {
             DraftAccountEntity response = draftAccountTransactional.getDraftAccount(draftAccountId);
@@ -98,7 +98,7 @@ public class DraftAccountService {
         Optional<List<String>> optionalSubmittedBys, Optional<List<String>> optionalNotSubmittedBys,
         Optional<LocalDate> accountStatusDateFrom, Optional<LocalDate> accountStatusDateTo) {
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
         if (userState.anyBusinessUnitUserHasAnyPermission(FinesPermission.DRAFT_ACCOUNT_PERMISSIONS)) {
 
             List<String> submittedBys = optionalSubmittedBys.orElse(Collections.emptyList());
@@ -165,7 +165,7 @@ public class DraftAccountService {
 
     public DraftAccountResponseDto submitDraftAccount(AddDraftAccountRequestDto dto) {
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (userState.hasBusinessUnitUserWithPermission(dto.getBusinessUnitId(),
                                                         FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS)) {
@@ -192,7 +192,7 @@ public class DraftAccountService {
     public DraftAccountResponseDto replaceDraftAccount(Long draftAccountId, ReplaceDraftAccountRequestDto dto,
                                                        String ifMatch) {
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (userState.hasBusinessUnitUserWithPermission(dto.getBusinessUnitId(),
                                                         FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS)) {
@@ -219,7 +219,7 @@ public class DraftAccountService {
     public DraftAccountResponseDto updateDraftAccount(Long draftAccountId, UpdateDraftAccountRequestDto dto,
         String ifMatch) {
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
         Optional<BusinessUnitUser> unitUser = userState.getBusinessUnitUserForBusinessUnit(dto.getBusinessUnitId());
         log.info(":updateDraftAccount: unit user: {}", unitUser);
         if (UserState.userHasPermission(unitUser, FinesPermission.CHECK_VALIDATE_DRAFT_ACCOUNTS)) {

--- a/src/main/java/uk/gov/hmcts/opal/service/DraftAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DraftAccountService.java
@@ -70,9 +70,9 @@ public class DraftAccountService {
     private final SecurityEventLoggingService securityEventLoggingService;
     private final Clock clock;
 
-    public DraftAccountResponseDto getDraftAccount(long draftAccountId, String authHeaderValue) {
+    public DraftAccountResponseDto getDraftAccount(long draftAccountId) {
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (userState.anyBusinessUnitUserHasAnyPermission(FinesPermission.DRAFT_ACCOUNT_PERMISSIONS)) {
             DraftAccountEntity response = draftAccountTransactional.getDraftAccount(draftAccountId);
@@ -96,10 +96,9 @@ public class DraftAccountService {
     public DraftAccountsResponseDto getDraftAccounts(
         Optional<List<Short>> optionalBusinessUnitIds, Optional<List<DraftAccountStatus>> optionalStatus,
         Optional<List<String>> optionalSubmittedBys, Optional<List<String>> optionalNotSubmittedBys,
-        Optional<LocalDate> accountStatusDateFrom, Optional<LocalDate> accountStatusDateTo,
-        String authHeaderValue) {
+        Optional<LocalDate> accountStatusDateFrom, Optional<LocalDate> accountStatusDateTo) {
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
         if (userState.anyBusinessUnitUserHasAnyPermission(FinesPermission.DRAFT_ACCOUNT_PERMISSIONS)) {
 
             List<String> submittedBys = optionalSubmittedBys.orElse(Collections.emptyList());
@@ -143,9 +142,7 @@ public class DraftAccountService {
         }
     }
 
-    public String deleteDraftAccount(long draftAccountId, boolean checkExisted, String authHeaderValue) {
-        userStateService.checkForAuthorisedUser(authHeaderValue);
-
+    public String deleteDraftAccount(long draftAccountId, boolean checkExisted) {
         try {
             boolean deleted =  draftAccountTransactional.deleteDraftAccount(draftAccountId, draftAccountTransactional);
             if (deleted) {
@@ -159,18 +156,16 @@ public class DraftAccountService {
         return String.format(ACCOUNT_DELETED_MESSAGE_FORMAT, draftAccountId);
     }
 
-    public List<DraftAccountResponseDto> searchDraftAccounts(DraftAccountSearchDto criteria, String authHeaderValue) {
-        userStateService.checkForAuthorisedUser(authHeaderValue);
-
+    public List<DraftAccountResponseDto> searchDraftAccounts(DraftAccountSearchDto criteria) {
         return draftAccountTransactional.searchDraftAccounts(criteria)
             .stream()
             .map(draftAccountMapper::toResponseDto)
             .toList();
     }
 
-    public DraftAccountResponseDto submitDraftAccount(AddDraftAccountRequestDto dto, String authHeaderValue) {
+    public DraftAccountResponseDto submitDraftAccount(AddDraftAccountRequestDto dto) {
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (userState.hasBusinessUnitUserWithPermission(dto.getBusinessUnitId(),
                                                         FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS)) {
@@ -195,9 +190,9 @@ public class DraftAccountService {
     }
 
     public DraftAccountResponseDto replaceDraftAccount(Long draftAccountId, ReplaceDraftAccountRequestDto dto,
-                                                       String authHeaderValue, String ifMatch) {
+                                                       String ifMatch) {
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (userState.hasBusinessUnitUserWithPermission(dto.getBusinessUnitId(),
                                                         FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS)) {
@@ -222,9 +217,9 @@ public class DraftAccountService {
     }
 
     public DraftAccountResponseDto updateDraftAccount(Long draftAccountId, UpdateDraftAccountRequestDto dto,
-        String authHeaderValue, String ifMatch) {
+        String ifMatch) {
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
         Optional<BusinessUnitUser> unitUser = userState.getBusinessUnitUserForBusinessUnit(dto.getBusinessUnitId());
         log.info(":updateDraftAccount: unit user: {}", unitUser);
         if (UserState.userHasPermission(unitUser, FinesPermission.CHECK_VALIDATE_DRAFT_ACCOUNTS)) {

--- a/src/main/java/uk/gov/hmcts/opal/service/ImpositionService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/ImpositionService.java
@@ -56,7 +56,7 @@ public class ImpositionService {
 
         log.debug(":getImpositions:");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             return impositionServiceProxy.getImpositions(defendantAccountId);

--- a/src/main/java/uk/gov/hmcts/opal/service/ImpositionService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/ImpositionService.java
@@ -52,12 +52,11 @@ public class ImpositionService {
     private final UserStateService userStateService;
 
     public GetDefendantAccountImpositionsResponse getImpositions(
-        Long defendantAccountId,
-        String authHeaderValue) {
+        Long defendantAccountId) {
 
         log.debug(":getImpositions:");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             return impositionServiceProxy.getImpositions(defendantAccountId);

--- a/src/main/java/uk/gov/hmcts/opal/service/MajorCreditorAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/MajorCreditorAccountService.java
@@ -22,7 +22,7 @@ public class MajorCreditorAccountService {
     public GetMajorCreditorAccountAtAGlanceResponse getAtAGlance(Long majorCreditorAccountId) {
         log.debug(":getAtAGlance: id={}", majorCreditorAccountId);
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
         if (!userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         }

--- a/src/main/java/uk/gov/hmcts/opal/service/MajorCreditorAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/MajorCreditorAccountService.java
@@ -33,7 +33,7 @@ public class MajorCreditorAccountService {
     public GetMajorCreditorAccountHeaderSummaryResponse getHeaderSummary(Long majorCreditorAccountId) {
         log.debug(":getHeaderSummary: id={}", majorCreditorAccountId);
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (!userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);

--- a/src/main/java/uk/gov/hmcts/opal/service/MinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/MinorCreditorService.java
@@ -26,11 +26,10 @@ public class MinorCreditorService {
 
     private final UserStateService userStateService;
 
-    public PostMinorCreditorAccountsSearchResponse searchMinorCreditors(MinorCreditorSearch entity,
-                                                                        String authHeaderValue) {
+    public PostMinorCreditorAccountsSearchResponse searchMinorCreditors(MinorCreditorSearch entity) {
         log.debug(":searchMinorCreditor:");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             return minorCreditorSearchProxy.searchMinorCreditors(entity);
@@ -53,12 +52,11 @@ public class MinorCreditorService {
         return redactBacsDetailsWhenNotPermitted(minorCreditorAccountId, response, userState);
     }
 
-    public GetMinorCreditorAccountAtAGlanceResponse getMinorCreditorAtAGlance(Long minorCreditorId,
-        String authHeaderValue) {
+    public GetMinorCreditorAccountAtAGlanceResponse getMinorCreditorAtAGlance(Long minorCreditorId) {
 
         log.debug(":getMinorCreditorAccountAtAGlance: id= {}", minorCreditorId);
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (!userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
@@ -71,12 +69,11 @@ public class MinorCreditorService {
     }
 
     public GetMinorCreditorAccountHeaderSummaryResponse getMinorCreditorAccountHeaderSummary(
-        Long minorCreditorId,
-        String authHeaderValue) {
+        Long minorCreditorId) {
 
         log.debug(":getMinorCreditorAccountHeaderSummary: id={}", minorCreditorId);
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             return minorCreditorSearchProxy.getHeaderSummary(minorCreditorId);
@@ -89,7 +86,6 @@ public class MinorCreditorService {
         Long minorCreditorId,
         PatchMinorCreditorAccountRequest request,
         BigInteger ifMatch,
-        String authHeaderValue,
         String businessUnitId) {
         log.debug(":updateMinorCreditorAccount:");
 
@@ -106,7 +102,7 @@ public class MinorCreditorService {
             throw new IllegalArgumentException("Payment, party_details and address groups must be provided");
         }
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
         if (businessUnitId == null) {
             throw new PermissionNotAllowedException(
                 (Short) null,

--- a/src/main/java/uk/gov/hmcts/opal/service/MinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/MinorCreditorService.java
@@ -29,7 +29,7 @@ public class MinorCreditorService {
     public PostMinorCreditorAccountsSearchResponse searchMinorCreditors(MinorCreditorSearch entity) {
         log.debug(":searchMinorCreditor:");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             return minorCreditorSearchProxy.searchMinorCreditors(entity);
@@ -41,7 +41,7 @@ public class MinorCreditorService {
     public MinorCreditorAccountResponse getMinorCreditorAccount(Long minorCreditorAccountId) {
         log.debug(":getMinorCreditorAccount: id={}", minorCreditorAccountId);
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (!userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
@@ -56,7 +56,7 @@ public class MinorCreditorService {
 
         log.debug(":getMinorCreditorAccountAtAGlance: id= {}", minorCreditorId);
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (!userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
@@ -73,7 +73,7 @@ public class MinorCreditorService {
 
         log.debug(":getMinorCreditorAccountHeaderSummary: id={}", minorCreditorId);
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             return minorCreditorSearchProxy.getHeaderSummary(minorCreditorId);
@@ -102,7 +102,7 @@ public class MinorCreditorService {
             throw new IllegalArgumentException("Payment, party_details and address groups must be provided");
         }
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
         if (businessUnitId == null) {
             throw new PermissionNotAllowedException(
                 (Short) null,

--- a/src/main/java/uk/gov/hmcts/opal/service/NotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/NotesService.java
@@ -23,10 +23,10 @@ public class NotesService {
     private final DefendantAccountRepository defendantAccountRepository;
 
 
-    public String addNote(AddNoteRequest request, String ifMatch, String authHeaderValue) {
+    public String addNote(AddNoteRequest request, String ifMatch) {
         log.debug(":addNote:");
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.checkForAuthorisedUser();
 
         DefendantAccountEntity account =
             defendantAccountRepository

--- a/src/main/java/uk/gov/hmcts/opal/service/NotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/NotesService.java
@@ -26,7 +26,7 @@ public class NotesService {
     public String addNote(AddNoteRequest request, String ifMatch) {
         log.debug(":addNote:");
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         DefendantAccountEntity account =
             defendantAccountRepository

--- a/src/main/java/uk/gov/hmcts/opal/service/ReportService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/ReportService.java
@@ -25,7 +25,7 @@ public class ReportService extends AbstractPermissionService {
     public ReportReports getReport(String reportId) {
         log.debug(":getReport: reportId={}", reportId);
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
         ReportEntity entity = reportRepository.findById(reportId)
             .orElseThrow(() -> new EntityNotFoundException("Report not found with id: " + reportId));
         checkPermission(userState, entity.getPermission());

--- a/src/main/java/uk/gov/hmcts/opal/service/UserStateService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/UserStateService.java
@@ -32,7 +32,7 @@ public class UserStateService {
     // Stop gap solution until all permissions are resolved directly in service-layer auth checks.
     @SuppressWarnings({"java:S1874", "java:S1133"})
     @Deprecated(since = "2")
-    public UserState checkForAuthorisedUser() {
+    public UserState getUserStateV1FromSecurityContext() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (!(authentication instanceof OpalJwtAuthenticationToken authToken)) {
             throw new AccessDeniedException("Unexpected token type");

--- a/src/main/java/uk/gov/hmcts/opal/service/UserStateService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/UserStateService.java
@@ -25,30 +25,14 @@ public class UserStateService {
     private final UserStateMapper userStateMapper;
 
     /**
-0     * Returns the authorised user state from the current security context.
+0     * Returns the V1 user state from the current security context.
      *
      * @deprecated Use {@link #getUserStateFromSecurityContext()} for V2 user state.
      */
-    @Deprecated(since = "2")
-    @SuppressWarnings("java:S1133")
-    public UserState checkForAuthorisedUser() {
-        return checkForAuthorisedUser("");
-    }
-
-    /**
-     * Returns the authorised user state from the current security context.
-     *
-     * @deprecated Use {@link #getUserStateFromSecurityContext()} for V2 user state.
-     */
-    @Deprecated(since = "2")
-    @SuppressWarnings("java:S1133")
-    public UserState checkForAuthorisedUser(String authorization) {
-        return getUserStateV1FromSecurityContext();
-    }
-
     // Stop gap solution until all permissions are resolved directly in service-layer auth checks.
     @SuppressWarnings({"java:S1874", "java:S1133"})
-    private UserState getUserStateV1FromSecurityContext() {
+    @Deprecated(since = "2")
+    public UserState checkForAuthorisedUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (!(authentication instanceof OpalJwtAuthenticationToken authToken)) {
             throw new AccessDeniedException("Unexpected token type");

--- a/src/main/java/uk/gov/hmcts/opal/service/iface/DefendantAccountEnforcementServiceInterface.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/iface/DefendantAccountEnforcementServiceInterface.java
@@ -13,7 +13,6 @@ public interface DefendantAccountEnforcementServiceInterface {
                                           Short businessUnitId,
                                           String businessUnitUserId,
                                           String ifMatch,
-                                          String authHeader,
                                           AddDefendantAccountEnforcementRequest request) throws JacksonException;
 
     EnforcementStatus getEnforcementStatus(Long defendantAccountId);
@@ -23,6 +22,5 @@ public interface DefendantAccountEnforcementServiceInterface {
         Short businessUnitId,
         String businessUnitUserId,
         String ifMatch,
-        String authHeader,
         RemoveDefendantAccountEnforcementHoldRequest request);
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/iface/DefendantAccountPaymentTermsServiceInterface.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/iface/DefendantAccountPaymentTermsServiceInterface.java
@@ -9,5 +9,5 @@ public interface DefendantAccountPaymentTermsServiceInterface {
 
     AddPaymentCardRequestResponse addPaymentCardRequest(Long defendantAccountId, String businessUnitId,
         String businessUnitUserId,
-        String ifMatch, String authHeader);
+        String ifMatch);
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/iface/DefendantAccountServiceInterface.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/iface/DefendantAccountServiceInterface.java
@@ -50,10 +50,10 @@ public interface DefendantAccountServiceInterface {
 
     AddPaymentCardRequestResponse addPaymentCardRequest(Long defendantAccountId, String businessUnitId,
         String businessUnitUserId,
-        String ifMatch, String authHeader);
+        String ifMatch);
 
     AddEnforcementResponse addEnforcement(Long defendantAccountId, String businessUnitId, String businessUnitUserId,
-        String ifMatch, String authHeader, AddDefendantAccountEnforcementRequest request);
+        String ifMatch, AddDefendantAccountEnforcementRequest request);
 
 
     GetDefendantAccountPartyResponse replaceDefendantAccountParty(Long defendantAccountId,
@@ -83,6 +83,5 @@ public interface DefendantAccountServiceInterface {
                                             String businessUnitId,
                                             String businessUnitUserId,
                                             String ifMatch,
-                                            String authHeader,
                                             AddDefendantAccountPaymentTermsRequest addPaymentTermsRequest);
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountEnforcementService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountEnforcementService.java
@@ -65,7 +65,6 @@ public class LegacyDefendantAccountEnforcementService implements DefendantAccoun
                                                  Short businessUnitId,
                                                  String businessUnitUserId,
                                                  String ifMatch,
-                                                 String authHeader,
                                                  AddDefendantAccountEnforcementRequest request) {
 
         // build legacy request object
@@ -110,7 +109,6 @@ public class LegacyDefendantAccountEnforcementService implements DefendantAccoun
         Short businessUnitId,
         String businessUnitUserId,
         String ifMatch,
-        String authHeader,
         RemoveDefendantAccountEnforcementHoldRequest request) {
 
         LegacyRemoveDefendantAccountEnforcementHoldRequest legacyRequest =

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPaymentTermsService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPaymentTermsService.java
@@ -151,8 +151,7 @@ public class LegacyDefendantAccountPaymentTermsService implements DefendantAccou
         Long defendantAccountId,
         String businessUnitId,
         String businessUnitUserId,
-        String ifMatch,
-        String authHeader
+        String ifMatch
     ) {
         log.info(":addPaymentCardRequest (Legacy): accountId={}, bu={}", defendantAccountId, businessUnitId);
 

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
@@ -883,8 +883,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
         Long defendantAccountId,
         String businessUnitId,
         String businessUnitUserId,
-        String ifMatch,
-        String authHeader
+        String ifMatch
     ) {
         log.info(":addPaymentCardRequest (Legacy): accountId={}, bu={}", defendantAccountId, businessUnitId);
 
@@ -1161,7 +1160,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
     @Override
     //TODO: Remove method, duplicated in refactored class
     public AddEnforcementResponse addEnforcement(Long defendantAccountId, String businessUnitId,
-        String businessUnitUserId, String ifMatch, String authHeader, AddDefendantAccountEnforcementRequest request) {
+        String businessUnitUserId, String ifMatch, AddDefendantAccountEnforcementRequest request) {
 
         // build legacy request object
         AddDefendantAccountEnforcementLegacyRequest legacyRequest =
@@ -1328,7 +1327,6 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
         String businessUnitId,
         String businessUnitUserId,
         String ifMatch,
-        String postedBy,
         AddDefendantAccountPaymentTermsRequest addPaymentTermsRequest) {
 
         var legacyRequest = createAddPaymentTermsLegacyRequest(

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalCreditorAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalCreditorAccountService.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.UnexpectedRollbackException;
-import uk.gov.hmcts.opal.service.UserStateService;
 import uk.gov.hmcts.opal.service.opal.jpa.CreditorAccountTransactional;
 
 @Service
@@ -18,11 +17,7 @@ public class OpalCreditorAccountService {
 
     private final CreditorAccountTransactional creditorAccountTransactional;
 
-    private final UserStateService userStateService;
-
-    public String deleteCreditorAccount(long minorCreditorId, boolean checkExisted, String authHeaderValue) {
-        userStateService.checkForAuthorisedUser(authHeaderValue);
-
+    public String deleteCreditorAccount(long minorCreditorId, boolean checkExisted) {
         try {
             boolean deleted =  creditorAccountTransactional
                 .deleteMinorCreditorAccountAndRelatedData(minorCreditorId, creditorAccountTransactional);

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementService.java
@@ -81,7 +81,6 @@ public class OpalDefendantAccountEnforcementService
         Short businessUnitId,
         String businessUnitUserId,
         String ifMatch,
-        String authHeader,
         AddDefendantAccountEnforcementRequest request) throws JacksonException {
 
         String reason = null;
@@ -106,7 +105,7 @@ public class OpalDefendantAccountEnforcementService
 
         String resultResponses = objectMapper.writeValueAsString(request.getEnforcementResultResponses());
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeader);
+        UserState userState = userStateService.checkForAuthorisedUser();
         DefendantAccountEntity defendant = defendantAccountRepositoryService.findById(defendantAccountId);
 
         Long enforcementId = enforcementRepositoryService.addDefendantAccountEnforcement(
@@ -131,7 +130,6 @@ public class OpalDefendantAccountEnforcementService
                                                         businessUnitId.toString(),
                                                         businessUnitUserId,
                                                         defendantEntity.getVersion().toString(),
-                                                        authHeader,
                                                         AddDefendantAccountPaymentTermsRequest.builder()
                                                             .paymentTerms(request.getPaymentTerms())
                                                             .requestPaymentCard(false)
@@ -156,13 +154,12 @@ public class OpalDefendantAccountEnforcementService
         Short businessUnitId,
         String businessUnitUserId,
         String ifMatch,
-        String authHeader,
         RemoveDefendantAccountEnforcementHoldRequest request) {
 
         log.debug(":removeEnforcementHold: defendantAccountId={}, businessUnitId={}",
             defendantAccountId, businessUnitId);
 
-        final UserState userState = userStateService.checkForAuthorisedUser(authHeader);
+        final UserState userState = userStateService.checkForAuthorisedUser();
         DefendantAccountEntity defendantEntity = defendantAccountRepositoryService.findById(defendantAccountId);
 
         if (ifMatch == null || ifMatch.isBlank()) {

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementService.java
@@ -105,7 +105,7 @@ public class OpalDefendantAccountEnforcementService
 
         String resultResponses = objectMapper.writeValueAsString(request.getEnforcementResultResponses());
 
-        UserState userState = userStateService.checkForAuthorisedUser();
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
         DefendantAccountEntity defendant = defendantAccountRepositoryService.findById(defendantAccountId);
 
         Long enforcementId = enforcementRepositoryService.addDefendantAccountEnforcement(
@@ -159,7 +159,7 @@ public class OpalDefendantAccountEnforcementService
         log.debug(":removeEnforcementHold: defendantAccountId={}, businessUnitId={}",
             defendantAccountId, businessUnitId);
 
-        final UserState userState = userStateService.checkForAuthorisedUser();
+        final UserState userState = userStateService.getUserStateV1FromSecurityContext();
         DefendantAccountEntity defendantEntity = defendantAccountRepositoryService.findById(defendantAccountId);
 
         if (ifMatch == null || ifMatch.isBlank()) {

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPaymentTermsService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPaymentTermsService.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
 import uk.gov.hmcts.opal.dto.AddPaymentCardRequestResponse;
 import uk.gov.hmcts.opal.dto.GetDefendantAccountPaymentTermsResponse;
 import uk.gov.hmcts.opal.dto.RecordType;
@@ -19,6 +18,7 @@ import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.PaymentCardRequestRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.PaymentTermsRepositoryService;
 import uk.gov.hmcts.opal.util.VersionUtils;
+import uk.gov.hmcts.opal.service.UserStateService;
 
 import java.time.LocalDate;
 
@@ -35,7 +35,7 @@ public class OpalDefendantAccountPaymentTermsService implements DefendantAccount
 
     private final PaymentCardRequestRepositoryService paymentCardRequestRepositoryService;
 
-    private final AccessTokenService accessTokenService;
+    private final UserStateService userStateService;
 
 
     @Override
@@ -55,8 +55,7 @@ public class OpalDefendantAccountPaymentTermsService implements DefendantAccount
     public AddPaymentCardRequestResponse addPaymentCardRequest(Long defendantAccountId,
         String businessUnitId,
         String businessUnitUserId,
-        String ifMatch,
-        String authHeader) {
+        String ifMatch) {
 
         log.debug(":addPaymentCardRequest (Opal): accountId={}, bu={}", defendantAccountId, businessUnitId);
 
@@ -69,7 +68,7 @@ public class OpalDefendantAccountPaymentTermsService implements DefendantAccount
 
         createPaymentCardRequest(defendantAccountId);
 
-        String displayName = accessTokenService.extractName(authHeader);
+        String displayName = userStateService.checkForAuthorisedUser().getDisplayName();
         updateDefendantAccountWithPcr(account, businessUnitUserId, displayName);
 
         auditComplete(defendantAccountId, account, businessUnitUserId, displayName);

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPaymentTermsService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPaymentTermsService.java
@@ -68,7 +68,7 @@ public class OpalDefendantAccountPaymentTermsService implements DefendantAccount
 
         createPaymentCardRequest(defendantAccountId);
 
-        String displayName = userStateService.checkForAuthorisedUser().getDisplayName();
+        String displayName = userStateService.getUserStateV1FromSecurityContext().getDisplayName();
         updateDefendantAccountWithPcr(account, businessUnitUserId, displayName);
 
         auditComplete(defendantAccountId, account, businessUnitUserId, displayName);

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
@@ -976,11 +976,11 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
             businessUnitId,
             businessUnitUserId,
             ifMatch,
-            userStateService.checkForAuthorisedUser().getDisplayName()
+            userStateService.getUserStateV1FromSecurityContext().getDisplayName()
         );
 
         auditComplete(defendantAccountId, account, businessUnitUserId,
-            userStateService.checkForAuthorisedUser().getDisplayName());
+            userStateService.getUserStateV1FromSecurityContext().getDisplayName());
 
         return paymentCardResponse;
     }
@@ -1110,7 +1110,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
             log.debug(":addPaymentTerms: Request Payment Card flag is TRUE for account {}",
                 defAccount.getDefendantAccountId());
             addPaymentCard(defendantAccountId, businessUnitId, businessUnitUserId, ifMatch,
-                userStateService.checkForAuthorisedUser().getDisplayName());
+                userStateService.getUserStateV1FromSecurityContext().getDisplayName());
         }
 
         // if generate_payment_terms_change_letter is true

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
@@ -38,7 +38,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
 import uk.gov.hmcts.opal.controllers.advice.GlobalExceptionHandler.PaymentCardRequestAlreadyExistsException;
 import uk.gov.hmcts.opal.dto.AddDefendantAccountEnforcementRequest;
 import uk.gov.hmcts.opal.dto.AddEnforcementResponse;
@@ -121,6 +120,7 @@ import uk.gov.hmcts.opal.service.iface.DefendantAccountServiceInterface;
 import uk.gov.hmcts.opal.service.opal.history.defendant.DefendantAccountHistoryService;
 import uk.gov.hmcts.opal.service.iface.ReportEntryServiceInterface;
 import uk.gov.hmcts.opal.service.persistence.PartyRepositoryService;
+import uk.gov.hmcts.opal.service.UserStateService;
 import uk.gov.hmcts.opal.util.VersionUtils;
 
 @Service
@@ -165,9 +165,9 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
 
     private final PaymentCardRequestRepository paymentCardRequestRepository;
 
-    private final AccessTokenService accessTokenService;
-
     private final PartyRepositoryService partyRepositoryService;
+
+    private final UserStateService userStateService;
 
     private final ResultRepository resultRepository;
 
@@ -501,7 +501,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
         String businessUnitId,
         String businessUnitUserId,
         String ifMatch,
-        String authHeader) {
+        String displayName) {
 
         log.debug(":addPaymentCard (Opal): accountId={}, bu={}", defendantAccountId, businessUnitId);
 
@@ -512,7 +512,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
 
         createPaymentCardRequest(defendantAccountId);
 
-        updateDefendantAccountWithPcr(account, businessUnitUserId, authHeader);
+        updateDefendantAccountWithPcr(account, businessUnitUserId, displayName);
 
         // Minimal response
         return new AddPaymentCardRequestResponse(defendantAccountId);
@@ -531,7 +531,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
     //TODO - Remove once OpalDefendantAccountEnforcementService is in use
     @Override
     public AddEnforcementResponse addEnforcement(Long defendantAccountId, String businessUnitId,
-        String businessUnitUserId, String ifMatch, String authHeader, AddDefendantAccountEnforcementRequest request) {
+        String businessUnitUserId, String ifMatch, AddDefendantAccountEnforcementRequest request) {
         return null;
     }
 
@@ -963,8 +963,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
     public AddPaymentCardRequestResponse addPaymentCardRequest(Long defendantAccountId,
         String businessUnitId,
         String businessUnitUserId,
-        String ifMatch,
-        String authHeader) {
+        String ifMatch) {
 
         log.debug(":addPaymentCardRequest (Opal): accountId={}, bu={}", defendantAccountId, businessUnitId);
 
@@ -977,10 +976,11 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
             businessUnitId,
             businessUnitUserId,
             ifMatch,
-            authHeader
+            userStateService.checkForAuthorisedUser().getDisplayName()
         );
 
-        auditComplete(defendantAccountId, account, businessUnitUserId, accessTokenService.extractName(authHeader));
+        auditComplete(defendantAccountId, account, businessUnitUserId,
+            userStateService.checkForAuthorisedUser().getDisplayName());
 
         return paymentCardResponse;
     }
@@ -1026,9 +1026,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
     //TODO: Remove this method once OpalDefendantAccountPaymentTermsService is in use
     private void updateDefendantAccountWithPcr(DefendantAccountEntity account,
         String businessUnitUserId,
-        String authHeader) {
-
-        String displayName = accessTokenService.extractName(authHeader);
+        String displayName) {
 
         account.setPaymentCardRequested(true);
         account.setPaymentCardRequestedDate(LocalDate.now());
@@ -1063,7 +1061,6 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
         String businessUnitId,
         String businessUnitUserId,
         String ifMatch,
-        String authHeader,
         AddDefendantAccountPaymentTermsRequest addPaymentTermsRequest) {
 
         log.debug(":addPaymentTerms (Opal): accountId={}, bu={}", defendantAccountId, businessUnitId);
@@ -1112,7 +1109,8 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
         if (Boolean.TRUE.equals(addPaymentTermsRequest.getRequestPaymentCard())) {
             log.debug(":addPaymentTerms: Request Payment Card flag is TRUE for account {}",
                 defAccount.getDefendantAccountId());
-            addPaymentCard(defendantAccountId, businessUnitId, businessUnitUserId, ifMatch, authHeader);
+            addPaymentCard(defendantAccountId, businessUnitId, businessUnitUserId, ifMatch,
+                userStateService.checkForAuthorisedUser().getDisplayName());
         }
 
         // if generate_payment_terms_change_letter is true

--- a/src/main/java/uk/gov/hmcts/opal/service/proxy/DefendantAccountEnforcementServiceProxy.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/proxy/DefendantAccountEnforcementServiceProxy.java
@@ -38,11 +38,10 @@ public class DefendantAccountEnforcementServiceProxy implements DefendantAccount
                                                  Short businessUnitId,
                                                  String businessUnitUserId,
                                                  String ifMatch,
-                                                 String authHeader,
                                                  AddDefendantAccountEnforcementRequest request)
         throws JacksonException {
         return getCurrentModeService().addEnforcement(defendantAccountId, businessUnitId, businessUnitUserId,
-            ifMatch, authHeader, request);
+            ifMatch, request);
     }
 
     @Override
@@ -51,7 +50,6 @@ public class DefendantAccountEnforcementServiceProxy implements DefendantAccount
         Short businessUnitId,
         String businessUnitUserId,
         String ifMatch,
-        String authHeader,
         RemoveDefendantAccountEnforcementHoldRequest request) {
 
         return getCurrentModeService().removeEnforcementHold(
@@ -59,7 +57,6 @@ public class DefendantAccountEnforcementServiceProxy implements DefendantAccount
             businessUnitId,
             businessUnitUserId,
             ifMatch,
-            authHeader,
             request
         );
     }

--- a/src/main/java/uk/gov/hmcts/opal/service/proxy/DefendantAccountPaymentTermsServiceProxy.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/proxy/DefendantAccountPaymentTermsServiceProxy.java
@@ -33,9 +33,8 @@ public class DefendantAccountPaymentTermsServiceProxy implements DefendantAccoun
     public AddPaymentCardRequestResponse addPaymentCardRequest(Long defendantAccountId,
         String businessUnitId,
         String businessUnitUserId,
-        String ifMatch,
-        String authHeader) {
+        String ifMatch) {
         return getCurrentModeService().addPaymentCardRequest(defendantAccountId, businessUnitId,
-            businessUnitUserId, ifMatch, authHeader);
+            businessUnitUserId, ifMatch);
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/proxy/DefendantAccountServiceProxy.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/proxy/DefendantAccountServiceProxy.java
@@ -104,10 +104,9 @@ public class DefendantAccountServiceProxy implements DefendantAccountServiceInte
     public AddPaymentCardRequestResponse addPaymentCardRequest(Long defendantAccountId,
         String businessUnitId,
         String businessUnitUserId,
-        String ifMatch,
-        String authHeader) {
+        String ifMatch) {
         return getCurrentModeService().addPaymentCardRequest(defendantAccountId, businessUnitId,
-            businessUnitUserId, ifMatch, authHeader);
+            businessUnitUserId, ifMatch);
     }
 
     @Override
@@ -115,10 +114,9 @@ public class DefendantAccountServiceProxy implements DefendantAccountServiceInte
         String businessUnitId,
         String businessUnitUserId,
         String ifMatch,
-        String authHeader,
         AddDefendantAccountEnforcementRequest request) {
         return getCurrentModeService().addEnforcement(defendantAccountId, businessUnitId, businessUnitUserId,
-            ifMatch, authHeader, request);
+            ifMatch, request);
     }
 
     @Override
@@ -126,13 +124,11 @@ public class DefendantAccountServiceProxy implements DefendantAccountServiceInte
         String businessUnitId,
         String businessUnitUserId,
         String ifMatch,
-        String authHeader,
         AddDefendantAccountPaymentTermsRequest addPaymentTermsRequest) {
         return getCurrentModeService().addPaymentTerms(defendantAccountId,
             businessUnitId,
             businessUnitUserId,
             ifMatch,
-            authHeader,
             addPaymentTermsRequest);
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/report/GenericReportService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/GenericReportService.java
@@ -93,7 +93,7 @@ public class GenericReportService implements GenericReportServiceInterface {
             throw new UnprocessableException("This report cannot be manually created");
         }
 
-        UserState userState = userStateService.checkForAuthorisedUser("");
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (!userState.getBusinessUnitUser().stream()
             .map(buUser -> buUser.getBusinessUnitId().intValue()).collect(Collectors.toSet())

--- a/src/main/java/uk/gov/hmcts/opal/util/PermissionUtil.java
+++ b/src/main/java/uk/gov/hmcts/opal/util/PermissionUtil.java
@@ -39,13 +39,12 @@ public class PermissionUtil {
     public static  List<BusinessUnitReferenceData> filterBusinessUnitsByPermission(
         UserStateService userStateService,
         List<BusinessUnitReferenceData> refData,
-        Optional<FinesPermission> optPermission,
-        String authHeaderValue) {
+        Optional<FinesPermission> optPermission) {
 
         return optPermission.map(
             permission -> {
                 UserState.UserBusinessUnits userBusinessUnits = userStateService
-                    .checkForAuthorisedUser(authHeaderValue)
+                    .checkForAuthorisedUser()
                     .allBusinessUnitUsersWithPermission(permission);
                 return refData
                     .stream()

--- a/src/main/java/uk/gov/hmcts/opal/util/PermissionUtil.java
+++ b/src/main/java/uk/gov/hmcts/opal/util/PermissionUtil.java
@@ -44,7 +44,7 @@ public class PermissionUtil {
         return optPermission.map(
             permission -> {
                 UserState.UserBusinessUnits userBusinessUnits = userStateService
-                    .checkForAuthorisedUser()
+                    .getUserStateV1FromSecurityContext()
                     .allBusinessUnitUsersWithPermission(permission);
                 return refData
                     .stream()

--- a/src/main/resources/openapi/DefendantAccount.yaml
+++ b/src/main/resources/openapi/DefendantAccount.yaml
@@ -27,12 +27,6 @@ paths:
             type: integer
             format: int64
           required: true
-        - in: header
-          name: Authorization
-          description: Bearer token
-          schema:
-            type: string
-          required: false
       responses:
         '200':
           description: OK
@@ -283,12 +277,6 @@ paths:
             type: integer
             format: int64
           required: true
-        - in: header
-          name: Authorization
-          description: Bearer token
-          schema:
-            type: string
-          required: true
       responses:
         '200':
           description: OK
@@ -366,12 +354,6 @@ paths:
           description: Version of the defendant account. DB Mapping - defendant_accounts.version
           schema:
             type: string
-        - in: header
-          name: Authorization
-          description: Bearer token
-          schema:
-            type: string
-          required: true
         - in: header
           name: Business-Unit-Id
           description: Business unit identifier
@@ -527,12 +509,6 @@ paths:
                 - paymentTerms
             style: form
             explode: false
-        - in: header
-          name: Authorization
-          description: Bearer token
-          schema:
-            type: string
-          required: false
       responses:
         '200':
           description: OK
@@ -580,6 +556,11 @@ paths:
               schema:
                 $ref: './common.yaml#/components/schemas/ProblemDetail'
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     enforcementOverview:
       type: object

--- a/src/main/resources/openapi/MajorCreditor.yaml
+++ b/src/main/resources/openapi/MajorCreditor.yaml
@@ -25,12 +25,6 @@ paths:
           schema:
             type: integer
           required: true
-        - in: header
-          name: Authorization
-          description: Bearer token
-          schema:
-            type: string
-          required: false
       responses:
         '200':
           description: OK
@@ -315,12 +309,6 @@ paths:
                 - note
             style: form
             explode: false
-        - in: header
-          name: Authorization
-          description: Bearer token
-          schema:
-            type: string
-          required: false
       responses:
         '200':
           description: OK

--- a/src/main/resources/openapi/MinorCreditor.yaml
+++ b/src/main/resources/openapi/MinorCreditor.yaml
@@ -95,12 +95,6 @@ paths:
           schema:
             type: string
         - in: header
-          name: Authorization
-          description: Bearer token
-          schema:
-            type: string
-          required: false
-        - in: header
           name: Business-Unit-Id
           description: Business unit identifier
           schema:
@@ -208,12 +202,6 @@ paths:
                 - note
             style: form
             explode: false
-        - in: header
-          name: Authorization
-          description: Bearer token
-          schema:
-            type: string
-          required: false
       responses:
         '200':
           description: OK
@@ -260,6 +248,11 @@ paths:
               schema:
                 $ref: './common.yaml#/components/schemas/ProblemDetail'
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   schemas:
     minorCreditorAccountResponse:
       additionalProperties: false

--- a/src/test/java/uk/gov/hmcts/opal/controllers/BusinessUnitControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/BusinessUnitControllerTest.java
@@ -106,7 +106,7 @@ class BusinessUnitControllerTest {
         List<BusinessUnitReferenceData> businessUnitList = List.of(entity);
 
         when(businessUnitService.getReferenceData(any())).thenReturn(businessUnitList);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.allBusinessUnitUsersWithPermission(any())).thenReturn(new TestUserBusinessUnits(true));
 
         // Act
@@ -132,7 +132,7 @@ class BusinessUnitControllerTest {
         List<BusinessUnitReferenceData> businessUnitList = List.of(entity);
 
         when(businessUnitService.getReferenceData(any())).thenReturn(businessUnitList);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.allBusinessUnitUsersWithPermission(any())).thenReturn(new TestUserBusinessUnits(false));
 
         // Act

--- a/src/test/java/uk/gov/hmcts/opal/controllers/BusinessUnitControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/BusinessUnitControllerTest.java
@@ -85,7 +85,6 @@ class BusinessUnitControllerTest {
         // Act
         Optional<String> filter = Optional.empty();
         Optional<FinesPermission> permission = Optional.empty();
-        String headerToken = "Bearer token";
         ResponseEntity<BusinessUnitReferenceDataResults> response = businessUnitController
             .getBusinessUnitRefData(filter, permission);
 
@@ -112,7 +111,6 @@ class BusinessUnitControllerTest {
         // Act
         Optional<String> filter = Optional.empty();
         Optional<FinesPermission> permission = Optional.of(FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS);
-        String headerToken = "Bearer token";
         ResponseEntity<BusinessUnitReferenceDataResults> response = businessUnitController
             .getBusinessUnitRefData(filter, permission);
 
@@ -138,7 +136,6 @@ class BusinessUnitControllerTest {
         // Act
         Optional<String> filter = Optional.empty();
         Optional<FinesPermission> permission = Optional.of(FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS);
-        String headerToken = "Bearer token";
         ResponseEntity<BusinessUnitReferenceDataResults> response = businessUnitController
             .getBusinessUnitRefData(filter, permission);
 

--- a/src/test/java/uk/gov/hmcts/opal/controllers/BusinessUnitControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/BusinessUnitControllerTest.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -88,7 +87,7 @@ class BusinessUnitControllerTest {
         Optional<FinesPermission> permission = Optional.empty();
         String headerToken = "Bearer token";
         ResponseEntity<BusinessUnitReferenceDataResults> response = businessUnitController
-            .getBusinessUnitRefData(filter, permission, headerToken);
+            .getBusinessUnitRefData(filter, permission);
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -107,7 +106,7 @@ class BusinessUnitControllerTest {
         List<BusinessUnitReferenceData> businessUnitList = List.of(entity);
 
         when(businessUnitService.getReferenceData(any())).thenReturn(businessUnitList);
-        when(userStateService.checkForAuthorisedUser(anyString())).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.allBusinessUnitUsersWithPermission(any())).thenReturn(new TestUserBusinessUnits(true));
 
         // Act
@@ -115,7 +114,7 @@ class BusinessUnitControllerTest {
         Optional<FinesPermission> permission = Optional.of(FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS);
         String headerToken = "Bearer token";
         ResponseEntity<BusinessUnitReferenceDataResults> response = businessUnitController
-            .getBusinessUnitRefData(filter, permission, headerToken);
+            .getBusinessUnitRefData(filter, permission);
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -133,7 +132,7 @@ class BusinessUnitControllerTest {
         List<BusinessUnitReferenceData> businessUnitList = List.of(entity);
 
         when(businessUnitService.getReferenceData(any())).thenReturn(businessUnitList);
-        when(userStateService.checkForAuthorisedUser(anyString())).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.allBusinessUnitUsersWithPermission(any())).thenReturn(new TestUserBusinessUnits(false));
 
         // Act
@@ -141,7 +140,7 @@ class BusinessUnitControllerTest {
         Optional<FinesPermission> permission = Optional.of(FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS);
         String headerToken = "Bearer token";
         ResponseEntity<BusinessUnitReferenceDataResults> response = businessUnitController
-            .getBusinessUnitRefData(filter, permission, headerToken);
+            .getBusinessUnitRefData(filter, permission);
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());

--- a/src/test/java/uk/gov/hmcts/opal/controllers/CourtControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/CourtControllerTest.java
@@ -47,7 +47,7 @@ class CourtControllerTest {
         when(courtService.getCourtById(any(Long.class))).thenReturn(entity);
 
         // Act
-        ResponseEntity<CourtEntity> response = courtController.getCourtById(1L, BEARER_TOKEN);
+        ResponseEntity<CourtEntity> response = courtController.getCourtById(1L);
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -66,7 +66,7 @@ class CourtControllerTest {
         // Act
         CourtSearchDto searchDto = CourtSearchDto.builder().build();
         ResponseEntity<SearchDataResponse<CourtEntity>> response =
-            courtController.postCourtsSearch(searchDto, BEARER_TOKEN);
+            courtController.postCourtsSearch(searchDto);
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());

--- a/src/test/java/uk/gov/hmcts/opal/controllers/CourtControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/CourtControllerTest.java
@@ -28,8 +28,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class CourtControllerTest {
 
-    static final String BEARER_TOKEN = "Bearer a_token_here";
-
     @Mock
     private CourtService courtService;
 

--- a/src/test/java/uk/gov/hmcts/opal/controllers/CreateFineAccountsControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/CreateFineAccountsControllerTest.java
@@ -34,8 +34,6 @@ class CreateFineAccountsControllerTest {
             """)
             .build();
 
-        ResponseEntity<OpalS2SResponseWrapper> responseEntity = new ResponseEntity<>(response, HttpStatus.OK);
-
         // Act
         ResponseEntity<OpalS2SResponseWrapper> actualResponse = createFineAccountsController
             .createFineAccounts(request);

--- a/src/test/java/uk/gov/hmcts/opal/controllers/DefendantAccountApiControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/DefendantAccountApiControllerTest.java
@@ -56,22 +56,22 @@ class DefendantAccountApiControllerTest {
             .payload(payload)
             .version(BigInteger.valueOf(12))
             .build();
-        when(impositionService.getImpositions(defendantId, BEARER_TOKEN))
+        when(impositionService.getImpositions(defendantId))
             .thenReturn(serviceResponse);
 
         ResponseEntity<DefendantAccountImpositionsResponseCommon> response =
-            defendantAccountApiController.getImpositions(defendantId, BEARER_TOKEN);
+            defendantAccountApiController.getImpositions(defendantId);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("\"12\"", response.getHeaders().getETag());
         assertSame(payload, response.getBody());
-        verify(impositionService).getImpositions(defendantId, BEARER_TOKEN);
+        verify(impositionService).getImpositions(defendantId);
     }
 
     @Test
     void getImpositions_isProtectedByRelease1BFeatureToggle() throws NoSuchMethodException {
         Method method = DefendantAccountApiController.class.getMethod(
-            "getImpositions", Long.class, String.class);
+            "getImpositions", Long.class);
 
         FeatureToggle featureToggle = method.getAnnotation(FeatureToggle.class);
 
@@ -85,15 +85,15 @@ class DefendantAccountApiControllerTest {
         Long defendantId = 1L;
         EnforcementStatus status = EnforcementStatus.builder()
             .build();
-        when(defendantAccountService.getEnforcementStatus(defendantId, BEARER_TOKEN))
+        when(defendantAccountService.getEnforcementStatus(defendantId))
             .thenReturn(status);
 
         ResponseEntity<GetEnforcementStatusResponse> response =
-            defendantAccountApiController.getEnforcementStatus(defendantId, BEARER_TOKEN);
+            defendantAccountApiController.getEnforcementStatus(defendantId);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertSame(status, response.getBody());
-        verify(defendantAccountService).getEnforcementStatus(defendantId, BEARER_TOKEN);
+        verify(defendantAccountService).getEnforcementStatus(defendantId);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/controllers/DefendantAccountApiControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/DefendantAccountApiControllerTest.java
@@ -34,8 +34,6 @@ import uk.gov.hmcts.opal.service.ImpositionService;
 @ExtendWith(MockitoExtension.class)
 class DefendantAccountApiControllerTest {
 
-    private static final String BEARER_TOKEN = "Bearer a_token_goes_here";
-
     @Mock
     private DefendantAccountService defendantAccountService;
 

--- a/src/test/java/uk/gov/hmcts/opal/controllers/DefendantAccountApiControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/DefendantAccountApiControllerTest.java
@@ -102,19 +102,18 @@ class DefendantAccountApiControllerTest {
             .build();
         GetDefendantAccountHistoryResponse generatedResponse = new GetDefendantAccountHistoryResponse();
 
-        when(defendantAccountService.getHistory(eq(defendantId), eq(null), eq(null), eq(List.of()), eq(BEARER_TOKEN)))
+        when(defendantAccountService.getHistory(eq(defendantId), eq(null), eq(null), eq(List.of())))
             .thenReturn(historyResponse);
         when(defendantAccountHistoryResponseMapper.toGeneratedResponse(historyResponse))
             .thenReturn(generatedResponse);
 
         ResponseEntity<GetDefendantAccountHistoryResponse> response =
-            defendantAccountApiController.getDefendantAccountHistory(defendantId, null, null, List.of(), BEARER_TOKEN);
+            defendantAccountApiController.getDefendantAccountHistory(defendantId, null, null, List.of());
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("\"1\"", response.getHeaders().getETag());
         assertSame(generatedResponse, response.getBody());
-        verify(defendantAccountService).getHistory(eq(defendantId), eq(null), eq(null), eq(List.of()),
-            eq(BEARER_TOKEN));
+        verify(defendantAccountService).getHistory(eq(defendantId), eq(null), eq(null), eq(List.of()));
         verify(defendantAccountHistoryResponseMapper).toGeneratedResponse(historyResponse);
     }
 
@@ -125,17 +124,14 @@ class DefendantAccountApiControllerTest {
         LocalDate dateTo = LocalDate.of(2026, 1, 31);
         List<String> itemTypes = List.of("note,paymentTerms", "enforcement");
         DefendantAccountHistoryResponse historyResponse = DefendantAccountHistoryResponse.builder().build();
-        when(defendantAccountService.getHistory(eq(defendantId), eq(dateFrom), eq(dateTo), eq(itemTypes),
-            eq(BEARER_TOKEN)))
+        when(defendantAccountService.getHistory(eq(defendantId), eq(dateFrom), eq(dateTo), eq(itemTypes)))
             .thenReturn(historyResponse);
         when(defendantAccountHistoryResponseMapper.toGeneratedResponse(historyResponse))
             .thenReturn(new GetDefendantAccountHistoryResponse());
 
-        defendantAccountApiController.getDefendantAccountHistory(defendantId, dateFrom, dateTo, itemTypes,
-            BEARER_TOKEN);
+        defendantAccountApiController.getDefendantAccountHistory(defendantId, dateFrom, dateTo, itemTypes);
 
-        verify(defendantAccountService).getHistory(eq(defendantId), eq(dateFrom), eq(dateTo), eq(itemTypes),
-            eq(BEARER_TOKEN));
+        verify(defendantAccountService).getHistory(eq(defendantId), eq(dateFrom), eq(dateTo), eq(itemTypes));
         verify(defendantAccountHistoryResponseMapper).toGeneratedResponse(historyResponse);
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/controllers/DefendantAccountControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/DefendantAccountControllerTest.java
@@ -46,8 +46,6 @@ import uk.gov.hmcts.opal.util.FeatureFlags;
 @ExtendWith(MockitoExtension.class)
 class DefendantAccountControllerTest {
 
-    static final String BEARER_TOKEN = "Bearer a_token_here";
-
     @Mock
     private DefendantAccountService defendantAccountService;
 
@@ -200,7 +198,6 @@ class DefendantAccountControllerTest {
         Long defendantAccountId = 1L;
         Long defendantAccountPartyId = 10L;
         Short businessUnitId = 10;
-        String businessUserId = "20";
         String ifMatch = "1";
 
         RemoveDefendantAccountPartyRequest request = new RemoveDefendantAccountPartyRequest();

--- a/src/test/java/uk/gov/hmcts/opal/controllers/DefendantAccountControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/DefendantAccountControllerTest.java
@@ -4,8 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -146,7 +144,7 @@ class DefendantAccountControllerTest {
         // Arrange
         DefendantAccountHeaderSummary mockBody = new DefendantAccountHeaderSummary();
 
-        when(defendantAccountService.getHeaderSummary(eq(1L)))
+        when(defendantAccountService.getHeaderSummary(1L))
             .thenReturn(mockBody);
 
         // Act
@@ -157,7 +155,7 @@ class DefendantAccountControllerTest {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(mockBody, response.getBody());
 
-        verify(defendantAccountService).getHeaderSummary(eq(1L));
+        verify(defendantAccountService).getHeaderSummary(1L);
     }
 
     @Test
@@ -335,10 +333,10 @@ class DefendantAccountControllerTest {
                 .build();
 
         when(defendantAccountEnforcementService.removeEnforcementHold(
-            eq(defendantAccountId),
-            eq(businessUnitId),
-            isNull(),
-            eq(request)
+            defendantAccountId,
+            businessUnitId,
+            null,
+            request
         )).thenThrow(new ResourceConflictException(
             "Defendant Account",
             defendantAccountId,

--- a/src/test/java/uk/gov/hmcts/opal/controllers/DefendantAccountControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/DefendantAccountControllerTest.java
@@ -69,12 +69,12 @@ class DefendantAccountControllerTest {
         AccountSearchDto requestEntity = AccountSearchDto.builder().build();
         DefendantAccountSearchResultsDto mockResponse = DefendantAccountSearchResultsDto.builder().build();
 
-        when(defendantAccountService.searchDefendantAccounts(any(AccountSearchDto.class), eq(BEARER_TOKEN)))
+        when(defendantAccountService.searchDefendantAccounts(any(AccountSearchDto.class)))
             .thenReturn(mockResponse);
 
         // Act
         ResponseEntity<DefendantAccountSearchResultsDto> responseEntity =
-            defendantAccountController.postDefendantAccountSearch(requestEntity, BEARER_TOKEN);
+            defendantAccountController.postDefendantAccountSearch(requestEntity);
 
         // Assert
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
@@ -82,7 +82,7 @@ class DefendantAccountControllerTest {
         assertEquals(mockResponse, responseEntity.getBody());
 
         verify(defendantAccountService, times(1))
-            .searchDefendantAccounts(any(AccountSearchDto.class), eq(BEARER_TOKEN));
+            .searchDefendantAccounts(any(AccountSearchDto.class));
         verifyNoInteractions(featureToggleApi);
     }
 
@@ -99,11 +99,11 @@ class DefendantAccountControllerTest {
             FeatureFlags.RELEASE_1C_ENABLED_PROPERTY,
             false
         )).thenReturn(true);
-        when(defendantAccountService.searchDefendantAccounts(requestEntity, BEARER_TOKEN)).thenReturn(mockResponse);
+        when(defendantAccountService.searchDefendantAccounts(requestEntity)).thenReturn(mockResponse);
 
         // Act
         ResponseEntity<DefendantAccountSearchResultsDto> responseEntity =
-            defendantAccountController.postDefendantAccountSearch(requestEntity, BEARER_TOKEN);
+            defendantAccountController.postDefendantAccountSearch(requestEntity);
 
         // Assert
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
@@ -113,7 +113,7 @@ class DefendantAccountControllerTest {
             FeatureFlags.RELEASE_1C_ENABLED_PROPERTY,
             false
         );
-        verify(defendantAccountService).searchDefendantAccounts(requestEntity, BEARER_TOKEN);
+        verify(defendantAccountService).searchDefendantAccounts(requestEntity);
     }
 
     @Test
@@ -130,7 +130,7 @@ class DefendantAccountControllerTest {
         // Act
         FeatureDisabledException exception = assertThrows(
             FeatureDisabledException.class,
-            () -> defendantAccountController.postDefendantAccountSearch(requestEntity, BEARER_TOKEN));
+            () -> defendantAccountController.postDefendantAccountSearch(requestEntity));
 
         // Assert
         assertEquals("Feature release-1c is not enabled for defendant account consolidated search",
@@ -148,18 +148,18 @@ class DefendantAccountControllerTest {
         // Arrange
         DefendantAccountHeaderSummary mockBody = new DefendantAccountHeaderSummary();
 
-        when(defendantAccountService.getHeaderSummary(eq(1L), any()))
+        when(defendantAccountService.getHeaderSummary(eq(1L)))
             .thenReturn(mockBody);
 
         // Act
         ResponseEntity<DefendantAccountHeaderSummary> response =
-            defendantAccountController.getHeaderSummary(1L, BEARER_TOKEN);
+            defendantAccountController.getHeaderSummary(1L);
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(mockBody, response.getBody());
 
-        verify(defendantAccountService).getHeaderSummary(eq(1L), any());
+        verify(defendantAccountService).getHeaderSummary(eq(1L));
     }
 
     @Test
@@ -179,20 +179,19 @@ class DefendantAccountControllerTest {
         AddDefendantAccountEnforcementRequest request = AddDefendantAccountEnforcementRequest.builder().build();
         AddEnforcementResponse mockResponse = AddEnforcementResponse.builder().build();
 
-        when(defendantAccountEnforcementService.addEnforcement(defendantAccountId, businessUnitId, ifMatch,
-            BEARER_TOKEN, request)).thenReturn(mockResponse);
+        when(defendantAccountEnforcementService.addEnforcement(
+            defendantAccountId, businessUnitId, ifMatch, request)).thenReturn(mockResponse);
 
         // Act
         ResponseEntity<AddEnforcementResponse> response =
-            defendantAccountController.addEnforcement(defendantAccountId, BEARER_TOKEN, businessUnitId, ifMatch,
+            defendantAccountController.addEnforcement(defendantAccountId, businessUnitId, ifMatch,
                 request);
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(mockResponse, response.getBody());
 
-        verify(defendantAccountEnforcementService).addEnforcement(defendantAccountId, businessUnitId, ifMatch,
-            BEARER_TOKEN, request);
+        verify(defendantAccountEnforcementService).addEnforcement(defendantAccountId, businessUnitId, ifMatch, request);
     }
 
     @Test
@@ -208,20 +207,23 @@ class DefendantAccountControllerTest {
         RemoveDefendantAccountPartyResponse mockResponse = new RemoveDefendantAccountPartyResponse();
 
         when(defendantAccountPartyService.removeDefendantAccountParty(defendantAccountId,
-            defendantAccountPartyId, businessUnitId, businessUserId, ifMatch, request
+            defendantAccountPartyId, businessUnitId,
+                ifMatch, request
         )).thenReturn(mockResponse);
 
         // Act
         ResponseEntity<RemoveDefendantAccountPartyResponse> response =
             defendantAccountController.removeDefendantAccountParty(defendantAccountId,
-                defendantAccountPartyId, businessUnitId, businessUserId, ifMatch, request);
+                defendantAccountPartyId, businessUnitId,
+                ifMatch, request);
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(mockResponse, response.getBody());
 
         verify(defendantAccountPartyService).removeDefendantAccountParty(defendantAccountId,
-            defendantAccountPartyId, businessUnitId, businessUserId, ifMatch, request);
+            defendantAccountPartyId, businessUnitId,
+                ifMatch, request);
     }
 
     @Test
@@ -242,7 +244,6 @@ class DefendantAccountControllerTest {
             defendantAccountId,
             businessUnitId,
             ifMatch,
-            BEARER_TOKEN,
             request
         )).thenReturn(expectedResponse);
 
@@ -251,7 +252,6 @@ class DefendantAccountControllerTest {
                 defendantAccountId,
                 businessUnitId,
                 ifMatch,
-                BEARER_TOKEN,
                 request
             );
 
@@ -272,7 +272,6 @@ class DefendantAccountControllerTest {
 
         when(defendantAccountPartyService.addDefendantAccountParty(
             defendantAccountId,
-            BEARER_TOKEN,
             ifMatch,
             businessUnitId,
             request
@@ -284,7 +283,6 @@ class DefendantAccountControllerTest {
                 defendantAccountId,
                 businessUnitId,
                 ifMatch,
-                BEARER_TOKEN,
                 request
             );
 
@@ -294,7 +292,6 @@ class DefendantAccountControllerTest {
 
         verify(defendantAccountPartyService).addDefendantAccountParty(
             defendantAccountId,
-            BEARER_TOKEN,
             ifMatch,
             businessUnitId,
             request
@@ -316,7 +313,6 @@ class DefendantAccountControllerTest {
             defendantAccountId,
             businessUnitId,
             ifMatch,
-            BEARER_TOKEN,
             request
         )).thenThrow(new PermissionNotAllowedException(FinesPermission.ENTER_ENFORCEMENT));
 
@@ -325,7 +321,6 @@ class DefendantAccountControllerTest {
                 defendantAccountId,
                 businessUnitId,
                 ifMatch,
-                BEARER_TOKEN,
                 request
             )
         );
@@ -346,7 +341,6 @@ class DefendantAccountControllerTest {
             eq(defendantAccountId),
             eq(businessUnitId),
             isNull(),
-            eq(BEARER_TOKEN),
             eq(request)
         )).thenThrow(new ResourceConflictException(
             "Defendant Account",
@@ -360,7 +354,6 @@ class DefendantAccountControllerTest {
                 defendantAccountId,
                 businessUnitId,
                 ifMatch,
-                BEARER_TOKEN,
                 request
             )
         );

--- a/src/test/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerTest.java
@@ -35,8 +35,6 @@ import static uk.gov.hmcts.opal.util.DateTimeUtils.toUtcDateTime;
 @ExtendWith(MockitoExtension.class)
 class DraftAccountControllerTest {
 
-    static final String BEARER_TOKEN = "Bearer a_token_here";
-
     private static final short BU_ID = (short)1;
 
     @Mock

--- a/src/test/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerTest.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -57,16 +56,16 @@ class DraftAccountControllerTest {
             .build();
         DraftAccountResponseDto responseDto = toGetDto(entity);
 
-        when(draftAccountService.getDraftAccount(any(Long.class),anyString())).thenReturn(responseDto);
+        when(draftAccountService.getDraftAccount(any(Long.class))).thenReturn(responseDto);
 
         // Act
         ResponseEntity<DraftAccountResponseDto> response = draftAccountController
-            .getDraftAccountById(1L, BEARER_TOKEN);
+            .getDraftAccountById(1L);
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(responseDto, response.getBody());
-        verify(draftAccountService, times(1)).getDraftAccount(any(Long.class), anyString());
+        verify(draftAccountService, times(1)).getDraftAccount(any(Long.class));
     }
 
 
@@ -80,7 +79,7 @@ class DraftAccountControllerTest {
             .summaries(List.of(toSummaryDto(entity)))
             .build();
 
-        when(draftAccountService.getDraftAccounts(any(), any(), any(), any(),any(), any(), any()))
+        when(draftAccountService.getDraftAccounts(any(), any(), any(), any(), any(), any()))
             .thenReturn(responseDto);
 
         // Act
@@ -88,7 +87,7 @@ class DraftAccountControllerTest {
             .getDraftAccountSummaries(Optional.of(List.of(BU_ID)),
                                       Optional.of(List.of(DraftAccountStatus.PUBLISHING_PENDING)),
                                       Optional.of(List.of()), Optional.of(List.of()),
-                                      Optional.empty(), Optional.empty(), BEARER_TOKEN);
+                                      Optional.empty(), Optional.empty());
         DraftAccountsResponseDto dto = response.getBody();
 
         // Assert
@@ -96,7 +95,7 @@ class DraftAccountControllerTest {
         assertEquals(1, dto.getCount());
         assertEquals(toSummaryDto(entity), dto.getSummaries().get(0));
         verify(draftAccountService, times(1))
-            .getDraftAccounts(any(), any(), any(), any(),any(), any(), any());
+            .getDraftAccounts(any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -107,16 +106,16 @@ class DraftAccountControllerTest {
             .build();
         DraftAccountResponseDto responseDto = toGetDto(entity);
 
-        when(draftAccountService.searchDraftAccounts(any(), any())).thenReturn(List.of(responseDto));
+        when(draftAccountService.searchDraftAccounts(any())).thenReturn(List.of(responseDto));
 
         // Act
         DraftAccountSearchDto searchDto = DraftAccountSearchDto.builder().build();
         ResponseEntity<List<DraftAccountResponseDto>> response = draftAccountController.postDraftAccountsSearch(
-            searchDto, BEARER_TOKEN);
+            searchDto);
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        verify(draftAccountService, times(1)).searchDraftAccounts(any(), any());
+        verify(draftAccountService, times(1)).searchDraftAccounts(any());
     }
 
     @Test
@@ -138,11 +137,11 @@ class DraftAccountControllerTest {
             .submittedByName("USER_NAME")
             .build();
 
-        when(draftAccountService.submitDraftAccount(any(), any())).thenReturn(toGetDto(entity));
+        when(draftAccountService.submitDraftAccount(any())).thenReturn(toGetDto(entity));
 
         // Act
         ResponseEntity<DraftAccountResponseDto> response = draftAccountController.postDraftAccount(
-            addDraftAccountDto, BEARER_TOKEN);
+            addDraftAccountDto);
 
         // Assert
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
@@ -152,13 +151,13 @@ class DraftAccountControllerTest {
         assertEquals(getAccountJson(), responseEntity.getAccount());
         assertEquals("USER_ID", responseEntity.getSubmittedBy());
         assertEquals(getTimelineJson(), responseEntity.getTimelineData());
-        verify(draftAccountService, times(1)).submitDraftAccount(any(), any());
+        verify(draftAccountService, times(1)).submitDraftAccount(any());
     }
 
     @Test
     void testDeleteDraftAccount_Success() {
         // Arrange
-        when(draftAccountService.deleteDraftAccount(any(Long.class), any(Boolean.class), any()))
+        when(draftAccountService.deleteDraftAccount(any(Long.class), any(Boolean.class)))
             .thenReturn("""
                          { "message": "Draft Account '7' deleted"}""");
 
@@ -166,32 +165,32 @@ class DraftAccountControllerTest {
 
         // Act
         ResponseEntity<String> response = draftAccountController
-            .deleteDraftAccountById(7L, BEARER_TOKEN, "", Optional.empty());
+            .deleteDraftAccountById(7L, "", Optional.empty());
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("""
                          { "message": "Draft Account '7' deleted"}""", response.getBody());
         verify(draftAccountService, times(1)).deleteDraftAccount(any(Long.class),
-                                                                 any(Boolean.class), any());
+                                                                 any(Boolean.class));
     }
 
     @Test
     void testDeleteDraftAccount_Fail() {
         // Arrange
-        when(draftAccountService.deleteDraftAccount(any(Long.class), any(Boolean.class), any())).thenThrow(
+        when(draftAccountService.deleteDraftAccount(any(Long.class), any(Boolean.class))).thenThrow(
             new UnexpectedRollbackException("Entity 7L not found.")
         );
 
         // Act
         RuntimeException rte = assertThrows(UnexpectedRollbackException.class, () ->
-            draftAccountController.deleteDraftAccountById(7L, BEARER_TOKEN, "", Optional.empty())
+            draftAccountController.deleteDraftAccountById(7L, "", Optional.empty())
         );
 
         // Assert
         assertEquals("Entity 7L not found.", rte.getMessage());
         verify(draftAccountService, times(1)).deleteDraftAccount(any(Long.class),
-                                                                 any(Boolean.class), any());
+                                                                 any(Boolean.class));
     }
 
     DraftAccountResponseDto toGetDto(DraftAccountEntity entity) {

--- a/src/test/java/uk/gov/hmcts/opal/controllers/MajorCreditorApiControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/MajorCreditorApiControllerTest.java
@@ -46,15 +46,15 @@ class MajorCreditorApiControllerTest {
             .version(BigInteger.valueOf(7))
             .build();
 
-        when(centralFundService.getCentralFundByBusinessUnit(70, AUTH_HEADER)).thenReturn(serviceResponse);
+        when(centralFundService.getCentralFundByBusinessUnit(70)).thenReturn(serviceResponse);
 
         ResponseEntity<GetCentralFundResponse> response =
-            controller.getCentralFundByBusinessUnit(70, AUTH_HEADER);
+            controller.getCentralFundByBusinessUnit(70);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals("\"7\"", response.getHeaders().getETag());
         assertSame(payload, response.getBody());
-        verify(centralFundService).getCentralFundByBusinessUnit(70, AUTH_HEADER);
+        verify(centralFundService).getCentralFundByBusinessUnit(70);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/controllers/MajorCreditorApiControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/MajorCreditorApiControllerTest.java
@@ -27,8 +27,6 @@ import uk.gov.hmcts.opal.service.MajorCreditorAccountService;
 @ExtendWith(MockitoExtension.class)
 class MajorCreditorApiControllerTest {
 
-    private static final String AUTH_HEADER = "Bearer test-token";
-
     @Mock
     private CentralFundService centralFundService;
 

--- a/src/test/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerTest.java
@@ -50,16 +50,14 @@ class MinorCreditorApiControllerTest {
 
         PatchMinorCreditorAccountRequest request = new PatchMinorCreditorAccountRequest();
 
-        when(minorCreditorService.updateMinorCreditorAccount(101L, request, BigInteger.ONE,
-            "Bearer token", "77")).thenReturn(response);
+        when(minorCreditorService.updateMinorCreditorAccount(101L, request, BigInteger.ONE, "77")).thenReturn(response);
 
         ResponseEntity<MinorCreditorAccountResponseMinorCreditor> result =
-            minorCreditorApiController.patchMinorCreditorAccount(101L, "77", "\"1\"", "Bearer token", request);
+            minorCreditorApiController.patchMinorCreditorAccount(101L, "77", "\"1\"", request);
 
         assertEquals(HttpStatus.OK, result.getStatusCode());
         assertEquals("\"2\"", result.getHeaders().getETag());
         assertSame(response, result.getBody());
-        verify(minorCreditorService).updateMinorCreditorAccount(101L, request, BigInteger.ONE,
-            "Bearer token", "77");
+        verify(minorCreditorService).updateMinorCreditorAccount(101L, request, BigInteger.ONE, "77");
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -52,16 +51,16 @@ class MinorCreditorControllerTest {
             .creditor(new Creditor(/* set Creditor fields as needed */))
             .build();
 
-        when(minorCreditorService.searchMinorCreditors(any(), any())).thenReturn(mockResponse);
+        when(minorCreditorService.searchMinorCreditors(any())).thenReturn(mockResponse);
 
         // Act
         ResponseEntity<PostMinorCreditorAccountsSearchResponse> responseEntity =
-            minorCreditorController.postMinorCreditorsSearch(search, BEARER_TOKEN);
+            minorCreditorController.postMinorCreditorsSearch(search);
 
         // Assert
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
         assertEquals(mockResponse, responseEntity.getBody());
-        verify(minorCreditorService, times(1)).searchMinorCreditors(any(), any());
+        verify(minorCreditorService, times(1)).searchMinorCreditors(any());
     }
 
     @Test
@@ -69,11 +68,11 @@ class MinorCreditorControllerTest {
         // Arrange
         GetMinorCreditorAccountAtAGlanceResponse mockResponse = new GetMinorCreditorAccountAtAGlanceResponse();
 
-        when(minorCreditorService.getMinorCreditorAtAGlance(101L, BEARER_TOKEN)).thenReturn(mockResponse);
+        when(minorCreditorService.getMinorCreditorAtAGlance(101L)).thenReturn(mockResponse);
 
         // Act
         ResponseEntity<GetMinorCreditorAccountAtAGlanceResponse> responseEntity =
-            minorCreditorController.getMinorCreditorsAtAGlance(101L,  BEARER_TOKEN);
+            minorCreditorController.getMinorCreditorsAtAGlance(101L);
 
         // Assert
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
@@ -83,11 +82,11 @@ class MinorCreditorControllerTest {
     @Test
     void testDeleteMinorCreditor_Success() {
         // Arrange
-        when(opalCreditorAccountService.deleteCreditorAccount(anyLong(), anyBoolean(), anyString())).thenReturn("OK");
+        when(opalCreditorAccountService.deleteCreditorAccount(anyLong(), anyBoolean())).thenReturn("OK");
 
         // Act
         ResponseEntity<String> responseEntity = minorCreditorController
-            .deleteMinorCreditorById(444L, "auth", "if-match", Optional.of(false));
+            .deleteMinorCreditorById(444L, "if-match", Optional.of(false));
 
         // Assert
         assertEquals(HttpStatus.OK, responseEntity.getStatusCode());

--- a/src/test/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerTest.java
@@ -28,8 +28,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class MinorCreditorControllerTest {
 
-    static final String BEARER_TOKEN = "Bearer a_token_here";
-
     @Mock
     MinorCreditorService minorCreditorService;
 

--- a/src/test/java/uk/gov/hmcts/opal/service/CentralFundServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/CentralFundServiceTest.java
@@ -51,28 +51,28 @@ class CentralFundServiceTest {
             .version(BigInteger.valueOf(7))
             .build();
 
-        when(userStateService.checkForAuthorisedUser(AUTH_HEADER)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(creditorAccountRepository.findCentralFundByBusinessUnitId((short) 70))
             .thenReturn(Optional.of(centralFund));
         when(centralFundMapper.toCentralFundResponse(centralFund)).thenReturn(mappedResponse);
 
-        CentralFundResponse response = centralFundService.getCentralFundByBusinessUnit(70, AUTH_HEADER);
+        CentralFundResponse response = centralFundService.getCentralFundByBusinessUnit(70);
 
         assertSame(mappedResponse, response);
-        verify(userStateService).checkForAuthorisedUser(AUTH_HEADER);
+        verify(userStateService).checkForAuthorisedUser();
         verify(creditorAccountRepository).findCentralFundByBusinessUnitId((short) 70);
         verify(centralFundMapper).toCentralFundResponse(centralFund);
     }
 
     @Test
     void getCentralFundByBusinessUnit_whenUserLacksPermission_throwsPermissionNotAllowedException() {
-        when(userStateService.checkForAuthorisedUser(AUTH_HEADER)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
 
         PermissionNotAllowedException exception = assertThrows(
             PermissionNotAllowedException.class,
-            () -> centralFundService.getCentralFundByBusinessUnit(70, AUTH_HEADER)
+            () -> centralFundService.getCentralFundByBusinessUnit(70)
         );
 
         assertThat(exception.getPermission()).containsExactly(SEARCH_AND_VIEW_ACCOUNTS);
@@ -81,13 +81,13 @@ class CentralFundServiceTest {
 
     @Test
     void getCentralFundByBusinessUnit_whenCentralFundDoesNotExist_throwsEntityNotFoundException() {
-        when(userStateService.checkForAuthorisedUser(AUTH_HEADER)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(creditorAccountRepository.findCentralFundByBusinessUnitId((short) 70)).thenReturn(Optional.empty());
 
         EntityNotFoundException exception = assertThrows(
             EntityNotFoundException.class,
-            () -> centralFundService.getCentralFundByBusinessUnit(70, AUTH_HEADER)
+            () -> centralFundService.getCentralFundByBusinessUnit(70)
         );
 
         assertEquals("Central fund not found for business unit: 70", exception.getMessage());
@@ -96,12 +96,12 @@ class CentralFundServiceTest {
 
     @Test
     void getCentralFundByBusinessUnit_whenBusinessUnitIdOutOfRange_throwsIllegalArgumentException() {
-        when(userStateService.checkForAuthorisedUser(AUTH_HEADER)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
 
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            () -> centralFundService.getCentralFundByBusinessUnit(Short.MAX_VALUE + 1, AUTH_HEADER)
+            () -> centralFundService.getCentralFundByBusinessUnit(Short.MAX_VALUE + 1)
         );
 
         assertEquals("Business unit id is out of range: 32768", exception.getMessage());

--- a/src/test/java/uk/gov/hmcts/opal/service/CentralFundServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/CentralFundServiceTest.java
@@ -51,7 +51,7 @@ class CentralFundServiceTest {
             .version(BigInteger.valueOf(7))
             .build();
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(creditorAccountRepository.findCentralFundByBusinessUnitId((short) 70))
             .thenReturn(Optional.of(centralFund));
@@ -60,14 +60,14 @@ class CentralFundServiceTest {
         CentralFundResponse response = centralFundService.getCentralFundByBusinessUnit(70);
 
         assertSame(mappedResponse, response);
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(creditorAccountRepository).findCentralFundByBusinessUnitId((short) 70);
         verify(centralFundMapper).toCentralFundResponse(centralFund);
     }
 
     @Test
     void getCentralFundByBusinessUnit_whenUserLacksPermission_throwsPermissionNotAllowedException() {
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
 
         PermissionNotAllowedException exception = assertThrows(
@@ -81,7 +81,7 @@ class CentralFundServiceTest {
 
     @Test
     void getCentralFundByBusinessUnit_whenCentralFundDoesNotExist_throwsEntityNotFoundException() {
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(creditorAccountRepository.findCentralFundByBusinessUnitId((short) 70)).thenReturn(Optional.empty());
 
@@ -96,7 +96,7 @@ class CentralFundServiceTest {
 
     @Test
     void getCentralFundByBusinessUnit_whenBusinessUnitIdOutOfRange_throwsIllegalArgumentException() {
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
 
         IllegalArgumentException exception = assertThrows(

--- a/src/test/java/uk/gov/hmcts/opal/service/CentralFundServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/CentralFundServiceTest.java
@@ -27,8 +27,6 @@ import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
 @ExtendWith(MockitoExtension.class)
 class CentralFundServiceTest {
 
-    private static final String AUTH_HEADER = "Bearer test-token";
-
     @Mock
     private UserStateService userStateService;
 

--- a/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountEnforcementServiceTest.java
@@ -68,7 +68,7 @@ class DefendantAccountEnforcementServiceTest {
             .version(3)
             .build();
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT)).thenReturn(true);
 
         // business unit user lookup returns an Optional<BusinessUnitUser> with a non-blank ID
@@ -90,7 +90,7 @@ class DefendantAccountEnforcementServiceTest {
         assertSame(proxyResponse, result, "Should return exactly the proxy response");
 
         // verify interactions
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT);
         verify(userState).getBusinessUnitUserForBusinessUnit((short)10);
         verify(defendantAccountEnforcementServiceProxy)
@@ -105,7 +105,7 @@ class DefendantAccountEnforcementServiceTest {
         Short businessUnitId = 10;
         String authHeader = "Bearer abc";
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT))
             .thenReturn(false);
 
@@ -122,7 +122,7 @@ class DefendantAccountEnforcementServiceTest {
         );
         assertThat(ex.getPermission()).containsExactly(FinesPermission.ENTER_ENFORCEMENT);
 
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT);
         verifyNoInteractions(defendantAccountEnforcementServiceProxy);
     }
@@ -136,7 +136,7 @@ class DefendantAccountEnforcementServiceTest {
 
         AddDefendantAccountEnforcementRequest req = mock(AddDefendantAccountEnforcementRequest.class);
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT)).thenReturn(true);
 
         // return Optional<BusinessUnitUser> but with blank ID -> results in null
@@ -182,7 +182,7 @@ class DefendantAccountEnforcementServiceTest {
             .isHmrcCheckEligible(true)
             .version(new BigInteger("1234567890123345678901234567890"))
             .build();
-        when(userStateService.checkForAuthorisedUser()).thenReturn(allPermissionsUser());
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(allPermissionsUser());
         when(defendantAccountEnforcementServiceProxy.getEnforcementStatus(anyLong())).thenReturn(status);
 
         // Act
@@ -220,7 +220,7 @@ class DefendantAccountEnforcementServiceTest {
             .filter(id -> !id.isBlank())
             .orElse(userState.getUserName());
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         when(defendantAccountEnforcementServiceProxy.removeEnforcementHold(
             eq(defendantAccountId),
@@ -242,7 +242,7 @@ class DefendantAccountEnforcementServiceTest {
         // assert
         assertSame(proxyResponse, result);
 
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(defendantAccountEnforcementServiceProxy).removeEnforcementHold(
             eq(defendantAccountId),
             eq(businessUnitId),
@@ -266,7 +266,7 @@ class DefendantAccountEnforcementServiceTest {
                 .reason("remove hold reason")
                 .build();
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUserForBusinessUnit((short) 10)).thenReturn(Optional.empty());
         when(userState.getUserName()).thenReturn("user-1");
         when(userState.hasBusinessUnitUserWithPermission((short) 10, FinesPermission.ENTER_ENFORCEMENT))
@@ -286,7 +286,7 @@ class DefendantAccountEnforcementServiceTest {
         // assert
         assertThat(ex.getPermission()).containsExactly(FinesPermission.ENTER_ENFORCEMENT);
 
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).getBusinessUnitUserForBusinessUnit((short) 10);
         verify(userState).getUserName();
         verify(userState).hasBusinessUnitUserWithPermission((short) 10, FinesPermission.ENTER_ENFORCEMENT);
@@ -319,7 +319,7 @@ class DefendantAccountEnforcementServiceTest {
                 .build()))
             .build();
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         when(defendantAccountEnforcementServiceProxy.removeEnforcementHold(
             eq(defendantAccountId),
@@ -341,7 +341,7 @@ class DefendantAccountEnforcementServiceTest {
         // assert
         assertSame(proxyResponse, result);
 
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(defendantAccountEnforcementServiceProxy).removeEnforcementHold(
             eq(defendantAccountId),
             eq(businessUnitId),
@@ -373,7 +373,7 @@ class DefendantAccountEnforcementServiceTest {
 
         UserState userState = mock(UserState.class);
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.hasBusinessUnitUserWithPermission((short) 10, FinesPermission.ENTER_ENFORCEMENT))
             .thenReturn(true);
         when(userState.getBusinessUnitUserForBusinessUnit((short) 10))
@@ -400,7 +400,7 @@ class DefendantAccountEnforcementServiceTest {
         // assert
         assertSame(proxyResponse, result);
 
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).hasBusinessUnitUserWithPermission((short) 10, FinesPermission.ENTER_ENFORCEMENT);
         verify(userState).getBusinessUnitUserForBusinessUnit((short) 10);
         verify(userState).getUserName();
@@ -438,7 +438,7 @@ class DefendantAccountEnforcementServiceTest {
             .filter(id -> !id.isBlank())
             .orElse(userState.getUserName());
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         when(defendantAccountEnforcementServiceProxy.removeEnforcementHold(
             eq(defendantAccountId),

--- a/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountEnforcementServiceTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -69,7 +68,7 @@ class DefendantAccountEnforcementServiceTest {
             .version(3)
             .build();
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT)).thenReturn(true);
 
         // business unit user lookup returns an Optional<BusinessUnitUser> with a non-blank ID
@@ -79,23 +78,23 @@ class DefendantAccountEnforcementServiceTest {
             .thenReturn(java.util.Optional.of(buUser));
 
         when(defendantAccountEnforcementServiceProxy.addEnforcement(
-            defendantAccountId, businessUnitId, "BU-USER-1", ifMatch, authHeader, req))
+            defendantAccountId, businessUnitId, "BU-USER-1", ifMatch, req))
             .thenReturn(proxyResponse);
 
         // act
         AddEnforcementResponse result =
             defendantAccountEnforcementService
-                .addEnforcement(defendantAccountId, businessUnitId, ifMatch, authHeader, req);
+                .addEnforcement(defendantAccountId, businessUnitId, ifMatch, req);
 
         // assert
         assertSame(proxyResponse, result, "Should return exactly the proxy response");
 
         // verify interactions
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT);
         verify(userState).getBusinessUnitUserForBusinessUnit((short)10);
         verify(defendantAccountEnforcementServiceProxy)
-            .addEnforcement(defendantAccountId, businessUnitId, "BU-USER-1", ifMatch, authHeader, req);
+            .addEnforcement(defendantAccountId, businessUnitId, "BU-USER-1", ifMatch, req);
         verifyNoMoreInteractions(userStateService, userState, defendantAccountEnforcementServiceProxy);
     }
 
@@ -106,7 +105,7 @@ class DefendantAccountEnforcementServiceTest {
         Short businessUnitId = 10;
         String authHeader = "Bearer abc";
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT))
             .thenReturn(false);
 
@@ -114,7 +113,7 @@ class DefendantAccountEnforcementServiceTest {
         PermissionNotAllowedException ex = assertThrows(
             PermissionNotAllowedException.class,
             () -> defendantAccountEnforcementService
-                .addEnforcement(defendantAccountId, businessUnitId, "3", authHeader, null)
+                .addEnforcement(defendantAccountId, businessUnitId, "3", null)
         );
 
         assertTrue(
@@ -123,7 +122,7 @@ class DefendantAccountEnforcementServiceTest {
         );
         assertThat(ex.getPermission()).containsExactly(FinesPermission.ENTER_ENFORCEMENT);
 
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT);
         verifyNoInteractions(defendantAccountEnforcementServiceProxy);
     }
@@ -137,7 +136,7 @@ class DefendantAccountEnforcementServiceTest {
 
         AddDefendantAccountEnforcementRequest req = mock(AddDefendantAccountEnforcementRequest.class);
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT)).thenReturn(true);
 
         // return Optional<BusinessUnitUser> but with blank ID -> results in null
@@ -155,14 +154,13 @@ class DefendantAccountEnforcementServiceTest {
             eq(businessUnitId),
             isNull(),                   // IMPORTANT: businessUnitUserId expected to be null
             eq("3"),
-            eq(authHeader),
             eq(req)
         )).thenReturn(proxyResult);
 
         // act
         AddEnforcementResponse out =
             defendantAccountEnforcementService
-                .addEnforcement(defendantAccountId, businessUnitId, "3", authHeader, req);
+                .addEnforcement(defendantAccountId, businessUnitId, "3", req);
 
         // assert
         assertNotNull(out);
@@ -171,7 +169,6 @@ class DefendantAccountEnforcementServiceTest {
             eq(businessUnitId),
             isNull(),                   // verifies null is passed
             eq("3"),
-            eq(authHeader),
             eq(req)
         );
     }
@@ -185,12 +182,12 @@ class DefendantAccountEnforcementServiceTest {
             .isHmrcCheckEligible(true)
             .version(new BigInteger("1234567890123345678901234567890"))
             .build();
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(allPermissionsUser());
+        when(userStateService.checkForAuthorisedUser()).thenReturn(allPermissionsUser());
         when(defendantAccountEnforcementServiceProxy.getEnforcementStatus(anyLong())).thenReturn(status);
 
         // Act
         EnforcementStatus response = defendantAccountEnforcementService
-            .getEnforcementStatus(33L, "Bearer a_bearer_token");
+            .getEnforcementStatus(33L);
 
         // Assert
         assertNotNull(response);
@@ -223,14 +220,13 @@ class DefendantAccountEnforcementServiceTest {
             .filter(id -> !id.isBlank())
             .orElse(userState.getUserName());
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
 
         when(defendantAccountEnforcementServiceProxy.removeEnforcementHold(
             eq(defendantAccountId),
             eq(businessUnitId),
             eq(businessUnitUserId),
             eq(ifMatch),
-            eq(authHeader),
             eq(request)
         )).thenReturn(proxyResponse);
 
@@ -240,20 +236,18 @@ class DefendantAccountEnforcementServiceTest {
                 defendantAccountId,
                 businessUnitId,
                 ifMatch,
-                authHeader,
                 request
             );
 
         // assert
         assertSame(proxyResponse, result);
 
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(defendantAccountEnforcementServiceProxy).removeEnforcementHold(
             eq(defendantAccountId),
             eq(businessUnitId),
             eq(businessUnitUserId),
             eq(ifMatch),
-            eq(authHeader),
             eq(request)
         );
         verifyNoMoreInteractions(defendantAccountEnforcementServiceProxy);
@@ -272,7 +266,7 @@ class DefendantAccountEnforcementServiceTest {
                 .reason("remove hold reason")
                 .build();
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.getBusinessUnitUserForBusinessUnit((short) 10)).thenReturn(Optional.empty());
         when(userState.getUserName()).thenReturn("user-1");
         when(userState.hasBusinessUnitUserWithPermission((short) 10, FinesPermission.ENTER_ENFORCEMENT))
@@ -285,7 +279,6 @@ class DefendantAccountEnforcementServiceTest {
                 defendantAccountId,
                 businessUnitId,
                 ifMatch,
-                authHeader,
                 request
             )
         );
@@ -293,7 +286,7 @@ class DefendantAccountEnforcementServiceTest {
         // assert
         assertThat(ex.getPermission()).containsExactly(FinesPermission.ENTER_ENFORCEMENT);
 
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).getBusinessUnitUserForBusinessUnit((short) 10);
         verify(userState).getUserName();
         verify(userState).hasBusinessUnitUserWithPermission((short) 10, FinesPermission.ENTER_ENFORCEMENT);
@@ -326,14 +319,13 @@ class DefendantAccountEnforcementServiceTest {
                 .build()))
             .build();
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
 
         when(defendantAccountEnforcementServiceProxy.removeEnforcementHold(
             eq(defendantAccountId),
             eq(businessUnitId),
             eq("user-1"),
             eq(ifMatch),
-            eq(authHeader),
             eq(request)
         )).thenReturn(proxyResponse);
 
@@ -343,20 +335,18 @@ class DefendantAccountEnforcementServiceTest {
                 defendantAccountId,
                 businessUnitId,
                 ifMatch,
-                authHeader,
                 request
             );
 
         // assert
         assertSame(proxyResponse, result);
 
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(defendantAccountEnforcementServiceProxy).removeEnforcementHold(
             eq(defendantAccountId),
             eq(businessUnitId),
             eq("user-1"),
             eq(ifMatch),
-            eq(authHeader),
             eq(request)
         );
         verifyNoMoreInteractions(defendantAccountEnforcementServiceProxy);
@@ -383,7 +373,7 @@ class DefendantAccountEnforcementServiceTest {
 
         UserState userState = mock(UserState.class);
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.hasBusinessUnitUserWithPermission((short) 10, FinesPermission.ENTER_ENFORCEMENT))
             .thenReturn(true);
         when(userState.getBusinessUnitUserForBusinessUnit((short) 10))
@@ -395,7 +385,6 @@ class DefendantAccountEnforcementServiceTest {
             eq(businessUnitId),
             eq("user-1"),
             eq(ifMatch),
-            eq(authHeader),
             eq(request)
         )).thenReturn(proxyResponse);
 
@@ -405,14 +394,13 @@ class DefendantAccountEnforcementServiceTest {
                 defendantAccountId,
                 businessUnitId,
                 ifMatch,
-                authHeader,
                 request
             );
 
         // assert
         assertSame(proxyResponse, result);
 
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).hasBusinessUnitUserWithPermission((short) 10, FinesPermission.ENTER_ENFORCEMENT);
         verify(userState).getBusinessUnitUserForBusinessUnit((short) 10);
         verify(userState).getUserName();
@@ -421,7 +409,6 @@ class DefendantAccountEnforcementServiceTest {
             eq(businessUnitId),
             eq("user-1"),
             eq(ifMatch),
-            eq(authHeader),
             eq(request)
         );
         verifyNoMoreInteractions(defendantAccountEnforcementServiceProxy);
@@ -451,14 +438,13 @@ class DefendantAccountEnforcementServiceTest {
             .filter(id -> !id.isBlank())
             .orElse(userState.getUserName());
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
 
         when(defendantAccountEnforcementServiceProxy.removeEnforcementHold(
             eq(defendantAccountId),
             eq(businessUnitId),
             eq(businessUnitUserId),
             isNull(), // key assertion
-            eq(authHeader),
             eq(request)
         )).thenReturn(proxyResponse);
 
@@ -467,7 +453,6 @@ class DefendantAccountEnforcementServiceTest {
                 defendantAccountId,
                 businessUnitId,
                 null, // key input
-                authHeader,
                 request
             );
 
@@ -478,7 +463,6 @@ class DefendantAccountEnforcementServiceTest {
             eq(businessUnitId),
             eq(businessUnitUserId),
             isNull(),
-            eq(authHeader),
             eq(request)
         );
     }

--- a/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountEnforcementServiceTest.java
@@ -59,7 +59,6 @@ class DefendantAccountEnforcementServiceTest {
         Long defendantAccountId = 77L;
         Short businessUnitId = 10;
         String ifMatch = "3";
-        String authHeader = "Bearer abc";
         AddDefendantAccountEnforcementRequest req = mock(AddDefendantAccountEnforcementRequest.class);
 
         AddEnforcementResponse proxyResponse = AddEnforcementResponse.builder()
@@ -103,7 +102,6 @@ class DefendantAccountEnforcementServiceTest {
         // arrange
         Long defendantAccountId = 77L;
         Short businessUnitId = 10;
-        String authHeader = "Bearer abc";
 
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT))
@@ -132,7 +130,6 @@ class DefendantAccountEnforcementServiceTest {
         // arrange
         Long defendantAccountId = 77L;
         Short businessUnitId = 10;
-        String authHeader = "Bearer abc";
 
         AddDefendantAccountEnforcementRequest req = mock(AddDefendantAccountEnforcementRequest.class);
 
@@ -203,7 +200,6 @@ class DefendantAccountEnforcementServiceTest {
         Long defendantAccountId = 77L;
         Short businessUnitId = 10;
         String ifMatch = "\"7\"";
-        String authHeader = "Bearer abc";
 
         RemoveDefendantAccountEnforcementHoldRequest request =
             RemoveDefendantAccountEnforcementHoldRequest.builder()
@@ -259,7 +255,6 @@ class DefendantAccountEnforcementServiceTest {
         Long defendantAccountId = 77L;
         Short businessUnitId = 10;
         String ifMatch = "\"7\"";
-        String authHeader = "Bearer abc";
 
         RemoveDefendantAccountEnforcementHoldRequest request =
             RemoveDefendantAccountEnforcementHoldRequest.builder()
@@ -299,7 +294,6 @@ class DefendantAccountEnforcementServiceTest {
         Long defendantAccountId = 77L;
         Short businessUnitId = 10;
         String ifMatch = "\"7\"";
-        String authHeader = "Bearer abc";
 
         RemoveDefendantAccountEnforcementHoldRequest request =
             RemoveDefendantAccountEnforcementHoldRequest.builder()
@@ -358,7 +352,6 @@ class DefendantAccountEnforcementServiceTest {
         Long defendantAccountId = 77L;
         Short businessUnitId = 10;
         String ifMatch = "\"7\"";
-        String authHeader = "Bearer abc";
 
         RemoveDefendantAccountEnforcementHoldRequest request =
             RemoveDefendantAccountEnforcementHoldRequest.builder()
@@ -418,7 +411,6 @@ class DefendantAccountEnforcementServiceTest {
     void removeEnforcementHold_whenIfMatchIsNull_passesNullToProxy() {
         Long defendantAccountId = 77L;
         Short businessUnitId = 10;
-        String authHeader = "Bearer abc";
 
         RemoveDefendantAccountEnforcementHoldRequest request =
             RemoveDefendantAccountEnforcementHoldRequest.builder()

--- a/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountPartyServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountPartyServiceTest.java
@@ -58,18 +58,18 @@ class DefendantAccountPartyServiceTest {
 
         GetDefendantAccountPartyResponse expectedResponse = mock(GetDefendantAccountPartyResponse.class);
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(defendantAccountPartyServiceProxy.getDefendantAccountParty(defendantAccountId, defendantAccountPartyId))
             .thenReturn(expectedResponse);
 
         // Act
         GetDefendantAccountPartyResponse actual = defendantAccountPartyService
-            .getDefendantAccountParty(defendantAccountId, defendantAccountPartyId, authHeader);
+            .getDefendantAccountParty(defendantAccountId, defendantAccountPartyId);
 
         // Assert
         assertThat(actual).isSameAs(expectedResponse);
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verify(defendantAccountPartyServiceProxy).getDefendantAccountParty(defendantAccountId, defendantAccountPartyId);
     }
@@ -81,19 +81,19 @@ class DefendantAccountPartyServiceTest {
         Long defendantAccountId = 1L;
         Long defendantAccountPartyId = 2L;
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
 
         // Act & Assert
         PermissionNotAllowedException ex = assertThrows(
             PermissionNotAllowedException.class, () ->
                 defendantAccountPartyService
-                    .getDefendantAccountParty(defendantAccountId, defendantAccountPartyId, authHeader)
+                    .getDefendantAccountParty(defendantAccountId, defendantAccountPartyId)
         );
 
         assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
 
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verifyNoInteractions(defendantAccountPartyServiceProxy);
     }
@@ -113,7 +113,7 @@ class DefendantAccountPartyServiceTest {
 
         BusinessUnitUser buUser = mock(BusinessUnitUser.class);
         when(buUser.getBusinessUnitUserId()).thenReturn("b-user-id");
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.getBusinessUnitUserForBusinessUnit(buId)).thenReturn(Optional.of(buUser));
         when(userState.getUserName()).thenReturn("theUserName");
         when(userState.hasBusinessUnitUserWithPermission(eq(buId), eq(FinesPermission.ACCOUNT_MAINTENANCE)))
@@ -126,7 +126,7 @@ class DefendantAccountPartyServiceTest {
 
         // Act
         GetDefendantAccountPartyResponse actual = defendantAccountPartyService.replaceDefendantAccountParty(
-            defendantAccountId, defendantAccountPartyId, authHeader, ifMatch, businessUnitId, request
+            defendantAccountId, defendantAccountPartyId, ifMatch, businessUnitId, request
         );
 
         // Assert
@@ -169,7 +169,7 @@ class DefendantAccountPartyServiceTest {
 
         BusinessUnitUser buUser = mock(BusinessUnitUser.class);
         when(buUser.getBusinessUnitUserId()).thenReturn("b-user-id");
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.getBusinessUnitUserForBusinessUnit(buId)).thenReturn(Optional.of(buUser));
         when(userState.getUserName()).thenReturn("theUserName");
         when(userState.hasBusinessUnitUserWithPermission(eq(buId), eq(FinesPermission.ACCOUNT_MAINTENANCE)))
@@ -182,7 +182,7 @@ class DefendantAccountPartyServiceTest {
 
         // Act
         GetDefendantAccountPartyResponse actual = defendantAccountPartyService.addDefendantAccountParty(
-            defendantAccountId, authHeader, ifMatch, businessUnitId, request
+            defendantAccountId, ifMatch, businessUnitId, request
         );
 
         // Assert
@@ -223,7 +223,7 @@ class DefendantAccountPartyServiceTest {
         GetDefendantAccountPartyResponse expectedResponse = mock(GetDefendantAccountPartyResponse.class);
 
         // No BusinessUnitUser present
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.getBusinessUnitUserForBusinessUnit(buId)).thenReturn(Optional.empty());
         when(userState.getUserName()).thenReturn("theUserName");
         when(userState.hasBusinessUnitUserWithPermission(eq(buId), eq(FinesPermission.ACCOUNT_MAINTENANCE)))
@@ -236,7 +236,7 @@ class DefendantAccountPartyServiceTest {
 
         // Act
         GetDefendantAccountPartyResponse actual = defendantAccountPartyService.replaceDefendantAccountParty(
-            defendantAccountId, defendantAccountPartyId, authHeader, ifMatch, businessUnitId, request
+            defendantAccountId, defendantAccountPartyId, ifMatch, businessUnitId, request
         );
 
         // Assert
@@ -277,7 +277,7 @@ class DefendantAccountPartyServiceTest {
         GetDefendantAccountPartyResponse expectedResponse = mock(GetDefendantAccountPartyResponse.class);
 
         // No BusinessUnitUser present
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.getBusinessUnitUserForBusinessUnit(buId)).thenReturn(Optional.empty());
         when(userState.getUserName()).thenReturn("theUserName");
         when(userState.hasBusinessUnitUserWithPermission(eq(buId), eq(FinesPermission.ACCOUNT_MAINTENANCE)))
@@ -290,7 +290,7 @@ class DefendantAccountPartyServiceTest {
 
         // Act
         GetDefendantAccountPartyResponse actual = defendantAccountPartyService.addDefendantAccountParty(
-            defendantAccountId, authHeader, ifMatch, businessUnitId, request
+            defendantAccountId, ifMatch, businessUnitId, request
         );
 
         // Assert
@@ -328,7 +328,7 @@ class DefendantAccountPartyServiceTest {
         String stringBusinessUnitId = String.valueOf(businessUnitId);
         DefendantAccountParty request = new DefendantAccountParty();
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.hasBusinessUnitUserWithPermission(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE))
             .thenReturn(false);
 
@@ -336,13 +336,13 @@ class DefendantAccountPartyServiceTest {
         PermissionNotAllowedException ex = assertThrows(
             PermissionNotAllowedException.class,
             () -> defendantAccountPartyService.replaceDefendantAccountParty(
-                defendantAccountId, defendantAccountPartyId, authHeader, ifMatch, stringBusinessUnitId, request)
+                defendantAccountId, defendantAccountPartyId, ifMatch, stringBusinessUnitId, request)
         );
 
         assertThat(ex.getPermission()).containsExactly(FinesPermission.ACCOUNT_MAINTENANCE);
         assertThat(ex.getBusinessUnitId()).isEqualTo(businessUnitId);
 
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).hasBusinessUnitUserWithPermission(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE);
         verifyNoInteractions(defendantAccountPartyServiceProxy);
     }
@@ -358,7 +358,7 @@ class DefendantAccountPartyServiceTest {
         String stringBusinessUnitId = String.valueOf(businessUnitId);
         AddDefendantAccountPartyRequest request = new AddDefendantAccountPartyRequest();
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.hasBusinessUnitUserWithPermission(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE))
             .thenReturn(false);
 
@@ -366,13 +366,13 @@ class DefendantAccountPartyServiceTest {
         PermissionNotAllowedException ex = assertThrows(
             PermissionNotAllowedException.class,
             () -> defendantAccountPartyService.addDefendantAccountParty(
-                defendantAccountId, authHeader, ifMatch, stringBusinessUnitId, request)
+                defendantAccountId, ifMatch, stringBusinessUnitId, request)
         );
 
         assertThat(ex.getPermission()).containsExactly(FinesPermission.ACCOUNT_MAINTENANCE);
         assertThat(ex.getBusinessUnitId()).isEqualTo(businessUnitId);
 
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).hasBusinessUnitUserWithPermission(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE);
         verifyNoInteractions(defendantAccountPartyServiceProxy);
     }
@@ -390,7 +390,7 @@ class DefendantAccountPartyServiceTest {
 
         BusinessUnitUser buUser = mock(BusinessUnitUser.class);
         when(buUser.getBusinessUnitUserId()).thenReturn("bu-user-id");
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.getBusinessUnitUserForBusinessUnit(businessUnitId)).thenReturn(Optional.of(buUser));
         when(userState.getUserName()).thenReturn("theUserName");
         when(userState.hasBusinessUnitUserWithPermission(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE))
@@ -408,7 +408,7 @@ class DefendantAccountPartyServiceTest {
 
         // Act
         RemoveDefendantAccountPartyResponse actual = defendantAccountPartyService.removeDefendantAccountParty(
-            defendantAccountId, defendantAccountPartyId, businessUnitId, ifMatch, authHeader, request);
+            defendantAccountId, defendantAccountPartyId, businessUnitId, ifMatch, request);
 
         // Assert
         assertThat(actual).isSameAs(expectedResponse);
@@ -447,7 +447,7 @@ class DefendantAccountPartyServiceTest {
         RemoveDefendantAccountPartyResponse expectedResponse = mock(RemoveDefendantAccountPartyResponse.class);
 
         // No BusinessUnitUser present
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.getBusinessUnitUserForBusinessUnit(businessUnitId)).thenReturn(Optional.empty());
         when(userState.getUserName()).thenReturn("fallback-user");
         when(userState.hasBusinessUnitUserWithPermission(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE))
@@ -465,7 +465,7 @@ class DefendantAccountPartyServiceTest {
 
         // Act
         RemoveDefendantAccountPartyResponse actual = defendantAccountPartyService.removeDefendantAccountParty(
-            defendantAccountId, defendantAccountPartyId, businessUnitId, ifMatch, authHeader, request);
+            defendantAccountId, defendantAccountPartyId, businessUnitId, ifMatch, request);
 
         // Assert
         assertThat(actual).isSameAs(expectedResponse);
@@ -501,7 +501,7 @@ class DefendantAccountPartyServiceTest {
         String ifMatch = "W/\"5\"";
         RemoveDefendantAccountPartyRequest request = new RemoveDefendantAccountPartyRequest();
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.hasBusinessUnitUserWithPermission(
             businessUnitId,
             FinesPermission.ACCOUNT_MAINTENANCE
@@ -510,13 +510,13 @@ class DefendantAccountPartyServiceTest {
         PermissionNotAllowedException ex = assertThrows(
             PermissionNotAllowedException.class, () ->
                 defendantAccountPartyService.removeDefendantAccountParty(
-                    defendantAccountId, defendantAccountPartyId, businessUnitId, ifMatch, authHeader, request)
+                    defendantAccountId, defendantAccountPartyId, businessUnitId, ifMatch, request)
         );
 
         // When the user does not have the correct permission, the call is not passed to the proxy
         assertThat(ex.getPermission()).containsExactly(FinesPermission.ACCOUNT_MAINTENANCE);
         assertThat(ex.getBusinessUnitId()).isNull();
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).hasBusinessUnitUserWithPermission(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE);
         verifyNoInteractions(defendantAccountPartyServiceProxy);
     }

--- a/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountPartyServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountPartyServiceTest.java
@@ -52,7 +52,6 @@ class DefendantAccountPartyServiceTest {
     @Test
     void getDefendantAccountParty_whenUserHasPermission_returnsResponse() {
         // Arrange
-        String authHeader = "Bearer token";
         Long defendantAccountId = 1L;
         Long defendantAccountPartyId = 2L;
 
@@ -77,7 +76,6 @@ class DefendantAccountPartyServiceTest {
     @Test
     void getDefendantAccountParty_whenUserLacksPermission_throwsPermissionNotAllowedException() {
         // Arrange
-        String authHeader = "Bearer token";
         Long defendantAccountId = 1L;
         Long defendantAccountPartyId = 2L;
 
@@ -101,7 +99,6 @@ class DefendantAccountPartyServiceTest {
     @Test
     void replaceDefendantAccountParty_whenUserHasPermission_passesPostedByAndBusinessUnitUserIdToProxy() {
         // Arrange
-        String authHeader = "Bearer token";
         Long defendantAccountId = 10L;
         Long defendantAccountPartyId = 20L;
         String ifMatch = "W/\"1\"";
@@ -156,7 +153,6 @@ class DefendantAccountPartyServiceTest {
     @Test
     void addDefendantAccountParty_whenUserHasPermission_passesPostedByAndBusinessUnitUserIdToProxy() {
         // Arrange
-        String authHeader = "Bearer token";
         Long defendantAccountId = 10L;
         Long defendantAccountPartyId = 20L;
         String ifMatch = "W/\"1\"";
@@ -212,7 +208,6 @@ class DefendantAccountPartyServiceTest {
     @Test
     void replaceDefendantAccountParty_whenBusinessUnitUserMissing_usesUserNameForPostedByAndEmptyBusinessUnitUserId() {
         // Arrange
-        String authHeader = "Bearer token";
         Long defendantAccountId = 11L;
         Long defendantAccountPartyId = 22L;
         String ifMatch = "W/\"2\"";
@@ -266,7 +261,6 @@ class DefendantAccountPartyServiceTest {
     @Test
     void addDefendantAccountParty_whenBusinessUnitUserMissing_usesUserNameForPostedByAndEmptyBusinessUnitUserId() {
         // Arrange
-        String authHeader = "Bearer token";
         Long defendantAccountId = 11L;
         Long defendantAccountPartyId = 22L;
         String ifMatch = "W/\"2\"";
@@ -320,7 +314,6 @@ class DefendantAccountPartyServiceTest {
     @Test
     void replaceDefendantAccountParty_whenUserLacksPermission_throwsPermissionNotAllowedException() {
         // Arrange
-        String authHeader = "Bearer token";
         Long defendantAccountId = 100L;
         Long defendantAccountPartyId = 200L;
         String ifMatch = "W/\"X\"";
@@ -350,7 +343,6 @@ class DefendantAccountPartyServiceTest {
     @Test
     void addDefendantAccountParty_whenUserLacksPermission_throwsPermissionNotAllowedException() {
         // Arrange
-        String authHeader = "Bearer token";
         Long defendantAccountId = 100L;
         Long defendantAccountPartyId = 200L;
         String ifMatch = "W/\"X\"";
@@ -380,7 +372,6 @@ class DefendantAccountPartyServiceTest {
     @Test
     void removeDefendantAccountParty_whenUserHasPermission_passesPostedByAndBusinessUnitUserIdToProxy() {
         // Arrange
-        String authHeader = "Bearer token";
         Long defendantAccountId = 33L;
         Long defendantAccountPartyId = 44L;
         short businessUnitId = 9;
@@ -438,7 +429,6 @@ class DefendantAccountPartyServiceTest {
     @Test
     void removeDefendantAccountParty_whenBusinessUnitUserMissing_usesUserNameAndEmptyBusinessUnitUserId() {
         // Arrange
-        String authHeader = "Bearer token";
         Long defendantAccountId = 55L;
         Long defendantAccountPartyId = 66L;
         short businessUnitId = 11;
@@ -494,7 +484,6 @@ class DefendantAccountPartyServiceTest {
     @Test
     void removeDefendantAccountParty_whenUserLacksPermission_throwsPermissionNotAllowedException() {
         // Arrange
-        String authHeader = "Bearer token";
         Long defendantAccountId = 77L;
         Long defendantAccountPartyId = 88L;
         short businessUnitId = 13;

--- a/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountPartyServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountPartyServiceTest.java
@@ -58,7 +58,7 @@ class DefendantAccountPartyServiceTest {
 
         GetDefendantAccountPartyResponse expectedResponse = mock(GetDefendantAccountPartyResponse.class);
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(defendantAccountPartyServiceProxy.getDefendantAccountParty(defendantAccountId, defendantAccountPartyId))
             .thenReturn(expectedResponse);
@@ -69,7 +69,7 @@ class DefendantAccountPartyServiceTest {
 
         // Assert
         assertThat(actual).isSameAs(expectedResponse);
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verify(defendantAccountPartyServiceProxy).getDefendantAccountParty(defendantAccountId, defendantAccountPartyId);
     }
@@ -81,7 +81,7 @@ class DefendantAccountPartyServiceTest {
         Long defendantAccountId = 1L;
         Long defendantAccountPartyId = 2L;
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
 
         // Act & Assert
@@ -93,7 +93,7 @@ class DefendantAccountPartyServiceTest {
 
         assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
 
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verifyNoInteractions(defendantAccountPartyServiceProxy);
     }
@@ -113,7 +113,7 @@ class DefendantAccountPartyServiceTest {
 
         BusinessUnitUser buUser = mock(BusinessUnitUser.class);
         when(buUser.getBusinessUnitUserId()).thenReturn("b-user-id");
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUserForBusinessUnit(buId)).thenReturn(Optional.of(buUser));
         when(userState.getUserName()).thenReturn("theUserName");
         when(userState.hasBusinessUnitUserWithPermission(eq(buId), eq(FinesPermission.ACCOUNT_MAINTENANCE)))
@@ -169,7 +169,7 @@ class DefendantAccountPartyServiceTest {
 
         BusinessUnitUser buUser = mock(BusinessUnitUser.class);
         when(buUser.getBusinessUnitUserId()).thenReturn("b-user-id");
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUserForBusinessUnit(buId)).thenReturn(Optional.of(buUser));
         when(userState.getUserName()).thenReturn("theUserName");
         when(userState.hasBusinessUnitUserWithPermission(eq(buId), eq(FinesPermission.ACCOUNT_MAINTENANCE)))
@@ -223,7 +223,7 @@ class DefendantAccountPartyServiceTest {
         GetDefendantAccountPartyResponse expectedResponse = mock(GetDefendantAccountPartyResponse.class);
 
         // No BusinessUnitUser present
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUserForBusinessUnit(buId)).thenReturn(Optional.empty());
         when(userState.getUserName()).thenReturn("theUserName");
         when(userState.hasBusinessUnitUserWithPermission(eq(buId), eq(FinesPermission.ACCOUNT_MAINTENANCE)))
@@ -277,7 +277,7 @@ class DefendantAccountPartyServiceTest {
         GetDefendantAccountPartyResponse expectedResponse = mock(GetDefendantAccountPartyResponse.class);
 
         // No BusinessUnitUser present
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUserForBusinessUnit(buId)).thenReturn(Optional.empty());
         when(userState.getUserName()).thenReturn("theUserName");
         when(userState.hasBusinessUnitUserWithPermission(eq(buId), eq(FinesPermission.ACCOUNT_MAINTENANCE)))
@@ -328,7 +328,7 @@ class DefendantAccountPartyServiceTest {
         String stringBusinessUnitId = String.valueOf(businessUnitId);
         DefendantAccountParty request = new DefendantAccountParty();
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.hasBusinessUnitUserWithPermission(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE))
             .thenReturn(false);
 
@@ -342,7 +342,7 @@ class DefendantAccountPartyServiceTest {
         assertThat(ex.getPermission()).containsExactly(FinesPermission.ACCOUNT_MAINTENANCE);
         assertThat(ex.getBusinessUnitId()).isEqualTo(businessUnitId);
 
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).hasBusinessUnitUserWithPermission(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE);
         verifyNoInteractions(defendantAccountPartyServiceProxy);
     }
@@ -358,7 +358,7 @@ class DefendantAccountPartyServiceTest {
         String stringBusinessUnitId = String.valueOf(businessUnitId);
         AddDefendantAccountPartyRequest request = new AddDefendantAccountPartyRequest();
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.hasBusinessUnitUserWithPermission(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE))
             .thenReturn(false);
 
@@ -372,7 +372,7 @@ class DefendantAccountPartyServiceTest {
         assertThat(ex.getPermission()).containsExactly(FinesPermission.ACCOUNT_MAINTENANCE);
         assertThat(ex.getBusinessUnitId()).isEqualTo(businessUnitId);
 
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).hasBusinessUnitUserWithPermission(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE);
         verifyNoInteractions(defendantAccountPartyServiceProxy);
     }
@@ -390,7 +390,7 @@ class DefendantAccountPartyServiceTest {
 
         BusinessUnitUser buUser = mock(BusinessUnitUser.class);
         when(buUser.getBusinessUnitUserId()).thenReturn("bu-user-id");
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUserForBusinessUnit(businessUnitId)).thenReturn(Optional.of(buUser));
         when(userState.getUserName()).thenReturn("theUserName");
         when(userState.hasBusinessUnitUserWithPermission(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE))
@@ -447,7 +447,7 @@ class DefendantAccountPartyServiceTest {
         RemoveDefendantAccountPartyResponse expectedResponse = mock(RemoveDefendantAccountPartyResponse.class);
 
         // No BusinessUnitUser present
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUserForBusinessUnit(businessUnitId)).thenReturn(Optional.empty());
         when(userState.getUserName()).thenReturn("fallback-user");
         when(userState.hasBusinessUnitUserWithPermission(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE))
@@ -501,7 +501,7 @@ class DefendantAccountPartyServiceTest {
         String ifMatch = "W/\"5\"";
         RemoveDefendantAccountPartyRequest request = new RemoveDefendantAccountPartyRequest();
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.hasBusinessUnitUserWithPermission(
             businessUnitId,
             FinesPermission.ACCOUNT_MAINTENANCE
@@ -516,7 +516,7 @@ class DefendantAccountPartyServiceTest {
         // When the user does not have the correct permission, the call is not passed to the proxy
         assertThat(ex.getPermission()).containsExactly(FinesPermission.ACCOUNT_MAINTENANCE);
         assertThat(ex.getBusinessUnitId()).isNull();
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).hasBusinessUnitUserWithPermission(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE);
         verifyNoInteractions(defendantAccountPartyServiceProxy);
     }

--- a/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountPaymentTermsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountPaymentTermsServiceTest.java
@@ -40,7 +40,7 @@ class DefendantAccountPaymentTermsServiceTest {
         Long defendantAccountId = 77L;
         String authHeader = "Bearer abc";
         GetDefendantAccountPaymentTermsResponse proxyResponse = new GetDefendantAccountPaymentTermsResponse();
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(defendantAccountPaymentTermsServiceProxy.getPaymentTerms(defendantAccountId)).thenReturn(proxyResponse);
 
@@ -52,7 +52,7 @@ class DefendantAccountPaymentTermsServiceTest {
         assertSame(proxyResponse, result, "Should return exactly the proxy response");
 
         // verify interactions
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verify(defendantAccountPaymentTermsServiceProxy).getPaymentTerms(defendantAccountId);
         verifyNoMoreInteractions(userStateService, userState, defendantAccountPaymentTermsServiceProxy);
@@ -63,7 +63,7 @@ class DefendantAccountPaymentTermsServiceTest {
         // arrange
         Long defendantAccountId = 77L;
         String authHeader = "Bearer abc";
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
 
         // act + assert
@@ -77,7 +77,7 @@ class DefendantAccountPaymentTermsServiceTest {
         );
 
         // proxy must not be called
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verifyNoInteractions(defendantAccountPaymentTermsServiceProxy);
         verifyNoMoreInteractions(userStateService, userState);

--- a/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountPaymentTermsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountPaymentTermsServiceTest.java
@@ -38,7 +38,6 @@ class DefendantAccountPaymentTermsServiceTest {
     void getPaymentTerms_whenUserHasPermission_returnsProxyResult() {
         // arrange
         Long defendantAccountId = 77L;
-        String authHeader = "Bearer abc";
         GetDefendantAccountPaymentTermsResponse proxyResponse = new GetDefendantAccountPaymentTermsResponse();
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
@@ -62,7 +61,6 @@ class DefendantAccountPaymentTermsServiceTest {
     void getPaymentTerms_whenUserLacksPermission_throwsPermissionNotAllowed() {
         // arrange
         Long defendantAccountId = 77L;
-        String authHeader = "Bearer abc";
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
 

--- a/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountPaymentTermsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountPaymentTermsServiceTest.java
@@ -40,19 +40,19 @@ class DefendantAccountPaymentTermsServiceTest {
         Long defendantAccountId = 77L;
         String authHeader = "Bearer abc";
         GetDefendantAccountPaymentTermsResponse proxyResponse = new GetDefendantAccountPaymentTermsResponse();
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(defendantAccountPaymentTermsServiceProxy.getPaymentTerms(defendantAccountId)).thenReturn(proxyResponse);
 
         // act
         GetDefendantAccountPaymentTermsResponse result =
-            defendantAccountPaymentTermsService.getPaymentTerms(defendantAccountId, authHeader);
+            defendantAccountPaymentTermsService.getPaymentTerms(defendantAccountId);
 
         // assert
         assertSame(proxyResponse, result, "Should return exactly the proxy response");
 
         // verify interactions
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verify(defendantAccountPaymentTermsServiceProxy).getPaymentTerms(defendantAccountId);
         verifyNoMoreInteractions(userStateService, userState, defendantAccountPaymentTermsServiceProxy);
@@ -63,13 +63,13 @@ class DefendantAccountPaymentTermsServiceTest {
         // arrange
         Long defendantAccountId = 77L;
         String authHeader = "Bearer abc";
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
 
         // act + assert
         PermissionNotAllowedException ex = assertThrows(
             PermissionNotAllowedException.class,
-            () -> defendantAccountPaymentTermsService.getPaymentTerms(defendantAccountId, authHeader)
+            () -> defendantAccountPaymentTermsService.getPaymentTerms(defendantAccountId)
         );
         assertTrue(
             ex.getMessage() == null || ex.getMessage().contains(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS.name()),
@@ -77,7 +77,7 @@ class DefendantAccountPaymentTermsServiceTest {
         );
 
         // proxy must not be called
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verifyNoInteractions(defendantAccountPaymentTermsServiceProxy);
         verifyNoMoreInteractions(userStateService, userState);

--- a/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountServiceTest.java
@@ -83,7 +83,6 @@ class DefendantAccountServiceTest {
     void getPaymentTerms_whenUserHasPermission_returnsProxyResult() {
         // arrange
         Long defendantAccountId = 77L;
-        String authHeader = "Bearer abc";
         GetDefendantAccountPaymentTermsResponse proxyResponse = new GetDefendantAccountPaymentTermsResponse();
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
@@ -107,7 +106,6 @@ class DefendantAccountServiceTest {
     void getPaymentTerms_whenUserLacksPermission_throwsPermissionNotAllowed() {
         // arrange
         Long defendantAccountId = 77L;
-        String authHeader = "Bearer abc";
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
 
@@ -235,7 +233,6 @@ class DefendantAccountServiceTest {
         Long defendantAccountId = 77L;
         String businessUnitId = "78";
         String ifMatch = "\"1\"";
-        String authHeader = "Bearer token";
 
         UserState userWithPerm = UserStateUtil.permissionUser((short) 78, FinesPermission.AMEND_PAYMENT_TERMS);
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userWithPerm);
@@ -280,7 +277,6 @@ class DefendantAccountServiceTest {
     void getAtAGlance_whenUserHasPermission_returnsProxyResult() {
         // arrange
         Long defendantAccountId = 77L;
-        String authHeader = "Bearer abc";
         DefendantAccountAtAGlanceResponse proxyResponse = new DefendantAccountAtAGlanceResponse();
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
@@ -304,7 +300,6 @@ class DefendantAccountServiceTest {
     void getAtAGlance_whenUserLacksPermission_throwsPermissionNotAllowed() {
         // arrange
         Long defendantAccountId = 77L;
-        String authHeader = "Bearer abc";
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
 
@@ -333,7 +328,6 @@ class DefendantAccountServiceTest {
         Long defendantAccountId = 77L;
         String businessUnitId = "10";
         String ifMatch = "\"3\"";
-        String authHeader = "Bearer abc";
         AddDefendantAccountEnforcementRequest req = mock(AddDefendantAccountEnforcementRequest.class);
 
         AddEnforcementResponse proxyResponse = AddEnforcementResponse.builder()
@@ -376,7 +370,6 @@ class DefendantAccountServiceTest {
         // arrange
         Long defendantAccountId = 77L;
         String businessUnitId = "10";
-        String authHeader = "Bearer abc";
 
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT))
@@ -403,7 +396,6 @@ class DefendantAccountServiceTest {
         // arrange
         Long defendantAccountId = 77L;
         String businessUnitId = "10";
-        String authHeader = "Bearer abc";
 
         AddDefendantAccountEnforcementRequest req = mock(AddDefendantAccountEnforcementRequest.class);
 

--- a/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountServiceTest.java
@@ -70,7 +70,7 @@ class DefendantAccountServiceTest {
 
         when(defendantAccountServiceProxy.getHeaderSummary(anyLong())).thenReturn(headerSummary);
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(UserStateUtil.allFinesPermissionUser());
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(UserStateUtil.allFinesPermissionUser());
         // Act
         DefendantAccountHeaderSummary result = defendantAccountService.getHeaderSummary(1L);
 
@@ -85,7 +85,7 @@ class DefendantAccountServiceTest {
         Long defendantAccountId = 77L;
         String authHeader = "Bearer abc";
         GetDefendantAccountPaymentTermsResponse proxyResponse = new GetDefendantAccountPaymentTermsResponse();
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(defendantAccountServiceProxy.getPaymentTerms(defendantAccountId)).thenReturn(proxyResponse);
 
@@ -97,7 +97,7 @@ class DefendantAccountServiceTest {
         assertSame(proxyResponse, result, "Should return exactly the proxy response");
 
         // verify interactions
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verify(defendantAccountServiceProxy).getPaymentTerms(defendantAccountId);
         verifyNoMoreInteractions(userStateService, userState, defendantAccountServiceProxy);
@@ -108,7 +108,7 @@ class DefendantAccountServiceTest {
         // arrange
         Long defendantAccountId = 77L;
         String authHeader = "Bearer abc";
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
 
         // act + assert
@@ -122,7 +122,7 @@ class DefendantAccountServiceTest {
         );
 
         // proxy must not be called
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verifyNoInteractions(defendantAccountServiceProxy);
         verifyNoMoreInteractions(userStateService, userState);
@@ -136,7 +136,7 @@ class DefendantAccountServiceTest {
             .userName("noperms")
             .businessUnitUser(java.util.Collections.emptySet())
             .build();
-        when(userStateService.checkForAuthorisedUser()).thenReturn(user);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(user);
 
         // Act & Assert
         PermissionNotAllowedException ex = assertThrows(
@@ -167,7 +167,7 @@ class DefendantAccountServiceTest {
 
         DefendantAccountHeaderSummary expected = DefendantAccountHeaderSummary.builder().accountNumber("X123").build();
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userWithPerm);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userWithPerm);
         when(defendantAccountServiceProxy.getHeaderSummary(anyLong())).thenReturn(expected);
 
         DefendantAccountHeaderSummary result = defendantAccountService.getHeaderSummary(1L);
@@ -186,7 +186,7 @@ class DefendantAccountServiceTest {
             .userName("noperms")
             .businessUnitUser(java.util.Collections.emptySet())
             .build();
-        when(userStateService.checkForAuthorisedUser()).thenReturn(user);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(user);
 
         AccountSearchDto dto = AccountSearchDto.builder().build();
 
@@ -220,7 +220,7 @@ class DefendantAccountServiceTest {
 
         DefendantAccountSearchResultsDto expected = DefendantAccountSearchResultsDto.builder().build();
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userWithPerm);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userWithPerm);
         when(defendantAccountServiceProxy.searchDefendantAccounts(any(AccountSearchDto.class))).thenReturn(expected);
 
         AccountSearchDto dto = AccountSearchDto.builder().build();
@@ -238,7 +238,7 @@ class DefendantAccountServiceTest {
         String authHeader = "Bearer token";
 
         UserState userWithPerm = UserStateUtil.permissionUser((short) 78, FinesPermission.AMEND_PAYMENT_TERMS);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userWithPerm);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userWithPerm);
 
         AddDefendantAccountPaymentTermsRequest request = AddDefendantAccountPaymentTermsRequest.builder()
             .paymentTerms(PaymentTerms.builder()
@@ -282,7 +282,7 @@ class DefendantAccountServiceTest {
         Long defendantAccountId = 77L;
         String authHeader = "Bearer abc";
         DefendantAccountAtAGlanceResponse proxyResponse = new DefendantAccountAtAGlanceResponse();
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(defendantAccountServiceProxy.getAtAGlance(defendantAccountId)).thenReturn(proxyResponse);
 
@@ -294,7 +294,7 @@ class DefendantAccountServiceTest {
         assertSame(proxyResponse, result, "Should return exactly the proxy response");
 
         // verify interactions
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verify(defendantAccountServiceProxy).getAtAGlance(defendantAccountId);
         verifyNoMoreInteractions(userStateService, userState, defendantAccountServiceProxy);
@@ -305,7 +305,7 @@ class DefendantAccountServiceTest {
         // arrange
         Long defendantAccountId = 77L;
         String authHeader = "Bearer abc";
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
 
         // act + assert
@@ -320,7 +320,7 @@ class DefendantAccountServiceTest {
         assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
 
         // proxy must not be called
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verifyNoInteractions(defendantAccountServiceProxy);
         verifyNoMoreInteractions(userStateService, userState);
@@ -342,7 +342,7 @@ class DefendantAccountServiceTest {
             .version(3)
             .build();
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT)).thenReturn(true);
 
         // business unit user lookup returns an Optional<BusinessUnitUser> with a non-blank ID
@@ -363,7 +363,7 @@ class DefendantAccountServiceTest {
         assertSame(proxyResponse, result, "Should return exactly the proxy response");
 
         // verify interactions
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT);
         verify(userState).getBusinessUnitUserForBusinessUnit((short)10);
         verify(defendantAccountServiceProxy)
@@ -378,7 +378,7 @@ class DefendantAccountServiceTest {
         String businessUnitId = "10";
         String authHeader = "Bearer abc";
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT))
             .thenReturn(false);
 
@@ -393,7 +393,7 @@ class DefendantAccountServiceTest {
         );
         assertThat(ex.getPermission()).containsExactly(FinesPermission.ENTER_ENFORCEMENT);
 
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT);
         verifyNoInteractions(defendantAccountServiceProxy);
     }
@@ -407,7 +407,7 @@ class DefendantAccountServiceTest {
 
         AddDefendantAccountEnforcementRequest req = mock(AddDefendantAccountEnforcementRequest.class);
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT)).thenReturn(true);
 
         // return Optional<BusinessUnitUser> but with blank ID -> results in null
@@ -452,7 +452,7 @@ class DefendantAccountServiceTest {
             .isHmrcCheckEligible(true)
             .version(new BigInteger("1234567890123345678901234567890"))
             .build();
-        when(userStateService.checkForAuthorisedUser()).thenReturn(allPermissionsUser());
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(allPermissionsUser());
         when(defendantAccountServiceProxy.getEnforcementStatus(anyLong())).thenReturn(status);
 
         // Act
@@ -472,7 +472,7 @@ class DefendantAccountServiceTest {
         // Arrange
         Long id = 1L;
         UpdateDefendantAccountRequestPayload req = UpdateDefendantAccountRequestPayload.builder().build();
-        when(userStateService.checkForAuthorisedUser()).thenReturn(allPermissionsUser());
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(allPermissionsUser());
 
         // Act
         final String buHeader = "10";

--- a/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DefendantAccountServiceTest.java
@@ -70,9 +70,9 @@ class DefendantAccountServiceTest {
 
         when(defendantAccountServiceProxy.getHeaderSummary(anyLong())).thenReturn(headerSummary);
 
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(UserStateUtil.allFinesPermissionUser());
+        when(userStateService.checkForAuthorisedUser()).thenReturn(UserStateUtil.allFinesPermissionUser());
         // Act
-        DefendantAccountHeaderSummary result = defendantAccountService.getHeaderSummary(1L, "authHeaderValue");
+        DefendantAccountHeaderSummary result = defendantAccountService.getHeaderSummary(1L);
 
         // Assert
         assertNotNull(result);
@@ -85,19 +85,19 @@ class DefendantAccountServiceTest {
         Long defendantAccountId = 77L;
         String authHeader = "Bearer abc";
         GetDefendantAccountPaymentTermsResponse proxyResponse = new GetDefendantAccountPaymentTermsResponse();
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(defendantAccountServiceProxy.getPaymentTerms(defendantAccountId)).thenReturn(proxyResponse);
 
         // act
         GetDefendantAccountPaymentTermsResponse result =
-            defendantAccountService.getPaymentTerms(defendantAccountId, authHeader);
+            defendantAccountService.getPaymentTerms(defendantAccountId);
 
         // assert
         assertSame(proxyResponse, result, "Should return exactly the proxy response");
 
         // verify interactions
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verify(defendantAccountServiceProxy).getPaymentTerms(defendantAccountId);
         verifyNoMoreInteractions(userStateService, userState, defendantAccountServiceProxy);
@@ -108,13 +108,13 @@ class DefendantAccountServiceTest {
         // arrange
         Long defendantAccountId = 77L;
         String authHeader = "Bearer abc";
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
 
         // act + assert
         PermissionNotAllowedException ex = assertThrows(
             PermissionNotAllowedException.class,
-            () -> defendantAccountService.getPaymentTerms(defendantAccountId, authHeader)
+            () -> defendantAccountService.getPaymentTerms(defendantAccountId)
         );
         assertTrue(
             ex.getMessage() == null || ex.getMessage().contains(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS.name()),
@@ -122,7 +122,7 @@ class DefendantAccountServiceTest {
         );
 
         // proxy must not be called
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verifyNoInteractions(defendantAccountServiceProxy);
         verifyNoMoreInteractions(userStateService, userState);
@@ -136,12 +136,12 @@ class DefendantAccountServiceTest {
             .userName("noperms")
             .businessUnitUser(java.util.Collections.emptySet())
             .build();
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(user);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(user);
 
         // Act & Assert
         PermissionNotAllowedException ex = assertThrows(
             PermissionNotAllowedException.class,
-            () ->  defendantAccountService.getHeaderSummary(1L, "authHeaderValue")
+            () ->  defendantAccountService.getHeaderSummary(1L)
         );
         assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
     }
@@ -167,10 +167,10 @@ class DefendantAccountServiceTest {
 
         DefendantAccountHeaderSummary expected = DefendantAccountHeaderSummary.builder().accountNumber("X123").build();
 
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(userWithPerm);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userWithPerm);
         when(defendantAccountServiceProxy.getHeaderSummary(anyLong())).thenReturn(expected);
 
-        DefendantAccountHeaderSummary result = defendantAccountService.getHeaderSummary(1L, "authHeaderValue");
+        DefendantAccountHeaderSummary result = defendantAccountService.getHeaderSummary(1L);
 
         assertNotNull(result);
         assertEquals("X123", result.getAccountNumber());
@@ -186,14 +186,14 @@ class DefendantAccountServiceTest {
             .userName("noperms")
             .businessUnitUser(java.util.Collections.emptySet())
             .build();
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(user);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(user);
 
         AccountSearchDto dto = AccountSearchDto.builder().build();
 
         // Act & Assert
         PermissionNotAllowedException ex = assertThrows(
             PermissionNotAllowedException.class,
-            () -> defendantAccountService.searchDefendantAccounts(dto, "authHeaderValue")
+            () -> defendantAccountService.searchDefendantAccounts(dto)
         );
 
         assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
@@ -220,12 +220,11 @@ class DefendantAccountServiceTest {
 
         DefendantAccountSearchResultsDto expected = DefendantAccountSearchResultsDto.builder().build();
 
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(userWithPerm);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userWithPerm);
         when(defendantAccountServiceProxy.searchDefendantAccounts(any(AccountSearchDto.class))).thenReturn(expected);
 
         AccountSearchDto dto = AccountSearchDto.builder().build();
-        DefendantAccountSearchResultsDto result = defendantAccountService.searchDefendantAccounts(dto,
-            "authHeaderValue");
+        DefendantAccountSearchResultsDto result = defendantAccountService.searchDefendantAccounts(dto);
 
         assertNotNull(result);
         verify(defendantAccountServiceProxy).searchDefendantAccounts(dto);
@@ -239,7 +238,7 @@ class DefendantAccountServiceTest {
         String authHeader = "Bearer token";
 
         UserState userWithPerm = UserStateUtil.permissionUser((short) 78, FinesPermission.AMEND_PAYMENT_TERMS);
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userWithPerm);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userWithPerm);
 
         AddDefendantAccountPaymentTermsRequest request = AddDefendantAccountPaymentTermsRequest.builder()
             .paymentTerms(PaymentTerms.builder()
@@ -255,12 +254,11 @@ class DefendantAccountServiceTest {
             eq(businessUnitId),
             eq("USER01"),
             eq(ifMatch),
-            eq(authHeader),
             any(AddDefendantAccountPaymentTermsRequest.class)))
             .thenReturn(proxyResponse);
 
         GetDefendantAccountPaymentTermsResponse result = defendantAccountService.addPaymentTerms(
-            defendantAccountId, businessUnitId, ifMatch, authHeader, request);
+            defendantAccountId, businessUnitId, ifMatch, request);
 
         assertSame(proxyResponse, result);
 
@@ -270,7 +268,6 @@ class DefendantAccountServiceTest {
             eq(businessUnitId),
             eq("USER01"),
             eq(ifMatch),
-            eq(authHeader),
             captor.capture());
 
         PostedDetails postedDetails = captor.getValue().getPaymentTerms().getPostedDetails();
@@ -285,19 +282,19 @@ class DefendantAccountServiceTest {
         Long defendantAccountId = 77L;
         String authHeader = "Bearer abc";
         DefendantAccountAtAGlanceResponse proxyResponse = new DefendantAccountAtAGlanceResponse();
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(defendantAccountServiceProxy.getAtAGlance(defendantAccountId)).thenReturn(proxyResponse);
 
         // act
         DefendantAccountAtAGlanceResponse result =
-            defendantAccountService.getAtAGlance(defendantAccountId, authHeader);
+            defendantAccountService.getAtAGlance(defendantAccountId);
 
         // assert
         assertSame(proxyResponse, result, "Should return exactly the proxy response");
 
         // verify interactions
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verify(defendantAccountServiceProxy).getAtAGlance(defendantAccountId);
         verifyNoMoreInteractions(userStateService, userState, defendantAccountServiceProxy);
@@ -308,13 +305,13 @@ class DefendantAccountServiceTest {
         // arrange
         Long defendantAccountId = 77L;
         String authHeader = "Bearer abc";
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
 
         // act + assert
         PermissionNotAllowedException ex = assertThrows(
             PermissionNotAllowedException.class,
-            () -> defendantAccountService.getAtAGlance(defendantAccountId, authHeader)
+            () -> defendantAccountService.getAtAGlance(defendantAccountId)
         );
         assertTrue(
             ex.getMessage() == null || ex.getMessage().contains(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS.name()),
@@ -323,7 +320,7 @@ class DefendantAccountServiceTest {
         assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
 
         // proxy must not be called
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verifyNoInteractions(defendantAccountServiceProxy);
         verifyNoMoreInteractions(userStateService, userState);
@@ -345,7 +342,7 @@ class DefendantAccountServiceTest {
             .version(3)
             .build();
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT)).thenReturn(true);
 
         // business unit user lookup returns an Optional<BusinessUnitUser> with a non-blank ID
@@ -355,22 +352,22 @@ class DefendantAccountServiceTest {
             .thenReturn(java.util.Optional.of(buUser));
 
         when(defendantAccountServiceProxy.addEnforcement(
-            defendantAccountId, businessUnitId, "BU-USER-1", ifMatch, authHeader, req))
+            defendantAccountId, businessUnitId, "BU-USER-1", ifMatch, req))
             .thenReturn(proxyResponse);
 
         // act
         AddEnforcementResponse result =
-            defendantAccountService.addEnforcement(defendantAccountId, businessUnitId, ifMatch, authHeader, req);
+            defendantAccountService.addEnforcement(defendantAccountId, businessUnitId, ifMatch, req);
 
         // assert
         assertSame(proxyResponse, result, "Should return exactly the proxy response");
 
         // verify interactions
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT);
         verify(userState).getBusinessUnitUserForBusinessUnit((short)10);
         verify(defendantAccountServiceProxy)
-            .addEnforcement(defendantAccountId, businessUnitId, "BU-USER-1", ifMatch, authHeader, req);
+            .addEnforcement(defendantAccountId, businessUnitId, "BU-USER-1", ifMatch, req);
         verifyNoMoreInteractions(userStateService, userState, defendantAccountServiceProxy);
     }
 
@@ -381,14 +378,14 @@ class DefendantAccountServiceTest {
         String businessUnitId = "10";
         String authHeader = "Bearer abc";
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT))
             .thenReturn(false);
 
         // act + assert
         PermissionNotAllowedException ex = assertThrows(
             PermissionNotAllowedException.class,
-            () -> defendantAccountService.addEnforcement(defendantAccountId, businessUnitId, "\"3\"", authHeader, null)
+            () -> defendantAccountService.addEnforcement(defendantAccountId, businessUnitId, "\"3\"", null)
         );
         assertTrue(
             ex.getMessage() == null || ex.getMessage().contains(FinesPermission.ENTER_ENFORCEMENT.name()),
@@ -396,7 +393,7 @@ class DefendantAccountServiceTest {
         );
         assertThat(ex.getPermission()).containsExactly(FinesPermission.ENTER_ENFORCEMENT);
 
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT);
         verifyNoInteractions(defendantAccountServiceProxy);
     }
@@ -410,7 +407,7 @@ class DefendantAccountServiceTest {
 
         AddDefendantAccountEnforcementRequest req = mock(AddDefendantAccountEnforcementRequest.class);
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.ENTER_ENFORCEMENT)).thenReturn(true);
 
         // return Optional<BusinessUnitUser> but with blank ID -> results in null
@@ -428,13 +425,12 @@ class DefendantAccountServiceTest {
             eq(businessUnitId),
             isNull(),                   // IMPORTANT: businessUnitUserId expected to be null
             eq("\"3\""),
-            eq(authHeader),
             eq(req)
         )).thenReturn(proxyResult);
 
         // act
         AddEnforcementResponse out =
-            defendantAccountService.addEnforcement(defendantAccountId, businessUnitId, "\"3\"", authHeader, req);
+            defendantAccountService.addEnforcement(defendantAccountId, businessUnitId, "\"3\"", req);
 
         // assert
         assertNotNull(out);
@@ -443,7 +439,6 @@ class DefendantAccountServiceTest {
             eq(businessUnitId),
             isNull(),                   // verifies null is passed
             eq("\"3\""),
-            eq(authHeader),
             eq(req)
         );
     }
@@ -457,12 +452,12 @@ class DefendantAccountServiceTest {
             .isHmrcCheckEligible(true)
             .version(new BigInteger("1234567890123345678901234567890"))
             .build();
-        when(userStateService.checkForAuthorisedUser("Bearer a_bearer_token")).thenReturn(allPermissionsUser());
+        when(userStateService.checkForAuthorisedUser()).thenReturn(allPermissionsUser());
         when(defendantAccountServiceProxy.getEnforcementStatus(anyLong())).thenReturn(status);
 
         // Act
         EnforcementStatus response = defendantAccountService
-            .getEnforcementStatus(33L, "Bearer a_bearer_token");
+            .getEnforcementStatus(33L);
 
         // Assert
         assertNotNull(response);
@@ -477,13 +472,12 @@ class DefendantAccountServiceTest {
         // Arrange
         Long id = 1L;
         UpdateDefendantAccountRequestPayload req = UpdateDefendantAccountRequestPayload.builder().build();
-        when(userStateService.checkForAuthorisedUser("UNIT_TEST")).thenReturn(allPermissionsUser());
+        when(userStateService.checkForAuthorisedUser()).thenReturn(allPermissionsUser());
 
         // Act
         final String buHeader = "10";
         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
-            defendantAccountService.updateDefendantAccount(id, buHeader, req, "UNIT_TEST",
-                "1")
+            defendantAccountService.updateDefendantAccount(id, buHeader, req, "1")
         );
 
         // Assert

--- a/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;

--- a/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
@@ -111,10 +111,10 @@ class DraftAccountServiceTest {
             .thenReturn(DraftAccountResponseDto.builder().build());
         when(draftAccountTransactional.getDraftAccount(anyLong())).thenReturn(draftAccountEntity);
         var userState = UserStateUtil.allPermissionsUser();
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
 
         // Act
-        DraftAccountResponseDto result = draftAccountService.getDraftAccount(1, "authHeaderValue");
+        DraftAccountResponseDto result = draftAccountService.getDraftAccount(1);
 
         // Assert
         assertNotNull(result);
@@ -132,13 +132,12 @@ class DraftAccountServiceTest {
         when(draftAccountTransactional.getDraftAccounts(any(), any(), any(), any(), any(), any()))
             .thenReturn(List.of(draftAccountEntity));
         var userState = UserStateUtil.allPermissionsUser();
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
 
         // Act
         DraftAccountsResponseDto result = draftAccountService.getDraftAccounts(
             Optional.of(List.copyOf(Set.of((short) 1))), Optional.of(List.copyOf(Set.of(DraftAccountStatus.REJECTED))),
-            Optional.of(List.of()), Optional.of(List.of()), Optional.empty(), Optional.empty(),
-            "authHeaderValue"
+            Optional.of(List.of()), Optional.of(List.of()), Optional.empty(), Optional.empty()
         );
 
         // Assert
@@ -156,11 +155,10 @@ class DraftAccountServiceTest {
             DraftAccountResponseDto.builder().account(accountText).build()
         );
         when(draftAccountTransactional.searchDraftAccounts(any())).thenReturn(List.of(draftAccountEntity));
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(UserStateUtil.allPermissionsUser());
 
         // Act
         List<DraftAccountResponseDto> result = draftAccountService.searchDraftAccounts(
-            DraftAccountSearchDto.builder().build(), "authHeaderValue");
+            DraftAccountSearchDto.builder().build());
 
         // Assert
         assertEquals(accountText, result.get(0).getAccount());
@@ -174,7 +172,7 @@ class DraftAccountServiceTest {
             .thenReturn(DraftAccountResponseDto.builder().build());
         when(draftAccountTransactional.submitDraftAccount(any())).thenReturn(draftAccountEntity);
         var userState = UserStateUtil.permissionUser((short) 2, FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS);
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         AddDraftAccountRequestDto addDraftAccountDto = AddDraftAccountRequestDto.builder()
             .businessUnitId((short) 2)
             .submittedBy("SpoofedUser")
@@ -184,7 +182,7 @@ class DraftAccountServiceTest {
             .build();
         // Act
         DraftAccountResponseDto result = draftAccountService
-            .submitDraftAccount(addDraftAccountDto, "authHeaderValue");
+            .submitDraftAccount(addDraftAccountDto);
 
         // Assert
         assertEquals(draftAccountEntity.getAccount(), result.getAccount());
@@ -207,12 +205,12 @@ class DraftAccountServiceTest {
             .submittedBy("TestUser")
             .submittedByName("Test User")
             .build();
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(UserStateUtil.noPermissionsUser());
+        when(userStateService.checkForAuthorisedUser()).thenReturn(UserStateUtil.noPermissionsUser());
 
         // Act & Assert
         PermissionNotAllowedException ex = assertThrows(
             PermissionNotAllowedException.class,
-            () -> draftAccountService.submitDraftAccount(addDraftAccountDto, "authHeaderValue")
+            () -> draftAccountService.submitDraftAccount(addDraftAccountDto)
         );
 
         assertThat(ex.getPermission()).containsExactly(FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS);
@@ -229,13 +227,13 @@ class DraftAccountServiceTest {
             .accountType(DraftAccountType.FINE)
             .build();
 
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(
+        when(userStateService.checkForAuthorisedUser()).thenReturn(
             UserStateUtil.permissionUser((short) 2, FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS)
         );
 
         JsonSchemaValidationException ex = assertThrows(
             JsonSchemaValidationException.class,
-            () -> draftAccountService.submitDraftAccount(addDraftAccountDto, "authHeaderValue")
+            () -> draftAccountService.submitDraftAccount(addDraftAccountDto)
         );
 
         assertTrue(ex.getMessage().contains("hearing_language"));
@@ -244,11 +242,8 @@ class DraftAccountServiceTest {
 
     @Test
     void testDeleteDraftAccount_success() {
-        // Arrange
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(UserStateUtil.allPermissionsUser());
-
         // Act
-        draftAccountService.deleteDraftAccount(1, true, "authHeaderValue");
+        draftAccountService.deleteDraftAccount(1, true);
 
         // Assert
         // delete does not call PDPL logging
@@ -259,12 +254,11 @@ class DraftAccountServiceTest {
         // Arrange
         when(draftAccountTransactional.deleteDraftAccount(anyLong(), any())).thenThrow(
             new EntityNotFoundException("Draft Account not found with id: 1"));
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(UserStateUtil.allPermissionsUser());
 
         // Act & Assert
         EntityNotFoundException enfe = assertThrows(
             EntityNotFoundException.class, () -> draftAccountService
-                .deleteDraftAccount(1, true, "authHeaderValue")
+                .deleteDraftAccount(1, true)
         );
         assertEquals("Draft Account not found with id: 1", enfe.getMessage());
     }
@@ -296,7 +290,7 @@ class DraftAccountServiceTest {
         );
         when(draftAccountTransactional.replaceDraftAccount(any(), any(), any(), any())).thenReturn(updatedAccount);
         var userState = UserStateUtil.permissionUser((short) 2, FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS);
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         ReplaceDraftAccountRequestDto replaceDto = ReplaceDraftAccountRequestDto.builder()
             .businessUnitId((short) 2)
             .submittedBy("SpoofedUser")
@@ -307,7 +301,7 @@ class DraftAccountServiceTest {
             .build();
         // Act
         DraftAccountResponseDto result = draftAccountService
-            .replaceDraftAccount(draftAccountId, replaceDto, "authHeaderValue", "");
+            .replaceDraftAccount(draftAccountId, replaceDto, "");
 
         // Assert
         assertNotNull(result);
@@ -343,12 +337,12 @@ class DraftAccountServiceTest {
             .build();
         when(draftAccountTransactional.replaceDraftAccount(any(), any(), any(), any())).thenThrow(
             new EntityNotFoundException("Draft Account not found with id: " + draftAccountId));
-        when(userStateService.checkForAuthorisedUser(any()))
+        when(userStateService.checkForAuthorisedUser())
             .thenReturn(UserStateUtil.permissionUser((short) 1, FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS));
 
         // Act & Assert
         RuntimeException exception = assertThrows(RuntimeException.class, () -> draftAccountService
-            .replaceDraftAccount(draftAccountId, replaceDto, "authHeaderValue", "")
+            .replaceDraftAccount(draftAccountId, replaceDto, "")
         );
         assertEquals("Draft Account not found with id: 1", exception.getMessage());
     }
@@ -370,12 +364,12 @@ class DraftAccountServiceTest {
             .version(BigInteger.valueOf(0L))
             .build();
         when(draftAccountTransactional.replaceDraftAccount(any(), any(), any(), any())).thenReturn(existingAccount);
-        when(userStateService.checkForAuthorisedUser(any()))
+        when(userStateService.checkForAuthorisedUser())
             .thenReturn(UserStateUtil.permissionUser((short) 2, FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS));
 
         // Act & Assert
         assertThrows(ResourceConflictException.class, () -> draftAccountService
-            .replaceDraftAccount(draftAccountId, dto, "authHeaderValue", "")
+            .replaceDraftAccount(draftAccountId, dto, "")
         );
         verify(jsonSchemaValidationService).validateOrError(any(), any());
     }
@@ -394,12 +388,12 @@ class DraftAccountServiceTest {
             .build();
         when(draftAccountTransactional.updateDraftAccount(any(), any(), any(), any(), any()))
             .thenReturn(existingAccount);
-        when(userStateService.checkForAuthorisedUser(any()))
+        when(userStateService.checkForAuthorisedUser())
             .thenReturn(UserStateUtil.permissionUser((short) 2, FinesPermission.CHECK_VALIDATE_DRAFT_ACCOUNTS));
 
         // Act & Assert
         assertThrows(ResourceConflictException.class, () -> draftAccountService
-            .updateDraftAccount(draftAccountId, updateDto, "authHeaderValue", "0")
+            .updateDraftAccount(draftAccountId, updateDto, "0")
         );
 
         verify(securityEventLoggingService, never()).logEvent(any(), any(), any(), any(), any(), any());
@@ -429,7 +423,7 @@ class DraftAccountServiceTest {
         when(draftAccountTransactional.updateDraftAccount(any(), any(), any(), any(), any()))
             .thenReturn(updatedAccount);
         var userState = UserStateUtil.permissionUser((short) 2, FinesPermission.CHECK_VALIDATE_DRAFT_ACCOUNTS);
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
 
         publishPending_success(updatedAccount, draftAccountId, updateDto, userState);
 
@@ -479,7 +473,7 @@ class DraftAccountServiceTest {
 
         when(draftAccountTransactional.updateDraftAccount(any(), any(), any(), any(), any()))
             .thenReturn(updatedAccount);
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(draftAccountMapper.toResponseDto(updatedAccount)).thenReturn(
             DraftAccountResponseDto.builder()
                 .draftAccountId(draftAccountId)
@@ -491,7 +485,7 @@ class DraftAccountServiceTest {
         );
 
         DraftAccountResponseDto result = draftAccountService
-            .updateDraftAccount(draftAccountId, updateDto, "authHeaderValue", "0");
+            .updateDraftAccount(draftAccountId, updateDto, "0");
 
         assertNotNull(result);
         assertEquals("PATCH002_REVIEWER", result.getValidatedBy());
@@ -538,7 +532,7 @@ class DraftAccountServiceTest {
 
         // Act
         DraftAccountResponseDto result = draftAccountService
-            .updateDraftAccount(draftAccountId, updateDto, "authHeaderValue", "0");
+            .updateDraftAccount(draftAccountId, updateDto, "0");
 
         // Assert
         assertNotNull(result);

--- a/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
@@ -19,6 +19,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
@@ -61,7 +62,7 @@ import uk.gov.hmcts.opal.service.proxy.DraftAccountPublishProxy;
 @ExtendWith(MockitoExtension.class)
 class DraftAccountServiceTest {
 
-    private static final LocalDate TIMELINE_STATUS_DATE = LocalDate.of(2026, 4, 22);
+    private static final LocalDate TIMELINE_STATUS_DATE = LocalDate.of(2026, Month.APRIL, 22);
     private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-04-22T00:00:00Z"), ZoneOffset.UTC);
 
     @Mock
@@ -440,7 +441,7 @@ class DraftAccountServiceTest {
             "Success",
             (short) 2,
             "Approval",
-            LocalDateTime.of(2026, 4, 22, 0, 0),
+            LocalDateTime.of(2026, Month.APRIL, 22, 0, 0),
             Map.of(
                 "UserIdentifier", 1L,
                 "DraftAccountIdentifier", draftAccountId,

--- a/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
@@ -243,10 +243,11 @@ class DraftAccountServiceTest {
     @Test
     void testDeleteDraftAccount_success() {
         // Act
-        draftAccountService.deleteDraftAccount(1, true);
+        String result = draftAccountService.deleteDraftAccount(1, true);
 
         // Assert
-        // delete does not call PDPL logging
+        assertEquals(String.format(DraftAccountService.ACCOUNT_DELETED_MESSAGE_FORMAT, 1), result);
+        verify(draftAccountTransactional).deleteDraftAccount(1L, draftAccountTransactional);
     }
 
     @Test
@@ -436,16 +437,16 @@ class DraftAccountServiceTest {
 
         verify(jsonSchemaValidationService).validateOrError(any(), any());
         verify(securityEventLoggingService, times(1)).logEvent(
-            eq("Business Function - Approval of Draft Account"),
-            eq("Success"),
-            eq((short) 2),
-            eq("Approval"),
-            eq(LocalDateTime.of(2026, 4, 22, 0, 0)),
-            eq(Map.of(
+            "Business Function - Approval of Draft Account",
+            "Success",
+            (short) 2,
+            "Approval",
+            LocalDateTime.of(2026, 4, 22, 0, 0),
+            Map.of(
                 "UserIdentifier", 1L,
                 "DraftAccountIdentifier", draftAccountId,
                 "DraftAccountSubmittedByUserIdentifier", "Pablo"
-            ))
+            )
         );
 
         verify(jsonSchemaValidationService).validateOrError(any(), any());

--- a/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
@@ -111,7 +111,7 @@ class DraftAccountServiceTest {
             .thenReturn(DraftAccountResponseDto.builder().build());
         when(draftAccountTransactional.getDraftAccount(anyLong())).thenReturn(draftAccountEntity);
         var userState = UserStateUtil.allPermissionsUser();
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         // Act
         DraftAccountResponseDto result = draftAccountService.getDraftAccount(1);
@@ -132,7 +132,7 @@ class DraftAccountServiceTest {
         when(draftAccountTransactional.getDraftAccounts(any(), any(), any(), any(), any(), any()))
             .thenReturn(List.of(draftAccountEntity));
         var userState = UserStateUtil.allPermissionsUser();
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         // Act
         DraftAccountsResponseDto result = draftAccountService.getDraftAccounts(
@@ -172,7 +172,7 @@ class DraftAccountServiceTest {
             .thenReturn(DraftAccountResponseDto.builder().build());
         when(draftAccountTransactional.submitDraftAccount(any())).thenReturn(draftAccountEntity);
         var userState = UserStateUtil.permissionUser((short) 2, FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         AddDraftAccountRequestDto addDraftAccountDto = AddDraftAccountRequestDto.builder()
             .businessUnitId((short) 2)
             .submittedBy("SpoofedUser")
@@ -205,7 +205,7 @@ class DraftAccountServiceTest {
             .submittedBy("TestUser")
             .submittedByName("Test User")
             .build();
-        when(userStateService.checkForAuthorisedUser()).thenReturn(UserStateUtil.noPermissionsUser());
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(UserStateUtil.noPermissionsUser());
 
         // Act & Assert
         PermissionNotAllowedException ex = assertThrows(
@@ -227,7 +227,7 @@ class DraftAccountServiceTest {
             .accountType(DraftAccountType.FINE)
             .build();
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(
             UserStateUtil.permissionUser((short) 2, FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS)
         );
 
@@ -290,7 +290,7 @@ class DraftAccountServiceTest {
         );
         when(draftAccountTransactional.replaceDraftAccount(any(), any(), any(), any())).thenReturn(updatedAccount);
         var userState = UserStateUtil.permissionUser((short) 2, FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         ReplaceDraftAccountRequestDto replaceDto = ReplaceDraftAccountRequestDto.builder()
             .businessUnitId((short) 2)
             .submittedBy("SpoofedUser")
@@ -337,7 +337,7 @@ class DraftAccountServiceTest {
             .build();
         when(draftAccountTransactional.replaceDraftAccount(any(), any(), any(), any())).thenThrow(
             new EntityNotFoundException("Draft Account not found with id: " + draftAccountId));
-        when(userStateService.checkForAuthorisedUser())
+        when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(UserStateUtil.permissionUser((short) 1, FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS));
 
         // Act & Assert
@@ -364,7 +364,7 @@ class DraftAccountServiceTest {
             .version(BigInteger.valueOf(0L))
             .build();
         when(draftAccountTransactional.replaceDraftAccount(any(), any(), any(), any())).thenReturn(existingAccount);
-        when(userStateService.checkForAuthorisedUser())
+        when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(UserStateUtil.permissionUser((short) 2, FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS));
 
         // Act & Assert
@@ -388,7 +388,7 @@ class DraftAccountServiceTest {
             .build();
         when(draftAccountTransactional.updateDraftAccount(any(), any(), any(), any(), any()))
             .thenReturn(existingAccount);
-        when(userStateService.checkForAuthorisedUser())
+        when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(UserStateUtil.permissionUser((short) 2, FinesPermission.CHECK_VALIDATE_DRAFT_ACCOUNTS));
 
         // Act & Assert
@@ -423,7 +423,7 @@ class DraftAccountServiceTest {
         when(draftAccountTransactional.updateDraftAccount(any(), any(), any(), any(), any()))
             .thenReturn(updatedAccount);
         var userState = UserStateUtil.permissionUser((short) 2, FinesPermission.CHECK_VALIDATE_DRAFT_ACCOUNTS);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         publishPending_success(updatedAccount, draftAccountId, updateDto, userState);
 
@@ -473,7 +473,7 @@ class DraftAccountServiceTest {
 
         when(draftAccountTransactional.updateDraftAccount(any(), any(), any(), any(), any()))
             .thenReturn(updatedAccount);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(draftAccountMapper.toResponseDto(updatedAccount)).thenReturn(
             DraftAccountResponseDto.builder()
                 .draftAccountId(draftAccountId)

--- a/src/test/java/uk/gov/hmcts/opal/service/ImpositionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/ImpositionServiceTest.java
@@ -114,15 +114,15 @@ class ImpositionServiceTest {
         GetDefendantAccountImpositionsResponse impositionsResponse = GetDefendantAccountImpositionsResponse.builder()
             .version(BigInteger.valueOf(9))
             .build();
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(impositionServiceProxy.getImpositions(defendantAccountId)).thenReturn(impositionsResponse);
 
         GetDefendantAccountImpositionsResponse result =
-            impositionService.getImpositions(defendantAccountId, authHeader);
+            impositionService.getImpositions(defendantAccountId);
 
         assertSame(impositionsResponse, result);
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verify(impositionServiceProxy).getImpositions(defendantAccountId);
         verifyNoMoreInteractions(userStateService, userState, impositionServiceProxy);
@@ -132,15 +132,15 @@ class ImpositionServiceTest {
     void getImpositions_whenUserLacksPermission_throwsPermissionNotAllowed() {
         Long defendantAccountId = 77L;
         String authHeader = "Bearer abc";
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
 
         assertThrows(
             PermissionNotAllowedException.class,
-            () -> impositionService.getImpositions(defendantAccountId, authHeader)
+            () -> impositionService.getImpositions(defendantAccountId)
         );
 
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verifyNoInteractions(impositionServiceProxy);
         verifyNoMoreInteractions(userStateService, userState);

--- a/src/test/java/uk/gov/hmcts/opal/service/ImpositionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/ImpositionServiceTest.java
@@ -114,7 +114,7 @@ class ImpositionServiceTest {
         GetDefendantAccountImpositionsResponse impositionsResponse = GetDefendantAccountImpositionsResponse.builder()
             .version(BigInteger.valueOf(9))
             .build();
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(impositionServiceProxy.getImpositions(defendantAccountId)).thenReturn(impositionsResponse);
 
@@ -122,7 +122,7 @@ class ImpositionServiceTest {
             impositionService.getImpositions(defendantAccountId);
 
         assertSame(impositionsResponse, result);
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verify(impositionServiceProxy).getImpositions(defendantAccountId);
         verifyNoMoreInteractions(userStateService, userState, impositionServiceProxy);
@@ -132,7 +132,7 @@ class ImpositionServiceTest {
     void getImpositions_whenUserLacksPermission_throwsPermissionNotAllowed() {
         Long defendantAccountId = 77L;
         String authHeader = "Bearer abc";
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
 
         assertThrows(
@@ -140,7 +140,7 @@ class ImpositionServiceTest {
             () -> impositionService.getImpositions(defendantAccountId)
         );
 
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verifyNoInteractions(impositionServiceProxy);
         verifyNoMoreInteractions(userStateService, userState);

--- a/src/test/java/uk/gov/hmcts/opal/service/ImpositionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/ImpositionServiceTest.java
@@ -110,7 +110,6 @@ class ImpositionServiceTest {
     @Test
     void getImpositions_whenUserHasPermission_returnsImpositionsServiceResult() {
         Long defendantAccountId = 77L;
-        String authHeader = "Bearer abc";
         GetDefendantAccountImpositionsResponse impositionsResponse = GetDefendantAccountImpositionsResponse.builder()
             .version(BigInteger.valueOf(9))
             .build();
@@ -131,7 +130,6 @@ class ImpositionServiceTest {
     @Test
     void getImpositions_whenUserLacksPermission_throwsPermissionNotAllowed() {
         Long defendantAccountId = 77L;
-        String authHeader = "Bearer abc";
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
 

--- a/src/test/java/uk/gov/hmcts/opal/service/MajorCreditorAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/MajorCreditorAccountServiceTest.java
@@ -70,7 +70,7 @@ class MajorCreditorAccountServiceTest {
         UserState userState = mock(UserState.class);
         GetMajorCreditorAccountHeaderSummaryResponse response = responseWithBusinessUnit("77");
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(userState.hasBusinessUnitUserWithPermission((short) 77, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS))
             .thenReturn(true);
@@ -80,7 +80,7 @@ class MajorCreditorAccountServiceTest {
             majorCreditorAccountService.getHeaderSummary(123L);
 
         assertEquals(response, result);
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(userState).hasBusinessUnitUserWithPermission((short) 77, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verify(majorCreditorAccountProxy).getHeaderSummary(123L);
     }
@@ -90,7 +90,7 @@ class MajorCreditorAccountServiceTest {
         UserState userState = mock(UserState.class);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS))
             .thenReturn(false);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         PermissionNotAllowedException exception = assertThrows(
             PermissionNotAllowedException.class,
@@ -106,7 +106,7 @@ class MajorCreditorAccountServiceTest {
         UserState userState = mock(UserState.class);
         GetMajorCreditorAccountHeaderSummaryResponse response = responseWithBusinessUnit("77");
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(userState.hasBusinessUnitUserWithPermission((short) 77, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS))
             .thenReturn(false);

--- a/src/test/java/uk/gov/hmcts/opal/service/MajorCreditorAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/MajorCreditorAccountServiceTest.java
@@ -38,14 +38,14 @@ class MajorCreditorAccountServiceTest {
         UserState userState = mock(UserState.class);
         GetMajorCreditorAccountAtAGlanceResponse response = new GetMajorCreditorAccountAtAGlanceResponse();
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(majorCreditorAccountProxy.getAtAGlance(123L)).thenReturn(response);
 
         GetMajorCreditorAccountAtAGlanceResponse result = majorCreditorAccountService.getAtAGlance(123L);
 
         assertEquals(response, result);
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(majorCreditorAccountProxy).getAtAGlance(123L);
     }
 
@@ -54,7 +54,7 @@ class MajorCreditorAccountServiceTest {
         UserState userState = mock(UserState.class);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS))
             .thenReturn(false);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         PermissionNotAllowedException exception = assertThrows(
             PermissionNotAllowedException.class,

--- a/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
@@ -299,12 +299,12 @@ class MinorCreditorServiceTest {
             FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(noBacsPermissionUser.anyBusinessUnitUserHasPermission(
             FinesPermission.VIEW_CREDITOR_BACS)).thenReturn(false);
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(noBacsPermissionUser);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(noBacsPermissionUser);
 
         // Act & Assert
         PermissionNotAllowedException ex = Assertions.assertThrows(
             PermissionNotAllowedException.class,
-            () -> minorCreditorService.getMinorCreditorAtAGlance(123L, "authHeaderValue")
+            () -> minorCreditorService.getMinorCreditorAtAGlance(123L)
         );
         assertThat(ex.getPermission()).containsExactly(FinesPermission.VIEW_CREDITOR_BACS);
     }
@@ -485,14 +485,14 @@ class MinorCreditorServiceTest {
             .thenReturn(true);
         when(userState.hasBusinessUnitUserWithPermission((short) 10, FinesPermission.VIEW_CREDITOR_BACS))
             .thenReturn(false);
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         PatchMinorCreditorAccountRequest request = validPatchRequest();
 
         // Act & Assert
         PermissionNotAllowedException ex = Assertions.assertThrows(
             PermissionNotAllowedException.class,
-            () -> minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "authHeaderValue", "10")
+            () -> minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "10")
         );
         assertThat(ex.getPermission()).containsExactly(FinesPermission.VIEW_CREDITOR_BACS);
         assertThat(ex.getBusinessUnitId()).isEqualTo((short) 10);

--- a/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
@@ -58,7 +58,7 @@ class MinorCreditorServiceTest {
             PostMinorCreditorAccountsSearchResponse.builder().build();
 
         when(minorCreditorSearchProxy.searchMinorCreditors(any())).thenReturn(postMinorCreditorAccountsSearchResponse);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(UserStateUtil.allFinesPermissionUser());
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(UserStateUtil.allFinesPermissionUser());
 
         // Act
         PostMinorCreditorAccountsSearchResponse result =
@@ -77,7 +77,7 @@ class MinorCreditorServiceTest {
             GetMinorCreditorAccountHeaderSummaryResponse.builder().build();
 
         when(minorCreditorSearchProxy.getHeaderSummary(id)).thenReturn(response);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(UserStateUtil.allFinesPermissionUser());
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(UserStateUtil.allFinesPermissionUser());
 
         // Act
         GetMinorCreditorAccountHeaderSummaryResponse result =
@@ -95,7 +95,7 @@ class MinorCreditorServiceTest {
         UserState noPermissionUser = mock(UserState.class);
         when(noPermissionUser.anyBusinessUnitUserHasPermission(
             FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(noPermissionUser);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(noPermissionUser);
 
         // Act & Assert
         PermissionNotAllowedException ex = Assertions.assertThrows(
@@ -117,7 +117,7 @@ class MinorCreditorServiceTest {
         );
 
         when(minorCreditorSearchProxy.getMinorCreditorAccount(id)).thenReturn(response);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         // Act
         MinorCreditorAccountResponse result = minorCreditorService.getMinorCreditorAccount(id);
@@ -136,7 +136,7 @@ class MinorCreditorServiceTest {
         UserState noPermissionUser = mock(UserState.class);
         when(noPermissionUser.anyBusinessUnitUserHasPermission(
             FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(noPermissionUser);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(noPermissionUser);
 
         // Act & Assert
         PermissionNotAllowedException ex = Assertions.assertThrows(
@@ -155,7 +155,7 @@ class MinorCreditorServiceTest {
         MinorCreditorAccountResponse response = responseWithBacsDetails();
 
         when(minorCreditorSearchProxy.getMinorCreditorAccount(id)).thenReturn(response);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         // Act
         MinorCreditorAccountResponse result = minorCreditorService.getMinorCreditorAccount(id);
@@ -183,7 +183,7 @@ class MinorCreditorServiceTest {
         MinorCreditorAccountResponse response = responseWithBacsDetails();
 
         when(minorCreditorSearchProxy.getMinorCreditorAccount(id)).thenReturn(response);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         // Act
         MinorCreditorAccountResponse result = minorCreditorService.getMinorCreditorAccount(id);
@@ -211,7 +211,7 @@ class MinorCreditorServiceTest {
         MinorCreditorAccountResponse response = responseWithBacsDetails();
 
         when(minorCreditorSearchProxy.getMinorCreditorAccount(id)).thenReturn(response);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         // Act
         MinorCreditorAccountResponse result = minorCreditorService.getMinorCreditorAccount(id);
@@ -240,7 +240,7 @@ class MinorCreditorServiceTest {
         response.setBusinessUnitId(null);
 
         when(minorCreditorSearchProxy.getMinorCreditorAccount(id)).thenReturn(response);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         // Act
         MinorCreditorAccountResponse result = minorCreditorService.getMinorCreditorAccount(id);
@@ -263,7 +263,7 @@ class MinorCreditorServiceTest {
         GetMinorCreditorAccountAtAGlanceResponse response = GetMinorCreditorAccountAtAGlanceResponse.builder().build();
 
         when(minorCreditorSearchProxy.getMinorCreditorAtAGlance(id)).thenReturn(response);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(UserStateUtil.allFinesPermissionUser());
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(UserStateUtil.allFinesPermissionUser());
 
         // Act
         GetMinorCreditorAccountAtAGlanceResponse result =
@@ -281,7 +281,7 @@ class MinorCreditorServiceTest {
         UserState noPermissionUser = mock(UserState.class);
         when(noPermissionUser.anyBusinessUnitUserHasPermission(
             FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(noPermissionUser);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(noPermissionUser);
 
         // Act & Assert
         PermissionNotAllowedException ex = Assertions.assertThrows(
@@ -315,7 +315,7 @@ class MinorCreditorServiceTest {
         UserState noPermissionUser = mock(UserState.class);
         when(noPermissionUser.anyBusinessUnitUserHasPermission(
             FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(noPermissionUser);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(noPermissionUser);
 
         // Act & Assert
         PermissionNotAllowedException ex = Assertions.assertThrows(
@@ -395,7 +395,7 @@ class MinorCreditorServiceTest {
     @Test
     void updateMinorCreditorAccount_missingBusinessUnit_throwsPermissionNotAllowed() {
         // Arrange
-        when(userStateService.checkForAuthorisedUser()).thenReturn(mock(UserState.class));
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(mock(UserState.class));
 
         PatchMinorCreditorAccountRequest request = new PatchMinorCreditorAccountRequest()
             .partyDetails(new PartyDetailsCommon().partyId("1").organisationFlag(true))
@@ -431,7 +431,7 @@ class MinorCreditorServiceTest {
                 .build()
         ));
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(minorCreditorSearchProxy.updateMinorCreditorAccount(eq(1L), any(), eq(BigInteger.ONE), any(),
             any(), anyShort()))
             .thenReturn(new MinorCreditorAccountResponse());
@@ -457,7 +457,7 @@ class MinorCreditorServiceTest {
         UserState userState = UserStateUtil.permissionUser((short) 10, FinesPermission.ACCOUNT_MAINTENANCE);
         PatchMinorCreditorAccountRequest request = unchangedHoldPatchRequest();
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         // Act & Assert
         PermissionNotAllowedException ex = Assertions.assertThrows(
@@ -504,7 +504,7 @@ class MinorCreditorServiceTest {
         UserState userState = UserStateUtil.permissionUser((short) 10, FinesPermission.ACCOUNT_MAINTENANCE);
         PatchMinorCreditorAccountRequest request = validPatchRequest();
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         // Act & Assert
         PermissionNotAllowedException ex = Assertions.assertThrows(

--- a/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
@@ -58,12 +58,12 @@ class MinorCreditorServiceTest {
             PostMinorCreditorAccountsSearchResponse.builder().build();
 
         when(minorCreditorSearchProxy.searchMinorCreditors(any())).thenReturn(postMinorCreditorAccountsSearchResponse);
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(UserStateUtil.allFinesPermissionUser());
+        when(userStateService.checkForAuthorisedUser()).thenReturn(UserStateUtil.allFinesPermissionUser());
 
         // Act
         PostMinorCreditorAccountsSearchResponse result =
             minorCreditorService.searchMinorCreditors(
-                (MinorCreditorSearch.builder().build()), "authHeaderValue");
+                (MinorCreditorSearch.builder().build()));
 
         // Assert
         assertNotNull(result);
@@ -77,11 +77,11 @@ class MinorCreditorServiceTest {
             GetMinorCreditorAccountHeaderSummaryResponse.builder().build();
 
         when(minorCreditorSearchProxy.getHeaderSummary(id)).thenReturn(response);
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(UserStateUtil.allFinesPermissionUser());
+        when(userStateService.checkForAuthorisedUser()).thenReturn(UserStateUtil.allFinesPermissionUser());
 
         // Act
         GetMinorCreditorAccountHeaderSummaryResponse result =
-            minorCreditorService.getMinorCreditorAccountHeaderSummary(id, "authHeaderValue");
+            minorCreditorService.getMinorCreditorAccountHeaderSummary(id);
 
         // Assert
         assertNotNull(result);
@@ -95,12 +95,12 @@ class MinorCreditorServiceTest {
         UserState noPermissionUser = mock(UserState.class);
         when(noPermissionUser.anyBusinessUnitUserHasPermission(
             FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(noPermissionUser);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(noPermissionUser);
 
         // Act & Assert
         PermissionNotAllowedException ex = Assertions.assertThrows(
             PermissionNotAllowedException.class,
-                () -> minorCreditorService.getMinorCreditorAccountHeaderSummary(123L, "authHeaderValue")
+                () -> minorCreditorService.getMinorCreditorAccountHeaderSummary(123L)
         );
         assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
     }
@@ -263,11 +263,11 @@ class MinorCreditorServiceTest {
         GetMinorCreditorAccountAtAGlanceResponse response = GetMinorCreditorAccountAtAGlanceResponse.builder().build();
 
         when(minorCreditorSearchProxy.getMinorCreditorAtAGlance(id)).thenReturn(response);
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(UserStateUtil.allFinesPermissionUser());
+        when(userStateService.checkForAuthorisedUser()).thenReturn(UserStateUtil.allFinesPermissionUser());
 
         // Act
         GetMinorCreditorAccountAtAGlanceResponse result =
-            minorCreditorService.getMinorCreditorAtAGlance(id, "authHeaderValue");
+            minorCreditorService.getMinorCreditorAtAGlance(id);
 
         // Assert
         assertNotNull(result);
@@ -281,12 +281,12 @@ class MinorCreditorServiceTest {
         UserState noPermissionUser = mock(UserState.class);
         when(noPermissionUser.anyBusinessUnitUserHasPermission(
             FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(noPermissionUser);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(noPermissionUser);
 
         // Act & Assert
         PermissionNotAllowedException ex = Assertions.assertThrows(
             PermissionNotAllowedException.class,
-            () -> minorCreditorService.getMinorCreditorAtAGlance(123L, "authHeaderValue")
+            () -> minorCreditorService.getMinorCreditorAtAGlance(123L)
         );
         assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
     }
@@ -315,12 +315,12 @@ class MinorCreditorServiceTest {
         UserState noPermissionUser = mock(UserState.class);
         when(noPermissionUser.anyBusinessUnitUserHasPermission(
             FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(noPermissionUser);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(noPermissionUser);
 
         // Act & Assert
         PermissionNotAllowedException ex = Assertions.assertThrows(
             PermissionNotAllowedException.class,
-            () -> minorCreditorService.searchMinorCreditors(MinorCreditorSearch.builder().build(), "authHeaderValue")
+            () -> minorCreditorService.searchMinorCreditors(MinorCreditorSearch.builder().build())
         );
         assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
     }
@@ -331,7 +331,7 @@ class MinorCreditorServiceTest {
 
         assertThrows(
             ResourceConflictException.class, () ->
-                minorCreditorService.updateMinorCreditorAccount(1L, request, null, "authHeaderValue", "10")
+                minorCreditorService.updateMinorCreditorAccount(1L, request, null, "10")
         );
     }
 
@@ -339,7 +339,7 @@ class MinorCreditorServiceTest {
     void updateMinorCreditorAccount_missingPaymentGroup_throwsIllegalArgument() {
         assertThrows(
             IllegalArgumentException.class, () ->
-                minorCreditorService.updateMinorCreditorAccount(1L, null, BigInteger.ONE, "authHeaderValue", "10")
+                minorCreditorService.updateMinorCreditorAccount(1L, null, BigInteger.ONE, "10")
         );
     }
 
@@ -351,7 +351,7 @@ class MinorCreditorServiceTest {
 
         assertThrows(
             IllegalArgumentException.class, () ->
-                minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "authHeaderValue", "10")
+                minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "10")
         );
     }
 
@@ -364,7 +364,7 @@ class MinorCreditorServiceTest {
 
         assertThrows(
             IllegalArgumentException.class, () ->
-                minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "authHeaderValue", "10")
+                minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "10")
         );
     }
 
@@ -376,7 +376,7 @@ class MinorCreditorServiceTest {
 
         assertThrows(
             IllegalArgumentException.class, () ->
-                minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "authHeaderValue", "10")
+                minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "10")
         );
     }
 
@@ -388,14 +388,14 @@ class MinorCreditorServiceTest {
 
         assertThrows(
             IllegalArgumentException.class, () ->
-                minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "authHeaderValue", "10")
+                minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "10")
         );
     }
 
     @Test
     void updateMinorCreditorAccount_missingBusinessUnit_throwsPermissionNotAllowed() {
         // Arrange
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(mock(UserState.class));
+        when(userStateService.checkForAuthorisedUser()).thenReturn(mock(UserState.class));
 
         PatchMinorCreditorAccountRequest request = new PatchMinorCreditorAccountRequest()
             .partyDetails(new PartyDetailsCommon().partyId("1").organisationFlag(true))
@@ -405,7 +405,7 @@ class MinorCreditorServiceTest {
         // Act & Assert
         PermissionNotAllowedException ex = Assertions.assertThrows(
             PermissionNotAllowedException.class,
-            () -> minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "authHeaderValue", null)
+            () -> minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, null)
         );
 
         assertThat(ex.getPermission()).containsExactly(FinesPermission.ADD_AND_REMOVE_PAYMENT_HOLD);
@@ -431,7 +431,7 @@ class MinorCreditorServiceTest {
                 .build()
         ));
 
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(minorCreditorSearchProxy.updateMinorCreditorAccount(eq(1L), any(), eq(BigInteger.ONE), any(),
             any(), anyShort()))
             .thenReturn(new MinorCreditorAccountResponse());
@@ -439,7 +439,7 @@ class MinorCreditorServiceTest {
         PatchMinorCreditorAccountRequest request = validPatchRequest();
 
         // Act
-        minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "authHeaderValue", "10");
+        minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "10");
 
         // Assert
         ArgumentCaptor<String> postedByCaptor = ArgumentCaptor.forClass(String.class);
@@ -457,7 +457,7 @@ class MinorCreditorServiceTest {
         UserState userState = UserStateUtil.permissionUser((short) 10, FinesPermission.ACCOUNT_MAINTENANCE);
         PatchMinorCreditorAccountRequest request = unchangedHoldPatchRequest();
 
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
 
         // Act & Assert
         PermissionNotAllowedException ex = Assertions.assertThrows(
@@ -466,7 +466,6 @@ class MinorCreditorServiceTest {
                 1L,
                 request,
                 BigInteger.ONE,
-                "authHeaderValue",
                 "10"
             )
         );
@@ -505,13 +504,13 @@ class MinorCreditorServiceTest {
         UserState userState = UserStateUtil.permissionUser((short) 10, FinesPermission.ACCOUNT_MAINTENANCE);
         PatchMinorCreditorAccountRequest request = validPatchRequest();
 
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
 
         // Act & Assert
         PermissionNotAllowedException ex = Assertions.assertThrows(
             PermissionNotAllowedException.class,
             () -> minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE,
-                "authHeaderValue", "10")
+                "10")
         );
         assertThat(ex.getPermission()).containsExactly(FinesPermission.ADD_AND_REMOVE_PAYMENT_HOLD);
         assertThat(ex.getBusinessUnitId()).isEqualTo((short) 10);
@@ -567,7 +566,7 @@ class MinorCreditorServiceTest {
         // Act + Assert
         IllegalArgumentException ex = Assertions.assertThrows(
             IllegalArgumentException.class,
-            () -> minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "test.user", "10")
+            () -> minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "10")
         );
         assertEquals("Payment, party_details and address groups must be provided", ex.getMessage());
     }
@@ -576,7 +575,7 @@ class MinorCreditorServiceTest {
     void updateMinorCreditorAccount_nullRequest_throwsIllegalArgumentException() {
         IllegalArgumentException ex = Assertions.assertThrows(
             IllegalArgumentException.class,
-            () -> minorCreditorService.updateMinorCreditorAccount(1L, null, BigInteger.ONE, "test.user", "10")
+            () -> minorCreditorService.updateMinorCreditorAccount(1L, null, BigInteger.ONE, "10")
         );
         assertEquals("Payment, party_details and address groups must be provided", ex.getMessage());
     }
@@ -590,7 +589,7 @@ class MinorCreditorServiceTest {
 
         IllegalArgumentException ex = Assertions.assertThrows(
             IllegalArgumentException.class,
-            () -> minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "test.user", "10")
+            () -> minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "10")
         );
         assertEquals("Payment, party_details and address groups must be provided", ex.getMessage());
     }
@@ -603,7 +602,7 @@ class MinorCreditorServiceTest {
 
         IllegalArgumentException ex = Assertions.assertThrows(
             IllegalArgumentException.class,
-            () -> minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "test.user", "10")
+            () -> minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "10")
         );
         assertEquals("Payment, party_details and address groups must be provided", ex.getMessage());
     }
@@ -616,7 +615,7 @@ class MinorCreditorServiceTest {
 
         IllegalArgumentException ex = Assertions.assertThrows(
             IllegalArgumentException.class,
-            () -> minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "test.user", "10")
+            () -> minorCreditorService.updateMinorCreditorAccount(1L, request, BigInteger.ONE, "10")
         );
         assertEquals("Payment, party_details and address groups must be provided", ex.getMessage());
     }

--- a/src/test/java/uk/gov/hmcts/opal/service/ReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/ReportServiceTest.java
@@ -48,7 +48,7 @@ class ReportServiceTest {
 
     private UserState stubUserAndRepo(String reportId, ReportEntity repoResult) {
         UserState userState = mock(UserState.class);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(reportRepository.findById(reportId)).thenReturn(Optional.ofNullable(repoResult));
         return userState;
     }

--- a/src/test/java/uk/gov/hmcts/opal/service/UserStateServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/UserStateServiceTest.java
@@ -107,7 +107,7 @@ class UserStateServiceTest {
 
         // Act
         AccessDeniedException ade = assertThrows(AccessDeniedException.class,
-                                                 () -> userStateService.checkForAuthorisedUser("ignored"));
+                                                 () -> userStateService.checkForAuthorisedUser());
 
         // Assert
         assertEquals("Unexpected token type", ade.getMessage());
@@ -123,7 +123,7 @@ class UserStateServiceTest {
 
         // Act
         AccessDeniedException ade = assertThrows(AccessDeniedException.class,
-                                                 () -> userStateService.checkForAuthorisedUser("ignored"));
+                                                 () -> userStateService.checkForAuthorisedUser());
 
         // Assert
         assertEquals("User state not found in token", ade.getMessage());

--- a/src/test/java/uk/gov/hmcts/opal/service/UserStateServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/UserStateServiceTest.java
@@ -83,7 +83,7 @@ class UserStateServiceTest {
     }
 
     @Test
-    void testCheckForAuthorisedUser_mapsV2StateToV1FinesDomain() {
+    void testGetUser_StateV1FromSecurityContext_mapsV2StateToV1FinesDomain() {
         // Arrange
         OpalJwtAuthenticationToken authToken = mock(OpalJwtAuthenticationToken.class);
         UserStateV2 userStateV2 = mock(UserStateV2.class);
@@ -93,21 +93,21 @@ class UserStateServiceTest {
         when(userStateMapper.toUserState(userStateV2, Domain.FINES)).thenReturn(userState);
 
         // Act
-        UserState result = userStateService.checkForAuthorisedUser();
+        UserState result = userStateService.getUserStateV1FromSecurityContext();
 
         // Assert
         assertSame(userState, result);
     }
 
     @Test
-    void testCheckForAuthorisedUser_unexpectedTokenType() {
+    void testGetUser_StateV1FromSecurityContext_unexpectedTokenType() {
         // Arrange
         Authentication authentication = mock(Authentication.class);
         setAuthentication(authentication);
 
         // Act
         AccessDeniedException ade = assertThrows(AccessDeniedException.class,
-                                                 () -> userStateService.checkForAuthorisedUser());
+                                                 () -> userStateService.getUserStateV1FromSecurityContext());
 
         // Assert
         assertEquals("Unexpected token type", ade.getMessage());
@@ -115,7 +115,7 @@ class UserStateServiceTest {
     }
 
     @Test
-    void testCheckForAuthorisedUser_userStateMissingFromToken() {
+    void testGetUser_userStateV1FromSecurityContextStateMissingFromToken() {
         // Arrange
         OpalJwtAuthenticationToken authToken = mock(OpalJwtAuthenticationToken.class);
         setAuthentication(authToken);
@@ -123,7 +123,7 @@ class UserStateServiceTest {
 
         // Act
         AccessDeniedException ade = assertThrows(AccessDeniedException.class,
-                                                 () -> userStateService.checkForAuthorisedUser());
+                                                 () -> userStateService.getUserStateV1FromSecurityContext());
 
         // Assert
         assertEquals("User state not found in token", ade.getMessage());

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceAddEnforcementTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceAddEnforcementTest.java
@@ -47,7 +47,7 @@ class LegacyDefAccServiceAddEnforcementTest extends AbstractLegacyDefAccServiceT
         );
 
         AddEnforcementResponse out =
-            legacyDefendantAccountService.addEnforcement(123L, "BU-1", "user-1", "\"1\"", "auth", null);
+            legacyDefendantAccountService.addEnforcement(123L, "BU-1", "user-1", "\"1\"", null);
 
         assertNotNull(out);
         assertEquals("ENF-1", out.getEnforcementId());
@@ -74,7 +74,7 @@ class LegacyDefAccServiceAddEnforcementTest extends AbstractLegacyDefAccServiceT
         );
 
         AddEnforcementResponse out =
-            legacyDefendantAccountService.addEnforcement(500L, "BU-500", "user-500", "\"5\"", "auth", null);
+            legacyDefendantAccountService.addEnforcement(500L, "BU-500", "user-500", "\"5\"", null);
 
         assertNotNull(out);
         assertEquals("ENF-500", out.getEnforcementId());
@@ -118,7 +118,7 @@ class LegacyDefAccServiceAddEnforcementTest extends AbstractLegacyDefAccServiceT
         );
 
         AddEnforcementResponse out =
-            legacyDefendantAccountService.addEnforcement(999L, "BU-TEST", "user-test", "\"11\"", "auth", request);
+            legacyDefendantAccountService.addEnforcement(999L, "BU-TEST", "user-test", "\"11\"", request);
 
         assertNotNull(out);
         assertEquals("ENF-CAP", out.getEnforcementId());
@@ -167,7 +167,7 @@ class LegacyDefAccServiceAddEnforcementTest extends AbstractLegacyDefAccServiceT
         );
 
         AddEnforcementResponse out =
-            legacyDefendantAccountService.addEnforcement(500L, "BU-500", "user-500", "\"5\"", "auth", null);
+            legacyDefendantAccountService.addEnforcement(500L, "BU-500", "user-500", "\"5\"", null);
 
         assertNotNull(out);
         assertEquals("ENF-500", out.getEnforcementId());
@@ -188,7 +188,7 @@ class LegacyDefAccServiceAddEnforcementTest extends AbstractLegacyDefAccServiceT
         );
 
         assertThrows(NullPointerException.class, () ->
-            legacyDefendantAccountService.addEnforcement(1L, "BU", "U", "\"1\"", "auth", null)
+            legacyDefendantAccountService.addEnforcement(1L, "BU", "U", "\"1\"", null)
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServicePaymentCardRequestTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServicePaymentCardRequestTest.java
@@ -45,7 +45,7 @@ class LegacyDefAccServicePaymentCardRequestTest extends AbstractLegacyDefAccServ
         );
 
         AddPaymentCardRequestResponse out =
-            legacyDefendantAccountService.addPaymentCardRequest(123L, "78", null, "4", "AUTH");
+            legacyDefendantAccountService.addPaymentCardRequest(123L, "78", null, "4");
 
         assertNotNull(out);
         assertEquals(123L, out.getDefendantAccountId());
@@ -65,7 +65,7 @@ class LegacyDefAccServicePaymentCardRequestTest extends AbstractLegacyDefAccServ
             isNull()
         );
 
-        legacyDefendantAccountService.addPaymentCardRequest(123L, "78", null, "9", "AUTH");
+        legacyDefendantAccountService.addPaymentCardRequest(123L, "78", null, "9");
 
         AddPaymentCardLegacyRequest sent = captor.getValue();
         assertEquals("123", sent.getDefendantAccountId());
@@ -87,7 +87,7 @@ class LegacyDefAccServicePaymentCardRequestTest extends AbstractLegacyDefAccServ
         );
 
         assertThrows(RuntimeException.class, () ->
-            legacyDefendantAccountService.addPaymentCardRequest(99L, "78", null, "1", "AUTH")
+            legacyDefendantAccountService.addPaymentCardRequest(99L, "78", null, "1")
         );
     }
 
@@ -106,7 +106,7 @@ class LegacyDefAccServicePaymentCardRequestTest extends AbstractLegacyDefAccServ
         );
 
         assertThrows(RuntimeException.class, () ->
-            legacyDefendantAccountService.addPaymentCardRequest(88L, "78", null, "2", "AUTH")
+            legacyDefendantAccountService.addPaymentCardRequest(88L, "78", null, "2")
         );
     }
 
@@ -123,14 +123,14 @@ class LegacyDefAccServicePaymentCardRequestTest extends AbstractLegacyDefAccServ
         );
 
         assertThrows(RuntimeException.class, () ->
-            legacyDefendantAccountService.addPaymentCardRequest(55L, "78", null, "3", "AUTH")
+            legacyDefendantAccountService.addPaymentCardRequest(55L, "78", null, "3")
         );
     }
 
     @Test
     void addPaymentCardRequest_legacy_invalidIfMatchThrows() {
         assertThrows(IllegalArgumentException.class, () ->
-            legacyDefendantAccountService.addPaymentCardRequest(1L, "78", null, "notANumber", "AUTH")
+            legacyDefendantAccountService.addPaymentCardRequest(1L, "78", null, "notANumber")
         );
     }
 
@@ -150,8 +150,7 @@ class LegacyDefAccServicePaymentCardRequestTest extends AbstractLegacyDefAccServ
 
         var actualResponse = legacyDefendantAccountService.addPaymentTerms(
             defendantAccountId, businessUnitId,
-            businessUnitUserId, ifMatch,
-            "auth", null
+            businessUnitUserId, ifMatch, null
         );
 
         // Then
@@ -226,8 +225,7 @@ class LegacyDefAccServicePaymentCardRequestTest extends AbstractLegacyDefAccServ
             HttpServerErrorException.class, () ->
                 legacyDefendantAccountService.addPaymentTerms(
                     defendantAccountId, businessUnitId,
-                    businessUnitUserId, ifMatch,
-                    "auth", null
+                    businessUnitUserId, ifMatch, null
                 )
         );
 
@@ -266,8 +264,7 @@ class LegacyDefAccServicePaymentCardRequestTest extends AbstractLegacyDefAccServ
 
         var actualResponse = legacyDefendantAccountService.addPaymentTerms(
             defendantAccountId, businessUnitId,
-            businessUnitUserId, ifMatch,
-            "auth", null
+            businessUnitUserId, ifMatch, null
         );
 
         // Then

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountEnforcementServiceTest.java
@@ -138,7 +138,6 @@ public class LegacyDefendantAccountEnforcementServiceTest {
                 (short) 1,
                 "user-1",
                 "1",
-                "auth",
                 null
             );
 
@@ -173,7 +172,7 @@ public class LegacyDefendantAccountEnforcementServiceTest {
         AddEnforcementResponse out =
             legacyDefendantAccountEnforcementService.addEnforcement(
                 500L,
-                (short) 500, "user-500", "5", "auth", null
+                (short) 500, "user-500", "5", null
             );
 
         // Assert
@@ -228,7 +227,7 @@ public class LegacyDefendantAccountEnforcementServiceTest {
             legacyDefendantAccountEnforcementService
                 .addEnforcement(
                     999L, (short) 101, "user-test",
-                    "11", "auth", request
+                    "11", request
                 );
 
         // Assert - public DTO returned correctly
@@ -291,7 +290,7 @@ public class LegacyDefendantAccountEnforcementServiceTest {
         AddEnforcementResponse out =
             legacyDefendantAccountEnforcementService.addEnforcement(
                 500L, (short) 500,
-                "user-500", "5", "auth", null
+                "user-500", "5", null
             );
 
         // Assert
@@ -322,7 +321,6 @@ public class LegacyDefendantAccountEnforcementServiceTest {
                     (short) 1,
                     "U",
                     "1",
-                    "auth",
                     null
                 )
         );
@@ -623,7 +621,6 @@ public class LegacyDefendantAccountEnforcementServiceTest {
                 (short) 10,
                 "user-1",
                 "\"7\"",
-                "auth",
                 request
             );
 
@@ -697,7 +694,6 @@ public class LegacyDefendantAccountEnforcementServiceTest {
                     (short) 10,
                     "user-1",
                     "\"1\"",
-                    "auth",
                     request
                 )
         );
@@ -753,7 +749,6 @@ public class LegacyDefendantAccountEnforcementServiceTest {
                     (short) 10,
                     "user-1",
                     "\"5\"",
-                    "auth",
                     request
                 )
         );
@@ -802,7 +797,6 @@ public class LegacyDefendantAccountEnforcementServiceTest {
                     (short) 10,
                     "user-2",
                     "\"2\"",
-                    "auth",
                     request
                 )
         );

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPaymentTermsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPaymentTermsServiceTest.java
@@ -93,7 +93,7 @@ class LegacyDefendantAccountPaymentTermsServiceTest {
 
         // When
         AddPaymentCardRequestResponse out =
-            legacyDefendantAccountPaymentTermsService.addPaymentCardRequest(123L, "78", null,"4", "AUTH");
+            legacyDefendantAccountPaymentTermsService.addPaymentCardRequest(123L, "78", null,"4");
 
         // Then
         assertNotNull(out);
@@ -120,7 +120,7 @@ class LegacyDefendantAccountPaymentTermsServiceTest {
         );
 
         // When
-        legacyDefendantAccountPaymentTermsService.addPaymentCardRequest(123L, "78",null, "9", "AUTH");
+        legacyDefendantAccountPaymentTermsService.addPaymentCardRequest(123L, "78",null, "9");
 
         // Then
         AddPaymentCardLegacyRequest sent = captor.getValue();
@@ -144,7 +144,7 @@ class LegacyDefendantAccountPaymentTermsServiceTest {
         );
 
         assertThrows(RuntimeException.class, () ->
-            legacyDefendantAccountPaymentTermsService.addPaymentCardRequest(99L, "78", null,"1", "AUTH")
+            legacyDefendantAccountPaymentTermsService.addPaymentCardRequest(99L, "78", null,"1")
         );
     }
 
@@ -164,7 +164,7 @@ class LegacyDefendantAccountPaymentTermsServiceTest {
         );
 
         assertThrows(RuntimeException.class, () ->
-            legacyDefendantAccountPaymentTermsService.addPaymentCardRequest(88L, "78", null,"2", "AUTH")
+            legacyDefendantAccountPaymentTermsService.addPaymentCardRequest(88L, "78", null,"2")
         );
     }
 
@@ -182,14 +182,14 @@ class LegacyDefendantAccountPaymentTermsServiceTest {
         );
 
         assertThrows(RuntimeException.class, () ->
-            legacyDefendantAccountPaymentTermsService.addPaymentCardRequest(55L, "78", null, "3", "AUTH")
+            legacyDefendantAccountPaymentTermsService.addPaymentCardRequest(55L, "78", null, "3")
         );
     }
 
     @Test
     void addPaymentCardRequest_legacy_invalidIfMatchThrows() {
         assertThrows(IllegalArgumentException.class, () ->
-            legacyDefendantAccountPaymentTermsService.addPaymentCardRequest(1L, "78", null,"notANumber", "AUTH")
+            legacyDefendantAccountPaymentTermsService.addPaymentCardRequest(1L, "78", null,"notANumber")
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalCreditorAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalCreditorAccountServiceTest.java
@@ -7,8 +7,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
-import uk.gov.hmcts.opal.controllers.util.UserStateUtil;
-import uk.gov.hmcts.opal.service.UserStateService;
 import uk.gov.hmcts.opal.service.opal.jpa.CreditorAccountTransactional;
 
 import jakarta.persistence.EntityNotFoundException;
@@ -24,9 +22,6 @@ class OpalCreditorAccountServiceTest {
     @Mock
     private CreditorAccountTransactional creditorAccountTransactional;
 
-    @Mock
-    private UserStateService userStateService;
-
     @InjectMocks
     private OpalCreditorAccountService service;
 
@@ -36,7 +31,7 @@ class OpalCreditorAccountServiceTest {
         when(creditorAccountTransactional.deleteMinorCreditorAccountAndRelatedData(anyLong(), any())).thenReturn(true);
 
         // Act
-        String response = service.deleteCreditorAccount(555L, true, "authHeader");
+        String response = service.deleteCreditorAccount(555L, true);
 
         // Assert
         assertEquals("{ \"message\": \"Creditor Account '555' deleted\"}", response);
@@ -49,7 +44,7 @@ class OpalCreditorAccountServiceTest {
 
         // Act
         String result =
-            service.deleteCreditorAccount(777L, false, "authHeaderValue");
+            service.deleteCreditorAccount(777L, false);
 
         // Assert
         assertEquals("""
@@ -59,14 +54,13 @@ class OpalCreditorAccountServiceTest {
     @Test
     void testDeleteMinorCreditor_fail_checkExisted() {
         // Arrange
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(UserStateUtil.allPermissionsUser());
         when(creditorAccountTransactional.deleteMinorCreditorAccountAndRelatedData(anyLong(), any()))
             .thenThrow(new EntityNotFoundException("No Creditor Account!"));
 
         // Act
         EntityNotFoundException error = assertThrows(
             EntityNotFoundException.class, () ->
-                service.deleteCreditorAccount(777L, true, "authHeaderValue")
+                service.deleteCreditorAccount(777L, true)
         );
 
         // Assert

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
@@ -132,7 +132,6 @@ public class OpalDefendantAccountEnforcementServiceTest {
             BUSINESS_UNIT_ID,
             BUSINESS_UNIT_USER_ID,
             IF_MATCH,
-            AUTH_HEADER,
             request
         );
 
@@ -161,7 +160,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
     public void testAddEnforcement_whenOnlyGivenReason_createsEnforcement() throws JacksonException {
         UserState userState = mock(UserState.class);
         when(userState.getDisplayName()).thenReturn(USER_DISPLAY_NAME);
-        when(userStateService.checkForAuthorisedUser(AUTH_HEADER)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
 
         DefendantAccountEntity defendant = mock(DefendantAccountEntity.class);
         when(defendant.getProsecutorCaseReference()).thenReturn(PROSECUTOR_CASE_REFERENCE);
@@ -198,7 +197,6 @@ public class OpalDefendantAccountEnforcementServiceTest {
             BUSINESS_UNIT_ID,
             BUSINESS_UNIT_USER_ID,
             IF_MATCH,
-            AUTH_HEADER,
             request
         );
 
@@ -227,7 +225,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
     public void testAddEnforcement_whenOnlyGivenJailDays_createsEnforcement() throws JacksonException {
         UserState userState = mock(UserState.class);
         when(userState.getDisplayName()).thenReturn(USER_DISPLAY_NAME);
-        when(userStateService.checkForAuthorisedUser(AUTH_HEADER)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
 
         DefendantAccountEntity defendant = mock(DefendantAccountEntity.class);
         when(defendant.getProsecutorCaseReference()).thenReturn(PROSECUTOR_CASE_REFERENCE);
@@ -264,7 +262,6 @@ public class OpalDefendantAccountEnforcementServiceTest {
             BUSINESS_UNIT_ID,
             BUSINESS_UNIT_USER_ID,
             IF_MATCH,
-            AUTH_HEADER,
             request
         );
 
@@ -293,7 +290,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
     public void testAddEnforcement_whenOnlyGivenEnforcer_createsEnforcement() throws JacksonException {
         UserState userState = mock(UserState.class);
         when(userState.getDisplayName()).thenReturn(USER_DISPLAY_NAME);
-        when(userStateService.checkForAuthorisedUser(AUTH_HEADER)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
 
         DefendantAccountEntity defendant = mock(DefendantAccountEntity.class);
         when(defendant.getProsecutorCaseReference()).thenReturn(PROSECUTOR_CASE_REFERENCE);
@@ -330,7 +327,6 @@ public class OpalDefendantAccountEnforcementServiceTest {
             BUSINESS_UNIT_ID,
             BUSINESS_UNIT_USER_ID,
             IF_MATCH,
-            AUTH_HEADER,
             request
         );
 
@@ -359,7 +355,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
     public void testAddEnforcement_whenOnlyGivenReleaseDate_createsEnforcement() throws JacksonException {
         UserState userState = mock(UserState.class);
         when(userState.getDisplayName()).thenReturn(USER_DISPLAY_NAME);
-        when(userStateService.checkForAuthorisedUser(AUTH_HEADER)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
 
         DefendantAccountEntity defendant = mock(DefendantAccountEntity.class);
         when(defendant.getProsecutorCaseReference()).thenReturn(PROSECUTOR_CASE_REFERENCE);
@@ -396,7 +392,6 @@ public class OpalDefendantAccountEnforcementServiceTest {
             BUSINESS_UNIT_ID,
             BUSINESS_UNIT_USER_ID,
             IF_MATCH,
-            AUTH_HEADER,
             request
         );
 
@@ -425,7 +420,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
     public void testAddEnforcement_whenGivenPaymentTerms_callsPaymentTermsService() throws JacksonException {
         UserState userState = mock(UserState.class);
         when(userState.getDisplayName()).thenReturn(USER_DISPLAY_NAME);
-        when(userStateService.checkForAuthorisedUser(AUTH_HEADER)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
 
         DefendantAccountEntity defendant = mock(DefendantAccountEntity.class);
         when(defendant.getProsecutorCaseReference()).thenReturn(PROSECUTOR_CASE_REFERENCE);
@@ -475,7 +470,6 @@ public class OpalDefendantAccountEnforcementServiceTest {
             BUSINESS_UNIT_ID,
             BUSINESS_UNIT_USER_ID,
             IF_MATCH,
-            AUTH_HEADER,
             request
         );
 
@@ -502,7 +496,6 @@ public class OpalDefendantAccountEnforcementServiceTest {
             eq(BUSINESS_UNIT_ID.toString()),
             eq(BUSINESS_UNIT_USER_ID),
             eq(IF_MATCH),
-            eq(AUTH_HEADER),
             org.mockito.ArgumentMatchers.any(AddDefendantAccountPaymentTermsRequest.class)
         );
     }
@@ -532,7 +525,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
         LocalDate expectedLastMovementDate = LocalDate.of(2026, 4, 22);
         ArgumentCaptor<AddNoteRequest> addNoteRequestCaptor = ArgumentCaptor.forClass(AddNoteRequest.class);
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(defendantAccountRepositoryService.findById(defendantAccountId)).thenReturn(defendantEntity);
         when(defendantAccountRepositoryService.saveAndFlush(defendantEntity)).thenReturn(defendantEntity);
 
@@ -552,7 +545,6 @@ public class OpalDefendantAccountEnforcementServiceTest {
                     businessUnitId,
                     businessUnitUserId,
                     ifMatch,
-                    authHeader,
                     request
                 );
 
@@ -563,7 +555,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
             assertNull(defendantEntity.getLastEnforcement());
             assertEquals(expectedLastMovementDate, defendantEntity.getLastMovementDate());
 
-            verify(userStateService).checkForAuthorisedUser(authHeader);
+            verify(userStateService).checkForAuthorisedUser();
             verify(defendantAccountRepositoryService).findById(defendantAccountId);
             verify(amendmentService).auditInitialiseStoredProc(
                 defendantAccountId,
@@ -618,7 +610,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
 
         UserState userState = allPermissionsUser();
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(defendantAccountRepositoryService.findById(defendantAccountId)).thenReturn(defendantEntity);
 
         ResourceConflictException ex = assertThrows(
@@ -628,7 +620,6 @@ public class OpalDefendantAccountEnforcementServiceTest {
                 businessUnitId,
                 businessUnitUserId,
                 "   ",
-                authHeader,
                 request
             )
         );
@@ -639,7 +630,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
         assertEquals("If-Match header is required", ex.getConflictReason());
         assertSame(defendantEntity, ex.getVersioned());
 
-        verify(userStateService).checkForAuthorisedUser(authHeader);
+        verify(userStateService).checkForAuthorisedUser();
         verify(defendantAccountRepositoryService).findById(defendantAccountId);
         verifyNoInteractions(amendmentService, reportEntryService, notesProxy);
         verifyNoMoreInteractions(defendantAccountRepositoryService);
@@ -666,7 +657,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
 
         UserState userState = allPermissionsUser();
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(defendantAccountRepositoryService.findById(defendantAccountId)).thenReturn(defendantEntity);
 
         try (MockedStatic<VersionUtils> versionUtils = mockStatic(VersionUtils.class)) {
@@ -684,7 +675,6 @@ public class OpalDefendantAccountEnforcementServiceTest {
                     businessUnitId,
                     businessUnitUserId,
                     ifMatch,
-                    authHeader,
                     request
                 )
             );
@@ -695,7 +685,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
             assertEquals("No enforcement hold to remove", ex.getConflictReason());
             assertSame(defendantEntity, ex.getVersioned());
 
-            verify(userStateService).checkForAuthorisedUser(authHeader);
+            verify(userStateService).checkForAuthorisedUser();
             verify(defendantAccountRepositoryService).findById(defendantAccountId);
             verifyNoInteractions(amendmentService, reportEntryService, notesProxy);
             verifyNoMoreInteractions(defendantAccountRepositoryService);
@@ -723,7 +713,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
 
         UserState userState = allPermissionsUser();
 
-        when(userStateService.checkForAuthorisedUser(authHeader)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
         when(defendantAccountRepositoryService.findById(defendantAccountId)).thenReturn(defendantEntity);
         doThrow(new ObjectOptimisticLockingFailureException(defendantEntity.getClass(), defendantAccountId))
             .when(defendantAccountRepositoryService)
@@ -744,7 +734,6 @@ public class OpalDefendantAccountEnforcementServiceTest {
                     businessUnitId,
                     businessUnitUserId,
                     ifMatch,
-                    authHeader,
                     request
                 )
             );
@@ -753,7 +742,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
             assertEquals(defendantEntity.getClass().getName(), ex.getPersistentClassName());
             assertEquals(defendantAccountId, ex.getIdentifier());
 
-            verify(userStateService).checkForAuthorisedUser(authHeader);
+            verify(userStateService).checkForAuthorisedUser();
             verify(defendantAccountRepositoryService).findById(defendantAccountId);
             verify(amendmentService).auditInitialiseStoredProc(
                 defendantAccountId,
@@ -782,7 +771,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
     private void mockAuthorisedUser() {
         UserState userState = mock(UserState.class);
         when(userState.getDisplayName()).thenReturn(USER_DISPLAY_NAME);
-        when(userStateService.checkForAuthorisedUser(AUTH_HEADER)).thenReturn(userState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
     }
 
     private void mockDefendantAccount() {

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
@@ -507,7 +507,6 @@ public class OpalDefendantAccountEnforcementServiceTest {
         String businessUnitUserId = "BU-USER-1";
         String ifMatch = "\"7\"";
         String updatedIfMatch = "\"7\"";
-        String authHeader = "Bearer abc";
 
         RemoveDefendantAccountEnforcementHoldRequest request =
             RemoveDefendantAccountEnforcementHoldRequest.builder()
@@ -594,7 +593,6 @@ public class OpalDefendantAccountEnforcementServiceTest {
         Long defendantAccountId = 77L;
         Short businessUnitId = 10;
         String businessUnitUserId = "BU-USER-1";
-        String authHeader = "Bearer abc";
 
         RemoveDefendantAccountEnforcementHoldRequest request =
             RemoveDefendantAccountEnforcementHoldRequest.builder()
@@ -641,7 +639,6 @@ public class OpalDefendantAccountEnforcementServiceTest {
         Short businessUnitId = 10;
         String businessUnitUserId = "BU-USER-1";
         String ifMatch = "\"7\"";
-        String authHeader = "Bearer abc";
 
         RemoveDefendantAccountEnforcementHoldRequest request =
             RemoveDefendantAccountEnforcementHoldRequest.builder()
@@ -697,7 +694,6 @@ public class OpalDefendantAccountEnforcementServiceTest {
         Short businessUnitId = 10;
         String businessUnitUserId = "BU-USER-1";
         String ifMatch = "\"7\"";
-        String authHeader = "Bearer abc";
 
         RemoveDefendantAccountEnforcementHoldRequest request =
             RemoveDefendantAccountEnforcementHoldRequest.builder()

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
@@ -160,7 +160,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
     public void testAddEnforcement_whenOnlyGivenReason_createsEnforcement() throws JacksonException {
         UserState userState = mock(UserState.class);
         when(userState.getDisplayName()).thenReturn(USER_DISPLAY_NAME);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         DefendantAccountEntity defendant = mock(DefendantAccountEntity.class);
         when(defendant.getProsecutorCaseReference()).thenReturn(PROSECUTOR_CASE_REFERENCE);
@@ -225,7 +225,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
     public void testAddEnforcement_whenOnlyGivenJailDays_createsEnforcement() throws JacksonException {
         UserState userState = mock(UserState.class);
         when(userState.getDisplayName()).thenReturn(USER_DISPLAY_NAME);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         DefendantAccountEntity defendant = mock(DefendantAccountEntity.class);
         when(defendant.getProsecutorCaseReference()).thenReturn(PROSECUTOR_CASE_REFERENCE);
@@ -290,7 +290,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
     public void testAddEnforcement_whenOnlyGivenEnforcer_createsEnforcement() throws JacksonException {
         UserState userState = mock(UserState.class);
         when(userState.getDisplayName()).thenReturn(USER_DISPLAY_NAME);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         DefendantAccountEntity defendant = mock(DefendantAccountEntity.class);
         when(defendant.getProsecutorCaseReference()).thenReturn(PROSECUTOR_CASE_REFERENCE);
@@ -355,7 +355,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
     public void testAddEnforcement_whenOnlyGivenReleaseDate_createsEnforcement() throws JacksonException {
         UserState userState = mock(UserState.class);
         when(userState.getDisplayName()).thenReturn(USER_DISPLAY_NAME);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         DefendantAccountEntity defendant = mock(DefendantAccountEntity.class);
         when(defendant.getProsecutorCaseReference()).thenReturn(PROSECUTOR_CASE_REFERENCE);
@@ -420,7 +420,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
     public void testAddEnforcement_whenGivenPaymentTerms_callsPaymentTermsService() throws JacksonException {
         UserState userState = mock(UserState.class);
         when(userState.getDisplayName()).thenReturn(USER_DISPLAY_NAME);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
 
         DefendantAccountEntity defendant = mock(DefendantAccountEntity.class);
         when(defendant.getProsecutorCaseReference()).thenReturn(PROSECUTOR_CASE_REFERENCE);
@@ -525,7 +525,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
         LocalDate expectedLastMovementDate = LocalDate.of(2026, 4, 22);
         ArgumentCaptor<AddNoteRequest> addNoteRequestCaptor = ArgumentCaptor.forClass(AddNoteRequest.class);
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(defendantAccountRepositoryService.findById(defendantAccountId)).thenReturn(defendantEntity);
         when(defendantAccountRepositoryService.saveAndFlush(defendantEntity)).thenReturn(defendantEntity);
 
@@ -555,7 +555,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
             assertNull(defendantEntity.getLastEnforcement());
             assertEquals(expectedLastMovementDate, defendantEntity.getLastMovementDate());
 
-            verify(userStateService).checkForAuthorisedUser();
+            verify(userStateService).getUserStateV1FromSecurityContext();
             verify(defendantAccountRepositoryService).findById(defendantAccountId);
             verify(amendmentService).auditInitialiseStoredProc(
                 defendantAccountId,
@@ -610,7 +610,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
 
         UserState userState = allPermissionsUser();
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(defendantAccountRepositoryService.findById(defendantAccountId)).thenReturn(defendantEntity);
 
         ResourceConflictException ex = assertThrows(
@@ -630,7 +630,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
         assertEquals("If-Match header is required", ex.getConflictReason());
         assertSame(defendantEntity, ex.getVersioned());
 
-        verify(userStateService).checkForAuthorisedUser();
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(defendantAccountRepositoryService).findById(defendantAccountId);
         verifyNoInteractions(amendmentService, reportEntryService, notesProxy);
         verifyNoMoreInteractions(defendantAccountRepositoryService);
@@ -657,7 +657,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
 
         UserState userState = allPermissionsUser();
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(defendantAccountRepositoryService.findById(defendantAccountId)).thenReturn(defendantEntity);
 
         try (MockedStatic<VersionUtils> versionUtils = mockStatic(VersionUtils.class)) {
@@ -685,7 +685,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
             assertEquals("No enforcement hold to remove", ex.getConflictReason());
             assertSame(defendantEntity, ex.getVersioned());
 
-            verify(userStateService).checkForAuthorisedUser();
+            verify(userStateService).getUserStateV1FromSecurityContext();
             verify(defendantAccountRepositoryService).findById(defendantAccountId);
             verifyNoInteractions(amendmentService, reportEntryService, notesProxy);
             verifyNoMoreInteractions(defendantAccountRepositoryService);
@@ -713,7 +713,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
 
         UserState userState = allPermissionsUser();
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(defendantAccountRepositoryService.findById(defendantAccountId)).thenReturn(defendantEntity);
         doThrow(new ObjectOptimisticLockingFailureException(defendantEntity.getClass(), defendantAccountId))
             .when(defendantAccountRepositoryService)
@@ -742,7 +742,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
             assertEquals(defendantEntity.getClass().getName(), ex.getPersistentClassName());
             assertEquals(defendantAccountId, ex.getIdentifier());
 
-            verify(userStateService).checkForAuthorisedUser();
+            verify(userStateService).getUserStateV1FromSecurityContext();
             verify(defendantAccountRepositoryService).findById(defendantAccountId);
             verify(amendmentService).auditInitialiseStoredProc(
                 defendantAccountId,
@@ -771,7 +771,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
     private void mockAuthorisedUser() {
         UserState userState = mock(UserState.class);
         when(userState.getDisplayName()).thenReturn(USER_DISPLAY_NAME);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
     }
 
     private void mockDefendantAccount() {

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
@@ -69,7 +69,6 @@ public class OpalDefendantAccountEnforcementServiceTest {
     private static final Short BUSINESS_UNIT_ID = 2002;
     private static final String BUSINESS_UNIT_USER_ID = "bu-user-123";
     private static final String IF_MATCH = "7";
-    private static final String AUTH_HEADER = "Bearer token";
     private static final String USER_DISPLAY_NAME = "Test User";
     private static final String PROSECUTOR_CASE_REFERENCE = "PCR-12345";
     private static final Long ENFORCEMENT_ID = 9876L;

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceAddPaymentTermsTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceAddPaymentTermsTest.java
@@ -146,7 +146,7 @@ public class OpalDefendantAccountServiceAddPaymentTermsTest {
 
         // Act
         defendantAccountService.addPaymentTerms(defendantAccountId, businessUnitId, "tester",
-            ifMatch, postedBy, request);
+            ifMatch, request);
 
         // Assert
         // 1) Verify PaymentTermsService.addPaymentTerm was called
@@ -205,8 +205,8 @@ public class OpalDefendantAccountServiceAddPaymentTermsTest {
         when(paymentTermsService.addPaymentTerm(any(PaymentTermsEntity.class))).thenReturn(savedPaymentTermsEntity);
 
         // Act
-        defendantAccountService.addPaymentTerms(defendantAccountId, businessUnitId, businessUnitUserId, ifMatch,
-            authHeader, request);
+        defendantAccountService.addPaymentTerms(
+            defendantAccountId, businessUnitId, businessUnitUserId, ifMatch, request);
 
         // Assert
         verify(paymentTermsService).addPaymentTerm(argThat(entity ->

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceAddPaymentTermsTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceAddPaymentTermsTest.java
@@ -167,7 +167,6 @@ public class OpalDefendantAccountServiceAddPaymentTermsTest {
         final String businessUnitId = "10";
         final String businessUnitUserId = "userX";
         final String ifMatch = "\"1\"";
-        final String authHeader = "Bearer token";
 
         BusinessUnitEntity bu = BusinessUnitEntity.builder()
             .businessUnitId((short) 10)

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServicePaymentCardTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServicePaymentCardTest.java
@@ -69,13 +69,14 @@ class OpalDefendantAccountServicePaymentCardTest {
             .thenReturn(account);
         when(paymentCardRequestRepositoryService.existsByDefendantAccountId(accountId))
             .thenReturn(false);
-        when(accessTokenService.extractName("AUTH"))
-            .thenReturn("John Smith");
+        UserState userState = mock(UserState.class);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userState.getDisplayName()).thenReturn("John Smith");
         when(defendantAccountRepositoryService.save(any()))
             .thenAnswer(inv -> inv.getArgument(0));
 
         AddPaymentCardRequestResponse response = service.addPaymentCardRequest(
-            accountId, "10", "L080JG", "\"1\"", "AUTH"
+            accountId, "10", "L080JG", "\"1\""
         );
 
         assertNotNull(response);
@@ -98,7 +99,7 @@ class OpalDefendantAccountServicePaymentCardTest {
         when(paymentCardRequestRepositoryService.existsByDefendantAccountId(1L)).thenReturn(true);
 
         assertThrows(PaymentCardRequestAlreadyExistsException.class, () ->
-            service.addPaymentCardRequest(1L, "10", null, "\"1\"", "AUTH")
+            service.addPaymentCardRequest(1L, "10", null, "\"1\"")
         );
     }
 
@@ -112,7 +113,7 @@ class OpalDefendantAccountServicePaymentCardTest {
         when(defendantAccountRepositoryService.findById(1L)).thenReturn(account);
 
         assertThrows(EntityNotFoundException.class, () ->
-            service.addPaymentCardRequest(1L, "10", null, "\"1\"", "AUTH")
+            service.addPaymentCardRequest(1L, "10", null, "\"1\"")
         );
     }
 
@@ -126,9 +127,12 @@ class OpalDefendantAccountServicePaymentCardTest {
         when(defendantAccountRepositoryService.findById(1L)).thenReturn(account);
         when(paymentCardRequestRepositoryService.existsByDefendantAccountId(1L)).thenReturn(false);
         when(defendantAccountRepositoryService.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        UserState userState = mock(UserState.class);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userState.getDisplayName()).thenReturn("John Smith");
 
         assertDoesNotThrow(() ->
-            service.addPaymentCardRequest(1L, "10", null, "\"1\"", "AUTH")
+            service.addPaymentCardRequest(1L, "10", null, "\"1\"")
         );
 
         assertTrue(account.getPaymentCardRequested());
@@ -145,7 +149,7 @@ class OpalDefendantAccountServicePaymentCardTest {
         when(defendantAccountRepositoryService.findById(1L)).thenReturn(account);
 
         assertThrows(ObjectOptimisticLockingFailureException.class, () ->
-            service.addPaymentCardRequest(1L, "10", null, "\"0\"", "AUTH")
+            service.addPaymentCardRequest(1L, "10", null, "\"0\"")
         );
     }
 
@@ -159,7 +163,7 @@ class OpalDefendantAccountServicePaymentCardTest {
         when(defendantAccountRepositoryService.findById(1L)).thenReturn(account);
 
         assertThrows(EntityNotFoundException.class, () ->
-            service.addPaymentCardRequest(1L, "10", "BU-USER-123", "\"1\"", "AUTH")
+            service.addPaymentCardRequest(1L, "10", "BU-USER-123", "\"1\"")
         );
 
         verify(defendantAccountRepositoryService, never()).save(any());
@@ -181,11 +185,13 @@ class OpalDefendantAccountServicePaymentCardTest {
 
         when(defendantAccountRepositoryService.findById(accountId)).thenReturn(account);
         when(paymentCardRequestRepositoryService.existsByDefendantAccountId(accountId)).thenReturn(false);
-        when(accessTokenService.extractName("AUTH")).thenReturn("John Smith");
+        UserState userState = mock(UserState.class);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userState.getDisplayName()).thenReturn("John Smith");
         when(defendantAccountRepositoryService.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         AddPaymentCardRequestResponse response = service.addPaymentCardRequest(
-            accountId, "10", "L080JG", "\"1\"", "AUTH"
+            accountId, "10", "L080JG", "\"1\""
         );
 
         assertNotNull(response);
@@ -203,7 +209,7 @@ class OpalDefendantAccountServicePaymentCardTest {
         DefendantAccountPaymentTermsServiceProxy proxy = mock(DefendantAccountPaymentTermsServiceProxy.class);
 
         UserState userState = mock(UserState.class);
-        when(userStateService.checkForAuthorisedUser("AUTH"))
+        when(userStateService.checkForAuthorisedUser())
             .thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.AMEND_PAYMENT_TERMS))
             .thenReturn(false);
@@ -212,7 +218,7 @@ class OpalDefendantAccountServicePaymentCardTest {
 
         PermissionNotAllowedException ex = assertThrows(
             PermissionNotAllowedException.class,
-            () -> svc.addPaymentCardRequest(1L, "10", "USR", "\"1\"", "AUTH")
+            () -> svc.addPaymentCardRequest(1L, "10", "USR", "\"1\"")
         );
         assertThat(ex.getPermission()).containsExactly(FinesPermission.AMEND_PAYMENT_TERMS);
 

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServicePaymentCardTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServicePaymentCardTest.java
@@ -70,7 +70,7 @@ class OpalDefendantAccountServicePaymentCardTest {
         when(paymentCardRequestRepositoryService.existsByDefendantAccountId(accountId))
             .thenReturn(false);
         UserState userState = mock(UserState.class);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getDisplayName()).thenReturn("John Smith");
         when(defendantAccountRepositoryService.save(any()))
             .thenAnswer(inv -> inv.getArgument(0));
@@ -128,7 +128,7 @@ class OpalDefendantAccountServicePaymentCardTest {
         when(paymentCardRequestRepositoryService.existsByDefendantAccountId(1L)).thenReturn(false);
         when(defendantAccountRepositoryService.save(any())).thenAnswer(inv -> inv.getArgument(0));
         UserState userState = mock(UserState.class);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getDisplayName()).thenReturn("John Smith");
 
         assertDoesNotThrow(() ->
@@ -186,7 +186,7 @@ class OpalDefendantAccountServicePaymentCardTest {
         when(defendantAccountRepositoryService.findById(accountId)).thenReturn(account);
         when(paymentCardRequestRepositoryService.existsByDefendantAccountId(accountId)).thenReturn(false);
         UserState userState = mock(UserState.class);
-        when(userStateService.checkForAuthorisedUser()).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getDisplayName()).thenReturn("John Smith");
         when(defendantAccountRepositoryService.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
@@ -209,7 +209,7 @@ class OpalDefendantAccountServicePaymentCardTest {
         DefendantAccountPaymentTermsServiceProxy proxy = mock(DefendantAccountPaymentTermsServiceProxy.class);
 
         UserState userState = mock(UserState.class);
-        when(userStateService.checkForAuthorisedUser())
+        when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(userState);
         when(userState.anyBusinessUnitUserHasPermission(FinesPermission.AMEND_PAYMENT_TERMS))
             .thenReturn(false);

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceTest02.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceTest02.java
@@ -135,14 +135,14 @@ class OpalDefendantAccountServiceTest02 {
         var mockUserState = mock(UserState.class);
         var mockResponse = new GetDefendantAccountFixedPenaltyResponse();
 
-        when(userStateService.checkForAuthorisedUser("Bearer token")).thenReturn(mockUserState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(mockUserState);
         when(mockUserState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(proxy.getDefendantAccountFixedPenalty(123L)).thenReturn(mockResponse);
 
         var service = new DefendantAccountFixedPenaltyService(proxy, userStateService);
 
         // Act
-        var response = service.getDefendantAccountFixedPenalty(123L, "Bearer token");
+        var response = service.getDefendantAccountFixedPenalty(123L);
 
         // Assert
         verify(proxy).getDefendantAccountFixedPenalty(123L);
@@ -157,7 +157,7 @@ class OpalDefendantAccountServiceTest02 {
         var userStateService = mock(UserStateService.class);
         var mockUserState = mock(UserState.class);
 
-        when(userStateService.checkForAuthorisedUser("auth")).thenReturn(mockUserState);
+        when(userStateService.checkForAuthorisedUser()).thenReturn(mockUserState);
         when(mockUserState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS))
             .thenReturn(false);
 
@@ -165,7 +165,7 @@ class OpalDefendantAccountServiceTest02 {
 
         // Act + Assert
         assertThrows(PermissionNotAllowedException.class,
-            () -> service.getDefendantAccountFixedPenalty(123L, "auth")
+            () -> service.getDefendantAccountFixedPenalty(123L)
         );
 
         verifyNoInteractions(proxy);

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceTest02.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceTest02.java
@@ -135,7 +135,7 @@ class OpalDefendantAccountServiceTest02 {
         var mockUserState = mock(UserState.class);
         var mockResponse = new GetDefendantAccountFixedPenaltyResponse();
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(mockUserState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(mockUserState);
         when(mockUserState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(true);
         when(proxy.getDefendantAccountFixedPenalty(123L)).thenReturn(mockResponse);
 
@@ -157,7 +157,7 @@ class OpalDefendantAccountServiceTest02 {
         var userStateService = mock(UserStateService.class);
         var mockUserState = mock(UserState.class);
 
-        when(userStateService.checkForAuthorisedUser()).thenReturn(mockUserState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(mockUserState);
         when(mockUserState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS))
             .thenReturn(false);
 

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountUpdateTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountUpdateTest.java
@@ -174,7 +174,7 @@ class OpalDefendantAccountUpdateTest {
 
         // ---------- Act ----------
         final String buHeader = "10"; // near first use for Checkstyle
-        var resp = service.updateDefendantAccount(id, buHeader, req, "UNIT_TEST");
+        var resp = service.updateDefendantAccount(id, buHeader, req, "tester");
 
         // ---------- Assert ----------
         verify(defendantAccountRepository).save(entity);
@@ -239,7 +239,7 @@ class OpalDefendantAccountUpdateTest {
             .build();
 
         assertThrows(EntityNotFoundException.class, () ->
-            service.updateDefendantAccount(id, buHeader, req, "UNIT_TEST")
+            service.updateDefendantAccount(id, buHeader, req, "tester")
         );
         verify(defendantAccountRepository, never()).save(any());
     }
@@ -258,7 +258,7 @@ class OpalDefendantAccountUpdateTest {
             .build();
 
         assertThrows(EntityNotFoundException.class, () ->
-            service.updateDefendantAccount(99L, "10", req, "UNIT_TEST")
+            service.updateDefendantAccount(99L, "10", req, "tester")
         );
         verify(defendantAccountRepository, never()).save(any());
     }

--- a/src/test/java/uk/gov/hmcts/opal/service/proxy/DefendantAccountEnforcementServiceProxyTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/proxy/DefendantAccountEnforcementServiceProxyTest.java
@@ -102,17 +102,17 @@ class DefendantAccountEnforcementServiceProxyTest extends ProxyTestsBase {
             .build();
 
         when(legacyService.addEnforcement(defendantAccountId, businessUnitId,
-            businessUnitUserId, ifMatch, auth, req))
+            businessUnitUserId, ifMatch, req))
             .thenReturn(expected);
 
         // act
         AddEnforcementResponse result =
             serviceProxy.addEnforcement(defendantAccountId, businessUnitId,
-                businessUnitUserId, ifMatch, auth, req);
+                businessUnitUserId, ifMatch, req);
 
         // assert
         verify(legacyService).addEnforcement(defendantAccountId, businessUnitId,
-            businessUnitUserId, ifMatch, auth, req);
+            businessUnitUserId, ifMatch, req);
         verifyNoInteractions(opalService);
         assertEquals(expected, result);
     }
@@ -137,17 +137,17 @@ class DefendantAccountEnforcementServiceProxyTest extends ProxyTestsBase {
             .build();
 
         when(opalService.addEnforcement(defendantAccountId, businessUnitId,
-            businessUnitUserId, ifMatch, auth, req))
+            businessUnitUserId, ifMatch, req))
             .thenReturn(expected);
 
         // act
         AddEnforcementResponse result =
             serviceProxy.addEnforcement(defendantAccountId, businessUnitId,
-                businessUnitUserId, ifMatch, auth, req);
+                businessUnitUserId, ifMatch, req);
 
         // assert
         verify(opalService).addEnforcement(defendantAccountId, businessUnitId,
-            businessUnitUserId, ifMatch, auth, req);
+            businessUnitUserId, ifMatch, req);
         verifyNoInteractions(legacyService);
         assertEquals(expected, result);
     }
@@ -173,7 +173,6 @@ class DefendantAccountEnforcementServiceProxyTest extends ProxyTestsBase {
             businessUnitId,
             businessUnitUserId,
             ifMatch,
-            auth,
             req
         )).thenReturn(expected);
 
@@ -183,7 +182,6 @@ class DefendantAccountEnforcementServiceProxyTest extends ProxyTestsBase {
                 businessUnitId,
                 businessUnitUserId,
                 ifMatch,
-                auth,
                 req
             );
 
@@ -193,7 +191,6 @@ class DefendantAccountEnforcementServiceProxyTest extends ProxyTestsBase {
             businessUnitId,
             businessUnitUserId,
             ifMatch,
-            auth,
             req
         );
         verifyNoInteractions(opalService);

--- a/src/test/java/uk/gov/hmcts/opal/service/report/GenericReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/GenericReportServiceTest.java
@@ -242,7 +242,7 @@ class GenericReportServiceTest {
     @Test
     public void addReportInstance_success_singleBU() throws JacksonException {
         //setup
-        when(userStateService.checkForAuthorisedUser("")).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
         when(reportRepository.findById(reportId)).thenReturn(Optional.of(reportEntity));
         when(reportEntity.isSupportsMultiBu()).thenReturn(false);
@@ -271,7 +271,7 @@ class GenericReportServiceTest {
     @Test
     public void addReportInstance_success_multiBU() throws JacksonException {
         //setup
-        when(userStateService.checkForAuthorisedUser("")).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1, businessUnitUser2));
         when(reportRepository.findById(reportId)).thenReturn(Optional.of(reportEntity));
         when(reportEntity.isSupportsMultiBu()).thenReturn(true);
@@ -339,7 +339,7 @@ class GenericReportServiceTest {
     @Test
     public void addReportInstance_userNotAuthorizedWithBU_throwsException() {
         //setup
-        when(userStateService.checkForAuthorisedUser("")).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1, businessUnitUser2));
         when(reportRepository.findById(reportId)).thenReturn(Optional.of(reportEntity));
         when(reportEntity.isSupportsMultiBu()).thenReturn(true);
@@ -362,7 +362,7 @@ class GenericReportServiceTest {
     @Test
     public void addReportInstance_failsValidation_throwsException() {
         //setup
-        when(userStateService.checkForAuthorisedUser("")).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1, businessUnitUser2));
         when(reportRepository.findById(reportId)).thenReturn(Optional.of(reportEntity));
         when(reportEntity.isSupportsMultiBu()).thenReturn(true);
@@ -387,7 +387,7 @@ class GenericReportServiceTest {
     @Test
     public void addReportInstance_genReportAsyncFalse_throwsException() throws JacksonException {
         //setup
-        when(userStateService.checkForAuthorisedUser("")).thenReturn(userState);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
         when(reportRepository.findById(reportId)).thenReturn(Optional.of(reportEntity));
         when(reportEntity.isSupportsMultiBu()).thenReturn(false);


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/PO-7246

### Changes

- OpenAPI change, so controllers don’t expect authHeader parameter in method signatures
- Controller and service layer so no longer receiving or passing on authHeader strings.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
