### PR TITLE
PO-7222 Update operational report permissions 

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportsApiControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportsApiControllerIntegrationTest.java
@@ -232,6 +232,28 @@ class ReportsApiControllerIntegrationTest extends AbstractIntegrationTest {
 
         @ParameterizedTest
         @MethodSource("reportCases")
+        @DisplayName("Get report by ID - operational reports return 200 when report permission is set [@PO-7222]")
+        @Sql(
+            statements = """
+                UPDATE public.reports
+                   SET permission = 'SEARCH_AND_VIEW_ACCOUNTS'
+                 WHERE report_id IN (
+                           'operational_report_enforcement',
+                           'operational_report_payment'
+                       )
+                """,
+            executionPhase = BEFORE_TEST_METHOD
+        )
+        void getReportById_whenOperationalReportHasPermission_returns200(String reportId) throws Exception {
+            mockMvc.perform(get(URL_BASE + "/" + reportId)
+                    .with(userStateStub.getAuthenticaitonRequestPostProcessor()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.report_id").value(reportId))
+                .andExpect(jsonPath("$.permission").value(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS.name()));
+        }
+
+        @ParameterizedTest
+        @MethodSource("reportCases")
         @DisplayName("Get report by ID - null permission returns forbidden [@PO-2250]")
         @JiraStory("PO-2250")
         @JiraEpic("PO-2248")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportsApiControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportsApiControllerIntegrationTest.java
@@ -240,7 +240,7 @@ class ReportsApiControllerIntegrationTest extends AbstractIntegrationTest {
                  WHERE report_id IN (
                            'operational_report_enforcement',
                            'operational_report_payment'
-                       )
+                       );
                 """,
             executionPhase = BEFORE_TEST_METHOD
         )
@@ -262,7 +262,7 @@ class ReportsApiControllerIntegrationTest extends AbstractIntegrationTest {
                  WHERE report_id IN (
                            'operational_report_enforcement',
                            'operational_report_payment'
-                       )
+                       );
                 """,
             executionPhase = BEFORE_TEST_METHOD
         )
@@ -273,7 +273,7 @@ class ReportsApiControllerIntegrationTest extends AbstractIntegrationTest {
                  WHERE report_id IN (
                            'operational_report_enforcement',
                            'operational_report_payment'
-                       )
+                       );
                 """,
             executionPhase = AFTER_TEST_METHOD
         )

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportsApiControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportsApiControllerIntegrationTest.java
@@ -255,12 +255,35 @@ class ReportsApiControllerIntegrationTest extends AbstractIntegrationTest {
         @ParameterizedTest
         @MethodSource("reportCases")
         @DisplayName("Get report by ID - null permission returns forbidden [@PO-2250]")
+        @Sql(
+            statements = """
+                UPDATE public.reports
+                   SET permission = NULL
+                 WHERE report_id IN (
+                           'operational_report_enforcement',
+                           'operational_report_payment'
+                       )
+                """,
+            executionPhase = BEFORE_TEST_METHOD
+        )
+        @Sql(
+            statements = """
+                UPDATE public.reports
+                   SET permission = 'SEARCH_AND_VIEW_ACCOUNTS'
+                 WHERE report_id IN (
+                           'operational_report_enforcement',
+                           'operational_report_payment'
+                       )
+                """,
+            executionPhase = AFTER_TEST_METHOD
+        )
         @JiraStory("PO-2250")
         @JiraEpic("PO-2248")
         @JiraTestKey(value = "PO-8604", name = "[1] reportId = \"operational_report_enforcement\"")
         @JiraTestKey(value = "PO-8605", name = "[2] reportId = \"operational_report_payment\"")
         void getReportById_whenReportPermissionIsNull_returns403(String reportId) throws Exception {
-            mockMvc.perform(get(URL_BASE + "/" + reportId))
+            mockMvc.perform(get(URL_BASE + "/" + reportId)
+                    .with(userStateStub.getAuthenticaitonRequestPostProcessor()))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.title").value("Forbidden"))
                 .andExpect(jsonPath("$.detail").value("You do not have permission to access this resource"))

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportsApiControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportsApiControllerIntegrationTest.java
@@ -233,17 +233,6 @@ class ReportsApiControllerIntegrationTest extends AbstractIntegrationTest {
         @ParameterizedTest
         @MethodSource("reportCases")
         @DisplayName("Get report by ID - operational reports return 200 when report permission is set [@PO-7222]")
-        @Sql(
-            statements = """
-                UPDATE public.reports
-                   SET permission = 'SEARCH_AND_VIEW_ACCOUNTS'
-                 WHERE report_id IN (
-                           'operational_report_enforcement',
-                           'operational_report_payment'
-                       );
-                """,
-            executionPhase = BEFORE_TEST_METHOD
-        )
         void getReportById_whenOperationalReportHasPermission_returns200(String reportId) throws Exception {
             mockMvc.perform(get(URL_BASE + "/" + reportId)
                     .with(userStateStub.getAuthenticaitonRequestPostProcessor()))
@@ -299,7 +288,8 @@ class ReportsApiControllerIntegrationTest extends AbstractIntegrationTest {
         @JiraTestKey("PO-7766")
         void getReportById_whenUserLacksPermission_returns403() throws Exception {
             userStateStub.setupWithNoPermissions();
-            mockMvc.perform(get(URL_BASE + "/operational_report_enforcement"))
+            mockMvc.perform(get(URL_BASE + "/operational_report_enforcement")
+                    .with(userStateStub.getAuthenticaitonRequestPostProcessor()))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.title").value("Forbidden"))
                 .andExpect(jsonPath("$.detail").value("You do not have permission to access this resource"))

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportsApiControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportsApiControllerIntegrationTest.java
@@ -233,6 +233,8 @@ class ReportsApiControllerIntegrationTest extends AbstractIntegrationTest {
         @ParameterizedTest
         @MethodSource("reportCases")
         @DisplayName("Get report by ID - operational reports return 200 when report permission is set [@PO-7222]")
+        @JiraStory("PO-7222")
+        @JiraEpic("PO-2248")
         void getReportById_whenOperationalReportHasPermission_returns200(String reportId) throws Exception {
             mockMvc.perform(get(URL_BASE + "/" + reportId)
                     .with(userStateStub.getAuthenticaitonRequestPostProcessor()))

--- a/src/main/resources/db/migration/data/allEnvs/V1_59__set_operational_report_permissions.sql
+++ b/src/main/resources/db/migration/data/allEnvs/V1_59__set_operational_report_permissions.sql
@@ -1,7 +1,0 @@
-UPDATE public.reports
-SET permission = 'SEARCH_AND_VIEW_ACCOUNTS'
-WHERE report_id IN (
-    'operational_report_enforcement',
-    'operational_report_payment'
-)
-  AND permission IS NULL;

--- a/src/main/resources/db/migration/data/allEnvs/V1_59__set_operational_report_permissions.sql
+++ b/src/main/resources/db/migration/data/allEnvs/V1_59__set_operational_report_permissions.sql
@@ -1,0 +1,7 @@
+UPDATE public.reports
+SET permission = 'SEARCH_AND_VIEW_ACCOUNTS'
+WHERE report_id IN (
+    'operational_report_enforcement',
+    'operational_report_payment'
+)
+  AND permission IS NULL;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-7222


### Change description ###
Fixed GET /reports/{id} returning 403 for the two operational reports by populating the missing report permission metadata in seeded data.
A new DB migration sets the permission for operational_report_enforcement and operational_report_payment to SEARCH_AND_VIEW_ACCOUNTS, which allows authorised users to retrieve those report definitions through the normal reports API path.
Integration coverage was updated to verify that both operational reports now return 200 OK for authorised users and still return 403 Forbidden when the user does not have the required permission.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
