### PR TITLE
Added the serenity report to the artifacts

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -88,9 +88,7 @@ def publishIntegrationResults = {
 }
 
 def publishFunctionalResults = { reportNameSuffix ->
-  steps.junit '**/test-results/functional/*.xml'
-  steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/functional/*.xml'
-  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'target/zephyr/**/*.json'
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-test-report/**/*'
   publishHTML target: [
     allowMissing         : true,
     alwaysLinkToLastBuild: true,
@@ -107,6 +105,9 @@ def publishFunctionalResults = { reportNameSuffix ->
     reportFiles          : "test-summary.html",
     reportName           : "Test Summary Report${reportNameSuffix}"
   ]
+  steps.junit allowEmptyResults: true, testResults: '**/test-results/functional/*.xml'
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/functional/*.xml'
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'target/zephyr/**/*.json'
 }
 
 def runIntegrationStage = { stageName, gradleTask ->

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -136,7 +136,11 @@ def runFunctionalStage = { stageName, shouldRunWithZephyr, reportNameSuffix ->
       } catch (error) {
         steps.echo "${stageName} failed, but continuing with the pipeline. Error: " + error.message
       } finally {
-        publishFunctionalResults(reportNameSuffix)
+        try {
+          publishFunctionalResults(reportNameSuffix)
+        } catch (publishError) {
+          steps.echo "${stageName} result publication failed, but continuing with the pipeline. Error: " + publishError.message
+        }
       }
     }
   }
@@ -156,7 +160,11 @@ def runTaggedFunctionalStage = { enabled, stageName, shouldRunWithZephyr, report
       } catch (error) {
         steps.echo "${stageName} failed, but continuing with the pipeline. Error: " + error.message
       } finally {
-        publishFunctionalResults(reportNameSuffix)
+        try {
+          publishFunctionalResults(reportNameSuffix)
+        } catch (publishError) {
+          steps.echo "${stageName} result publication failed, but continuing with the pipeline. Error: " + publishError.message
+        }
       }
     }
   }
@@ -189,7 +197,7 @@ withNightlyPipeline(type, product, component) {
         configureZephyrExecution(testEnvironments.demo)
       }
       runTaggedFunctionalStage(
-        params.Functional,
+        params.Demo,
         'Demo R1A Functional Tests',
         shouldRunWithZephyr,
         testEnvironments.demo.reportNameSuffix,


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

- Archive functional-test-report/**/* in nightly runs so copied Serenity reports are available as Jenkins artifacts.
- Publish Serenity HTML reports before collecting functional JUnit XMLs.
- Allow empty functional JUnit results so missing merged XMLs do not block report publishing.
- Catch functional report-publication errors so later nightly stages can still run.
- Gate Demo R1A Functional Tests from the Demo parameter instead of Functional, allowing R1A to run independently of the main functional suite.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
