### PR TITLE
Po 7280 missing 'allow additional action' flag

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
@@ -85,7 +85,14 @@ class ResultControllerIntegrationTest extends AbstractIntegrationTest {
             .andExpect(jsonPath("$.prevent_payment_card").value(true))
             .andExpect(jsonPath("$.lists_monies").value(true))
             .andExpect(jsonPath("$.result_parameters").value("{\"param1\":\"value1\",\"param2\":\"value2\"}"))
-            .andExpect(jsonPath("$.requires_employment_data").value(true));
+            .andExpect(jsonPath("$.requires_employment_data").value(true))
+            // New fields added for PO-7280
+            .andExpect(jsonPath("$.allow_payment_terms").value(true))
+            .andExpect(jsonPath("$.allow_additional_action").value(true))
+            .andExpect(jsonPath("$.generates_warrant").value(true))
+            .andExpect(jsonPath("$.requires_lja").value(true))
+            .andExpect(jsonPath("$.manual_enforcement").value(false))
+            .andExpect(jsonPath("$.enf_next_permitted_actions").value("NOENF,WDN"));
     }
 
     @Test

--- a/src/integrationTest/resources/db/insertData/insert_into_results.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_results.sql
@@ -39,7 +39,11 @@ INSERT INTO results
     prevent_payment_card,
     lists_monies,
     result_parameters,
+    allow_payment_terms,
     requires_employment_data,
+    allow_additional_action,
+    enf_next_permitted_actions,
+    requires_lja,
     manual_enforcement
 )
 VALUES
@@ -68,7 +72,11 @@ VALUES
         FALSE,
         FALSE,
         NULL,
+        FALSE,   -- allow_payment_terms
         NULL,
+        FALSE,   -- allow_additional_action
+        NULL,    -- enf_next_permitted_actions
+        NULL,    -- requires_lja
         TRUE     -- manual_enforcement = true
     ),
     (
@@ -96,8 +104,12 @@ VALUES
         TRUE,
         TRUE,
         '{"param1":"value1","param2":"value2"}',
+        TRUE,    -- allow_payment_terms
         TRUE,
-        FALSE
+        TRUE,    -- allow_additional_action
+        'NOENF,WDN',  -- enf_next_permitted_actions
+        TRUE,    -- requires_lja
+        FALSE    -- manual_enforcement
     ),
     (
         'DDDDDD',
@@ -124,8 +136,12 @@ VALUES
         FALSE,
         FALSE,
         '{"warrantDate":"2023-08-15","issuedBy":"Court A"}',
+        NULL,    -- allow_payment_terms
         FALSE,
-        TRUE
+        NULL,    -- allow_additional_action
+        NULL,    -- enf_next_permitted_actions
+        FALSE,   -- requires_lja
+        TRUE     -- manual_enforcement
     ),
     (
         'CC0000',
@@ -152,6 +168,10 @@ VALUES
         FALSE,
         FALSE,
         NULL,
+        NULL,    -- allow_payment_terms
         NULL,
-        FALSE
+        NULL,    -- allow_additional_action
+        NULL,    -- enf_next_permitted_actions
+        NULL,    -- requires_lja
+        FALSE    -- manual_enforcement
     );

--- a/src/main/java/uk/gov/hmcts/opal/dto/ResultDto.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/ResultDto.java
@@ -85,4 +85,22 @@ public class ResultDto {
 
     @JsonProperty("requires_employment_data")
     private Boolean requiresEmploymentData;
+
+    @JsonProperty("allow_payment_terms")
+    private Boolean allowPaymentTerms;
+
+    @JsonProperty("allow_additional_action")
+    private Boolean allowAdditionalAction;
+
+    @JsonProperty("generates_warrant")
+    private boolean generatesWarrant;
+
+    @JsonProperty("requires_lja")
+    private Boolean requiresLja;
+
+    @JsonProperty("manual_enforcement")
+    private boolean manualEnforcement;
+
+    @JsonProperty("enf_next_permitted_actions")
+    private String enfNextPermittedActions;
 }

--- a/src/main/java/uk/gov/hmcts/opal/dto/ResultDto.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/ResultDto.java
@@ -90,6 +90,7 @@ public class ResultDto {
     private Boolean allowPaymentTerms;
 
     @JsonProperty("allow_additional_action")
+    @JsonInclude(JsonInclude.Include.ALWAYS)
     private Boolean allowAdditionalAction;
 
     @JsonProperty("generates_warrant")

--- a/src/main/java/uk/gov/hmcts/opal/entity/result/ResultEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/result/ResultEntity.java
@@ -112,6 +112,18 @@ public class ResultEntity {
     @Column(name = "requires_employment_data")
     private Boolean requiresEmploymentData;
 
+    @Column(name = "allow_payment_terms")
+    private Boolean allowPaymentTerms;
+
+    @Column(name = "allow_additional_action")
+    private Boolean allowAdditionalAction;
+
+    @Column(name = "generates_warrant", nullable = false)
+    private boolean generatesWarrant;
+
+    @Column(name = "requires_lja")
+    private Boolean requiresLja;
+
     @Column(name = "manual_enforcement", nullable = false)
     private boolean manualEnforcement;
 

--- a/src/test/java/uk/gov/hmcts/opal/controllers/ResultControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/ResultControllerTest.java
@@ -68,6 +68,11 @@ class ResultControllerTest {
             .resultTitleCy("Welsh Title")
             .resultType("TYPE1")
             .active(true)
+            .allowAdditionalAction(true)
+            .allowPaymentTerms(false)
+            .generatesWarrant(true)
+            .requiresLja(false)
+            .manualEnforcement(true)
             .build();
 
         when(resultService.getResult("ABC")).thenReturn(dto);
@@ -82,6 +87,11 @@ class ResultControllerTest {
         assertEquals("Welsh Title", response.getBody().getResultTitleCy());
         assertEquals("TYPE1", response.getBody().getResultType());
         assertEquals(true, response.getBody().isActive());
+        assertEquals(true, response.getBody().getAllowAdditionalAction());
+        assertEquals(false, response.getBody().getAllowPaymentTerms());
+        assertEquals(true, response.getBody().isGeneratesWarrant());
+        assertEquals(false, response.getBody().getRequiresLja());
+        assertEquals(true, response.getBody().isManualEnforcement());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/dto/ResultDtoTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/dto/ResultDtoTest.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.opal.dto;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ResultDtoTest {
+
+    @Test
+    void toJson_shouldIncludeAllowAdditionalActionWhenNull() throws Exception {
+        ResultDto dto = ResultDto.builder()
+            .resultId("AAAAAA")
+            .allowAdditionalAction(null)
+            .build();
+
+        String json = ToJsonString.getObjectMapper().writeValueAsString(dto);
+
+        assertTrue(json.contains("\"allow_additional_action\":null"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/mapper/ResultMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/mapper/ResultMapperTest.java
@@ -135,6 +135,12 @@ class ResultMapperTest {
             .listsMonies(true)
             .resultParameters("A,B,C")
             .requiresEmploymentData(true)
+            .allowPaymentTerms(false)
+            .allowAdditionalAction(true)
+            .generatesWarrant(true)
+            .requiresLja(false)
+            .manualEnforcement(true)
+            .enfNextPermittedActions("ACTION1,ACTION2")
             .build();
 
         // Act
@@ -166,6 +172,12 @@ class ResultMapperTest {
         assertEquals(entity.isListsMonies(), dto.isListsMonies());
         assertEquals(entity.getResultParameters(), dto.getResultParameters());
         assertEquals(entity.getRequiresEmploymentData(), dto.getRequiresEmploymentData());
+        assertEquals(entity.getAllowPaymentTerms(), dto.getAllowPaymentTerms());
+        assertEquals(entity.getAllowAdditionalAction(), dto.getAllowAdditionalAction());
+        assertEquals(entity.isGeneratesWarrant(), dto.isGeneratesWarrant());
+        assertEquals(entity.getRequiresLja(), dto.getRequiresLja());
+        assertEquals(entity.isManualEnforcement(), dto.isManualEnforcement());
+        assertEquals(entity.getEnfNextPermittedActions(), dto.getEnfNextPermittedActions());
     }
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-7280


### Change description ###
Changes Made:

ResultEntity.java - Added 5 missing database columns:
allowPaymentTerms (Boolean)
allowAdditionalAction (Boolean) - Primary field from ticket
generatesWarrant (boolean)
requiresLja (Boolean)

ResultDto.java - Added 6 missing fields (including manualEnforcement which existed in entity but not DTO):
allowPaymentTerms
allowAdditionalAction 
generatesWarrant
requiresLja
manualEnforcement
enfNextPermittedActions

ResultControllerTest.java - Updated test to include new fields


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
