### PR TITLE
PO-2642 Minor Creditor History (Opal)

### DIFF
--- a/bruno/collections/MinorCreditor/Get-Minor-Creditor-History.bru
+++ b/bruno/collections/MinorCreditor/Get-Minor-Creditor-History.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Get-Minor-Creditor-History
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseURL}}/minor-creditor-accounts/99000000000808/history
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{BEARER_TOKEN}}
+}
+
+params:query {
+  dateFrom: 2026-05-01
+  dateTo: 2026-05-31
+  itemTypes: financial
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagIntegrationTest.java
@@ -2,8 +2,10 @@ package uk.gov.hmcts.opal.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -15,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
@@ -23,9 +26,10 @@ import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
 import uk.gov.hmcts.opal.generated.model.AddressDetailsCommon;
 import uk.gov.hmcts.opal.generated.model.CreditorAccountPaymentDetailsCommon;
 import uk.gov.hmcts.opal.generated.model.IndividualDetailsCommon;
-import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
 import uk.gov.hmcts.opal.generated.model.PartyDetailsCommon;
+import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
 import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
+import uk.gov.hmcts.opal.service.MinorCreditorService;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
@@ -42,6 +46,9 @@ class MinorCreditorApiControllerFeatureFlagIntegrationTest extends AbstractInteg
 
     private static final long MINOR_CREDITOR_ACCOUNT_ID = 607L;
     private static final short BUSINESS_UNIT_ID = 10;
+
+    @MockitoBean
+    private MinorCreditorService minorCreditorService;
 
     @Autowired
     private CreditorAccountRepository creditorAccountRepository;
@@ -71,6 +78,26 @@ class MinorCreditorApiControllerFeatureFlagIntegrationTest extends AbstractInteg
         CreditorAccountEntity creditorAccount = getCurrentCreditorAccount();
         assertFalse(creditorAccount.isHoldPayout());
         assertEquals(1L, creditorAccount.getVersionNumber());
+        verifyNoInteractions(minorCreditorService);
+    }
+
+    @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-3685")
+    @JiraTestKey("PO-2642")
+    void getMinorCreditorHistory_whenLocalDefaultDisabled_returns405AndDoesNotCallService() throws Exception {
+        ResultActions result = mockMvc.perform(get("/minor-creditor-accounts/" + MINOR_CREDITOR_ACCOUNT_ID + "/history")
+                                                   .header("Authorization", "Bearer some_value"));
+
+        String body = result.andReturn().getResponse().getContentAsString();
+        log.info(":getMinorCreditorHistory_whenLocalDefaultDisabled_returns405AndDoesNotCallService body:\n{}",
+            ToJsonString.toPrettyJson(body));
+        result.andExpect(status().isMethodNotAllowed())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE))
+            .andExpect(jsonPath("$.title").value("Feature Disabled"))
+            .andExpect(jsonPath("$.detail").value("The requested feature is not currently available"));
+
+        verifyNoInteractions(minorCreditorService);
     }
 
     private PatchMinorCreditorAccountRequest patchMinorCreditorAccountRequest() {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagIntegrationTest.java
@@ -85,14 +85,14 @@ class MinorCreditorApiControllerFeatureFlagIntegrationTest extends AbstractInteg
     @JiraStory("PO-2642")
     @JiraEpic("PO-3685")
     @JiraTestKey("PO-2642")
-    void getMinorCreditorHistory_whenLocalDefaultDisabled_returns405AndDoesNotCallService() throws Exception {
+    void getMinorCreditorHistory_whenRelease1bDisabled_returns404AndDoesNotCallService() throws Exception {
         ResultActions result = mockMvc.perform(get("/minor-creditor-accounts/" + MINOR_CREDITOR_ACCOUNT_ID + "/history")
                                                    .header("Authorization", "Bearer some_value"));
 
         String body = result.andReturn().getResponse().getContentAsString();
-        log.info(":getMinorCreditorHistory_whenLocalDefaultDisabled_returns405AndDoesNotCallService body:\n{}",
+        log.info(":getMinorCreditorHistory_whenRelease1bDisabled_returns404AndDoesNotCallService body:\n{}",
             ToJsonString.toPrettyJson(body));
-        result.andExpect(status().isMethodNotAllowed())
+        result.andExpect(status().isNotFound())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE))
             .andExpect(jsonPath("$.title").value("Feature Disabled"))
             .andExpect(jsonPath("$.detail").value("The requested feature is not currently available"));

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -87,6 +88,57 @@ class MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest
         CreditorAccountEntity creditorAccount = getCurrentCreditorAccount();
         assertTrue(creditorAccount.isHoldPayout());
         assertEquals(3L, creditorAccount.getVersionNumber());
+    }
+
+    @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-3685")
+    @JiraTestKey("PO-2642")
+    void getMinorCreditorHistory_whenItemTypeInvalid_returns400ProblemResponse() throws Exception {
+        when(userStateService.checkForAuthorisedUser(any())).thenReturn(permissionUser(
+            BUSINESS_UNIT_ID,
+            FinesPermission.SEARCH_AND_VIEW_ACCOUNTS
+        ));
+
+        ResultActions result = mockMvc.perform(get("/minor-creditor-accounts/" + MINOR_CREDITOR_ACCOUNT_ID + "/history")
+                                                   .header("Authorization", "Bearer some_value")
+                                                   .queryParam("itemTypes", "payment"));
+
+        String body = result.andReturn().getResponse().getContentAsString();
+        log.info(":getMinorCreditorHistory_whenItemTypeInvalid_returns400ProblemResponse body:\n{}",
+                 ToJsonString.toPrettyJson(body));
+
+        result.andExpect(status().isBadRequest())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.title").value("Bad Request"))
+            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/illegal-argument"))
+            .andExpect(jsonPath("$.detail").value("Invalid arguments were provided in the request"));
+    }
+
+    @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-3685")
+    @JiraTestKey("PO-2642")
+    void getMinorCreditorHistory_whenDateFromAfterDateTo_returns400ProblemResponse() throws Exception {
+        when(userStateService.checkForAuthorisedUser(any())).thenReturn(permissionUser(
+            BUSINESS_UNIT_ID,
+            FinesPermission.SEARCH_AND_VIEW_ACCOUNTS
+        ));
+
+        ResultActions result = mockMvc.perform(get("/minor-creditor-accounts/" + MINOR_CREDITOR_ACCOUNT_ID + "/history")
+                                                   .header("Authorization", "Bearer some_value")
+                                                   .queryParam("dateFrom", "2026-02-01")
+                                                   .queryParam("dateTo", "2026-01-31"));
+
+        String body = result.andReturn().getResponse().getContentAsString();
+        log.info(":getMinorCreditorHistory_whenDateFromAfterDateTo_returns400ProblemResponse body:\n{}",
+                 ToJsonString.toPrettyJson(body));
+
+        result.andExpect(status().isBadRequest())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.title").value("Bad Request"))
+            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/illegal-argument"))
+            .andExpect(jsonPath("$.detail").value("Invalid arguments were provided in the request"));
     }
 
     private PatchMinorCreditorAccountRequest patchMinorCreditorAccountRequest() {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest.java
@@ -94,6 +94,48 @@ class MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest
     @JiraStory("PO-2642")
     @JiraEpic("PO-3685")
     @JiraTestKey("PO-2642")
+    void getMinorCreditorHistory_whenHistoryExists_returnsMergedHistoryItems() throws Exception {
+        when(userStateService.checkForAuthorisedUser(any())).thenReturn(permissionUser(
+            BUSINESS_UNIT_ID,
+            FinesPermission.SEARCH_AND_VIEW_ACCOUNTS
+        ));
+
+        ResultActions result = mockMvc.perform(get("/minor-creditor-accounts/" + MINOR_CREDITOR_ACCOUNT_ID + "/history")
+                                                   .header("Authorization", "Bearer some_value")
+                                                   .queryParam("dateFrom", "2026-01-29")
+                                                   .queryParam("dateTo", "2026-01-31"));
+
+        String body = result.andReturn().getResponse().getContentAsString();
+        log.info(":getMinorCreditorHistory_whenHistoryExists_returnsMergedHistoryItems body:\n{}",
+                 ToJsonString.toPrettyJson(body));
+
+        result.andExpect(status().isOk())
+            .andExpect(header().string("ETag", "\"1\""))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.historyItems.length()").value(3))
+            .andExpect(jsonPath("$.historyItems[0].type").value("Amendment"))
+            .andExpect(jsonPath("$.historyItems[0].postedDetails.posted_date").value("2026-01-31"))
+            .andExpect(jsonPath("$.historyItems[0].postedDetails.posted_by").value("AMENDUSR"))
+            .andExpect(jsonPath("$.historyItems[0].details.attributeName").value("Hold Pay Out"))
+            .andExpect(jsonPath("$.historyItems[0].details.oldValue").value("false"))
+            .andExpect(jsonPath("$.historyItems[0].details.newValue").value("true"))
+            .andExpect(jsonPath("$.historyItems[1].type").value("Note"))
+            .andExpect(jsonPath("$.historyItems[1].postedDetails.posted_date").value("2026-01-30"))
+            .andExpect(jsonPath("$.historyItems[1].details.noteText").value("Review creditor"))
+            .andExpect(jsonPath("$.historyItems[2].type").value("Financial"))
+            .andExpect(jsonPath("$.historyItems[2].postedDetails.posted_date").value("2026-01-29"))
+            .andExpect(jsonPath("$.historyItems[2].amount").value(42.00))
+            .andExpect(jsonPath("$.historyItems[2].details.transactionType.transactionType").value("PAYMNT"))
+            .andExpect(jsonPath("$.historyItems[2].details.status.creditorTransactionStatus").value("C"))
+            .andExpect(jsonPath("$.historyItems[2].details.accountNumber").value("HOLD1234"))
+            .andExpect(jsonPath("$.historyItems[2].details.defendantAccountNumber").value("DEF123456"))
+            .andExpect(jsonPath("$.historyItems[2].details.defendantAccountId").value(70000000000000L));
+    }
+
+    @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-3685")
+    @JiraTestKey("PO-2642")
     void getMinorCreditorHistory_whenItemTypeInvalid_returns400ProblemResponse() throws Exception {
         when(userStateService.checkForAuthorisedUser(any())).thenReturn(permissionUser(
             BUSINESS_UNIT_ID,

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest.java
@@ -92,7 +92,7 @@ class MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest
 
     @Test
     @JiraStory("PO-2642")
-    @JiraEpic("PO-3685")
+    @JiraEpic("PO-2653")
     @JiraTestKey("PO-2642")
     void getMinorCreditorHistory_whenHistoryExists_returnsMergedHistoryItems() throws Exception {
         userStateStub.setupWithNoPermissions();
@@ -133,7 +133,7 @@ class MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest
 
     @Test
     @JiraStory("PO-2642")
-    @JiraEpic("PO-3685")
+    @JiraEpic("PO-2653")
     @JiraTestKey("PO-2642")
     void getMinorCreditorHistory_whenItemTypeInvalid_returns400ProblemResponse() throws Exception {
         userStateStub.setupWithNoPermissions();
@@ -157,7 +157,7 @@ class MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest
 
     @Test
     @JiraStory("PO-2642")
-    @JiraEpic("PO-3685")
+    @JiraEpic("PO-2653")
     @JiraTestKey("PO-2642")
     void getMinorCreditorHistory_whenDateFromAfterDateTo_returns400ProblemResponse() throws Exception {
         userStateStub.setupWithNoPermissions();

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest.java
@@ -95,15 +95,14 @@ class MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest
     @JiraEpic("PO-3685")
     @JiraTestKey("PO-2642")
     void getMinorCreditorHistory_whenHistoryExists_returnsMergedHistoryItems() throws Exception {
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(permissionUser(
-            BUSINESS_UNIT_ID,
-            FinesPermission.SEARCH_AND_VIEW_ACCOUNTS
-        ));
+        userStateStub.setupWithNoPermissions();
+        userStateStub.addPermissions(BUSINESS_UNIT_ID, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
 
         ResultActions result = mockMvc.perform(get("/minor-creditor-accounts/" + MINOR_CREDITOR_ACCOUNT_ID + "/history")
-                                                   .header("Authorization", "Bearer some_value")
-                                                   .queryParam("dateFrom", "2026-01-29")
-                                                   .queryParam("dateTo", "2026-01-31"));
+            .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+            .header("authorization", userStateStub.getBearerToken())
+            .queryParam("dateFrom", "2026-01-29")
+            .queryParam("dateTo", "2026-01-31"));
 
         String body = result.andReturn().getResponse().getContentAsString();
         log.info(":getMinorCreditorHistory_whenHistoryExists_returnsMergedHistoryItems body:\n{}",
@@ -137,14 +136,13 @@ class MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest
     @JiraEpic("PO-3685")
     @JiraTestKey("PO-2642")
     void getMinorCreditorHistory_whenItemTypeInvalid_returns400ProblemResponse() throws Exception {
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(permissionUser(
-            BUSINESS_UNIT_ID,
-            FinesPermission.SEARCH_AND_VIEW_ACCOUNTS
-        ));
+        userStateStub.setupWithNoPermissions();
+        userStateStub.addPermissions(BUSINESS_UNIT_ID, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
 
         ResultActions result = mockMvc.perform(get("/minor-creditor-accounts/" + MINOR_CREDITOR_ACCOUNT_ID + "/history")
-                                                   .header("Authorization", "Bearer some_value")
-                                                   .queryParam("itemTypes", "payment"));
+            .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+            .header("authorization", userStateStub.getBearerToken())
+            .queryParam("itemTypes", "payment"));
 
         String body = result.andReturn().getResponse().getContentAsString();
         log.info(":getMinorCreditorHistory_whenItemTypeInvalid_returns400ProblemResponse body:\n{}",
@@ -162,15 +160,14 @@ class MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest
     @JiraEpic("PO-3685")
     @JiraTestKey("PO-2642")
     void getMinorCreditorHistory_whenDateFromAfterDateTo_returns400ProblemResponse() throws Exception {
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(permissionUser(
-            BUSINESS_UNIT_ID,
-            FinesPermission.SEARCH_AND_VIEW_ACCOUNTS
-        ));
+        userStateStub.setupWithNoPermissions();
+        userStateStub.addPermissions(BUSINESS_UNIT_ID, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
 
         ResultActions result = mockMvc.perform(get("/minor-creditor-accounts/" + MINOR_CREDITOR_ACCOUNT_ID + "/history")
-                                                   .header("Authorization", "Bearer some_value")
-                                                   .queryParam("dateFrom", "2026-02-01")
-                                                   .queryParam("dateTo", "2026-01-31"));
+            .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+            .header("authorization", userStateStub.getBearerToken())
+            .queryParam("dateFrom", "2026-02-01")
+            .queryParam("dateTo", "2026-01-31"));
 
         String body = result.andReturn().getResponse().getContentAsString();
         log.info(":getMinorCreditorHistory_whenDateFromAfterDateTo_returns400ProblemResponse body:\n{}",

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMinorCreditorHistoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMinorCreditorHistoryIntegrationTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.opal.controllers;
 
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
@@ -65,7 +64,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
 
     @BeforeEach
     void setUpAuthorisedUser() {
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(permissionUser(
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(permissionUser(
             BUSINESS_UNIT_ID,
             FinesPermission.SEARCH_AND_VIEW_ACCOUNTS
         ));
@@ -240,7 +239,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @DisplayName("PO-2642 common response returns 401 when the user is unauthorised")
     void getMinorCreditorHistory_whenUnauthorised_returns401() throws Exception {
         doThrow(new ResponseStatusException(UNAUTHORIZED, "Unauthorized"))
-            .when(userStateService).checkForAuthorisedUser(any());
+            .when(userStateService).getUserStateV1FromSecurityContext();
 
         getHistory()
             .andExpect(status().isUnauthorized())
@@ -253,7 +252,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @JiraEpic("PO-2653")
     @DisplayName("PO-2642 common response returns 403 when the user lacks permission")
     void getMinorCreditorHistory_whenUserLacksPermission_returns403() throws Exception {
-        when(userStateService.checkForAuthorisedUser(any())).thenReturn(noPermissionsUser());
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(noPermissionsUser());
 
         getHistory()
             .andExpect(status().isForbidden())
@@ -286,7 +285,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @DisplayName("PO-2642 common response returns 408 for a timeout")
     void getMinorCreditorHistory_whenTimeoutOccurs_returns408() throws Exception {
         doThrow(new QueryTimeoutException("timeout"))
-            .when(userStateService).checkForAuthorisedUser(any());
+            .when(userStateService).getUserStateV1FromSecurityContext();
 
         getHistory()
             .andExpect(status().isRequestTimeout())
@@ -300,7 +299,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @DisplayName("PO-2642 common response returns 503 for a database connectivity failure")
     void getMinorCreditorHistory_whenDatabaseUnavailable_returns503() throws Exception {
         doThrow(new DataAccessResourceFailureException("db unavailable"))
-            .when(userStateService).checkForAuthorisedUser(any());
+            .when(userStateService).getUserStateV1FromSecurityContext();
 
         getHistory()
             .andExpect(status().isServiceUnavailable())
@@ -314,7 +313,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @DisplayName("PO-2642 common response returns 500 for an unexpected failure")
     void getMinorCreditorHistory_whenUnexpectedFailureOccurs_returns500() throws Exception {
         doThrow(new ResponseStatusException(INTERNAL_SERVER_ERROR, "Boom"))
-            .when(userStateService).checkForAuthorisedUser(any());
+            .when(userStateService).getUserStateV1FromSecurityContext();
 
         getHistory()
             .andExpect(status().isInternalServerError())

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMinorCreditorHistoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMinorCreditorHistoryIntegrationTest.java
@@ -1,0 +1,351 @@
+package uk.gov.hmcts.opal.controllers;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_CLASS;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_CLASS;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.controllers.util.UserStateUtil.noPermissionsUser;
+import static uk.gov.hmcts.opal.controllers.util.UserStateUtil.permissionUser;
+
+import jakarta.persistence.QueryTimeoutException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.hmcts.opal.AbstractIntegrationTest;
+import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
+import uk.gov.hmcts.opal.service.UserStateService;
+
+@ActiveProfiles({"integration", "opal"})
+@TestPropertySource(properties = {
+    "launchdarkly.enabled=false",
+    "launchdarkly.default-flag-values.release-1b=true"
+})
+@Sql(scripts = {
+    "classpath:db/deleteData/delete_from_po_2642_minor_creditor_history.sql",
+    "classpath:db/insertData/insert_into_po_2642_minor_creditor_history.sql"
+}, executionPhase = BEFORE_TEST_CLASS)
+@Sql(
+    scripts = "classpath:db/deleteData/delete_from_po_2642_minor_creditor_history.sql",
+    executionPhase = AFTER_TEST_CLASS
+)
+@DisplayName("Minor Creditor History Controller Integration Tests")
+class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
+
+    private static final String HISTORY_URL = "/minor-creditor-accounts/{accountId}/history";
+    private static final String AUTH_HEADER = "Bearer some_value";
+    private static final long MINOR_CREDITOR_ACCOUNT_ID = 99264200000001L;
+    private static final long NON_MINOR_CREDITOR_ACCOUNT_ID = 99264200000002L;
+    private static final long MISSING_CREDITOR_ACCOUNT_ID = 99264299999999L;
+    private static final long DEFENDANT_ACCOUNT_ID = 99264200001001L;
+    private static final short BUSINESS_UNIT_ID = 32642;
+
+    @MockitoBean
+    private UserStateService userStateService;
+
+    @BeforeEach
+    void setUpAuthorisedUser() {
+        when(userStateService.checkForAuthorisedUser(any())).thenReturn(permissionUser(
+            BUSINESS_UNIT_ID,
+            FinesPermission.SEARCH_AND_VIEW_ACCOUNTS
+        ));
+    }
+
+    @Test
+    @DisplayName("PO-2642 INT.01/INT.05 returns all amendment history only when filtered")
+    void getMinorCreditorHistory_whenFilteredToAmendments_returnsAllAmendments() throws Exception {
+        ResultActions result = getHistory("itemTypes", "amendment");
+
+        expectSuccessfulHistoryResponse(result, 3);
+        expectAmendment(result, 0, "2026-01-31", "tie-1-old", "tie-1-new");
+        expectAmendment(result, 1, "2026-01-31", "tie-2-old", "tie-2-new");
+        expectAmendment(result, 2, "2026-01-15", "baseline-old", "baseline-new");
+    }
+
+    @Test
+    @DisplayName("PO-2642 INT.02/INT.06 returns all note history only when filtered")
+    void getMinorCreditorHistory_whenFilteredToNotes_returnsAllNotes() throws Exception {
+        ResultActions result = getHistory("itemTypes", "note");
+
+        expectSuccessfulHistoryResponse(result, 2);
+        expectNote(result, 0, "2026-01-31", "Same timestamp PO-2642 note");
+        expectNote(result, 1, "2026-01-10", "Older PO-2642 note");
+    }
+
+    @Test
+    @DisplayName("PO-2642 INT.03/INT.07 returns all financial history only when filtered")
+    void getMinorCreditorHistory_whenFilteredToFinancial_returnsAllFinancialItems() throws Exception {
+        ResultActions result = getHistory("itemTypes", "financial");
+
+        expectSuccessfulHistoryResponse(result, 3);
+        expectFinancial(result, 0, "2026-01-31", "FIN003", 31.00);
+        expectFinancial(result, 1, "2026-01-25", "FIN002", 25.00);
+        expectFinancial(result, 2, "2026-01-05", "FIN001", 10.00);
+    }
+
+    @Test
+    @DisplayName("PO-2642 INT.04 returns merged history latest-to-oldest")
+    void getMinorCreditorHistory_whenNoFilters_returnsMergedLatestToOldestHistory() throws Exception {
+        ResultActions result = getHistory();
+
+        expectSuccessfulHistoryResponse(result, 8);
+        expectAmendment(result, 0, "2026-01-31", "tie-1-old", "tie-1-new");
+        expectAmendment(result, 1, "2026-01-31", "tie-2-old", "tie-2-new");
+        expectFinancial(result, 2, "2026-01-31", "FIN003", 31.00);
+        expectNote(result, 3, "2026-01-31", "Same timestamp PO-2642 note");
+        expectFinancial(result, 4, "2026-01-25", "FIN002", 25.00);
+        expectAmendment(result, 5, "2026-01-15", "baseline-old", "baseline-new");
+        expectNote(result, 6, "2026-01-10", "Older PO-2642 note");
+        expectFinancial(result, 7, "2026-01-05", "FIN001", 10.00);
+    }
+
+    @Test
+    @DisplayName("PO-2642 INT.08 applies dateFrom as an inclusive lower bound")
+    void getMinorCreditorHistory_whenDateFromProvided_appliesInclusiveLowerBound() throws Exception {
+        ResultActions result = getHistory("dateFrom", "2026-01-15");
+
+        expectSuccessfulHistoryResponse(result, 6);
+        expectAmendment(result, 0, "2026-01-31", "tie-1-old", "tie-1-new");
+        expectAmendment(result, 5, "2026-01-15", "baseline-old", "baseline-new");
+    }
+
+    @Test
+    @DisplayName("PO-2642 INT.09 applies dateTo as an inclusive upper bound")
+    void getMinorCreditorHistory_whenDateToProvided_appliesInclusiveUpperBound() throws Exception {
+        ResultActions result = getHistory("dateTo", "2026-01-10");
+
+        expectSuccessfulHistoryResponse(result, 2);
+        expectNote(result, 0, "2026-01-10", "Older PO-2642 note");
+        expectFinancial(result, 1, "2026-01-05", "FIN001", 10.00);
+    }
+
+    @Test
+    @DisplayName("PO-2642 INT.10 applies an inclusive date range")
+    void getMinorCreditorHistory_whenDateRangeProvided_returnsItemsWithinRange() throws Exception {
+        ResultActions result = getHistory("dateFrom", "2026-01-10", "dateTo", "2026-01-25");
+
+        expectSuccessfulHistoryResponse(result, 3);
+        expectFinancial(result, 0, "2026-01-25", "FIN002", 25.00);
+        expectAmendment(result, 1, "2026-01-15", "baseline-old", "baseline-new");
+        expectNote(result, 2, "2026-01-10", "Older PO-2642 note");
+    }
+
+    @Test
+    @DisplayName("PO-2642 INT.11 combines date and item type filters")
+    void getMinorCreditorHistory_whenDateAndTypeFiltersProvided_appliesBothFilters() throws Exception {
+        ResultActions result = getHistory(
+            "itemTypes", "financial",
+            "dateFrom", "2026-01-20",
+            "dateTo", "2026-01-31"
+        );
+
+        expectSuccessfulHistoryResponse(result, 2);
+        expectFinancial(result, 0, "2026-01-31", "FIN003", 31.00);
+        expectFinancial(result, 1, "2026-01-25", "FIN002", 25.00);
+    }
+
+    @Test
+    @DisplayName("PO-2642 INT.12 orders equal timestamps deterministically")
+    void getMinorCreditorHistory_whenTimestampsMatch_ordersByTypeThenSourceId() throws Exception {
+        ResultActions result = getHistory("dateFrom", "2026-01-31", "dateTo", "2026-01-31");
+
+        expectSuccessfulHistoryResponse(result, 4);
+        expectAmendment(result, 0, "2026-01-31", "tie-1-old", "tie-1-new");
+        expectAmendment(result, 1, "2026-01-31", "tie-2-old", "tie-2-new");
+        expectFinancial(result, 2, "2026-01-31", "FIN003", 31.00);
+        expectNote(result, 3, "2026-01-31", "Same timestamp PO-2642 note");
+    }
+
+    @Test
+    @DisplayName("PO-2642 schema assertions verify documented history item shapes")
+    void getMinorCreditorHistory_whenHistoryExists_returnsDocumentedPolymorphicShapes() throws Exception {
+        ResultActions result = getHistory("dateFrom", "2026-01-31", "dateTo", "2026-01-31");
+
+        expectSuccessfulHistoryResponse(result, 4);
+        result.andExpect(jsonPath("$.historyItems[0].type").value("Amendment"))
+            .andExpect(jsonPath("$.historyItems[0].postedDetails.posted_date").value("2026-01-31"))
+            .andExpect(jsonPath("$.historyItems[0].postedDetails.posted_by").value("AMEND2"))
+            .andExpect(jsonPath("$.historyItems[0].postedDetails.posted_by_name").value("Amend User Two"))
+            .andExpect(jsonPath("$.historyItems[0].details.attributeName").value("Hold Pay Out"))
+            .andExpect(jsonPath("$.historyItems[0].details.oldValue").value("tie-1-old"))
+            .andExpect(jsonPath("$.historyItems[0].details.newValue").value("tie-1-new"))
+            .andExpect(jsonPath("$.historyItems[0].details.noteText").doesNotExist())
+            .andExpect(jsonPath("$.historyItems[0].details.transactionType").doesNotExist())
+            .andExpect(jsonPath("$.historyItems[0].amount").value(nullValue()))
+            .andExpect(jsonPath("$.historyItems[2].type").value("Financial"))
+            .andExpect(jsonPath("$.historyItems[2].details.transactionType.transactionType").value("PAYMNT"))
+            .andExpect(jsonPath("$.historyItems[2].details.transactionType.transactionTypeDisplayName").value("PAYMNT"))
+            .andExpect(jsonPath("$.historyItems[2].details.paymentReference").value("FIN003"))
+            .andExpect(jsonPath("$.historyItems[2].details.status.creditorTransactionStatus").value("C"))
+            .andExpect(jsonPath("$.historyItems[2].details.status.creditorTransactionStatusDisplayName").value("C"))
+            .andExpect(jsonPath("$.historyItems[2].details.associatedRecordType").value("defendant_accounts"))
+            .andExpect(jsonPath("$.historyItems[2].details.associatedRecordId")
+                           .value(String.valueOf(DEFENDANT_ACCOUNT_ID)))
+            .andExpect(jsonPath("$.historyItems[2].details.accountNumber").value("P264MN01"))
+            .andExpect(jsonPath("$.historyItems[2].details.defendantAccountNumber").value("P264DEF1"))
+            .andExpect(jsonPath("$.historyItems[2].details.defendantAccountId").value(DEFENDANT_ACCOUNT_ID))
+            .andExpect(jsonPath("$.historyItems[2].details.attributeName").doesNotExist())
+            .andExpect(jsonPath("$.historyItems[2].details.noteText").doesNotExist())
+            .andExpect(jsonPath("$.historyItems[2].amount").value(31.00))
+            .andExpect(jsonPath("$.historyItems[3].type").value("Note"))
+            .andExpect(jsonPath("$.historyItems[3].details.noteText").value("Same timestamp PO-2642 note"))
+            .andExpect(jsonPath("$.historyItems[3].details.attributeName").doesNotExist())
+            .andExpect(jsonPath("$.historyItems[3].details.transactionType").doesNotExist())
+            .andExpect(jsonPath("$.historyItems[3].amount").value(nullValue()));
+    }
+
+    @Test
+    @DisplayName("PO-2642 common response returns 401 when the user is unauthorised")
+    void getMinorCreditorHistory_whenUnauthorised_returns401() throws Exception {
+        doThrow(new ResponseStatusException(UNAUTHORIZED, "Unauthorized"))
+            .when(userStateService).checkForAuthorisedUser(any());
+
+        getHistory()
+            .andExpect(status().isUnauthorized())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.detail").value("Unauthorized"));
+    }
+
+    @Test
+    @DisplayName("PO-2642 common response returns 403 when the user lacks permission")
+    void getMinorCreditorHistory_whenUserLacksPermission_returns403() throws Exception {
+        when(userStateService.checkForAuthorisedUser(any())).thenReturn(noPermissionsUser());
+
+        getHistory()
+            .andExpect(status().isForbidden())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON));
+    }
+
+    @Test
+    @DisplayName("PO-2642 common response returns 404 when the account is missing")
+    void getMinorCreditorHistory_whenAccountMissing_returns404() throws Exception {
+        getHistory(MISSING_CREDITOR_ACCOUNT_ID)
+            .andExpect(status().isNotFound())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON));
+    }
+
+    @Test
+    @DisplayName("PO-2642 common response returns 404 when the account is not a minor creditor")
+    void getMinorCreditorHistory_whenAccountIsNotMinorCreditor_returns404() throws Exception {
+        getHistory(NON_MINOR_CREDITOR_ACCOUNT_ID)
+            .andExpect(status().isNotFound())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON));
+    }
+
+    @Test
+    @DisplayName("PO-2642 common response returns 408 for a timeout")
+    void getMinorCreditorHistory_whenTimeoutOccurs_returns408() throws Exception {
+        doThrow(new QueryTimeoutException("timeout"))
+            .when(userStateService).checkForAuthorisedUser(any());
+
+        getHistory()
+            .andExpect(status().isRequestTimeout())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.retriable").value(true));
+    }
+
+    @Test
+    @DisplayName("PO-2642 common response returns 503 for a database connectivity failure")
+    void getMinorCreditorHistory_whenDatabaseUnavailable_returns503() throws Exception {
+        doThrow(new DataAccessResourceFailureException("db unavailable"))
+            .when(userStateService).checkForAuthorisedUser(any());
+
+        getHistory()
+            .andExpect(status().isServiceUnavailable())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.retriable").value(true));
+    }
+
+    @Test
+    @DisplayName("PO-2642 common response returns 500 for an unexpected failure")
+    void getMinorCreditorHistory_whenUnexpectedFailureOccurs_returns500() throws Exception {
+        doThrow(new ResponseStatusException(INTERNAL_SERVER_ERROR, "Boom"))
+            .when(userStateService).checkForAuthorisedUser(any());
+
+        getHistory()
+            .andExpect(status().isInternalServerError())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON));
+    }
+
+    private ResultActions getHistory(String... queryParams) throws Exception {
+        return getHistory(MINOR_CREDITOR_ACCOUNT_ID, queryParams);
+    }
+
+    private ResultActions getHistory(long accountId, String... queryParams) throws Exception {
+        MockHttpServletRequestBuilder request = get(HISTORY_URL, accountId)
+            .header(HttpHeaders.AUTHORIZATION, AUTH_HEADER)
+            .accept(MediaType.APPLICATION_JSON);
+
+        for (int index = 0; index < queryParams.length; index += 2) {
+            request.queryParam(queryParams[index], queryParams[index + 1]);
+        }
+
+        return mockMvc.perform(request);
+    }
+
+    private void expectSuccessfulHistoryResponse(ResultActions result, int itemCount) throws Exception {
+        result.andExpect(status().isOk())
+            .andExpect(header().string(HttpHeaders.ETAG, "\"4\""))
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.historyItems.length()").value(itemCount));
+    }
+
+    private void expectAmendment(
+        ResultActions result,
+        int index,
+        String postedDate,
+        String oldValue,
+        String newValue) throws Exception {
+
+        String itemPath = "$.historyItems[" + index + "]";
+        result.andExpect(jsonPath(itemPath + ".type").value("Amendment"))
+            .andExpect(jsonPath(itemPath + ".postedDetails.posted_date").value(postedDate))
+            .andExpect(jsonPath(itemPath + ".details.attributeName").value("Hold Pay Out"))
+            .andExpect(jsonPath(itemPath + ".details.oldValue").value(oldValue))
+            .andExpect(jsonPath(itemPath + ".details.newValue").value(newValue));
+    }
+
+    private void expectFinancial(
+        ResultActions result,
+        int index,
+        String postedDate,
+        String paymentReference,
+        double amount) throws Exception {
+
+        String itemPath = "$.historyItems[" + index + "]";
+        result.andExpect(jsonPath(itemPath + ".type").value("Financial"))
+            .andExpect(jsonPath(itemPath + ".postedDetails.posted_date").value(postedDate))
+            .andExpect(jsonPath(itemPath + ".amount").value(amount))
+            .andExpect(jsonPath(itemPath + ".details.transactionType.transactionType").value("PAYMNT"))
+            .andExpect(jsonPath(itemPath + ".details.paymentReference").value(paymentReference))
+            .andExpect(jsonPath(itemPath + ".details.status.creditorTransactionStatus").value("C"))
+            .andExpect(jsonPath(itemPath + ".details.accountNumber").value("P264MN01"))
+            .andExpect(jsonPath(itemPath + ".details.defendantAccountNumber").value("P264DEF1"))
+            .andExpect(jsonPath(itemPath + ".details.defendantAccountId").value(DEFENDANT_ACCOUNT_ID));
+    }
+
+    private void expectNote(ResultActions result, int index, String postedDate, String noteText) throws Exception {
+        String itemPath = "$.historyItems[" + index + "]";
+        result.andExpect(jsonPath(itemPath + ".type").value("Note"))
+            .andExpect(jsonPath(itemPath + ".postedDetails.posted_date").value(postedDate))
+            .andExpect(jsonPath(itemPath + ".details.noteText").value(noteText));
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMinorCreditorHistoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMinorCreditorHistoryIntegrationTest.java
@@ -33,6 +33,8 @@ import org.springframework.web.server.ResponseStatusException;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.service.UserStateService;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 
 @ActiveProfiles({"integration", "opal"})
 @TestPropertySource(properties = {
@@ -70,6 +72,8 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-2653")
     @DisplayName("PO-2642 INT.01/INT.05 returns all amendment history only when filtered")
     void getMinorCreditorHistory_whenFilteredToAmendments_returnsAllAmendments() throws Exception {
         ResultActions result = getHistory("itemTypes", "amendment");
@@ -81,6 +85,8 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-2653")
     @DisplayName("PO-2642 INT.02/INT.06 returns all note history only when filtered")
     void getMinorCreditorHistory_whenFilteredToNotes_returnsAllNotes() throws Exception {
         ResultActions result = getHistory("itemTypes", "note");
@@ -91,6 +97,8 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-2653")
     @DisplayName("PO-2642 INT.03/INT.07 returns all financial history only when filtered")
     void getMinorCreditorHistory_whenFilteredToFinancial_returnsAllFinancialItems() throws Exception {
         ResultActions result = getHistory("itemTypes", "financial");
@@ -102,6 +110,8 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-2653")
     @DisplayName("PO-2642 INT.04 returns merged history latest-to-oldest")
     void getMinorCreditorHistory_whenNoFilters_returnsMergedLatestToOldestHistory() throws Exception {
         ResultActions result = getHistory();
@@ -118,6 +128,8 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-2653")
     @DisplayName("PO-2642 INT.08 applies dateFrom as an inclusive lower bound")
     void getMinorCreditorHistory_whenDateFromProvided_appliesInclusiveLowerBound() throws Exception {
         ResultActions result = getHistory("dateFrom", "2026-01-15");
@@ -128,6 +140,8 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-2653")
     @DisplayName("PO-2642 INT.09 applies dateTo as an inclusive upper bound")
     void getMinorCreditorHistory_whenDateToProvided_appliesInclusiveUpperBound() throws Exception {
         ResultActions result = getHistory("dateTo", "2026-01-10");
@@ -138,6 +152,8 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-2653")
     @DisplayName("PO-2642 INT.10 applies an inclusive date range")
     void getMinorCreditorHistory_whenDateRangeProvided_returnsItemsWithinRange() throws Exception {
         ResultActions result = getHistory("dateFrom", "2026-01-10", "dateTo", "2026-01-25");
@@ -149,6 +165,8 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-2653")
     @DisplayName("PO-2642 INT.11 combines date and item type filters")
     void getMinorCreditorHistory_whenDateAndTypeFiltersProvided_appliesBothFilters() throws Exception {
         ResultActions result = getHistory(
@@ -163,6 +181,8 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-2653")
     @DisplayName("PO-2642 INT.12 orders equal timestamps deterministically")
     void getMinorCreditorHistory_whenTimestampsMatch_ordersByTypeThenSourceId() throws Exception {
         ResultActions result = getHistory("dateFrom", "2026-01-31", "dateTo", "2026-01-31");
@@ -175,6 +195,8 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-2653")
     @DisplayName("PO-2642 schema assertions verify documented history item shapes")
     void getMinorCreditorHistory_whenHistoryExists_returnsDocumentedPolymorphicShapes() throws Exception {
         ResultActions result = getHistory("dateFrom", "2026-01-31", "dateTo", "2026-01-31");
@@ -213,6 +235,8 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-2653")
     @DisplayName("PO-2642 common response returns 401 when the user is unauthorised")
     void getMinorCreditorHistory_whenUnauthorised_returns401() throws Exception {
         doThrow(new ResponseStatusException(UNAUTHORIZED, "Unauthorized"))
@@ -225,6 +249,8 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-2653")
     @DisplayName("PO-2642 common response returns 403 when the user lacks permission")
     void getMinorCreditorHistory_whenUserLacksPermission_returns403() throws Exception {
         when(userStateService.checkForAuthorisedUser(any())).thenReturn(noPermissionsUser());
@@ -235,6 +261,8 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-2653")
     @DisplayName("PO-2642 common response returns 404 when the account is missing")
     void getMinorCreditorHistory_whenAccountMissing_returns404() throws Exception {
         getHistory(MISSING_CREDITOR_ACCOUNT_ID)
@@ -243,6 +271,8 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-2653")
     @DisplayName("PO-2642 common response returns 404 when the account is not a minor creditor")
     void getMinorCreditorHistory_whenAccountIsNotMinorCreditor_returns404() throws Exception {
         getHistory(NON_MINOR_CREDITOR_ACCOUNT_ID)
@@ -251,6 +281,8 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-2653")
     @DisplayName("PO-2642 common response returns 408 for a timeout")
     void getMinorCreditorHistory_whenTimeoutOccurs_returns408() throws Exception {
         doThrow(new QueryTimeoutException("timeout"))
@@ -263,6 +295,8 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-2653")
     @DisplayName("PO-2642 common response returns 503 for a database connectivity failure")
     void getMinorCreditorHistory_whenDatabaseUnavailable_returns503() throws Exception {
         doThrow(new DataAccessResourceFailureException("db unavailable"))
@@ -275,6 +309,8 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @JiraStory("PO-2642")
+    @JiraEpic("PO-2653")
     @DisplayName("PO-2642 common response returns 500 for an unexpected failure")
     void getMinorCreditorHistory_whenUnexpectedFailureOccurs_returns500() throws Exception {
         doThrow(new ResponseStatusException(INTERNAL_SERVER_ERROR, "Boom"))

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/util/Release1bFeatureToggleRequestUtil.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/util/Release1bFeatureToggleRequestUtil.java
@@ -288,6 +288,10 @@ public final class Release1bFeatureToggleRequestUtil {
                 getWithAuthorization("/minor-creditor-accounts/" + MINOR_CREDITOR_ACCOUNT_ID)
             ),
             Arguments.of(
+                "Get Minor Creditor History",
+                getWithAuthorization("/minor-creditor-accounts/" + MINOR_CREDITOR_ACCOUNT_ID + "/history")
+            ),
+            Arguments.of(
                 "Patch Minor Creditor Account",
                 patchJsonWithBusinessHeaders("/minor-creditor-accounts/" + MINOR_CREDITOR_ACCOUNT_ID, """
                     {

--- a/src/integrationTest/resources/db/deleteData/delete_from_minor_creditors.sql
+++ b/src/integrationTest/resources/db/deleteData/delete_from_minor_creditors.sql
@@ -15,7 +15,13 @@
 
 -- Delete test creditor transactions first (FK references creditor_accounts)
 DELETE FROM public.creditor_transactions
-WHERE creditor_account_id IN (104, 606);
+WHERE creditor_account_id IN (104, 606, 607);
+
+DELETE FROM public.notes
+WHERE note_id = 90004;
+
+DELETE FROM public.amendments
+WHERE amendment_id = 90004;
 
 -- Delete test impositions first (FK references creditor_accounts, defendant_accounts)
 DELETE FROM public.impositions

--- a/src/integrationTest/resources/db/deleteData/delete_from_po_2642_minor_creditor_history.sql
+++ b/src/integrationTest/resources/db/deleteData/delete_from_po_2642_minor_creditor_history.sql
@@ -1,0 +1,29 @@
+/**
+* OPAL Program
+*
+* MODULE      : delete_from_po_2642_minor_creditor_history.sql
+*
+* DESCRIPTION : Deletes PO-2642 minor creditor history integration test data.
+*
+**/
+
+DELETE FROM public.creditor_transactions
+WHERE creditor_transaction_id IN (99264200002001, 99264200002002, 99264200002003);
+
+DELETE FROM public.notes
+WHERE note_id IN (99264200003001, 99264200003002);
+
+DELETE FROM public.amendments
+WHERE amendment_id IN (99264200004001, 99264200004002, 99264200004003);
+
+DELETE FROM public.creditor_accounts
+WHERE creditor_account_id IN (99264200000001, 99264200000002);
+
+DELETE FROM public.defendant_accounts
+WHERE defendant_account_id = 99264200001001;
+
+DELETE FROM public.parties
+WHERE party_id IN (99264200000101, 99264200000102);
+
+DELETE FROM public.business_units
+WHERE business_unit_id = 32642;

--- a/src/integrationTest/resources/db/insertData/insert_into_minor_creditors.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_minor_creditors.sql
@@ -187,7 +187,28 @@ VALUES
    'BACS', 'C', '2025-04-17', NULL, NULL),
   (90003, 606, '2025-05-16', 102, 'B. Admin',
    'PAYMNT', 350.00, NULL, FALSE,
-   'BACS', 'C', '2025-05-17', NULL, NULL);
+   'BACS', 'C', '2025-05-17', NULL, NULL),
+  (90004, 607, '2026-01-29 08:00:00', 'PAYUSR', 'Payment User',
+   'PAYMNT', 42.00, NULL, TRUE,
+   'PMT001', 'C', '2026-01-29 08:30:00', 'defendant_accounts', '70000000000000');
+
+INSERT INTO public.notes (
+  note_id, note_type, associated_record_type, associated_record_id,
+  note_text, posted_date, posted_by, posted_by_name
+)
+VALUES
+  (90004, 'AA', 'creditor_accounts', '607',
+   'Review creditor', '2026-01-30 09:00:00', 'NOTEUSR', 'Note User');
+
+INSERT INTO public.amendments (
+  amendment_id, business_unit_id, associated_record_type, associated_record_id,
+  amended_date, amended_by, amended_by_name, field_code, old_value, new_value,
+  case_reference, function_code
+)
+VALUES
+  (90004, 10, 'creditor_accounts', '607',
+   '2026-01-31 10:00:00', 'AMENDUSR', 'Amend User', 41, 'false', 'true',
+   NULL, 'minor-creditor-history');
 
    -- Need to insert a defendant for an imposition --
 INSERT INTO public.defendant_accounts (

--- a/src/integrationTest/resources/db/insertData/insert_into_po_2642_minor_creditor_history.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_po_2642_minor_creditor_history.sql
@@ -1,0 +1,107 @@
+/**
+* OPAL Program
+*
+* MODULE      : insert_into_po_2642_minor_creditor_history.sql
+*
+* DESCRIPTION : Inserts PO-2642 minor creditor history integration test data.
+*
+**/
+
+INSERT INTO public.business_units (
+  business_unit_id, business_unit_name, business_unit_code, business_unit_type,
+  account_number_prefix, parent_business_unit_id, opal_domain, welsh_language,
+  account_number_suffix
+)
+VALUES
+  (32642, 'PO-2642 History Business Unit', 'P264', 'Area',
+   'P2', NULL, 'Fines', false, 'H');
+
+INSERT INTO public.parties (
+  party_id, organisation, organisation_name,
+  surname, forenames, title,
+  address_line_1, address_line_2, address_line_3,
+  address_line_4, address_line_5, postcode,
+  account_type, birth_date, age, national_insurance_number, last_changed_date
+)
+VALUES
+  (99264200000101, 'N', NULL,
+   'History', 'Creditor', 'Mx',
+   '1 Integration Street', 'History Quarter', 'Test City',
+   NULL, NULL, 'PO2 6TF',
+   'Creditor', NULL, NULL, NULL, NULL),
+  (99264200000102, 'Y', 'PO-2642 Major Creditor',
+   NULL, NULL, NULL,
+   '2 Integration Street', 'History Quarter', 'Test City',
+   NULL, NULL, 'PO2 6MJ',
+   'Creditor', NULL, NULL, NULL, NULL);
+
+INSERT INTO public.creditor_accounts (
+  creditor_account_id, business_unit_id, account_number, creditor_account_type,
+  prosecution_service, major_creditor_id, minor_creditor_party_id,
+  from_suspense, hold_payout, pay_by_bacs,
+  bank_sort_code, bank_account_number, bank_account_name, bank_account_reference,
+  bank_account_type, version_number, last_changed_date
+)
+VALUES
+  (99264200000001, 32642, 'P264MN01', 'MN',
+   true, NULL, 99264200000101,
+   false, false, false,
+   NULL, NULL, NULL, NULL,
+   NULL, 4, '2026-01-31 11:00:00'),
+  (99264200000002, 32642, 'P264MJ01', 'MJ',
+   true, NULL, NULL,
+   false, false, false,
+   NULL, NULL, NULL, NULL,
+   NULL, 1, '2026-01-31 11:00:00');
+
+INSERT INTO public.defendant_accounts (
+  defendant_account_id, business_unit_id, account_number,
+  amount_imposed, amount_paid, account_balance, account_status, account_type,
+  version_number
+)
+VALUES
+  (99264200001001, 32642, 'P264DEF1',
+   100.00, 20.00, 80.00, 'CS', 'Fine',
+   1);
+
+INSERT INTO public.creditor_transactions (
+  creditor_transaction_id, creditor_account_id, posted_date, posted_by, posted_by_name,
+  transaction_type, transaction_amount, imposition_result_id, payment_processed,
+  payment_reference, status, status_date, associated_record_type, associated_record_id
+)
+VALUES
+  (99264200002001, 99264200000001, '2026-01-05 08:00:00', 'FINUSR1', 'Financial User One',
+   'PAYMNT', 10.00, NULL, true,
+   'FIN001', 'C', '2026-01-05 08:30:00', 'defendant_accounts', '99264200001001'),
+  (99264200002002, 99264200000001, '2026-01-25 12:00:00', 'FINUSR2', 'Financial User Two',
+   'PAYMNT', 25.00, NULL, true,
+   'FIN002', 'C', '2026-01-25 12:30:00', 'defendant_accounts', '99264200001001'),
+  (99264200002003, 99264200000001, '2026-01-31 10:00:00', 'FINUSR3', 'Financial User Three',
+   'PAYMNT', 31.00, NULL, true,
+   'FIN003', 'C', '2026-01-31 10:30:00', 'defendant_accounts', '99264200001001');
+
+INSERT INTO public.notes (
+  note_id, note_type, associated_record_type, associated_record_id,
+  note_text, posted_date, posted_by, posted_by_name
+)
+VALUES
+  (99264200003001, 'AA', 'creditor_accounts', '99264200000001',
+   'Older PO-2642 note', '2026-01-10 09:00:00', 'NOTEUSR1', 'Note User One'),
+  (99264200003002, 'AA', 'creditor_accounts', '99264200000001',
+   'Same timestamp PO-2642 note', '2026-01-31 10:00:00', 'NOTEUSR2', 'Note User Two');
+
+INSERT INTO public.amendments (
+  amendment_id, business_unit_id, associated_record_type, associated_record_id,
+  amended_date, amended_by, amended_by_name, field_code, old_value, new_value,
+  case_reference, function_code
+)
+VALUES
+  (99264200004001, 32642, 'creditor_accounts', '99264200000001',
+   '2026-01-15 10:00:00', 'AMEND1', 'Amend User One', 41, 'baseline-old', 'baseline-new',
+   NULL, 'minor-creditor-history'),
+  (99264200004002, 32642, 'creditor_accounts', '99264200000001',
+   '2026-01-31 10:00:00', 'AMEND2', 'Amend User Two', 41, 'tie-1-old', 'tie-1-new',
+   NULL, 'minor-creditor-history'),
+  (99264200004003, 32642, 'creditor_accounts', '99264200000001',
+   '2026-01-31 10:00:00', 'AMEND3', 'Amend User Three', 41, 'tie-2-old', 'tie-2-new',
+   NULL, 'minor-creditor-history');

--- a/src/main/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiController.java
@@ -5,16 +5,21 @@ import static uk.gov.hmcts.opal.util.FeatureFlags.RELEASE_1B_ENABLED_PROPERTY;
 import static uk.gov.hmcts.opal.util.HttpUtil.buildResponse;
 import static uk.gov.hmcts.opal.util.VersionUtils.extractOptionalBigInteger;
 
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.opal.common.launchdarkly.FeatureToggle;
 import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
+import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
 import uk.gov.hmcts.opal.generated.http.api.MinorCreditorApi;
+import uk.gov.hmcts.opal.generated.model.GetMinorCreditorHistory200Response;
 import uk.gov.hmcts.opal.generated.model.MinorCreditorAccountResponseMinorCreditor;
 import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
 import uk.gov.hmcts.opal.service.MinorCreditorService;
+import uk.gov.hmcts.opal.util.VersionUtils;
 
 @RestController
 @Slf4j(topic = "opal.MinorCreditorApiController")
@@ -31,6 +36,22 @@ public class MinorCreditorApiController implements MinorCreditorApi {
         MinorCreditorAccountResponse result = minorCreditorService.getMinorCreditorAccount(id);
 
         return buildResponse(result);
+    }
+
+    @Override
+    @FeatureToggle(feature = RELEASE_1B, defaultValueProperty = RELEASE_1B_ENABLED_PROPERTY)
+    public ResponseEntity<GetMinorCreditorHistory200Response> getMinorCreditorHistory(
+        Long id,
+        LocalDate dateFrom,
+        LocalDate dateTo,
+        List<String> itemTypes,
+        String authorization) {
+        log.debug(":GET:getMinorCreditorHistory: id={}", id);
+
+        GetMinorCreditorHistoryResponse response =
+            minorCreditorService.getMinorCreditorHistory(id, dateFrom, dateTo, itemTypes, authorization);
+
+        return ResponseEntity.ok().eTag(VersionUtils.createETag(response)).body(response.getPayload());
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiController.java
@@ -44,12 +44,11 @@ public class MinorCreditorApiController implements MinorCreditorApi {
         Long id,
         LocalDate dateFrom,
         LocalDate dateTo,
-        List<String> itemTypes,
-        String authorization) {
+        List<String> itemTypes) {
         log.debug(":GET:getMinorCreditorHistory: id={}", id);
 
         GetMinorCreditorHistoryResponse response =
-            minorCreditorService.getMinorCreditorHistory(id, dateFrom, dateTo, itemTypes, authorization);
+            minorCreditorService.getMinorCreditorHistory(id, dateFrom, dateTo, itemTypes);
 
         return ResponseEntity.ok().eTag(VersionUtils.createETag(response)).body(response.getPayload());
     }

--- a/src/main/java/uk/gov/hmcts/opal/dto/response/GetMinorCreditorHistoryResponse.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/response/GetMinorCreditorHistoryResponse.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.opal.dto.response;
+
+import java.math.BigInteger;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.opal.generated.model.GetMinorCreditorHistory200Response;
+import uk.gov.hmcts.opal.util.Versioned;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GetMinorCreditorHistoryResponse implements Versioned {
+
+    private GetMinorCreditorHistory200Response payload;
+
+    private BigInteger version;
+}

--- a/src/main/java/uk/gov/hmcts/opal/entity/minorcreditor/MinorCreditorHistoryFilters.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/minorcreditor/MinorCreditorHistoryFilters.java
@@ -1,0 +1,67 @@
+package uk.gov.hmcts.opal.entity.minorcreditor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+public record MinorCreditorHistoryFilters(
+    LocalDate dateFrom,
+    LocalDate dateTo,
+    LocalDateTime postedFromInclusive,
+    LocalDateTime postedToExclusive,
+    Set<MinorCreditorHistoryItemType> itemTypes) {
+
+    public MinorCreditorHistoryFilters {
+        itemTypes = Set.copyOf(itemTypes);
+    }
+
+    public static MinorCreditorHistoryFilters from(
+        LocalDate dateFrom,
+        LocalDate dateTo,
+        List<String> itemTypes) {
+
+        if (dateFrom != null && dateTo != null && dateFrom.isAfter(dateTo)) {
+            throw new IllegalArgumentException("dateFrom must be on or before dateTo");
+        }
+
+        return new MinorCreditorHistoryFilters(
+            dateFrom,
+            dateTo,
+            dateFrom == null ? null : dateFrom.atStartOfDay(),
+            dateTo == null ? null : dateTo.plusDays(1).atStartOfDay(),
+            parseItemTypes(itemTypes));
+    }
+
+    public boolean includes(MinorCreditorHistoryItemType itemType) {
+        return itemTypes.contains(itemType);
+    }
+
+    private static Set<MinorCreditorHistoryItemType> parseItemTypes(List<String> itemTypes) {
+        List<String> queryValues = queryValues(itemTypes);
+        if (queryValues.isEmpty()) {
+            return EnumSet.allOf(MinorCreditorHistoryItemType.class);
+        }
+
+        EnumSet<MinorCreditorHistoryItemType> parsedItemTypes =
+            EnumSet.noneOf(MinorCreditorHistoryItemType.class);
+        queryValues.stream()
+            .map(MinorCreditorHistoryItemType::fromQueryValue)
+            .forEach(parsedItemTypes::add);
+        return parsedItemTypes;
+    }
+
+    private static List<String> queryValues(List<String> itemTypes) {
+        if (itemTypes == null) {
+            return List.of();
+        }
+
+        return itemTypes.stream()
+            .flatMap(rawValue -> rawValue == null ? Stream.of("") : Arrays.stream(rawValue.split(",", -1)))
+            .map(String::trim)
+            .toList();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/entity/minorcreditor/MinorCreditorHistoryItem.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/minorcreditor/MinorCreditorHistoryItem.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.opal.entity.minorcreditor;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import uk.gov.hmcts.opal.generated.model.MinorCreditorHistoryItemHistory;
+
+public record MinorCreditorHistoryItem(
+    MinorCreditorHistoryItemType sourceType,
+    Long sourceId,
+    LocalDateTime postedDate,
+    MinorCreditorHistoryItemHistory responseItem) {
+
+    public static final Comparator<MinorCreditorHistoryItem> ORDERING =
+        Comparator.comparing(MinorCreditorHistoryItem::postedDate).reversed()
+            .thenComparingInt(item -> item.sourceType().sortOrder())
+            .thenComparing(MinorCreditorHistoryItem::sourceId);
+}

--- a/src/main/java/uk/gov/hmcts/opal/entity/minorcreditor/MinorCreditorHistoryItemType.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/minorcreditor/MinorCreditorHistoryItemType.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.opal.entity.minorcreditor;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public enum MinorCreditorHistoryItemType {
+    AMENDMENT("amendment"),
+    FINANCIAL("financial"),
+    NOTE("note");
+
+    private final String queryValue;
+
+    MinorCreditorHistoryItemType(String queryValue) {
+        this.queryValue = queryValue;
+    }
+
+    public String queryValue() {
+        return queryValue;
+    }
+
+    public static MinorCreditorHistoryItemType fromQueryValue(String queryValue) {
+        return Arrays.stream(values())
+            .filter(itemType -> itemType.queryValue.equals(queryValue))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException(
+                "itemTypes must contain only " + allowedValues()));
+    }
+
+    public static String allowedValues() {
+        return Arrays.stream(values())
+            .map(MinorCreditorHistoryItemType::queryValue)
+            .collect(Collectors.joining(", "));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/entity/minorcreditor/MinorCreditorHistoryItemType.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/minorcreditor/MinorCreditorHistoryItemType.java
@@ -2,20 +2,36 @@ package uk.gov.hmcts.opal.entity.minorcreditor;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
+import uk.gov.hmcts.opal.generated.model.MinorCreditorHistoryItemHistory;
 
 public enum MinorCreditorHistoryItemType {
-    AMENDMENT("amendment"),
-    FINANCIAL("financial"),
-    NOTE("note");
+    AMENDMENT("amendment", MinorCreditorHistoryItemHistory.TypeEnum.AMENDMENT, 1),
+    FINANCIAL("financial", MinorCreditorHistoryItemHistory.TypeEnum.FINANCIAL, 2),
+    NOTE("note", MinorCreditorHistoryItemHistory.TypeEnum.NOTE, 3);
 
     private final String queryValue;
+    private final MinorCreditorHistoryItemHistory.TypeEnum responseType;
+    private final int sortOrder;
 
-    MinorCreditorHistoryItemType(String queryValue) {
+    MinorCreditorHistoryItemType(
+        String queryValue,
+        MinorCreditorHistoryItemHistory.TypeEnum responseType,
+        int sortOrder) {
         this.queryValue = queryValue;
+        this.responseType = responseType;
+        this.sortOrder = sortOrder;
     }
 
     public String queryValue() {
         return queryValue;
+    }
+
+    public MinorCreditorHistoryItemHistory.TypeEnum responseType() {
+        return responseType;
+    }
+
+    public int sortOrder() {
+        return sortOrder;
     }
 
     public static MinorCreditorHistoryItemType fromQueryValue(String queryValue) {

--- a/src/main/java/uk/gov/hmcts/opal/mapper/MinorCreditorHistoryItemMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/mapper/MinorCreditorHistoryItemMapper.java
@@ -1,0 +1,114 @@
+package uk.gov.hmcts.opal.mapper;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItem;
+import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItemType;
+import uk.gov.hmcts.opal.generated.model.AmendmentTypeCommon;
+import uk.gov.hmcts.opal.generated.model.CreditorTransactionDetailsHistory;
+import uk.gov.hmcts.opal.generated.model.CreditorTransactionStatusReferenceCommon;
+import uk.gov.hmcts.opal.generated.model.CreditorTransactionTypeReferenceCommon;
+import uk.gov.hmcts.opal.generated.model.MinorCreditorHistoryItemHistory;
+import uk.gov.hmcts.opal.generated.model.MinorCreditorHistoryItemHistoryDetails;
+import uk.gov.hmcts.opal.generated.model.NoteDetailsHistory;
+import uk.gov.hmcts.opal.generated.model.PostedDetailsCommon;
+import uk.gov.hmcts.opal.repository.projection.MinorCreditorAmendmentHistoryProjection;
+import uk.gov.hmcts.opal.repository.projection.MinorCreditorNoteHistoryProjection;
+import uk.gov.hmcts.opal.repository.projection.MinorCreditorTransactionHistoryProjection;
+
+@Component
+public class MinorCreditorHistoryItemMapper {
+
+    public MinorCreditorHistoryItem toHistoryItem(MinorCreditorAmendmentHistoryProjection projection) {
+        return buildHistoryItem(
+            MinorCreditorHistoryItemType.AMENDMENT,
+            projection.getAmendmentId(),
+            projection.getPostedDate(),
+            projection.getPostedBy(),
+            projection.getPostedByName(),
+            new AmendmentTypeCommon()
+                .attributeName(projection.getAttributeName())
+                .oldValue(projection.getOldValue())
+                .newValue(projection.getNewValue()),
+            null
+        );
+    }
+
+    public MinorCreditorHistoryItem toHistoryItem(MinorCreditorNoteHistoryProjection projection) {
+        return buildHistoryItem(
+            MinorCreditorHistoryItemType.NOTE,
+            projection.getNoteId(),
+            projection.getPostedDate(),
+            projection.getPostedBy(),
+            projection.getPostedByName(),
+            new NoteDetailsHistory().noteText(projection.getNoteText()),
+            null
+        );
+    }
+
+    public MinorCreditorHistoryItem toHistoryItem(MinorCreditorTransactionHistoryProjection projection) {
+        return buildHistoryItem(
+            MinorCreditorHistoryItemType.FINANCIAL,
+            projection.getCreditorTransactionId(),
+            projection.getPostedDate(),
+            projection.getPostedBy(),
+            projection.getPostedByName(),
+            new CreditorTransactionDetailsHistory()
+                .transactionType(toCreditorTransactionType(projection.getTransactionType()))
+                .paymentReference(projection.getPaymentReference())
+                .status(toCreditorTransactionStatus(projection.getStatus()))
+                .statusDate(projection.getStatusDate())
+                .associatedRecordType(projection.getAssociatedRecordType())
+                .associatedRecordId(projection.getAssociatedRecordId())
+                .accountNumber(projection.getAccountNumber())
+                .defendantAccountNumber(projection.getDefendantAccountNumber())
+                .defendantAccountId(projection.getDefendantAccountId()),
+            projection.getTransactionAmount()
+        );
+    }
+
+    public PostedDetailsCommon toPostedDetails(LocalDateTime postedDate, String postedBy, String postedByName) {
+        return new PostedDetailsCommon()
+            .postedDate(postedDate.toLocalDate())
+            .postedBy(postedBy)
+            .postedByName(postedByName);
+    }
+
+    public CreditorTransactionTypeReferenceCommon toCreditorTransactionType(String transactionType) {
+        return new CreditorTransactionTypeReferenceCommon()
+            .transactionType(CreditorTransactionTypeReferenceCommon.TransactionTypeEnum.fromValue(transactionType))
+            .transactionTypeDisplayName(transactionType);
+    }
+
+    public CreditorTransactionStatusReferenceCommon toCreditorTransactionStatus(String status) {
+        if (status == null) {
+            return null;
+        }
+        return new CreditorTransactionStatusReferenceCommon()
+            .creditorTransactionStatus(
+                CreditorTransactionStatusReferenceCommon.CreditorTransactionStatusEnum.fromValue(status))
+            .creditorTransactionStatusDisplayName(status);
+    }
+
+    private MinorCreditorHistoryItem buildHistoryItem(
+        MinorCreditorHistoryItemType sourceType,
+        Long sourceId,
+        LocalDateTime postedDate,
+        String postedBy,
+        String postedByName,
+        MinorCreditorHistoryItemHistoryDetails details,
+        BigDecimal amount) {
+
+        return new MinorCreditorHistoryItem(
+            sourceType,
+            sourceId,
+            postedDate,
+            new MinorCreditorHistoryItemHistory()
+                .postedDetails(toPostedDetails(postedDate, postedBy, postedByName))
+                .type(sourceType.responseType())
+                .details(details)
+                .amount(amount)
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/repository/AmendmentRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/AmendmentRepository.java
@@ -1,12 +1,15 @@
 package uk.gov.hmcts.opal.repository;
 
-import uk.gov.hmcts.opal.entity.amendment.AmendmentEntity;
-
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.query.Procedure;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import uk.gov.hmcts.opal.entity.amendment.AmendmentEntity;
+import uk.gov.hmcts.opal.repository.projection.MinorCreditorAmendmentHistoryProjection;
 
 @Repository
 public interface AmendmentRepository extends JpaRepository<AmendmentEntity, Long>,
@@ -34,4 +37,25 @@ public interface AmendmentRepository extends JpaRepository<AmendmentEntity, Long
 
     void deleteByAssociatedRecordId(String defendantAccountId);
 
+    @Query(value = """
+        SELECT a.amendment_id AS amendmentId,
+               a.amended_date AS postedDate,
+               a.amended_by AS postedBy,
+               a.amended_by_name AS postedByName,
+               aaf.data_item AS attributeName,
+               a.old_value AS oldValue,
+               a.new_value AS newValue
+          FROM amendments a
+          JOIN audit_amendment_fields aaf
+            ON aaf.field_code = a.field_code
+         WHERE a.associated_record_type = 'creditor_accounts'
+           AND a.associated_record_id = :creditorAccountId
+           AND a.amended_date >= :postedFromInclusive
+           AND a.amended_date < :postedToExclusive
+         ORDER BY a.amended_date DESC, a.amendment_id
+        """, nativeQuery = true)
+    List<MinorCreditorAmendmentHistoryProjection> findMinorCreditorHistory(
+        @Param("creditorAccountId") String creditorAccountId,
+        @Param("postedFromInclusive") LocalDateTime postedFromInclusive,
+        @Param("postedToExclusive") LocalDateTime postedToExclusive);
 }

--- a/src/main/java/uk/gov/hmcts/opal/repository/CreditorTransactionRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/CreditorTransactionRepository.java
@@ -1,13 +1,52 @@
 package uk.gov.hmcts.opal.repository;
 
-import uk.gov.hmcts.opal.entity.CreditorTransactionEntity;
-
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import uk.gov.hmcts.opal.entity.CreditorTransactionEntity;
+import uk.gov.hmcts.opal.repository.projection.MinorCreditorTransactionHistoryProjection;
 
 @Repository
 public interface CreditorTransactionRepository extends JpaRepository<CreditorTransactionEntity, Long>,
     JpaSpecificationExecutor<CreditorTransactionEntity> {
 
+    @Query(value = """
+        SELECT ct.creditor_transaction_id AS creditorTransactionId,
+               ct.posted_date AS postedDate,
+               ct.posted_by AS postedBy,
+               ct.posted_by_name AS postedByName,
+               ct.transaction_type AS transactionType,
+               ct.transaction_amount AS transactionAmount,
+               ct.payment_reference AS paymentReference,
+               ct.status AS status,
+               ct.status_date AS statusDate,
+               ct.associated_record_type AS associatedRecordType,
+               ct.associated_record_id AS associatedRecordId,
+               ca.account_number AS accountNumber,
+               COALESCE(da_direct.account_number, da_from_transaction.account_number) AS defendantAccountNumber,
+               COALESCE(da_direct.defendant_account_id, da_from_transaction.defendant_account_id) AS defendantAccountId
+          FROM creditor_transactions ct
+          JOIN creditor_accounts ca
+            ON ca.creditor_account_id = ct.creditor_account_id
+          LEFT JOIN defendant_accounts da_direct
+            ON ct.associated_record_type = 'defendant_accounts'::public.t_associated_record_type_enum
+           AND ct.associated_record_id = da_direct.defendant_account_id::text
+          LEFT JOIN defendant_transactions dt
+            ON ct.associated_record_type = 'defendant_transactions'::public.t_associated_record_type_enum
+           AND ct.associated_record_id = dt.defendant_transaction_id::text
+          LEFT JOIN defendant_accounts da_from_transaction
+            ON da_from_transaction.defendant_account_id = dt.defendant_account_id
+         WHERE ct.creditor_account_id = :creditorAccountId
+           AND ct.posted_date >= :postedFromInclusive
+           AND ct.posted_date < :postedToExclusive
+         ORDER BY ct.posted_date DESC, ct.creditor_transaction_id
+        """, nativeQuery = true)
+    List<MinorCreditorTransactionHistoryProjection> findMinorCreditorHistory(
+        @Param("creditorAccountId") Long creditorAccountId,
+        @Param("postedFromInclusive") LocalDateTime postedFromInclusive,
+        @Param("postedToExclusive") LocalDateTime postedToExclusive);
 }

--- a/src/main/java/uk/gov/hmcts/opal/repository/NoteRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/NoteRepository.java
@@ -1,10 +1,14 @@
 package uk.gov.hmcts.opal.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.opal.entity.NoteEntity;
+import uk.gov.hmcts.opal.repository.projection.MinorCreditorNoteHistoryProjection;
 
 @Repository
 public interface NoteRepository extends JpaRepository<NoteEntity, Long>, JpaSpecificationExecutor<NoteEntity> {
@@ -15,4 +19,25 @@ public interface NoteRepository extends JpaRepository<NoteEntity, Long>, JpaSpec
         String associatedRecordId, String noteType);
 
     void deleteByAssociatedRecordId(String defendantAccountId);
+
+    @Query(value = """
+        SELECT n.note_id AS noteId,
+               n.posted_date AS postedDate,
+               n.posted_by AS postedBy,
+               n.posted_by_name AS postedByName,
+               n.note_text AS noteText
+          FROM notes n
+         WHERE n.associated_record_type = 'creditor_accounts'::public.t_associated_record_type_enum
+           AND n.associated_record_id = :creditorAccountId
+           AND n.note_type = 'AA'::public.t_note_type_enum
+           AND n.posted_date IS NOT NULL
+           AND n.posted_date >= :postedFromInclusive
+           AND n.posted_date < :postedToExclusive
+         ORDER BY n.posted_date DESC, n.note_id
+        """, nativeQuery = true)
+    List<MinorCreditorNoteHistoryProjection> findMinorCreditorHistory(
+        @Param("creditorAccountId") String creditorAccountId,
+        @Param("postedFromInclusive") LocalDateTime postedFromInclusive,
+        @Param("postedToExclusive") LocalDateTime postedToExclusive);
+
 }

--- a/src/main/java/uk/gov/hmcts/opal/repository/projection/MinorCreditorAmendmentHistoryProjection.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/projection/MinorCreditorAmendmentHistoryProjection.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.opal.repository.projection;
+
+import java.time.LocalDateTime;
+
+public interface MinorCreditorAmendmentHistoryProjection {
+
+    Long getAmendmentId();
+
+    LocalDateTime getPostedDate();
+
+    String getPostedBy();
+
+    String getPostedByName();
+
+    String getAttributeName();
+
+    String getOldValue();
+
+    String getNewValue();
+}

--- a/src/main/java/uk/gov/hmcts/opal/repository/projection/MinorCreditorNoteHistoryProjection.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/projection/MinorCreditorNoteHistoryProjection.java
@@ -1,0 +1,16 @@
+package uk.gov.hmcts.opal.repository.projection;
+
+import java.time.LocalDateTime;
+
+public interface MinorCreditorNoteHistoryProjection {
+
+    Long getNoteId();
+
+    LocalDateTime getPostedDate();
+
+    String getPostedBy();
+
+    String getPostedByName();
+
+    String getNoteText();
+}

--- a/src/main/java/uk/gov/hmcts/opal/repository/projection/MinorCreditorTransactionHistoryProjection.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/projection/MinorCreditorTransactionHistoryProjection.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.opal.repository.projection;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public interface MinorCreditorTransactionHistoryProjection {
+
+    Long getCreditorTransactionId();
+
+    LocalDateTime getPostedDate();
+
+    String getPostedBy();
+
+    String getPostedByName();
+
+    String getTransactionType();
+
+    BigDecimal getTransactionAmount();
+
+    String getPaymentReference();
+
+    String getStatus();
+
+    LocalDateTime getStatusDate();
+
+    String getAssociatedRecordType();
+
+    String getAssociatedRecordId();
+
+    String getAccountNumber();
+
+    String getDefendantAccountNumber();
+
+    Long getDefendantAccountId();
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/MinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/MinorCreditorService.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.opal.service;
 
 import java.math.BigInteger;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +15,7 @@ import uk.gov.hmcts.opal.dto.GetMinorCreditorAccountHeaderSummaryResponse;
 import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
 import uk.gov.hmcts.opal.dto.MinorCreditorSearch;
 import uk.gov.hmcts.opal.dto.PostMinorCreditorAccountsSearchResponse;
+import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
 import uk.gov.hmcts.opal.service.proxy.MinorCreditorSearchProxy;
@@ -50,6 +53,17 @@ public class MinorCreditorService {
         MinorCreditorAccountResponse response =
             minorCreditorSearchProxy.getMinorCreditorAccount(minorCreditorAccountId);
         return redactBacsDetailsWhenNotPermitted(minorCreditorAccountId, response, userState);
+    }
+
+    public GetMinorCreditorHistoryResponse getMinorCreditorHistory(
+        Long minorCreditorAccountId,
+        LocalDate dateFrom,
+        LocalDate dateTo,
+        List<String> itemTypes,
+        String authHeaderValue) {
+        log.debug(":getMinorCreditorHistory: id={}", minorCreditorAccountId);
+
+        throw new UnsupportedOperationException("Minor creditor history service has not been implemented");
     }
 
     public GetMinorCreditorAccountAtAGlanceResponse getMinorCreditorAtAGlance(Long minorCreditorId) {

--- a/src/main/java/uk/gov/hmcts/opal/service/MinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/MinorCreditorService.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
 import uk.gov.hmcts.opal.dto.MinorCreditorSearch;
 import uk.gov.hmcts.opal.dto.PostMinorCreditorAccountsSearchResponse;
 import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
+import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryFilters;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
 import uk.gov.hmcts.opal.service.proxy.MinorCreditorSearchProxy;
@@ -66,8 +67,9 @@ public class MinorCreditorService {
         UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
+            MinorCreditorHistoryFilters filters = MinorCreditorHistoryFilters.from(dateFrom, dateTo, itemTypes);
             return minorCreditorSearchProxy.getMinorCreditorHistory(
-                minorCreditorAccountId, dateFrom, dateTo, itemTypes);
+                minorCreditorAccountId, filters);
         } else {
             throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         }

--- a/src/main/java/uk/gov/hmcts/opal/service/MinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/MinorCreditorService.java
@@ -60,11 +60,10 @@ public class MinorCreditorService {
         Long minorCreditorAccountId,
         LocalDate dateFrom,
         LocalDate dateTo,
-        List<String> itemTypes,
-        String authHeaderValue) {
+        List<String> itemTypes) {
         log.debug(":getMinorCreditorHistory: id={}", minorCreditorAccountId);
 
-        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
 
         if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
             MinorCreditorHistoryFilters filters = MinorCreditorHistoryFilters.from(dateFrom, dateTo, itemTypes);

--- a/src/main/java/uk/gov/hmcts/opal/service/MinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/MinorCreditorService.java
@@ -63,7 +63,14 @@ public class MinorCreditorService {
         String authHeaderValue) {
         log.debug(":getMinorCreditorHistory: id={}", minorCreditorAccountId);
 
-        throw new UnsupportedOperationException("Minor creditor history service has not been implemented");
+        UserState userState = userStateService.checkForAuthorisedUser(authHeaderValue);
+
+        if (userState.anyBusinessUnitUserHasPermission(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)) {
+            return minorCreditorSearchProxy.getMinorCreditorHistory(
+                minorCreditorAccountId, dateFrom, dateTo, itemTypes);
+        } else {
+            throw new PermissionNotAllowedException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
+        }
     }
 
     public GetMinorCreditorAccountAtAGlanceResponse getMinorCreditorAtAGlance(Long minorCreditorId) {

--- a/src/main/java/uk/gov/hmcts/opal/service/iface/MinorCreditorServiceInterface.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/iface/MinorCreditorServiceInterface.java
@@ -1,11 +1,14 @@
 package uk.gov.hmcts.opal.service.iface;
 
 import java.math.BigInteger;
+import java.time.LocalDate;
+import java.util.List;
 import uk.gov.hmcts.opal.dto.GetMinorCreditorAccountAtAGlanceResponse;
 import uk.gov.hmcts.opal.dto.GetMinorCreditorAccountHeaderSummaryResponse;
 import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
-import uk.gov.hmcts.opal.dto.PostMinorCreditorAccountsSearchResponse;
 import uk.gov.hmcts.opal.dto.MinorCreditorSearch;
+import uk.gov.hmcts.opal.dto.PostMinorCreditorAccountsSearchResponse;
+import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
 import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
 
 public interface MinorCreditorServiceInterface {
@@ -13,6 +16,12 @@ public interface MinorCreditorServiceInterface {
     PostMinorCreditorAccountsSearchResponse searchMinorCreditors(MinorCreditorSearch minorCreditorSearchDto);
 
     MinorCreditorAccountResponse getMinorCreditorAccount(Long minorCreditorAccountId);
+
+    GetMinorCreditorHistoryResponse getMinorCreditorHistory(
+        Long minorCreditorAccountId,
+        LocalDate dateFrom,
+        LocalDate dateTo,
+        List<String> itemTypes);
 
     GetMinorCreditorAccountAtAGlanceResponse getMinorCreditorAtAGlance(Long minorCreditorId);
 

--- a/src/main/java/uk/gov/hmcts/opal/service/iface/MinorCreditorServiceInterface.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/iface/MinorCreditorServiceInterface.java
@@ -1,14 +1,13 @@
 package uk.gov.hmcts.opal.service.iface;
 
 import java.math.BigInteger;
-import java.time.LocalDate;
-import java.util.List;
 import uk.gov.hmcts.opal.dto.GetMinorCreditorAccountAtAGlanceResponse;
 import uk.gov.hmcts.opal.dto.GetMinorCreditorAccountHeaderSummaryResponse;
 import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
 import uk.gov.hmcts.opal.dto.MinorCreditorSearch;
 import uk.gov.hmcts.opal.dto.PostMinorCreditorAccountsSearchResponse;
 import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
+import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryFilters;
 import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
 
 public interface MinorCreditorServiceInterface {
@@ -19,9 +18,7 @@ public interface MinorCreditorServiceInterface {
 
     GetMinorCreditorHistoryResponse getMinorCreditorHistory(
         Long minorCreditorAccountId,
-        LocalDate dateFrom,
-        LocalDate dateTo,
-        List<String> itemTypes);
+        MinorCreditorHistoryFilters filters);
 
     GetMinorCreditorAccountAtAGlanceResponse getMinorCreditorAtAGlance(Long minorCreditorId);
 

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorService.java
@@ -1,8 +1,15 @@
 package uk.gov.hmcts.opal.service.legacy;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 import uk.gov.hmcts.opal.common.legacy.service.GatewayService;
 import uk.gov.hmcts.opal.common.legacy.service.GatewayService.Response;
 import uk.gov.hmcts.opal.dto.CreditorAccountDto;
@@ -23,6 +30,7 @@ import uk.gov.hmcts.opal.dto.legacy.LegacyUpdateMinorCreditorAccountRequest;
 import uk.gov.hmcts.opal.dto.legacy.LegacyUpdateMinorCreditorAccountResponse;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyMinorCreditorSearchResultsRequest;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyMinorCreditorSearchResultsResponse;
+import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
 import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
 import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
 import uk.gov.hmcts.opal.mapper.legacy.GetMinorCreditorAccountHeaderSummaryResponseLegacyMapper;
@@ -32,11 +40,6 @@ import uk.gov.hmcts.opal.mapper.request.UpdateMinorCreditorAccountRequestMapper;
 import uk.gov.hmcts.opal.mapper.response.GetMinorCreditorAccountAtAGlanceResponseMapper;
 import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
 import uk.gov.hmcts.opal.service.iface.MinorCreditorServiceInterface;
-
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -142,6 +145,15 @@ public class LegacyMinorCreditorService implements MinorCreditorServiceInterface
         }
 
         return mappedResponse;
+    }
+
+    @Override
+    public GetMinorCreditorHistoryResponse getMinorCreditorHistory(
+        Long minorCreditorAccountId,
+        LocalDate dateFrom,
+        LocalDate dateTo,
+        List<String> itemTypes) {
+        throw new ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "Not yet implemented");
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorService.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.opal.service.legacy;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +31,7 @@ import uk.gov.hmcts.opal.dto.legacy.search.LegacyMinorCreditorSearchResultsReque
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyMinorCreditorSearchResultsResponse;
 import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
 import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
+import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryFilters;
 import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
 import uk.gov.hmcts.opal.mapper.legacy.GetMinorCreditorAccountHeaderSummaryResponseLegacyMapper;
 import uk.gov.hmcts.opal.mapper.legacy.LegacyMinorCreditorAccountResponseMapper;
@@ -150,9 +150,7 @@ public class LegacyMinorCreditorService implements MinorCreditorServiceInterface
     @Override
     public GetMinorCreditorHistoryResponse getMinorCreditorHistory(
         Long minorCreditorAccountId,
-        LocalDate dateFrom,
-        LocalDate dateTo,
-        List<String> itemTypes) {
+        MinorCreditorHistoryFilters filters) {
         throw new ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "Not yet implemented");
     }
 

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorService.java
@@ -5,7 +5,6 @@ import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.LockModeType;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +26,7 @@ import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
 import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorAccountAtAGlanceEntity;
 import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorAccountHeaderEntity;
 import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorEntity;
+import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryFilters;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.opal.generated.model.GetMinorCreditorHistory200Response;
 import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
@@ -96,9 +96,7 @@ public class OpalMinorCreditorService implements MinorCreditorServiceInterface {
     @Transactional(readOnly = true)
     public GetMinorCreditorHistoryResponse getMinorCreditorHistory(
         Long minorCreditorAccountId,
-        LocalDate dateFrom,
-        LocalDate dateTo,
-        List<String> itemTypes) {
+        MinorCreditorHistoryFilters filters) {
         log.debug(":getMinorCreditorHistory (Opal): minorCreditorAccountId={}", minorCreditorAccountId);
 
         CreditorAccountEntity creditorAccount = creditorAccountRepository.findById(minorCreditorAccountId)

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorService.java
@@ -7,7 +7,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,20 +28,15 @@ import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorAccountAtAGlanceEntit
 import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorAccountHeaderEntity;
 import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorEntity;
 import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryFilters;
+import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItem;
 import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItemType;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
-import uk.gov.hmcts.opal.generated.model.AmendmentTypeCommon;
-import uk.gov.hmcts.opal.generated.model.CreditorTransactionDetailsHistory;
-import uk.gov.hmcts.opal.generated.model.CreditorTransactionStatusReferenceCommon;
-import uk.gov.hmcts.opal.generated.model.CreditorTransactionTypeReferenceCommon;
 import uk.gov.hmcts.opal.generated.model.GetMinorCreditorHistory200Response;
-import uk.gov.hmcts.opal.generated.model.MinorCreditorHistoryItemHistory;
-import uk.gov.hmcts.opal.generated.model.NoteDetailsHistory;
 import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
-import uk.gov.hmcts.opal.generated.model.PostedDetailsCommon;
 import uk.gov.hmcts.opal.mapper.MinorCreditorAccountHeaderEntityMapper;
 import uk.gov.hmcts.opal.mapper.MinorCreditorAccountResponseMapper;
 import uk.gov.hmcts.opal.mapper.MinorCreditorAccountUpdateMapper;
+import uk.gov.hmcts.opal.mapper.MinorCreditorHistoryItemMapper;
 import uk.gov.hmcts.opal.mapper.response.GetMinorCreditorAccountAtAGlanceResponseMapper;
 import uk.gov.hmcts.opal.repository.AmendmentRepository;
 import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
@@ -53,9 +47,6 @@ import uk.gov.hmcts.opal.repository.MinorCreditorRepository;
 import uk.gov.hmcts.opal.repository.NoteRepository;
 import uk.gov.hmcts.opal.repository.PartyRepository;
 import uk.gov.hmcts.opal.repository.jpa.MinorCreditorSpecs;
-import uk.gov.hmcts.opal.repository.projection.MinorCreditorAmendmentHistoryProjection;
-import uk.gov.hmcts.opal.repository.projection.MinorCreditorNoteHistoryProjection;
-import uk.gov.hmcts.opal.repository.projection.MinorCreditorTransactionHistoryProjection;
 import uk.gov.hmcts.opal.service.iface.MinorCreditorServiceInterface;
 import uk.gov.hmcts.opal.util.VersionUtils;
 
@@ -79,6 +70,7 @@ public class OpalMinorCreditorService implements MinorCreditorServiceInterface {
     private final MinorCreditorAccountHeaderEntityMapper headerSummaryMapper;
     private final MinorCreditorAccountUpdateMapper updateMapper;
     private final MinorCreditorAccountResponseMapper responseMapper;
+    private final MinorCreditorHistoryItemMapper historyItemMapper;
     private final GetMinorCreditorAccountAtAGlanceResponseMapper atAGlanceResponseMapper;
     private final EntityManager em;
     private final MinorCreditorSpecs specs = new MinorCreditorSpecs();
@@ -131,23 +123,22 @@ public class OpalMinorCreditorService implements MinorCreditorServiceInterface {
             throw new EntityNotFoundException("Account is not a minor creditor account: " + minorCreditorAccountId);
         }
 
-        List<MappedMinorCreditorHistoryItem> historyItems = getMinorCreditorHistoryItems(minorCreditorAccountId,
-                                                                                        filters);
+        List<MinorCreditorHistoryItem> historyItems = getMinorCreditorHistoryItems(minorCreditorAccountId, filters);
 
         return GetMinorCreditorHistoryResponse.builder()
             .payload(new GetMinorCreditorHistory200Response().historyItems(historyItems.stream()
-                .sorted(MappedMinorCreditorHistoryItem.ORDERING)
-                .map(MappedMinorCreditorHistoryItem::historyItem)
+                .sorted(MinorCreditorHistoryItem.ORDERING)
+                .map(MinorCreditorHistoryItem::responseItem)
                 .toList()))
             .version(creditorAccount.getVersion())
             .build();
     }
 
-    private List<MappedMinorCreditorHistoryItem> getMinorCreditorHistoryItems(
+    private List<MinorCreditorHistoryItem> getMinorCreditorHistoryItems(
         Long minorCreditorAccountId,
         MinorCreditorHistoryFilters filters) {
 
-        List<MappedMinorCreditorHistoryItem> historyItems = new ArrayList<>();
+        List<MinorCreditorHistoryItem> historyItems = new ArrayList<>();
         LocalDateTime postedFromInclusive = postedFromInclusive(filters);
         LocalDateTime postedToExclusive = postedToExclusive(filters);
         if (filters.includes(MinorCreditorHistoryItemType.AMENDMENT)) {
@@ -155,21 +146,21 @@ public class OpalMinorCreditorService implements MinorCreditorServiceInterface {
                 String.valueOf(minorCreditorAccountId),
                 postedFromInclusive,
                 postedToExclusive
-            ).stream().map(this::toAmendmentHistoryItem).forEach(historyItems::add);
+            ).stream().map(historyItemMapper::toHistoryItem).forEach(historyItems::add);
         }
         if (filters.includes(MinorCreditorHistoryItemType.NOTE)) {
             noteRepository.findMinorCreditorHistory(
                 String.valueOf(minorCreditorAccountId),
                 postedFromInclusive,
                 postedToExclusive
-            ).stream().map(this::toNoteHistoryItem).forEach(historyItems::add);
+            ).stream().map(historyItemMapper::toHistoryItem).forEach(historyItems::add);
         }
         if (filters.includes(MinorCreditorHistoryItemType.FINANCIAL)) {
             creditorTransactionRepository.findMinorCreditorHistory(
                 minorCreditorAccountId,
                 postedFromInclusive,
                 postedToExclusive
-            ).stream().map(this::toFinancialHistoryItem).forEach(historyItems::add);
+            ).stream().map(historyItemMapper::toHistoryItem).forEach(historyItems::add);
         }
         return historyItems;
     }
@@ -180,97 +171,6 @@ public class OpalMinorCreditorService implements MinorCreditorServiceInterface {
 
     private LocalDateTime postedToExclusive(MinorCreditorHistoryFilters filters) {
         return filters.postedToExclusive() == null ? MAX_HISTORY_POSTED_DATE : filters.postedToExclusive();
-    }
-
-    private MappedMinorCreditorHistoryItem toAmendmentHistoryItem(
-        MinorCreditorAmendmentHistoryProjection projection) {
-        return new MappedMinorCreditorHistoryItem(
-            MinorCreditorHistoryItemType.AMENDMENT,
-            projection.getAmendmentId(),
-            projection.getPostedDate(),
-            new MinorCreditorHistoryItemHistory()
-                .postedDetails(postedDetails(projection.getPostedDate(), projection.getPostedBy(),
-                                             projection.getPostedByName()))
-                .type(MinorCreditorHistoryItemHistory.TypeEnum.AMENDMENT)
-                .details(new AmendmentTypeCommon()
-                             .attributeName(projection.getAttributeName())
-                             .oldValue(projection.getOldValue())
-                             .newValue(projection.getNewValue()))
-                .amount(null)
-        );
-    }
-
-    private MappedMinorCreditorHistoryItem toNoteHistoryItem(MinorCreditorNoteHistoryProjection projection) {
-        return new MappedMinorCreditorHistoryItem(
-            MinorCreditorHistoryItemType.NOTE,
-            projection.getNoteId(),
-            projection.getPostedDate(),
-            new MinorCreditorHistoryItemHistory()
-                .postedDetails(postedDetails(projection.getPostedDate(), projection.getPostedBy(),
-                                             projection.getPostedByName()))
-                .type(MinorCreditorHistoryItemHistory.TypeEnum.NOTE)
-                .details(new NoteDetailsHistory().noteText(projection.getNoteText()))
-                .amount(null)
-        );
-    }
-
-    private MappedMinorCreditorHistoryItem toFinancialHistoryItem(
-        MinorCreditorTransactionHistoryProjection projection) {
-        return new MappedMinorCreditorHistoryItem(
-            MinorCreditorHistoryItemType.FINANCIAL,
-            projection.getCreditorTransactionId(),
-            projection.getPostedDate(),
-            new MinorCreditorHistoryItemHistory()
-                .postedDetails(postedDetails(projection.getPostedDate(), projection.getPostedBy(),
-                                             projection.getPostedByName()))
-                .type(MinorCreditorHistoryItemHistory.TypeEnum.FINANCIAL)
-                .details(new CreditorTransactionDetailsHistory()
-                             .transactionType(creditorTransactionType(projection.getTransactionType()))
-                             .paymentReference(projection.getPaymentReference())
-                             .status(creditorTransactionStatus(projection.getStatus()))
-                             .statusDate(projection.getStatusDate())
-                             .associatedRecordType(projection.getAssociatedRecordType())
-                             .associatedRecordId(projection.getAssociatedRecordId())
-                             .accountNumber(projection.getAccountNumber())
-                             .defendantAccountNumber(projection.getDefendantAccountNumber())
-                             .defendantAccountId(projection.getDefendantAccountId()))
-                .amount(projection.getTransactionAmount())
-        );
-    }
-
-    private PostedDetailsCommon postedDetails(LocalDateTime postedDate, String postedBy, String postedByName) {
-        return new PostedDetailsCommon()
-            .postedDate(postedDate.toLocalDate())
-            .postedBy(postedBy)
-            .postedByName(postedByName);
-    }
-
-    private CreditorTransactionTypeReferenceCommon creditorTransactionType(String transactionType) {
-        return new CreditorTransactionTypeReferenceCommon()
-            .transactionType(CreditorTransactionTypeReferenceCommon.TransactionTypeEnum.fromValue(transactionType))
-            .transactionTypeDisplayName(transactionType);
-    }
-
-    private CreditorTransactionStatusReferenceCommon creditorTransactionStatus(String status) {
-        if (status == null) {
-            return null;
-        }
-        return new CreditorTransactionStatusReferenceCommon()
-            .creditorTransactionStatus(
-                CreditorTransactionStatusReferenceCommon.CreditorTransactionStatusEnum.fromValue(status))
-            .creditorTransactionStatusDisplayName(status);
-    }
-
-    private record MappedMinorCreditorHistoryItem(
-        MinorCreditorHistoryItemType sourceType,
-        Long sourceId,
-        LocalDateTime postedDate,
-        MinorCreditorHistoryItemHistory historyItem) {
-
-        private static final Comparator<MappedMinorCreditorHistoryItem> ORDERING =
-            Comparator.comparing(MappedMinorCreditorHistoryItem::postedDate).reversed()
-                .thenComparing(MappedMinorCreditorHistoryItem::sourceType)
-                .thenComparing(MappedMinorCreditorHistoryItem::sourceId);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorService.java
@@ -6,6 +6,8 @@ import jakarta.persistence.LockModeType;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,19 +29,33 @@ import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorAccountAtAGlanceEntit
 import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorAccountHeaderEntity;
 import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorEntity;
 import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryFilters;
+import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItemType;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
+import uk.gov.hmcts.opal.generated.model.AmendmentTypeCommon;
+import uk.gov.hmcts.opal.generated.model.CreditorTransactionDetailsHistory;
+import uk.gov.hmcts.opal.generated.model.CreditorTransactionStatusReferenceCommon;
+import uk.gov.hmcts.opal.generated.model.CreditorTransactionTypeReferenceCommon;
 import uk.gov.hmcts.opal.generated.model.GetMinorCreditorHistory200Response;
+import uk.gov.hmcts.opal.generated.model.MinorCreditorHistoryItemHistory;
+import uk.gov.hmcts.opal.generated.model.NoteDetailsHistory;
 import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
+import uk.gov.hmcts.opal.generated.model.PostedDetailsCommon;
 import uk.gov.hmcts.opal.mapper.MinorCreditorAccountHeaderEntityMapper;
 import uk.gov.hmcts.opal.mapper.MinorCreditorAccountResponseMapper;
 import uk.gov.hmcts.opal.mapper.MinorCreditorAccountUpdateMapper;
 import uk.gov.hmcts.opal.mapper.response.GetMinorCreditorAccountAtAGlanceResponseMapper;
+import uk.gov.hmcts.opal.repository.AmendmentRepository;
 import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
+import uk.gov.hmcts.opal.repository.CreditorTransactionRepository;
 import uk.gov.hmcts.opal.repository.MinorCreditorAccountAtAGlanceRepository;
 import uk.gov.hmcts.opal.repository.MinorCreditorAccountHeaderRepository;
 import uk.gov.hmcts.opal.repository.MinorCreditorRepository;
+import uk.gov.hmcts.opal.repository.NoteRepository;
 import uk.gov.hmcts.opal.repository.PartyRepository;
 import uk.gov.hmcts.opal.repository.jpa.MinorCreditorSpecs;
+import uk.gov.hmcts.opal.repository.projection.MinorCreditorAmendmentHistoryProjection;
+import uk.gov.hmcts.opal.repository.projection.MinorCreditorNoteHistoryProjection;
+import uk.gov.hmcts.opal.repository.projection.MinorCreditorTransactionHistoryProjection;
 import uk.gov.hmcts.opal.service.iface.MinorCreditorServiceInterface;
 import uk.gov.hmcts.opal.util.VersionUtils;
 
@@ -48,11 +64,17 @@ import uk.gov.hmcts.opal.util.VersionUtils;
 @RequiredArgsConstructor
 public class OpalMinorCreditorService implements MinorCreditorServiceInterface {
 
+    private static final LocalDateTime MIN_HISTORY_POSTED_DATE = LocalDateTime.of(1, 1, 1, 0, 0);
+    private static final LocalDateTime MAX_HISTORY_POSTED_DATE = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
+
     private final MinorCreditorRepository minorCreditorRepository;
     private final MinorCreditorAccountHeaderRepository minorCreditorAccountHeaderRepository;
     private final MinorCreditorAccountAtAGlanceRepository minorCreditorAccountAtAGlanceRepository;
     private final CreditorAccountRepository creditorAccountRepository;
     private final PartyRepository partyRepository;
+    private final AmendmentRepository amendmentRepository;
+    private final NoteRepository noteRepository;
+    private final CreditorTransactionRepository creditorTransactionRepository;
     private final AmendmentService amendmentService;
     private final MinorCreditorAccountHeaderEntityMapper headerSummaryMapper;
     private final MinorCreditorAccountUpdateMapper updateMapper;
@@ -109,10 +131,146 @@ public class OpalMinorCreditorService implements MinorCreditorServiceInterface {
             throw new EntityNotFoundException("Account is not a minor creditor account: " + minorCreditorAccountId);
         }
 
+        List<MappedMinorCreditorHistoryItem> historyItems = getMinorCreditorHistoryItems(minorCreditorAccountId,
+                                                                                        filters);
+
         return GetMinorCreditorHistoryResponse.builder()
-            .payload(new GetMinorCreditorHistory200Response().historyItems(List.of()))
+            .payload(new GetMinorCreditorHistory200Response().historyItems(historyItems.stream()
+                .sorted(MappedMinorCreditorHistoryItem.ORDERING)
+                .map(MappedMinorCreditorHistoryItem::historyItem)
+                .toList()))
             .version(creditorAccount.getVersion())
             .build();
+    }
+
+    private List<MappedMinorCreditorHistoryItem> getMinorCreditorHistoryItems(
+        Long minorCreditorAccountId,
+        MinorCreditorHistoryFilters filters) {
+
+        List<MappedMinorCreditorHistoryItem> historyItems = new ArrayList<>();
+        LocalDateTime postedFromInclusive = postedFromInclusive(filters);
+        LocalDateTime postedToExclusive = postedToExclusive(filters);
+        if (filters.includes(MinorCreditorHistoryItemType.AMENDMENT)) {
+            amendmentRepository.findMinorCreditorHistory(
+                String.valueOf(minorCreditorAccountId),
+                postedFromInclusive,
+                postedToExclusive
+            ).stream().map(this::toAmendmentHistoryItem).forEach(historyItems::add);
+        }
+        if (filters.includes(MinorCreditorHistoryItemType.NOTE)) {
+            noteRepository.findMinorCreditorHistory(
+                String.valueOf(minorCreditorAccountId),
+                postedFromInclusive,
+                postedToExclusive
+            ).stream().map(this::toNoteHistoryItem).forEach(historyItems::add);
+        }
+        if (filters.includes(MinorCreditorHistoryItemType.FINANCIAL)) {
+            creditorTransactionRepository.findMinorCreditorHistory(
+                minorCreditorAccountId,
+                postedFromInclusive,
+                postedToExclusive
+            ).stream().map(this::toFinancialHistoryItem).forEach(historyItems::add);
+        }
+        return historyItems;
+    }
+
+    private LocalDateTime postedFromInclusive(MinorCreditorHistoryFilters filters) {
+        return filters.postedFromInclusive() == null ? MIN_HISTORY_POSTED_DATE : filters.postedFromInclusive();
+    }
+
+    private LocalDateTime postedToExclusive(MinorCreditorHistoryFilters filters) {
+        return filters.postedToExclusive() == null ? MAX_HISTORY_POSTED_DATE : filters.postedToExclusive();
+    }
+
+    private MappedMinorCreditorHistoryItem toAmendmentHistoryItem(
+        MinorCreditorAmendmentHistoryProjection projection) {
+        return new MappedMinorCreditorHistoryItem(
+            MinorCreditorHistoryItemType.AMENDMENT,
+            projection.getAmendmentId(),
+            projection.getPostedDate(),
+            new MinorCreditorHistoryItemHistory()
+                .postedDetails(postedDetails(projection.getPostedDate(), projection.getPostedBy(),
+                                             projection.getPostedByName()))
+                .type(MinorCreditorHistoryItemHistory.TypeEnum.AMENDMENT)
+                .details(new AmendmentTypeCommon()
+                             .attributeName(projection.getAttributeName())
+                             .oldValue(projection.getOldValue())
+                             .newValue(projection.getNewValue()))
+                .amount(null)
+        );
+    }
+
+    private MappedMinorCreditorHistoryItem toNoteHistoryItem(MinorCreditorNoteHistoryProjection projection) {
+        return new MappedMinorCreditorHistoryItem(
+            MinorCreditorHistoryItemType.NOTE,
+            projection.getNoteId(),
+            projection.getPostedDate(),
+            new MinorCreditorHistoryItemHistory()
+                .postedDetails(postedDetails(projection.getPostedDate(), projection.getPostedBy(),
+                                             projection.getPostedByName()))
+                .type(MinorCreditorHistoryItemHistory.TypeEnum.NOTE)
+                .details(new NoteDetailsHistory().noteText(projection.getNoteText()))
+                .amount(null)
+        );
+    }
+
+    private MappedMinorCreditorHistoryItem toFinancialHistoryItem(
+        MinorCreditorTransactionHistoryProjection projection) {
+        return new MappedMinorCreditorHistoryItem(
+            MinorCreditorHistoryItemType.FINANCIAL,
+            projection.getCreditorTransactionId(),
+            projection.getPostedDate(),
+            new MinorCreditorHistoryItemHistory()
+                .postedDetails(postedDetails(projection.getPostedDate(), projection.getPostedBy(),
+                                             projection.getPostedByName()))
+                .type(MinorCreditorHistoryItemHistory.TypeEnum.FINANCIAL)
+                .details(new CreditorTransactionDetailsHistory()
+                             .transactionType(creditorTransactionType(projection.getTransactionType()))
+                             .paymentReference(projection.getPaymentReference())
+                             .status(creditorTransactionStatus(projection.getStatus()))
+                             .statusDate(projection.getStatusDate())
+                             .associatedRecordType(projection.getAssociatedRecordType())
+                             .associatedRecordId(projection.getAssociatedRecordId())
+                             .accountNumber(projection.getAccountNumber())
+                             .defendantAccountNumber(projection.getDefendantAccountNumber())
+                             .defendantAccountId(projection.getDefendantAccountId()))
+                .amount(projection.getTransactionAmount())
+        );
+    }
+
+    private PostedDetailsCommon postedDetails(LocalDateTime postedDate, String postedBy, String postedByName) {
+        return new PostedDetailsCommon()
+            .postedDate(postedDate.toLocalDate())
+            .postedBy(postedBy)
+            .postedByName(postedByName);
+    }
+
+    private CreditorTransactionTypeReferenceCommon creditorTransactionType(String transactionType) {
+        return new CreditorTransactionTypeReferenceCommon()
+            .transactionType(CreditorTransactionTypeReferenceCommon.TransactionTypeEnum.fromValue(transactionType))
+            .transactionTypeDisplayName(transactionType);
+    }
+
+    private CreditorTransactionStatusReferenceCommon creditorTransactionStatus(String status) {
+        if (status == null) {
+            return null;
+        }
+        return new CreditorTransactionStatusReferenceCommon()
+            .creditorTransactionStatus(
+                CreditorTransactionStatusReferenceCommon.CreditorTransactionStatusEnum.fromValue(status))
+            .creditorTransactionStatusDisplayName(status);
+    }
+
+    private record MappedMinorCreditorHistoryItem(
+        MinorCreditorHistoryItemType sourceType,
+        Long sourceId,
+        LocalDateTime postedDate,
+        MinorCreditorHistoryItemHistory historyItem) {
+
+        private static final Comparator<MappedMinorCreditorHistoryItem> ORDERING =
+            Comparator.comparing(MappedMinorCreditorHistoryItem::postedDate).reversed()
+                .thenComparing(MappedMinorCreditorHistoryItem::sourceType)
+                .thenComparing(MappedMinorCreditorHistoryItem::sourceId);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorService.java
@@ -1,10 +1,11 @@
 package uk.gov.hmcts.opal.service.opal;
 
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.LockModeType;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,16 +21,18 @@ import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
 import uk.gov.hmcts.opal.dto.MinorCreditorSearch;
 import uk.gov.hmcts.opal.dto.PostMinorCreditorAccountsSearchResponse;
 import uk.gov.hmcts.opal.dto.RecordType;
+import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
 import uk.gov.hmcts.opal.entity.PartyEntity;
 import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
 import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorAccountAtAGlanceEntity;
 import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorAccountHeaderEntity;
 import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorEntity;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
-import uk.gov.hmcts.opal.mapper.MinorCreditorAccountHeaderEntityMapper;
-import uk.gov.hmcts.opal.mapper.MinorCreditorAccountUpdateMapper;
-import uk.gov.hmcts.opal.mapper.MinorCreditorAccountResponseMapper;
+import uk.gov.hmcts.opal.generated.model.GetMinorCreditorHistory200Response;
 import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
+import uk.gov.hmcts.opal.mapper.MinorCreditorAccountHeaderEntityMapper;
+import uk.gov.hmcts.opal.mapper.MinorCreditorAccountResponseMapper;
+import uk.gov.hmcts.opal.mapper.MinorCreditorAccountUpdateMapper;
 import uk.gov.hmcts.opal.mapper.response.GetMinorCreditorAccountAtAGlanceResponseMapper;
 import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
 import uk.gov.hmcts.opal.repository.MinorCreditorAccountAtAGlanceRepository;
@@ -87,6 +90,31 @@ public class OpalMinorCreditorService implements MinorCreditorServiceInterface {
         MinorCreditorAccountResponse response = responseMapper.toMinorCreditorAccountResponse(creditorAccount, party);
         response.setVersion(creditorAccount.getVersion());
         return response;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public GetMinorCreditorHistoryResponse getMinorCreditorHistory(
+        Long minorCreditorAccountId,
+        LocalDate dateFrom,
+        LocalDate dateTo,
+        List<String> itemTypes) {
+        log.debug(":getMinorCreditorHistory (Opal): minorCreditorAccountId={}", minorCreditorAccountId);
+
+        CreditorAccountEntity creditorAccount = creditorAccountRepository.findById(minorCreditorAccountId)
+            .orElseThrow(() -> new EntityNotFoundException(
+                "Minor creditor account not found: " + minorCreditorAccountId
+            ));
+
+        if (creditorAccount.getCreditorAccountType() == null || !creditorAccount.getCreditorAccountType()
+            .isMinorCreditor()) {
+            throw new EntityNotFoundException("Account is not a minor creditor account: " + minorCreditorAccountId);
+        }
+
+        return GetMinorCreditorHistoryResponse.builder()
+            .payload(new GetMinorCreditorHistory200Response().historyItems(List.of()))
+            .version(creditorAccount.getVersion())
+            .build();
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/opal/service/proxy/MinorCreditorSearchProxy.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/proxy/MinorCreditorSearchProxy.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.opal.service.proxy;
 
 import java.math.BigInteger;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -9,6 +11,7 @@ import uk.gov.hmcts.opal.dto.GetMinorCreditorAccountHeaderSummaryResponse;
 import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
 import uk.gov.hmcts.opal.dto.MinorCreditorSearch;
 import uk.gov.hmcts.opal.dto.PostMinorCreditorAccountsSearchResponse;
+import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
 import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
 import uk.gov.hmcts.opal.service.iface.MinorCreditorServiceInterface;
 import uk.gov.hmcts.opal.service.legacy.LegacyMinorCreditorService;
@@ -37,6 +40,17 @@ public class MinorCreditorSearchProxy implements MinorCreditorServiceInterface, 
     public MinorCreditorAccountResponse getMinorCreditorAccount(Long minorCreditorAccountId) {
         log.debug(":getMinorCreditorAccount: minorCreditorAccountId={}", minorCreditorAccountId);
         return getCurrentModeService().getMinorCreditorAccount(minorCreditorAccountId);
+    }
+
+    @Override
+    public GetMinorCreditorHistoryResponse getMinorCreditorHistory(
+        Long minorCreditorAccountId,
+        LocalDate dateFrom,
+        LocalDate dateTo,
+        List<String> itemTypes) {
+        log.debug(":getMinorCreditorHistory: minorCreditorAccountId={}", minorCreditorAccountId);
+        return getCurrentModeService().getMinorCreditorHistory(
+            minorCreditorAccountId, dateFrom, dateTo, itemTypes);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/opal/service/proxy/MinorCreditorSearchProxy.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/proxy/MinorCreditorSearchProxy.java
@@ -1,8 +1,6 @@
 package uk.gov.hmcts.opal.service.proxy;
 
 import java.math.BigInteger;
-import java.time.LocalDate;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -12,6 +10,7 @@ import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
 import uk.gov.hmcts.opal.dto.MinorCreditorSearch;
 import uk.gov.hmcts.opal.dto.PostMinorCreditorAccountsSearchResponse;
 import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
+import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryFilters;
 import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
 import uk.gov.hmcts.opal.service.iface.MinorCreditorServiceInterface;
 import uk.gov.hmcts.opal.service.legacy.LegacyMinorCreditorService;
@@ -45,12 +44,9 @@ public class MinorCreditorSearchProxy implements MinorCreditorServiceInterface, 
     @Override
     public GetMinorCreditorHistoryResponse getMinorCreditorHistory(
         Long minorCreditorAccountId,
-        LocalDate dateFrom,
-        LocalDate dateTo,
-        List<String> itemTypes) {
+        MinorCreditorHistoryFilters filters) {
         log.debug(":getMinorCreditorHistory: minorCreditorAccountId={}", minorCreditorAccountId);
-        return getCurrentModeService().getMinorCreditorHistory(
-            minorCreditorAccountId, dateFrom, dateTo, itemTypes);
+        return getCurrentModeService().getMinorCreditorHistory(minorCreditorAccountId, filters);
     }
 
     @Override

--- a/src/main/resources/openapi/MinorCreditor.yaml
+++ b/src/main/resources/openapi/MinorCreditor.yaml
@@ -212,6 +212,9 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: false
+                required:
+                  - historyItems
                 properties:
                   historyItems:
                     type: array
@@ -231,6 +234,18 @@ paths:
                 $ref: './common.yaml#/components/schemas/ProblemDetail'
         403:
           description: Forbidden
+          content:
+            application/json+problem:
+              schema:
+                $ref: './common.yaml#/components/schemas/ProblemDetail'
+        404:
+          description: Not Found
+          content:
+            application/json+problem:
+              schema:
+                $ref: './common.yaml#/components/schemas/ProblemDetail'
+        408:
+          description: Request timeout
           content:
             application/json+problem:
               schema:

--- a/src/main/resources/openapi/history.yaml
+++ b/src/main/resources/openapi/history.yaml
@@ -41,6 +41,7 @@ components:
     minorCreditorHistoryItem:
       name: historyItem
       type: object
+      additionalProperties: false
       required:
         - postedDetails
         - type
@@ -110,6 +111,7 @@ components:
           format: date
     noteDetails:
       type: object
+      additionalProperties: false
       required:
         - noteText
       properties:
@@ -156,6 +158,7 @@ components:
     creditorTransactionDetails:
       name: transactionDetails
       type: object
+      additionalProperties: false
       required:
         - transactionType
       properties:

--- a/src/main/resources/openapi/history.yaml
+++ b/src/main/resources/openapi/history.yaml
@@ -181,3 +181,4 @@ components:
           type: string
         defendantAccountId:
           type: integer
+          format: int64

--- a/src/test/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerTest.java
@@ -54,7 +54,6 @@ class MinorCreditorApiControllerTest {
         LocalDate dateFrom = LocalDate.of(2026, 1, 1);
         LocalDate dateTo = LocalDate.of(2026, 1, 31);
         List<String> itemTypes = List.of("amendment", "note");
-        String authorization = "Bearer token";
         GetMinorCreditorHistory200Response payload = new GetMinorCreditorHistory200Response()
             .historyItems(List.of());
         GetMinorCreditorHistoryResponse response = GetMinorCreditorHistoryResponse.builder()
@@ -63,19 +62,19 @@ class MinorCreditorApiControllerTest {
             .build();
 
         when(minorCreditorService.getMinorCreditorHistory(
-            minorCreditorAccountId, dateFrom, dateTo, itemTypes, authorization)).thenReturn(response);
+            minorCreditorAccountId, dateFrom, dateTo, itemTypes)).thenReturn(response);
 
         // Act
         ResponseEntity<GetMinorCreditorHistory200Response> result =
             minorCreditorApiController.getMinorCreditorHistory(
-                minorCreditorAccountId, dateFrom, dateTo, itemTypes, authorization);
+                minorCreditorAccountId, dateFrom, dateTo, itemTypes);
 
         // Assert
         assertEquals(HttpStatus.OK, result.getStatusCode());
         assertEquals("\"3\"", result.getHeaders().getETag());
         assertSame(payload, result.getBody());
         verify(minorCreditorService).getMinorCreditorHistory(
-            minorCreditorAccountId, dateFrom, dateTo, itemTypes, authorization);
+            minorCreditorAccountId, dateFrom, dateTo, itemTypes);
     }
 
     @Test
@@ -84,19 +83,19 @@ class MinorCreditorApiControllerTest {
         Long minorCreditorAccountId = 1L;
         RuntimeException expected = new RuntimeException("history failed");
         when(minorCreditorService.getMinorCreditorHistory(
-            minorCreditorAccountId, null, null, null, "Bearer token")).thenThrow(expected);
+            minorCreditorAccountId, null, null, null)).thenThrow(expected);
 
         // Act
         RuntimeException result = assertThrows(
             RuntimeException.class,
             () -> minorCreditorApiController.getMinorCreditorHistory(
-                minorCreditorAccountId, null, null, null, "Bearer token")
+                minorCreditorAccountId, null, null, null)
         );
 
         // Assert
         assertSame(expected, result);
         verify(minorCreditorService).getMinorCreditorHistory(
-            minorCreditorAccountId, null, null, null, "Bearer token");
+            minorCreditorAccountId, null, null, null);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.opal.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -75,6 +76,27 @@ class MinorCreditorApiControllerTest {
         assertSame(payload, result.getBody());
         verify(minorCreditorService).getMinorCreditorHistory(
             minorCreditorAccountId, dateFrom, dateTo, itemTypes, authorization);
+    }
+
+    @Test
+    void getMinorCreditorHistory_whenServiceThrows_propagatesException() {
+        // Arrange
+        Long minorCreditorAccountId = 1L;
+        RuntimeException expected = new RuntimeException("history failed");
+        when(minorCreditorService.getMinorCreditorHistory(
+            minorCreditorAccountId, null, null, null, "Bearer token")).thenThrow(expected);
+
+        // Act
+        RuntimeException result = assertThrows(
+            RuntimeException.class,
+            () -> minorCreditorApiController.getMinorCreditorHistory(
+                minorCreditorAccountId, null, null, null, "Bearer token")
+        );
+
+        // Assert
+        assertSame(expected, result);
+        verify(minorCreditorService).getMinorCreditorHistory(
+            minorCreditorAccountId, null, null, null, "Bearer token");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigInteger;
+import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,6 +16,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
+import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
+import uk.gov.hmcts.opal.generated.model.GetMinorCreditorHistory200Response;
 import uk.gov.hmcts.opal.generated.model.MinorCreditorAccountResponseMinorCreditor;
 import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
 import uk.gov.hmcts.opal.service.MinorCreditorService;
@@ -40,6 +44,37 @@ class MinorCreditorApiControllerTest {
         assertEquals(HttpStatus.OK, result.getStatusCode());
         assertSame(response, result.getBody());
         verify(minorCreditorService).getMinorCreditorAccount(minorCreditorAccountId);
+    }
+
+    @Test
+    void given_validRequest_when_getMinorCreditorHistory_then_returnsOkResponseWithETag() {
+        // Arrange
+        Long minorCreditorAccountId = 1L;
+        LocalDate dateFrom = LocalDate.of(2026, 1, 1);
+        LocalDate dateTo = LocalDate.of(2026, 1, 31);
+        List<String> itemTypes = List.of("amendment", "note");
+        String authorization = "Bearer token";
+        GetMinorCreditorHistory200Response payload = new GetMinorCreditorHistory200Response()
+            .historyItems(List.of());
+        GetMinorCreditorHistoryResponse response = GetMinorCreditorHistoryResponse.builder()
+            .payload(payload)
+            .version(BigInteger.valueOf(3))
+            .build();
+
+        when(minorCreditorService.getMinorCreditorHistory(
+            minorCreditorAccountId, dateFrom, dateTo, itemTypes, authorization)).thenReturn(response);
+
+        // Act
+        ResponseEntity<GetMinorCreditorHistory200Response> result =
+            minorCreditorApiController.getMinorCreditorHistory(
+                minorCreditorAccountId, dateFrom, dateTo, itemTypes, authorization);
+
+        // Assert
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals("\"3\"", result.getHeaders().getETag());
+        assertSame(payload, result.getBody());
+        verify(minorCreditorService).getMinorCreditorHistory(
+            minorCreditorAccountId, dateFrom, dateTo, itemTypes, authorization);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/controllers/Release1bFeatureToggleAnnotationTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/Release1bFeatureToggleAnnotationTest.java
@@ -4,15 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.hmcts.opal.util.FeatureFlags.RELEASE_1B;
 import static uk.gov.hmcts.opal.util.FeatureFlags.RELEASE_1B_ENABLED_PROPERTY;
 
-import org.junit.jupiter.api.Test;
-import uk.gov.hmcts.opal.common.launchdarkly.FeatureToggle;
-import uk.gov.hmcts.opal.controllers.print.PrintRequestController;
-
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.opal.common.launchdarkly.FeatureToggle;
+import uk.gov.hmcts.opal.controllers.print.PrintRequestController;
 
 class Release1bFeatureToggleAnnotationTest {
 
@@ -70,6 +69,7 @@ class Release1bFeatureToggleAnnotationTest {
             "MajorCreditorApiController#getMajorCreditorAccountAtAGlance",
             "MajorCreditorApiController#getMajorCreditorAccountHeaderSummary",
             "MinorCreditorApiController#getMinorCreditorAccount",
+            "MinorCreditorApiController#getMinorCreditorHistory",
             "MinorCreditorApiController#patchMinorCreditorAccount",
             "MinorCreditorController#getMinorCreditorAccountHeaderSummary",
             "MinorCreditorController#getMinorCreditorsAtAGlance",

--- a/src/test/java/uk/gov/hmcts/opal/entity/minorcreditor/MinorCreditorHistoryFiltersTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/entity/minorcreditor/MinorCreditorHistoryFiltersTest.java
@@ -1,0 +1,70 @@
+package uk.gov.hmcts.opal.entity.minorcreditor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItemType.AMENDMENT;
+import static uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItemType.FINANCIAL;
+import static uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItemType.NOTE;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MinorCreditorHistoryFiltersTest {
+
+    @Test
+    void from_withoutItemTypes_includesAllTypes() {
+        MinorCreditorHistoryFilters filters = MinorCreditorHistoryFilters.from(null, null, null);
+
+        assertThat(filters.itemTypes()).containsExactlyInAnyOrder(AMENDMENT, FINANCIAL, NOTE);
+        assertThat(filters.includes(AMENDMENT)).isTrue();
+        assertThat(filters.includes(FINANCIAL)).isTrue();
+        assertThat(filters.includes(NOTE)).isTrue();
+    }
+
+    @Test
+    void from_withDateRange_setsInclusiveStartAndExclusiveEnd() {
+        MinorCreditorHistoryFilters filters = MinorCreditorHistoryFilters.from(
+            LocalDate.of(2026, 1, 1),
+            LocalDate.of(2026, 1, 31),
+            null);
+
+        assertThat(filters.postedFromInclusive()).isEqualTo(LocalDateTime.of(2026, 1, 1, 0, 0));
+        assertThat(filters.postedToExclusive()).isEqualTo(LocalDateTime.of(2026, 2, 1, 0, 0));
+    }
+
+    @Test
+    void from_withRepeatedAndCommaSeparatedItemTypes_parsesAllValues() {
+        MinorCreditorHistoryFilters filters = MinorCreditorHistoryFilters.from(
+            null,
+            null,
+            List.of("amendment,note", "financial"));
+
+        assertThat(filters.itemTypes()).containsExactlyInAnyOrder(AMENDMENT, FINANCIAL, NOTE);
+    }
+
+    @Test
+    void from_withInvalidItemType_throwsIllegalArgumentException() {
+        assertThatThrownBy(() -> MinorCreditorHistoryFilters.from(null, null, List.of("payment")))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("itemTypes must contain only amendment, financial, note");
+    }
+
+    @Test
+    void from_withBlankItemType_throwsIllegalArgumentException() {
+        assertThatThrownBy(() -> MinorCreditorHistoryFilters.from(null, null, List.of("")))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("itemTypes must contain only amendment, financial, note");
+    }
+
+    @Test
+    void from_withDateFromAfterDateTo_throwsIllegalArgumentException() {
+        assertThatThrownBy(() -> MinorCreditorHistoryFilters.from(
+            LocalDate.of(2026, 2, 1),
+            LocalDate.of(2026, 1, 31),
+            null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("dateFrom must be on or before dateTo");
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/entity/minorcreditor/MinorCreditorHistoryItemTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/entity/minorcreditor/MinorCreditorHistoryItemTest.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.opal.entity.minorcreditor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItemType.AMENDMENT;
+import static uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItemType.FINANCIAL;
+import static uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItemType.NOTE;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.opal.generated.model.MinorCreditorHistoryItemHistory;
+
+class MinorCreditorHistoryItemTest {
+
+    @Test
+    void ordering_sortsByNewestTimestampThenTypeOrderThenSourceId() {
+        // Arrange
+        LocalDateTime olderTimestamp = LocalDateTime.of(2026, 1, 30, 10, 0);
+        LocalDateTime newerTimestamp = LocalDateTime.of(2026, 1, 31, 10, 0);
+        MinorCreditorHistoryItem olderAmendment = item(AMENDMENT, 1L, olderTimestamp);
+        MinorCreditorHistoryItem note = item(NOTE, 1L, newerTimestamp);
+        MinorCreditorHistoryItem financial = item(FINANCIAL, 1L, newerTimestamp);
+        MinorCreditorHistoryItem amendmentHighId = item(AMENDMENT, 3L, newerTimestamp);
+        MinorCreditorHistoryItem amendmentLowId = item(AMENDMENT, 2L, newerTimestamp);
+
+        // Act
+        List<MinorCreditorHistoryItem> sorted = List.of(
+            olderAmendment,
+            note,
+            financial,
+            amendmentHighId,
+            amendmentLowId
+        ).stream().sorted(MinorCreditorHistoryItem.ORDERING).toList();
+
+        // Assert
+        assertThat(sorted).containsExactly(amendmentLowId, amendmentHighId, financial, note, olderAmendment);
+    }
+
+    private MinorCreditorHistoryItem item(
+        MinorCreditorHistoryItemType sourceType,
+        Long sourceId,
+        LocalDateTime postedDate) {
+        return new MinorCreditorHistoryItem(sourceType, sourceId, postedDate, new MinorCreditorHistoryItemHistory());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/mapper/MinorCreditorHistoryItemMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/mapper/MinorCreditorHistoryItemMapperTest.java
@@ -1,0 +1,193 @@
+package uk.gov.hmcts.opal.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItemType.AMENDMENT;
+import static uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItemType.FINANCIAL;
+import static uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItemType.NOTE;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItem;
+import uk.gov.hmcts.opal.generated.model.AmendmentTypeCommon;
+import uk.gov.hmcts.opal.generated.model.CreditorTransactionDetailsHistory;
+import uk.gov.hmcts.opal.generated.model.CreditorTransactionStatusReferenceCommon;
+import uk.gov.hmcts.opal.generated.model.CreditorTransactionTypeReferenceCommon;
+import uk.gov.hmcts.opal.generated.model.NoteDetailsHistory;
+import uk.gov.hmcts.opal.generated.model.PostedDetailsCommon;
+import uk.gov.hmcts.opal.repository.projection.MinorCreditorAmendmentHistoryProjection;
+import uk.gov.hmcts.opal.repository.projection.MinorCreditorNoteHistoryProjection;
+import uk.gov.hmcts.opal.repository.projection.MinorCreditorTransactionHistoryProjection;
+
+class MinorCreditorHistoryItemMapperTest {
+
+    private final MinorCreditorHistoryItemMapper mapper = new MinorCreditorHistoryItemMapper();
+
+    @Test
+    void toHistoryItem_mapsAmendmentDetails() {
+        // Arrange
+        LocalDateTime postedDate = LocalDateTime.of(2026, 1, 31, 10, 30);
+        MinorCreditorAmendmentHistoryProjection projection =
+            mock(MinorCreditorAmendmentHistoryProjection.class);
+        when(projection.getAmendmentId()).thenReturn(11L);
+        when(projection.getPostedDate()).thenReturn(postedDate);
+        when(projection.getPostedBy()).thenReturn("AMENDUSR");
+        when(projection.getPostedByName()).thenReturn("Amend User");
+        when(projection.getAttributeName()).thenReturn("Hold Pay Out");
+        when(projection.getOldValue()).thenReturn("false");
+        when(projection.getNewValue()).thenReturn("true");
+
+        // Act
+        MinorCreditorHistoryItem mapped = mapper.toHistoryItem(projection);
+
+        // Assert
+        assertThat(mapped.sourceType()).isEqualTo(AMENDMENT);
+        assertThat(mapped.sourceId()).isEqualTo(11L);
+        assertThat(mapped.postedDate()).isEqualTo(postedDate);
+        assertThat(mapped.responseItem().getType()).isEqualTo(AMENDMENT.responseType());
+        assertThat(mapped.responseItem().getAmount()).isNull();
+        assertThat(mapped.responseItem().getPostedDetails().getPostedDate()).isEqualTo(postedDate.toLocalDate());
+        assertThat(mapped.responseItem().getPostedDetails().getPostedBy()).isEqualTo("AMENDUSR");
+        assertThat(mapped.responseItem().getPostedDetails().getPostedByName()).isEqualTo("Amend User");
+
+        AmendmentTypeCommon details = (AmendmentTypeCommon) mapped.responseItem().getDetails();
+        assertThat(details.getAttributeName()).isEqualTo("Hold Pay Out");
+        assertThat(details.getOldValue()).isEqualTo("false");
+        assertThat(details.getNewValue()).isEqualTo("true");
+    }
+
+    @Test
+    void toHistoryItem_mapsNoteDetails() {
+        // Arrange
+        LocalDateTime postedDate = LocalDateTime.of(2026, 1, 30, 9, 15);
+        MinorCreditorNoteHistoryProjection projection = mock(MinorCreditorNoteHistoryProjection.class);
+        when(projection.getNoteId()).thenReturn(12L);
+        when(projection.getPostedDate()).thenReturn(postedDate);
+        when(projection.getPostedBy()).thenReturn("NOTEUSR");
+        when(projection.getPostedByName()).thenReturn("Note User");
+        when(projection.getNoteText()).thenReturn("Review creditor");
+
+        // Act
+        MinorCreditorHistoryItem mapped = mapper.toHistoryItem(projection);
+
+        // Assert
+        assertThat(mapped.sourceType()).isEqualTo(NOTE);
+        assertThat(mapped.sourceId()).isEqualTo(12L);
+        assertThat(mapped.postedDate()).isEqualTo(postedDate);
+        assertThat(mapped.responseItem().getType()).isEqualTo(NOTE.responseType());
+        assertThat(mapped.responseItem().getAmount()).isNull();
+        assertThat(mapped.responseItem().getPostedDetails().getPostedDate()).isEqualTo(postedDate.toLocalDate());
+
+        NoteDetailsHistory details = (NoteDetailsHistory) mapped.responseItem().getDetails();
+        assertThat(details.getNoteText()).isEqualTo("Review creditor");
+    }
+
+    @Test
+    void toHistoryItem_mapsTransactionDetails() {
+        // Arrange
+        LocalDateTime postedDate = LocalDateTime.of(2026, 1, 29, 8, 0);
+        LocalDateTime statusDate = LocalDateTime.of(2026, 1, 29, 8, 30);
+        MinorCreditorTransactionHistoryProjection projection =
+            mock(MinorCreditorTransactionHistoryProjection.class);
+        when(projection.getCreditorTransactionId()).thenReturn(13L);
+        when(projection.getPostedDate()).thenReturn(postedDate);
+        when(projection.getPostedBy()).thenReturn("PAYUSR");
+        when(projection.getPostedByName()).thenReturn("Payment User");
+        when(projection.getTransactionType()).thenReturn("PAYMNT");
+        when(projection.getTransactionAmount()).thenReturn(BigDecimal.valueOf(42L));
+        when(projection.getPaymentReference()).thenReturn("PMT001");
+        when(projection.getStatus()).thenReturn("C");
+        when(projection.getStatusDate()).thenReturn(statusDate);
+        when(projection.getAssociatedRecordType()).thenReturn("defendant_accounts");
+        when(projection.getAssociatedRecordId()).thenReturn("70000000000000");
+        when(projection.getAccountNumber()).thenReturn("HOLD1234");
+        when(projection.getDefendantAccountNumber()).thenReturn("DEF123456");
+        when(projection.getDefendantAccountId()).thenReturn(70000000000000L);
+
+        // Act
+        MinorCreditorHistoryItem mapped = mapper.toHistoryItem(projection);
+
+        // Assert
+        assertThat(mapped.sourceType()).isEqualTo(FINANCIAL);
+        assertThat(mapped.sourceId()).isEqualTo(13L);
+        assertThat(mapped.responseItem().getType()).isEqualTo(FINANCIAL.responseType());
+        assertThat(mapped.responseItem().getAmount()).isEqualByComparingTo(BigDecimal.valueOf(42L));
+
+        CreditorTransactionDetailsHistory details =
+            (CreditorTransactionDetailsHistory) mapped.responseItem().getDetails();
+        assertThat(details.getTransactionType().getTransactionType().getValue()).isEqualTo("PAYMNT");
+        assertThat(details.getTransactionType().getTransactionTypeDisplayName()).isEqualTo("PAYMNT");
+        assertThat(details.getPaymentReference()).isEqualTo("PMT001");
+        assertThat(details.getStatus().getCreditorTransactionStatus().getValue()).isEqualTo("C");
+        assertThat(details.getStatus().getCreditorTransactionStatusDisplayName()).isEqualTo("C");
+        assertThat(details.getStatusDate()).isEqualTo(statusDate);
+        assertThat(details.getAssociatedRecordType()).isEqualTo("defendant_accounts");
+        assertThat(details.getAssociatedRecordId()).isEqualTo("70000000000000");
+        assertThat(details.getAccountNumber()).isEqualTo("HOLD1234");
+        assertThat(details.getDefendantAccountNumber()).isEqualTo("DEF123456");
+        assertThat(details.getDefendantAccountId()).isEqualTo(70000000000000L);
+    }
+
+    @Test
+    void toHistoryItem_mapsNullTransactionOptionals() {
+        // Arrange
+        LocalDateTime postedDate = LocalDateTime.of(2026, 1, 29, 8, 0);
+        MinorCreditorTransactionHistoryProjection projection =
+            mock(MinorCreditorTransactionHistoryProjection.class);
+        when(projection.getCreditorTransactionId()).thenReturn(13L);
+        when(projection.getPostedDate()).thenReturn(postedDate);
+        when(projection.getTransactionType()).thenReturn("PAYMNT");
+        when(projection.getTransactionAmount()).thenReturn(BigDecimal.valueOf(42L));
+        when(projection.getDefendantAccountId()).thenReturn(null);
+
+        // Act
+        MinorCreditorHistoryItem mapped = mapper.toHistoryItem(projection);
+
+        // Assert
+        CreditorTransactionDetailsHistory details =
+            (CreditorTransactionDetailsHistory) mapped.responseItem().getDetails();
+        assertThat(details.getPaymentReference()).isNull();
+        assertThat(details.getStatus()).isNull();
+        assertThat(details.getStatusDate()).isNull();
+        assertThat(details.getAssociatedRecordType()).isNull();
+        assertThat(details.getAssociatedRecordId()).isNull();
+        assertThat(details.getAccountNumber()).isNull();
+        assertThat(details.getDefendantAccountNumber()).isNull();
+        assertThat(details.getDefendantAccountId()).isNull();
+    }
+
+    @Test
+    void toReferenceObjects_mapsDisplayNamesFromCodes() {
+        // Arrange
+        String transactionType = "PAYMNT";
+        String status = "C";
+
+        // Act
+        CreditorTransactionTypeReferenceCommon typeReference =
+            mapper.toCreditorTransactionType(transactionType);
+        CreditorTransactionStatusReferenceCommon statusReference =
+            mapper.toCreditorTransactionStatus(status);
+
+        // Assert
+        assertThat(typeReference.getTransactionType().getValue()).isEqualTo(transactionType);
+        assertThat(typeReference.getTransactionTypeDisplayName()).isEqualTo(transactionType);
+        assertThat(statusReference.getCreditorTransactionStatus().getValue()).isEqualTo(status);
+        assertThat(statusReference.getCreditorTransactionStatusDisplayName()).isEqualTo(status);
+    }
+
+    @Test
+    void toPostedDetails_mapsDateComponentAndPostedUser() {
+        // Arrange
+        LocalDateTime postedDate = LocalDateTime.of(2026, 1, 31, 23, 59);
+
+        // Act
+        PostedDetailsCommon postedDetails = mapper.toPostedDetails(postedDate, "POSTUSR", "Post User");
+
+        // Assert
+        assertThat(postedDetails.getPostedDate()).isEqualTo(postedDate.toLocalDate());
+        assertThat(postedDetails.getPostedBy()).isEqualTo("POSTUSR");
+        assertThat(postedDetails.getPostedByName()).isEqualTo("Post User");
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.opal.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyShort;
@@ -202,6 +203,59 @@ class MinorCreditorServiceTest {
                 123L, LocalDate.of(2026, 1, 1), null, List.of("note"), "authHeaderValue")
         );
         assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
+        verifyNoInteractions(minorCreditorSearchProxy);
+    }
+
+    @Test
+    void getMinorCreditorHistory_authFailure_propagatesAndDoesNotDelegate() {
+        // Arrange
+        RuntimeException expected = new RuntimeException("auth failed");
+        when(userStateService.checkForAuthorisedUser("authHeaderValue")).thenThrow(expected);
+
+        // Act
+        RuntimeException result = assertThrows(
+            RuntimeException.class,
+            () -> minorCreditorService.getMinorCreditorHistory(123L, null, null, null, "authHeaderValue")
+        );
+
+        // Assert
+        assertSame(expected, result);
+        verifyNoInteractions(minorCreditorSearchProxy);
+    }
+
+    @Test
+    void getMinorCreditorHistory_invalidItemType_throwsIllegalArgumentException() {
+        // Arrange
+        when(userStateService.checkForAuthorisedUser("authHeaderValue"))
+            .thenReturn(UserStateUtil.permissionUser((short) 10, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS));
+
+        // Act & Assert
+        IllegalArgumentException result = assertThrows(
+            IllegalArgumentException.class,
+            () -> minorCreditorService.getMinorCreditorHistory(
+                123L, null, null, List.of("payment"), "authHeaderValue")
+        );
+        assertEquals("itemTypes must contain only amendment, financial, note", result.getMessage());
+        verifyNoInteractions(minorCreditorSearchProxy);
+    }
+
+    @Test
+    void getMinorCreditorHistory_dateFromAfterDateTo_throwsIllegalArgumentException() {
+        // Arrange
+        when(userStateService.checkForAuthorisedUser("authHeaderValue"))
+            .thenReturn(UserStateUtil.permissionUser((short) 10, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS));
+
+        // Act & Assert
+        IllegalArgumentException result = assertThrows(
+            IllegalArgumentException.class,
+            () -> minorCreditorService.getMinorCreditorHistory(
+                123L,
+                LocalDate.of(2026, 2, 1),
+                LocalDate.of(2026, 1, 31),
+                null,
+                "authHeaderValue")
+        );
+        assertEquals("dateFrom must be on or before dateTo", result.getMessage());
         verifyNoInteractions(minorCreditorSearchProxy);
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import java.math.BigInteger;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
@@ -34,6 +35,8 @@ import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
 import uk.gov.hmcts.opal.dto.MinorCreditorSearch;
 import uk.gov.hmcts.opal.dto.PostMinorCreditorAccountsSearchResponse;
 import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
+import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryFilters;
+import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItemType;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.opal.generated.model.AddressDetailsCommon;
 import uk.gov.hmcts.opal.generated.model.CreditorAccountPaymentDetailsCommon;
@@ -163,7 +166,8 @@ class MinorCreditorServiceTest {
 
         when(userStateService.checkForAuthorisedUser("authHeaderValue"))
             .thenReturn(UserStateUtil.permissionUser((short) 10, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS));
-        when(minorCreditorSearchProxy.getMinorCreditorHistory(id, dateFrom, dateTo, itemTypes)).thenReturn(response);
+        when(minorCreditorSearchProxy.getMinorCreditorHistory(eq(id), any(MinorCreditorHistoryFilters.class)))
+            .thenReturn(response);
 
         // Act
         GetMinorCreditorHistoryResponse result =
@@ -171,8 +175,16 @@ class MinorCreditorServiceTest {
 
         // Assert
         assertEquals(response, result);
+        ArgumentCaptor<MinorCreditorHistoryFilters> filtersCaptor =
+            ArgumentCaptor.forClass(MinorCreditorHistoryFilters.class);
         verify(userStateService).checkForAuthorisedUser("authHeaderValue");
-        verify(minorCreditorSearchProxy).getMinorCreditorHistory(id, dateFrom, dateTo, itemTypes);
+        verify(minorCreditorSearchProxy).getMinorCreditorHistory(eq(id), filtersCaptor.capture());
+        assertEquals(LocalDateTime.of(2026, 1, 1, 0, 0), filtersCaptor.getValue().postedFromInclusive());
+        assertEquals(LocalDateTime.of(2026, 2, 1, 0, 0), filtersCaptor.getValue().postedToExclusive());
+        assertThat(filtersCaptor.getValue().itemTypes()).containsExactlyInAnyOrder(
+            MinorCreditorHistoryItemType.AMENDMENT,
+            MinorCreditorHistoryItemType.NOTE
+        );
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
@@ -165,20 +165,20 @@ class MinorCreditorServiceTest {
             .version(BigInteger.ONE)
             .build();
 
-        when(userStateService.checkForAuthorisedUser("authHeaderValue"))
+        when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(UserStateUtil.permissionUser((short) 10, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS));
         when(minorCreditorSearchProxy.getMinorCreditorHistory(eq(id), any(MinorCreditorHistoryFilters.class)))
             .thenReturn(response);
 
         // Act
         GetMinorCreditorHistoryResponse result =
-            minorCreditorService.getMinorCreditorHistory(id, dateFrom, dateTo, itemTypes, "authHeaderValue");
+            minorCreditorService.getMinorCreditorHistory(id, dateFrom, dateTo, itemTypes);
 
         // Assert
         assertEquals(response, result);
         ArgumentCaptor<MinorCreditorHistoryFilters> filtersCaptor =
             ArgumentCaptor.forClass(MinorCreditorHistoryFilters.class);
-        verify(userStateService).checkForAuthorisedUser("authHeaderValue");
+        verify(userStateService).getUserStateV1FromSecurityContext();
         verify(minorCreditorSearchProxy).getMinorCreditorHistory(eq(id), filtersCaptor.capture());
         assertEquals(LocalDateTime.of(2026, 1, 1, 0, 0), filtersCaptor.getValue().postedFromInclusive());
         assertEquals(LocalDateTime.of(2026, 2, 1, 0, 0), filtersCaptor.getValue().postedToExclusive());
@@ -194,13 +194,13 @@ class MinorCreditorServiceTest {
         UserState noPermissionUser = mock(UserState.class);
         when(noPermissionUser.anyBusinessUnitUserHasPermission(
             FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
-        when(userStateService.checkForAuthorisedUser("authHeaderValue")).thenReturn(noPermissionUser);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(noPermissionUser);
 
         // Act & Assert
         PermissionNotAllowedException ex = Assertions.assertThrows(
             PermissionNotAllowedException.class,
             () -> minorCreditorService.getMinorCreditorHistory(
-                123L, LocalDate.of(2026, 1, 1), null, List.of("note"), "authHeaderValue")
+                123L, LocalDate.of(2026, 1, 1), null, List.of("note"))
         );
         assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verifyNoInteractions(minorCreditorSearchProxy);
@@ -210,12 +210,12 @@ class MinorCreditorServiceTest {
     void getMinorCreditorHistory_authFailure_propagatesAndDoesNotDelegate() {
         // Arrange
         RuntimeException expected = new RuntimeException("auth failed");
-        when(userStateService.checkForAuthorisedUser("authHeaderValue")).thenThrow(expected);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenThrow(expected);
 
         // Act
         RuntimeException result = assertThrows(
             RuntimeException.class,
-            () -> minorCreditorService.getMinorCreditorHistory(123L, null, null, null, "authHeaderValue")
+            () -> minorCreditorService.getMinorCreditorHistory(123L, null, null, null)
         );
 
         // Assert
@@ -226,14 +226,14 @@ class MinorCreditorServiceTest {
     @Test
     void getMinorCreditorHistory_invalidItemType_throwsIllegalArgumentException() {
         // Arrange
-        when(userStateService.checkForAuthorisedUser("authHeaderValue"))
+        when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(UserStateUtil.permissionUser((short) 10, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS));
 
         // Act & Assert
         IllegalArgumentException result = assertThrows(
             IllegalArgumentException.class,
             () -> minorCreditorService.getMinorCreditorHistory(
-                123L, null, null, List.of("payment"), "authHeaderValue")
+                123L, null, null, List.of("payment"))
         );
         assertEquals("itemTypes must contain only amendment, financial, note", result.getMessage());
         verifyNoInteractions(minorCreditorSearchProxy);
@@ -242,7 +242,7 @@ class MinorCreditorServiceTest {
     @Test
     void getMinorCreditorHistory_dateFromAfterDateTo_throwsIllegalArgumentException() {
         // Arrange
-        when(userStateService.checkForAuthorisedUser("authHeaderValue"))
+        when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(UserStateUtil.permissionUser((short) 10, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS));
 
         // Act & Assert
@@ -252,8 +252,7 @@ class MinorCreditorServiceTest {
                 123L,
                 LocalDate.of(2026, 2, 1),
                 LocalDate.of(2026, 1, 31),
-                null,
-                "authHeaderValue")
+                null)
         );
         assertEquals("dateFrom must be on or before dateTo", result.getMessage());
         verifyNoInteractions(minorCreditorSearchProxy);

--- a/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/MinorCreditorServiceTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.math.BigInteger;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -26,17 +28,18 @@ import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowe
 import uk.gov.hmcts.opal.common.user.authorisation.model.BusinessUnitUser;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.controllers.util.UserStateUtil;
-import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
 import uk.gov.hmcts.opal.dto.GetMinorCreditorAccountAtAGlanceResponse;
+import uk.gov.hmcts.opal.dto.GetMinorCreditorAccountHeaderSummaryResponse;
+import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
 import uk.gov.hmcts.opal.dto.MinorCreditorSearch;
 import uk.gov.hmcts.opal.dto.PostMinorCreditorAccountsSearchResponse;
-import uk.gov.hmcts.opal.dto.GetMinorCreditorAccountHeaderSummaryResponse;
+import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.opal.generated.model.AddressDetailsCommon;
 import uk.gov.hmcts.opal.generated.model.CreditorAccountPaymentDetailsCommon;
 import uk.gov.hmcts.opal.generated.model.MinorCreditorAccountResponseMinorCreditorPayment;
-import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
 import uk.gov.hmcts.opal.generated.model.PartyDetailsCommon;
+import uk.gov.hmcts.opal.generated.model.PatchMinorCreditorAccountRequest;
 import uk.gov.hmcts.opal.service.proxy.MinorCreditorSearchProxy;
 
 @ExtendWith(MockitoExtension.class)
@@ -142,6 +145,49 @@ class MinorCreditorServiceTest {
         PermissionNotAllowedException ex = Assertions.assertThrows(
             PermissionNotAllowedException.class,
             () -> minorCreditorService.getMinorCreditorAccount(123L)
+        );
+        assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
+        verifyNoInteractions(minorCreditorSearchProxy);
+    }
+
+    @Test
+    void getMinorCreditorHistory_withPermission_delegatesToProxy() {
+        // Arrange
+        Long id = 123L;
+        LocalDate dateFrom = LocalDate.of(2026, 1, 1);
+        LocalDate dateTo = LocalDate.of(2026, 1, 31);
+        List<String> itemTypes = List.of("amendment", "note");
+        GetMinorCreditorHistoryResponse response = GetMinorCreditorHistoryResponse.builder()
+            .version(BigInteger.ONE)
+            .build();
+
+        when(userStateService.checkForAuthorisedUser("authHeaderValue"))
+            .thenReturn(UserStateUtil.permissionUser((short) 10, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS));
+        when(minorCreditorSearchProxy.getMinorCreditorHistory(id, dateFrom, dateTo, itemTypes)).thenReturn(response);
+
+        // Act
+        GetMinorCreditorHistoryResponse result =
+            minorCreditorService.getMinorCreditorHistory(id, dateFrom, dateTo, itemTypes, "authHeaderValue");
+
+        // Assert
+        assertEquals(response, result);
+        verify(userStateService).checkForAuthorisedUser("authHeaderValue");
+        verify(minorCreditorSearchProxy).getMinorCreditorHistory(id, dateFrom, dateTo, itemTypes);
+    }
+
+    @Test
+    void getMinorCreditorHistory_withoutPermission_throwsPermissionNotAllowed() {
+        // Arrange
+        UserState noPermissionUser = mock(UserState.class);
+        when(noPermissionUser.anyBusinessUnitUserHasPermission(
+            FinesPermission.SEARCH_AND_VIEW_ACCOUNTS)).thenReturn(false);
+        when(userStateService.checkForAuthorisedUser("authHeaderValue")).thenReturn(noPermissionUser);
+
+        // Act & Assert
+        PermissionNotAllowedException ex = Assertions.assertThrows(
+            PermissionNotAllowedException.class,
+            () -> minorCreditorService.getMinorCreditorHistory(
+                123L, LocalDate.of(2026, 1, 1), null, List.of("note"), "authHeaderValue")
         );
         assertThat(ex.getPermission()).containsExactly(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
         verifyNoInteractions(minorCreditorSearchProxy);

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -20,6 +21,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 import uk.gov.hmcts.opal.common.legacy.service.GatewayService;
 import uk.gov.hmcts.opal.dto.GetMinorCreditorAccountAtAGlanceResponse;
 import uk.gov.hmcts.opal.dto.GetMinorCreditorAccountHeaderSummaryResponse;
@@ -79,6 +81,20 @@ class LegacyMinorCreditorServiceTest {
 
     @InjectMocks
     private LegacyMinorCreditorService legacyMinorCreditorService;
+
+    @Test
+    void getMinorCreditorHistory_throwsNotImplemented() {
+        // Act
+        ResponseStatusException result = assertThrows(
+            ResponseStatusException.class,
+            () -> legacyMinorCreditorService.getMinorCreditorHistory(101L, null, null, null)
+        );
+
+        // Assert
+        assertEquals(HttpStatus.NOT_IMPLEMENTED, result.getStatusCode());
+        assertEquals("Not yet implemented", result.getReason());
+        verifyNoMoreInteractions(gatewayService);
+    }
 
     @Test
     void searchMinorCreditors_shouldMapLegacyResponseToDto() {

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorServiceTest.java
@@ -43,6 +43,7 @@ import uk.gov.hmcts.opal.dto.legacy.common.LegacyCreditorAccountPaymentDetails;
 import uk.gov.hmcts.opal.dto.legacy.common.LegacyPartyDetails;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyMinorCreditorSearchResultsResponse;
 import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
+import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryFilters;
 import uk.gov.hmcts.opal.generated.model.AddressDetailsCommon;
 import uk.gov.hmcts.opal.generated.model.CreditorAccountPaymentDetailsCommon;
 import uk.gov.hmcts.opal.generated.model.OrganisationDetailsCommon;
@@ -87,7 +88,8 @@ class LegacyMinorCreditorServiceTest {
         // Act
         ResponseStatusException result = assertThrows(
             ResponseStatusException.class,
-            () -> legacyMinorCreditorService.getMinorCreditorHistory(101L, null, null, null)
+            () -> legacyMinorCreditorService.getMinorCreditorHistory(
+                101L, MinorCreditorHistoryFilters.from(null, null, null))
         );
 
         // Assert

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorHistoryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorHistoryServiceTest.java
@@ -1,0 +1,407 @@
+package uk.gov.hmcts.opal.service.opal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItemType.AMENDMENT;
+import static uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItemType.FINANCIAL;
+import static uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryItemType.NOTE;
+
+import jakarta.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
+import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
+import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountType;
+import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryFilters;
+import uk.gov.hmcts.opal.generated.model.AmendmentTypeCommon;
+import uk.gov.hmcts.opal.generated.model.CreditorTransactionDetailsHistory;
+import uk.gov.hmcts.opal.generated.model.MinorCreditorHistoryItemHistory;
+import uk.gov.hmcts.opal.generated.model.NoteDetailsHistory;
+import uk.gov.hmcts.opal.mapper.MinorCreditorHistoryItemMapper;
+import uk.gov.hmcts.opal.repository.AmendmentRepository;
+import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
+import uk.gov.hmcts.opal.repository.CreditorTransactionRepository;
+import uk.gov.hmcts.opal.repository.NoteRepository;
+import uk.gov.hmcts.opal.repository.projection.MinorCreditorAmendmentHistoryProjection;
+import uk.gov.hmcts.opal.repository.projection.MinorCreditorNoteHistoryProjection;
+import uk.gov.hmcts.opal.repository.projection.MinorCreditorTransactionHistoryProjection;
+
+@ExtendWith(MockitoExtension.class)
+class OpalMinorCreditorHistoryServiceTest {
+
+    private static final Long ACCOUNT_ID = 101L;
+    private static final LocalDateTime MIN_POSTED_DATE = LocalDateTime.of(1, 1, 1, 0, 0);
+    private static final LocalDateTime MAX_POSTED_DATE = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
+
+    @Mock
+    private CreditorAccountRepository creditorAccountRepository;
+
+    @Mock
+    private AmendmentRepository amendmentRepository;
+
+    @Mock
+    private NoteRepository noteRepository;
+
+    @Mock
+    private CreditorTransactionRepository creditorTransactionRepository;
+
+    @Spy
+    private MinorCreditorHistoryItemMapper historyItemMapper = new MinorCreditorHistoryItemMapper();
+
+    @InjectMocks
+    private OpalMinorCreditorService service;
+
+    @Test
+    void getMinorCreditorHistory_missingAccount_throwsEntityNotFoundException() {
+        // Arrange
+        when(creditorAccountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(EntityNotFoundException.class, () -> service.getMinorCreditorHistory(
+            ACCOUNT_ID, MinorCreditorHistoryFilters.from(null, null, null)));
+        verifyNoInteractions(amendmentRepository, noteRepository, creditorTransactionRepository);
+    }
+
+    @Test
+    void getMinorCreditorHistory_nonMinorCreditor_throwsEntityNotFoundException() {
+        // Arrange
+        when(creditorAccountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(
+            CreditorAccountEntity.builder()
+                .creditorAccountId(ACCOUNT_ID)
+                .creditorAccountType(CreditorAccountType.MJ)
+                .build()));
+
+        // Act & Assert
+        assertThrows(EntityNotFoundException.class, () -> service.getMinorCreditorHistory(
+            ACCOUNT_ID, MinorCreditorHistoryFilters.from(null, null, null)));
+        verifyNoInteractions(amendmentRepository, noteRepository, creditorTransactionRepository);
+    }
+
+    @Test
+    void getMinorCreditorHistory_withoutFilters_queriesAllSourcesWithOpenRange() {
+        // Arrange
+        givenMinorCreditorAccount();
+        when(amendmentRepository.findMinorCreditorHistory("101", MIN_POSTED_DATE, MAX_POSTED_DATE))
+            .thenReturn(List.of());
+        when(noteRepository.findMinorCreditorHistory("101", MIN_POSTED_DATE, MAX_POSTED_DATE))
+            .thenReturn(List.of());
+        when(creditorTransactionRepository.findMinorCreditorHistory(ACCOUNT_ID, MIN_POSTED_DATE, MAX_POSTED_DATE))
+            .thenReturn(List.of());
+
+        // Act
+        GetMinorCreditorHistoryResponse result = service.getMinorCreditorHistory(
+            ACCOUNT_ID, MinorCreditorHistoryFilters.from(null, null, null));
+
+        // Assert
+        assertThat(result.getVersion()).isEqualTo(BigInteger.valueOf(7L));
+        assertThat(result.getPayload().getHistoryItems()).isEmpty();
+        verify(amendmentRepository).findMinorCreditorHistory("101", MIN_POSTED_DATE, MAX_POSTED_DATE);
+        verify(noteRepository).findMinorCreditorHistory("101", MIN_POSTED_DATE, MAX_POSTED_DATE);
+        verify(creditorTransactionRepository).findMinorCreditorHistory(ACCOUNT_ID, MIN_POSTED_DATE, MAX_POSTED_DATE);
+    }
+
+    @Test
+    void getMinorCreditorHistory_withNoteFilter_queriesOnlyNotes() {
+        // Arrange
+        givenMinorCreditorAccount();
+        when(noteRepository.findMinorCreditorHistory("101", MIN_POSTED_DATE, MAX_POSTED_DATE))
+            .thenReturn(List.of());
+
+        // Act
+        service.getMinorCreditorHistory(ACCOUNT_ID, MinorCreditorHistoryFilters.from(null, null, List.of("note")));
+
+        // Assert
+        verify(noteRepository).findMinorCreditorHistory("101", MIN_POSTED_DATE, MAX_POSTED_DATE);
+        verifyNoInteractions(amendmentRepository, creditorTransactionRepository);
+    }
+
+    @Test
+    void getMinorCreditorHistory_withMultipleItemTypes_queriesRequestedSources() {
+        // Arrange
+        givenMinorCreditorAccount();
+        when(amendmentRepository.findMinorCreditorHistory("101", MIN_POSTED_DATE, MAX_POSTED_DATE))
+            .thenReturn(List.of());
+        when(creditorTransactionRepository.findMinorCreditorHistory(ACCOUNT_ID, MIN_POSTED_DATE, MAX_POSTED_DATE))
+            .thenReturn(List.of());
+
+        // Act
+        service.getMinorCreditorHistory(
+            ACCOUNT_ID, MinorCreditorHistoryFilters.from(null, null, List.of("amendment,financial")));
+
+        // Assert
+        verify(amendmentRepository).findMinorCreditorHistory("101", MIN_POSTED_DATE, MAX_POSTED_DATE);
+        verify(creditorTransactionRepository).findMinorCreditorHistory(ACCOUNT_ID, MIN_POSTED_DATE, MAX_POSTED_DATE);
+        verifyNoInteractions(noteRepository);
+    }
+
+    @Test
+    void getMinorCreditorHistory_withDateFrom_appliesInclusiveLowerBound() {
+        // Arrange
+        LocalDate dateFrom = LocalDate.of(2026, 1, 29);
+        LocalDateTime postedFrom = LocalDateTime.of(2026, 1, 29, 0, 0);
+        givenMinorCreditorAccount();
+        when(noteRepository.findMinorCreditorHistory("101", postedFrom, MAX_POSTED_DATE))
+            .thenReturn(List.of());
+
+        // Act
+        service.getMinorCreditorHistory(
+            ACCOUNT_ID, MinorCreditorHistoryFilters.from(dateFrom, null, List.of("note")));
+
+        // Assert
+        verify(noteRepository).findMinorCreditorHistory("101", postedFrom, MAX_POSTED_DATE);
+        verifyNoInteractions(amendmentRepository, creditorTransactionRepository);
+    }
+
+    @Test
+    void getMinorCreditorHistory_withDateTo_appliesInclusiveUpperBound() {
+        // Arrange
+        LocalDate dateTo = LocalDate.of(2026, 1, 31);
+        LocalDateTime postedToExclusive = LocalDateTime.of(2026, 2, 1, 0, 0);
+        givenMinorCreditorAccount();
+        when(noteRepository.findMinorCreditorHistory("101", MIN_POSTED_DATE, postedToExclusive))
+            .thenReturn(List.of());
+
+        // Act
+        service.getMinorCreditorHistory(
+            ACCOUNT_ID, MinorCreditorHistoryFilters.from(null, dateTo, List.of("note")));
+
+        // Assert
+        verify(noteRepository).findMinorCreditorHistory("101", MIN_POSTED_DATE, postedToExclusive);
+        verifyNoInteractions(amendmentRepository, creditorTransactionRepository);
+    }
+
+    @Test
+    void getMinorCreditorHistory_withDateRangeAndFinancialFilter_appliesCombinedFilters() {
+        // Arrange
+        LocalDate dateFrom = LocalDate.of(2026, 1, 1);
+        LocalDate dateTo = LocalDate.of(2026, 1, 31);
+        LocalDateTime postedFrom = LocalDateTime.of(2026, 1, 1, 0, 0);
+        LocalDateTime postedToExclusive = LocalDateTime.of(2026, 2, 1, 0, 0);
+        givenMinorCreditorAccount();
+        when(creditorTransactionRepository.findMinorCreditorHistory(
+            ACCOUNT_ID, postedFrom, postedToExclusive)).thenReturn(List.of());
+
+        // Act
+        service.getMinorCreditorHistory(
+            ACCOUNT_ID, MinorCreditorHistoryFilters.from(dateFrom, dateTo, List.of("financial")));
+
+        // Assert
+        verify(creditorTransactionRepository).findMinorCreditorHistory(ACCOUNT_ID, postedFrom, postedToExclusive);
+        verifyNoInteractions(amendmentRepository, noteRepository);
+    }
+
+    @Test
+    void getMinorCreditorHistory_ordersMergedItemsLatestToOldest() {
+        // Arrange
+        LocalDateTime oldest = LocalDateTime.of(2026, 1, 29, 8, 0);
+        LocalDateTime middle = LocalDateTime.of(2026, 1, 30, 9, 0);
+        LocalDateTime latest = LocalDateTime.of(2026, 1, 31, 10, 0);
+        MinorCreditorAmendmentHistoryProjection amendment = amendment(11L, oldest, "Old amendment");
+        MinorCreditorNoteHistoryProjection note = note(12L, latest, "Latest note");
+        final MinorCreditorTransactionHistoryProjection transaction =
+            transaction(13L, middle, "PAYMNT", BigDecimal.valueOf(42L));
+        givenMinorCreditorAccount();
+        when(amendmentRepository.findMinorCreditorHistory("101", MIN_POSTED_DATE, MAX_POSTED_DATE))
+            .thenReturn(List.of(amendment));
+        when(noteRepository.findMinorCreditorHistory("101", MIN_POSTED_DATE, MAX_POSTED_DATE))
+            .thenReturn(List.of(note));
+        when(creditorTransactionRepository.findMinorCreditorHistory(ACCOUNT_ID, MIN_POSTED_DATE, MAX_POSTED_DATE))
+            .thenReturn(List.of(transaction));
+
+        // Act
+        List<MinorCreditorHistoryItemHistory> historyItems = service.getMinorCreditorHistory(
+            ACCOUNT_ID, MinorCreditorHistoryFilters.from(null, null, null)).getPayload().getHistoryItems();
+
+        // Assert
+        assertThat(historyItems).extracting(MinorCreditorHistoryItemHistory::getType).containsExactly(
+            NOTE.responseType(),
+            FINANCIAL.responseType(),
+            AMENDMENT.responseType()
+        );
+    }
+
+    @Test
+    void getMinorCreditorHistory_ordersEqualTimestampsByTypeThenSourceId() {
+        // Arrange
+        LocalDateTime timestamp = LocalDateTime.of(2026, 1, 31, 10, 0);
+        MinorCreditorAmendmentHistoryProjection amendment20 = amendment(20L, timestamp, "Amendment 20");
+        MinorCreditorAmendmentHistoryProjection amendment10 = amendment(10L, timestamp, "Amendment 10");
+        MinorCreditorNoteHistoryProjection note = note(30L, timestamp, "Note 30");
+        final MinorCreditorTransactionHistoryProjection transaction =
+            transaction(40L, timestamp, "PAYMNT", BigDecimal.valueOf(42L));
+        givenMinorCreditorAccount();
+        when(amendmentRepository.findMinorCreditorHistory("101", MIN_POSTED_DATE, MAX_POSTED_DATE))
+            .thenReturn(List.of(amendment20, amendment10));
+        when(noteRepository.findMinorCreditorHistory("101", MIN_POSTED_DATE, MAX_POSTED_DATE))
+            .thenReturn(List.of(note));
+        when(creditorTransactionRepository.findMinorCreditorHistory(ACCOUNT_ID, MIN_POSTED_DATE, MAX_POSTED_DATE))
+            .thenReturn(List.of(transaction));
+
+        // Act
+        List<MinorCreditorHistoryItemHistory> historyItems = service.getMinorCreditorHistory(
+            ACCOUNT_ID, MinorCreditorHistoryFilters.from(null, null, null)).getPayload().getHistoryItems();
+
+        // Assert
+        assertThat(historyItems).extracting(MinorCreditorHistoryItemHistory::getType).containsExactly(
+            AMENDMENT.responseType(),
+            AMENDMENT.responseType(),
+            FINANCIAL.responseType(),
+            NOTE.responseType()
+        );
+        assertThat(((AmendmentTypeCommon) historyItems.get(0).getDetails()).getAttributeName())
+            .isEqualTo("Amendment 10");
+        assertThat(((AmendmentTypeCommon) historyItems.get(1).getDetails()).getAttributeName())
+            .isEqualTo("Amendment 20");
+    }
+
+    @Test
+    void getMinorCreditorHistory_mapsDetailsForAllSourceTypes() {
+        // Arrange
+        LocalDateTime amendmentDate = LocalDateTime.of(2026, 1, 31, 10, 0);
+        LocalDateTime noteDate = LocalDateTime.of(2026, 1, 30, 9, 0);
+        LocalDateTime transactionDate = LocalDateTime.of(2026, 1, 29, 8, 0);
+        MinorCreditorAmendmentHistoryProjection amendment = amendment(11L, amendmentDate, "Hold Pay Out");
+        MinorCreditorNoteHistoryProjection note = note(12L, noteDate, "Review creditor");
+        final MinorCreditorTransactionHistoryProjection transaction =
+            transaction(13L, transactionDate, "PAYMNT", BigDecimal.valueOf(42L));
+        givenMinorCreditorAccount();
+        when(amendmentRepository.findMinorCreditorHistory("101", MIN_POSTED_DATE, MAX_POSTED_DATE))
+            .thenReturn(List.of(amendment));
+        when(noteRepository.findMinorCreditorHistory("101", MIN_POSTED_DATE, MAX_POSTED_DATE))
+            .thenReturn(List.of(note));
+        when(creditorTransactionRepository.findMinorCreditorHistory(ACCOUNT_ID, MIN_POSTED_DATE, MAX_POSTED_DATE))
+            .thenReturn(List.of(transaction));
+
+        // Act
+        List<MinorCreditorHistoryItemHistory> historyItems = service.getMinorCreditorHistory(
+            ACCOUNT_ID, MinorCreditorHistoryFilters.from(null, null, null)).getPayload().getHistoryItems();
+
+        // Assert
+        AmendmentTypeCommon amendmentDetails = (AmendmentTypeCommon) historyItems.get(0).getDetails();
+        assertThat(amendmentDetails.getAttributeName()).isEqualTo("Hold Pay Out");
+        assertThat(amendmentDetails.getOldValue()).isEqualTo("old-Hold Pay Out");
+        assertThat(amendmentDetails.getNewValue()).isEqualTo("new-Hold Pay Out");
+
+        NoteDetailsHistory noteDetails = (NoteDetailsHistory) historyItems.get(1).getDetails();
+        assertThat(noteDetails.getNoteText()).isEqualTo("Review creditor");
+
+        CreditorTransactionDetailsHistory transactionDetails =
+            (CreditorTransactionDetailsHistory) historyItems.get(2).getDetails();
+        assertThat(historyItems.get(2).getAmount()).isEqualByComparingTo(BigDecimal.valueOf(42L));
+        assertThat(transactionDetails.getTransactionType().getTransactionType().getValue()).isEqualTo("PAYMNT");
+        assertThat(transactionDetails.getPaymentReference()).isEqualTo("PMT001");
+        assertThat(transactionDetails.getStatus().getCreditorTransactionStatus().getValue()).isEqualTo("C");
+        assertThat(transactionDetails.getAccountNumber()).isEqualTo("HOLD1234");
+        assertThat(transactionDetails.getDefendantAccountNumber()).isEqualTo("DEF123456");
+        assertThat(transactionDetails.getDefendantAccountId()).isEqualTo(70000000000000L);
+    }
+
+    @Test
+    void getMinorCreditorHistory_mapsNullTransactionOptionals() {
+        // Arrange
+        LocalDateTime transactionDate = LocalDateTime.of(2026, 1, 29, 8, 0);
+        MinorCreditorTransactionHistoryProjection transaction = transaction(
+            13L, transactionDate, "PAYMNT", BigDecimal.valueOf(42L));
+        when(transaction.getPaymentReference()).thenReturn(null);
+        when(transaction.getStatus()).thenReturn(null);
+        when(transaction.getStatusDate()).thenReturn(null);
+        when(transaction.getAssociatedRecordType()).thenReturn(null);
+        when(transaction.getAssociatedRecordId()).thenReturn(null);
+        when(transaction.getAccountNumber()).thenReturn(null);
+        when(transaction.getDefendantAccountNumber()).thenReturn(null);
+        when(transaction.getDefendantAccountId()).thenReturn(null);
+        givenMinorCreditorAccount();
+        when(creditorTransactionRepository.findMinorCreditorHistory(ACCOUNT_ID, MIN_POSTED_DATE, MAX_POSTED_DATE))
+            .thenReturn(List.of(transaction));
+
+        // Act
+        List<MinorCreditorHistoryItemHistory> historyItems = service.getMinorCreditorHistory(
+            ACCOUNT_ID, MinorCreditorHistoryFilters.from(null, null, List.of("financial")))
+            .getPayload().getHistoryItems();
+
+        // Assert
+        CreditorTransactionDetailsHistory details =
+            (CreditorTransactionDetailsHistory) historyItems.getFirst().getDetails();
+        assertThat(details.getPaymentReference()).isNull();
+        assertThat(details.getStatus()).isNull();
+        assertThat(details.getStatusDate()).isNull();
+        assertThat(details.getAssociatedRecordType()).isNull();
+        assertThat(details.getAssociatedRecordId()).isNull();
+        assertThat(details.getAccountNumber()).isNull();
+        assertThat(details.getDefendantAccountNumber()).isNull();
+        assertThat(details.getDefendantAccountId()).isNull();
+    }
+
+    private void givenMinorCreditorAccount() {
+        when(creditorAccountRepository.findById(ACCOUNT_ID)).thenReturn(Optional.of(
+            CreditorAccountEntity.builder()
+                .creditorAccountId(ACCOUNT_ID)
+                .creditorAccountType(CreditorAccountType.MN)
+                .versionNumber(7L)
+                .build()));
+    }
+
+    private MinorCreditorAmendmentHistoryProjection amendment(
+        Long amendmentId,
+        LocalDateTime postedDate,
+        String attributeName) {
+        MinorCreditorAmendmentHistoryProjection projection =
+            mock(MinorCreditorAmendmentHistoryProjection.class);
+        when(projection.getAmendmentId()).thenReturn(amendmentId);
+        when(projection.getPostedDate()).thenReturn(postedDate);
+        when(projection.getPostedBy()).thenReturn("AMENDUSR");
+        when(projection.getPostedByName()).thenReturn("Amend User");
+        when(projection.getAttributeName()).thenReturn(attributeName);
+        when(projection.getOldValue()).thenReturn("old-" + attributeName);
+        when(projection.getNewValue()).thenReturn("new-" + attributeName);
+        return projection;
+    }
+
+    private MinorCreditorNoteHistoryProjection note(Long noteId, LocalDateTime postedDate, String noteText) {
+        MinorCreditorNoteHistoryProjection projection = mock(MinorCreditorNoteHistoryProjection.class);
+        when(projection.getNoteId()).thenReturn(noteId);
+        when(projection.getPostedDate()).thenReturn(postedDate);
+        when(projection.getPostedBy()).thenReturn("NOTEUSR");
+        when(projection.getPostedByName()).thenReturn("Note User");
+        when(projection.getNoteText()).thenReturn(noteText);
+        return projection;
+    }
+
+    private MinorCreditorTransactionHistoryProjection transaction(
+        Long transactionId,
+        LocalDateTime postedDate,
+        String transactionType,
+        BigDecimal amount) {
+        MinorCreditorTransactionHistoryProjection projection =
+            mock(MinorCreditorTransactionHistoryProjection.class);
+        when(projection.getCreditorTransactionId()).thenReturn(transactionId);
+        when(projection.getPostedDate()).thenReturn(postedDate);
+        when(projection.getPostedBy()).thenReturn("PAYUSR");
+        when(projection.getPostedByName()).thenReturn("Payment User");
+        when(projection.getTransactionType()).thenReturn(transactionType);
+        when(projection.getTransactionAmount()).thenReturn(amount);
+        when(projection.getPaymentReference()).thenReturn("PMT001");
+        when(projection.getStatus()).thenReturn("C");
+        when(projection.getStatusDate()).thenReturn(postedDate.plusMinutes(30));
+        when(projection.getAssociatedRecordType()).thenReturn("defendant_accounts");
+        when(projection.getAssociatedRecordId()).thenReturn("70000000000000");
+        when(projection.getAccountNumber()).thenReturn("HOLD1234");
+        when(projection.getDefendantAccountNumber()).thenReturn("DEF123456");
+        when(projection.getDefendantAccountId()).thenReturn(70000000000000L);
+        return projection;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorServiceGetTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorServiceGetTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
 import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
@@ -28,6 +29,7 @@ import uk.gov.hmcts.opal.generated.model.CreditorTransactionDetailsHistory;
 import uk.gov.hmcts.opal.generated.model.MinorCreditorHistoryItemHistory;
 import uk.gov.hmcts.opal.generated.model.NoteDetailsHistory;
 import uk.gov.hmcts.opal.mapper.MinorCreditorAccountResponseMapper;
+import uk.gov.hmcts.opal.mapper.MinorCreditorHistoryItemMapper;
 import uk.gov.hmcts.opal.repository.AmendmentRepository;
 import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
 import uk.gov.hmcts.opal.repository.CreditorTransactionRepository;
@@ -72,6 +74,9 @@ class OpalMinorCreditorServiceGetTest {
 
     @Mock
     private MinorCreditorAccountResponseMapper responseMapper;
+
+    @Spy
+    private MinorCreditorHistoryItemMapper historyItemMapper = new MinorCreditorHistoryItemMapper();
 
     @InjectMocks
     private OpalMinorCreditorService service;

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorServiceGetTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorServiceGetTest.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
 import uk.gov.hmcts.opal.entity.PartyEntity;
 import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
 import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountType;
+import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryFilters;
 import uk.gov.hmcts.opal.mapper.MinorCreditorAccountResponseMapper;
 import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
 import uk.gov.hmcts.opal.repository.MinorCreditorAccountAtAGlanceRepository;
@@ -138,7 +139,8 @@ class OpalMinorCreditorServiceGetTest {
         when(creditorAccountRepository.findById(accountId)).thenReturn(Optional.of(account));
 
         // Act
-        GetMinorCreditorHistoryResponse result = service.getMinorCreditorHistory(accountId, null, null, null);
+        GetMinorCreditorHistoryResponse result = service.getMinorCreditorHistory(
+            accountId, MinorCreditorHistoryFilters.from(null, null, null));
 
         // Assert
         assertNotNull(result);
@@ -153,7 +155,8 @@ class OpalMinorCreditorServiceGetTest {
         when(creditorAccountRepository.findById(999L)).thenReturn(Optional.empty());
 
         // Act & Assert
-        assertThrows(EntityNotFoundException.class, () -> service.getMinorCreditorHistory(999L, null, null, null));
+        assertThrows(EntityNotFoundException.class, () -> service.getMinorCreditorHistory(
+            999L, MinorCreditorHistoryFilters.from(null, null, null)));
     }
 
     @Test
@@ -168,6 +171,7 @@ class OpalMinorCreditorServiceGetTest {
         when(creditorAccountRepository.findById(accountId)).thenReturn(Optional.of(account));
 
         // Act & Assert
-        assertThrows(EntityNotFoundException.class, () -> service.getMinorCreditorHistory(accountId, null, null, null));
+        assertThrows(EntityNotFoundException.class, () -> service.getMinorCreditorHistory(
+            accountId, MinorCreditorHistoryFilters.from(null, null, null)));
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorServiceGetTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorServiceGetTest.java
@@ -7,7 +7,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -21,12 +23,22 @@ import uk.gov.hmcts.opal.entity.PartyEntity;
 import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
 import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountType;
 import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryFilters;
+import uk.gov.hmcts.opal.generated.model.AmendmentTypeCommon;
+import uk.gov.hmcts.opal.generated.model.CreditorTransactionDetailsHistory;
+import uk.gov.hmcts.opal.generated.model.MinorCreditorHistoryItemHistory;
+import uk.gov.hmcts.opal.generated.model.NoteDetailsHistory;
 import uk.gov.hmcts.opal.mapper.MinorCreditorAccountResponseMapper;
+import uk.gov.hmcts.opal.repository.AmendmentRepository;
 import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
+import uk.gov.hmcts.opal.repository.CreditorTransactionRepository;
 import uk.gov.hmcts.opal.repository.MinorCreditorAccountAtAGlanceRepository;
 import uk.gov.hmcts.opal.repository.MinorCreditorAccountHeaderRepository;
 import uk.gov.hmcts.opal.repository.MinorCreditorRepository;
+import uk.gov.hmcts.opal.repository.NoteRepository;
 import uk.gov.hmcts.opal.repository.PartyRepository;
+import uk.gov.hmcts.opal.repository.projection.MinorCreditorAmendmentHistoryProjection;
+import uk.gov.hmcts.opal.repository.projection.MinorCreditorNoteHistoryProjection;
+import uk.gov.hmcts.opal.repository.projection.MinorCreditorTransactionHistoryProjection;
 
 @ExtendWith(MockitoExtension.class)
 class OpalMinorCreditorServiceGetTest {
@@ -45,6 +57,15 @@ class OpalMinorCreditorServiceGetTest {
 
     @Mock
     private PartyRepository partyRepository;
+
+    @Mock
+    private AmendmentRepository amendmentRepository;
+
+    @Mock
+    private NoteRepository noteRepository;
+
+    @Mock
+    private CreditorTransactionRepository creditorTransactionRepository;
 
     @Mock
     private AmendmentService amendmentService;
@@ -127,7 +148,7 @@ class OpalMinorCreditorServiceGetTest {
     }
 
     @Test
-    void getMinorCreditorHistory_success_returnsEmptyPayloadWithVersion() {
+    void getMinorCreditorHistory_success_returnsHistoryPayloadWithVersion() {
         // Arrange
         Long accountId = 101L;
         CreditorAccountEntity account = CreditorAccountEntity.builder()
@@ -135,18 +156,71 @@ class OpalMinorCreditorServiceGetTest {
             .creditorAccountType(CreditorAccountType.MN)
             .versionNumber(5L)
             .build();
+        LocalDateTime postedFrom = LocalDateTime.of(2026, 1, 1, 0, 0);
+        LocalDateTime postedTo = LocalDateTime.of(2026, 2, 1, 0, 0);
+        MinorCreditorHistoryFilters filters = MinorCreditorHistoryFilters.from(
+            postedFrom.toLocalDate(), postedTo.minusDays(1).toLocalDate(), null);
+
+        MinorCreditorAmendmentHistoryProjection amendment = new AmendmentHistoryProjection(
+            11L,
+            LocalDateTime.of(2026, 1, 31, 10, 0),
+            "AMEND",
+            "Amend User",
+            "Hold Pay Out",
+            "false",
+            "true");
+        MinorCreditorNoteHistoryProjection note = new NoteHistoryProjection(
+            12L,
+            LocalDateTime.of(2026, 1, 30, 9, 0),
+            "NOTE",
+            "Note User",
+            "Review creditor");
+        MinorCreditorTransactionHistoryProjection transaction = new TransactionHistoryProjection(
+            13L,
+            LocalDateTime.of(2026, 1, 29, 8, 0),
+            "PAY",
+            "Payment User",
+            "PAYMNT",
+            BigDecimal.valueOf(42L),
+            "PMT001",
+            "C",
+            LocalDateTime.of(2026, 1, 29, 8, 30),
+            "defendant_accounts",
+            "70000000000000",
+            "HOLD1234",
+            "DEF123456",
+            70000000000000L);
 
         when(creditorAccountRepository.findById(accountId)).thenReturn(Optional.of(account));
+        when(amendmentRepository.findMinorCreditorHistory("101", postedFrom, postedTo))
+            .thenReturn(List.of(amendment));
+        when(noteRepository.findMinorCreditorHistory("101", postedFrom, postedTo)).thenReturn(List.of(note));
+        when(creditorTransactionRepository.findMinorCreditorHistory(accountId, postedFrom, postedTo))
+            .thenReturn(List.of(transaction));
 
         // Act
-        GetMinorCreditorHistoryResponse result = service.getMinorCreditorHistory(
-            accountId, MinorCreditorHistoryFilters.from(null, null, null));
+        GetMinorCreditorHistoryResponse result = service.getMinorCreditorHistory(accountId, filters);
 
         // Assert
         assertNotNull(result);
         assertEquals(BigInteger.valueOf(5L), result.getVersion());
         assertNotNull(result.getPayload());
-        assertEquals(List.of(), result.getPayload().getHistoryItems());
+        List<MinorCreditorHistoryItemHistory> historyItems = result.getPayload().getHistoryItems();
+        assertEquals(3, historyItems.size());
+        assertEquals(MinorCreditorHistoryItemHistory.TypeEnum.AMENDMENT, historyItems.get(0).getType());
+        assertEquals("2026-01-31", historyItems.get(0).getPostedDetails().getPostedDate().toString());
+        assertEquals("Hold Pay Out", ((AmendmentTypeCommon) historyItems.get(0).getDetails()).getAttributeName());
+        assertEquals(MinorCreditorHistoryItemHistory.TypeEnum.NOTE, historyItems.get(1).getType());
+        assertEquals("Review creditor", ((NoteDetailsHistory) historyItems.get(1).getDetails()).getNoteText());
+        assertEquals(MinorCreditorHistoryItemHistory.TypeEnum.FINANCIAL, historyItems.get(2).getType());
+        CreditorTransactionDetailsHistory financialDetails =
+            (CreditorTransactionDetailsHistory) historyItems.get(2).getDetails();
+        assertEquals(BigDecimal.valueOf(42L), historyItems.get(2).getAmount());
+        assertEquals("PAYMNT", financialDetails.getTransactionType().getTransactionType().getValue());
+        assertEquals(70000000000000L, financialDetails.getDefendantAccountId());
+        verify(amendmentRepository).findMinorCreditorHistory("101", postedFrom, postedTo);
+        verify(noteRepository).findMinorCreditorHistory("101", postedFrom, postedTo);
+        verify(creditorTransactionRepository).findMinorCreditorHistory(accountId, postedFrom, postedTo);
     }
 
     @Test
@@ -173,5 +247,170 @@ class OpalMinorCreditorServiceGetTest {
         // Act & Assert
         assertThrows(EntityNotFoundException.class, () -> service.getMinorCreditorHistory(
             accountId, MinorCreditorHistoryFilters.from(null, null, null)));
+    }
+
+    private record AmendmentHistoryProjection(
+        Long amendmentId,
+        LocalDateTime postedDate,
+        String postedBy,
+        String postedByName,
+        String attributeName,
+        String oldValue,
+        String newValue) implements MinorCreditorAmendmentHistoryProjection {
+
+        @Override
+        public Long getAmendmentId() {
+            return amendmentId;
+        }
+
+        @Override
+        public LocalDateTime getPostedDate() {
+            return postedDate;
+        }
+
+        @Override
+        public String getPostedBy() {
+            return postedBy;
+        }
+
+        @Override
+        public String getPostedByName() {
+            return postedByName;
+        }
+
+        @Override
+        public String getAttributeName() {
+            return attributeName;
+        }
+
+        @Override
+        public String getOldValue() {
+            return oldValue;
+        }
+
+        @Override
+        public String getNewValue() {
+            return newValue;
+        }
+    }
+
+    private record NoteHistoryProjection(
+        Long noteId,
+        LocalDateTime postedDate,
+        String postedBy,
+        String postedByName,
+        String noteText) implements MinorCreditorNoteHistoryProjection {
+
+        @Override
+        public Long getNoteId() {
+            return noteId;
+        }
+
+        @Override
+        public LocalDateTime getPostedDate() {
+            return postedDate;
+        }
+
+        @Override
+        public String getPostedBy() {
+            return postedBy;
+        }
+
+        @Override
+        public String getPostedByName() {
+            return postedByName;
+        }
+
+        @Override
+        public String getNoteText() {
+            return noteText;
+        }
+    }
+
+    private record TransactionHistoryProjection(
+        Long creditorTransactionId,
+        LocalDateTime postedDate,
+        String postedBy,
+        String postedByName,
+        String transactionType,
+        BigDecimal transactionAmount,
+        String paymentReference,
+        String status,
+        LocalDateTime statusDate,
+        String associatedRecordType,
+        String associatedRecordId,
+        String accountNumber,
+        String defendantAccountNumber,
+        Long defendantAccountId) implements MinorCreditorTransactionHistoryProjection {
+
+        @Override
+        public Long getCreditorTransactionId() {
+            return creditorTransactionId;
+        }
+
+        @Override
+        public LocalDateTime getPostedDate() {
+            return postedDate;
+        }
+
+        @Override
+        public String getPostedBy() {
+            return postedBy;
+        }
+
+        @Override
+        public String getPostedByName() {
+            return postedByName;
+        }
+
+        @Override
+        public String getTransactionType() {
+            return transactionType;
+        }
+
+        @Override
+        public BigDecimal getTransactionAmount() {
+            return transactionAmount;
+        }
+
+        @Override
+        public String getPaymentReference() {
+            return paymentReference;
+        }
+
+        @Override
+        public String getStatus() {
+            return status;
+        }
+
+        @Override
+        public LocalDateTime getStatusDate() {
+            return statusDate;
+        }
+
+        @Override
+        public String getAssociatedRecordType() {
+            return associatedRecordType;
+        }
+
+        @Override
+        public String getAssociatedRecordId() {
+            return associatedRecordId;
+        }
+
+        @Override
+        public String getAccountNumber() {
+            return accountNumber;
+        }
+
+        @Override
+        public String getDefendantAccountNumber() {
+            return defendantAccountNumber;
+        }
+
+        @Override
+        public Long getDefendantAccountId() {
+            return defendantAccountId;
+        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorServiceGetTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalMinorCreditorServiceGetTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import jakarta.persistence.EntityNotFoundException;
 import java.math.BigInteger;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.opal.dto.MinorCreditorAccountResponse;
+import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
 import uk.gov.hmcts.opal.entity.PartyEntity;
 import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
 import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountType;
@@ -121,5 +123,51 @@ class OpalMinorCreditorServiceGetTest {
 
         // Act & Assert
         assertThrows(EntityNotFoundException.class, () -> service.getMinorCreditorAccount(accountId));
+    }
+
+    @Test
+    void getMinorCreditorHistory_success_returnsEmptyPayloadWithVersion() {
+        // Arrange
+        Long accountId = 101L;
+        CreditorAccountEntity account = CreditorAccountEntity.builder()
+            .creditorAccountId(accountId)
+            .creditorAccountType(CreditorAccountType.MN)
+            .versionNumber(5L)
+            .build();
+
+        when(creditorAccountRepository.findById(accountId)).thenReturn(Optional.of(account));
+
+        // Act
+        GetMinorCreditorHistoryResponse result = service.getMinorCreditorHistory(accountId, null, null, null);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(BigInteger.valueOf(5L), result.getVersion());
+        assertNotNull(result.getPayload());
+        assertEquals(List.of(), result.getPayload().getHistoryItems());
+    }
+
+    @Test
+    void getMinorCreditorHistory_missingAccount_throwsEntityNotFoundException() {
+        // Arrange
+        when(creditorAccountRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThrows(EntityNotFoundException.class, () -> service.getMinorCreditorHistory(999L, null, null, null));
+    }
+
+    @Test
+    void getMinorCreditorHistory_nonMinorCreditor_throwsEntityNotFoundException() {
+        // Arrange
+        Long accountId = 101L;
+        CreditorAccountEntity account = CreditorAccountEntity.builder()
+            .creditorAccountId(accountId)
+            .creditorAccountType(CreditorAccountType.MJ)
+            .build();
+
+        when(creditorAccountRepository.findById(accountId)).thenReturn(Optional.of(account));
+
+        // Act & Assert
+        assertThrows(EntityNotFoundException.class, () -> service.getMinorCreditorHistory(accountId, null, null, null));
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/proxy/MinorCreditorServiceProxyTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/proxy/MinorCreditorServiceProxyTest.java
@@ -17,6 +17,7 @@ import org.mockito.MockitoAnnotations;
 import uk.gov.hmcts.opal.dto.MinorCreditorSearch;
 import uk.gov.hmcts.opal.dto.PostMinorCreditorAccountsSearchResponse;
 import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
+import uk.gov.hmcts.opal.entity.minorcreditor.MinorCreditorHistoryFilters;
 import uk.gov.hmcts.opal.service.iface.MinorCreditorServiceInterface;
 import uk.gov.hmcts.opal.service.legacy.LegacyMinorCreditorService;
 import uk.gov.hmcts.opal.service.opal.OpalMinorCreditorService;
@@ -52,13 +53,14 @@ class MinorCreditorServiceProxyTest extends ProxyTestsBase {
         Long id = 123L;
         LocalDate dateFrom = LocalDate.of(2026, 1, 1);
         LocalDate dateTo = LocalDate.of(2026, 1, 31);
-        List<String> itemTypes = List.of("amendment");
+        MinorCreditorHistoryFilters filters = MinorCreditorHistoryFilters.from(
+            dateFrom, dateTo, List.of("amendment"));
         GetMinorCreditorHistoryResponse response = GetMinorCreditorHistoryResponse.builder().build();
-        when(targetService.getMinorCreditorHistory(id, dateFrom, dateTo, itemTypes)).thenReturn(response);
+        when(targetService.getMinorCreditorHistory(id, filters)).thenReturn(response);
 
-        GetMinorCreditorHistoryResponse result = serviceProxy.getMinorCreditorHistory(id, dateFrom, dateTo, itemTypes);
+        GetMinorCreditorHistoryResponse result = serviceProxy.getMinorCreditorHistory(id, filters);
 
-        verify(targetService).getMinorCreditorHistory(id, dateFrom, dateTo, itemTypes);
+        verify(targetService).getMinorCreditorHistory(id, filters);
         verifyNoInteractions(otherService);
         Assertions.assertEquals(response, result);
     }

--- a/src/test/java/uk/gov/hmcts/opal/service/proxy/MinorCreditorServiceProxyTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/proxy/MinorCreditorServiceProxyTest.java
@@ -1,5 +1,12 @@
 package uk.gov.hmcts.opal.service.proxy;
 
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -7,16 +14,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import uk.gov.hmcts.opal.dto.PostMinorCreditorAccountsSearchResponse;
 import uk.gov.hmcts.opal.dto.MinorCreditorSearch;
+import uk.gov.hmcts.opal.dto.PostMinorCreditorAccountsSearchResponse;
+import uk.gov.hmcts.opal.dto.response.GetMinorCreditorHistoryResponse;
 import uk.gov.hmcts.opal.service.iface.MinorCreditorServiceInterface;
 import uk.gov.hmcts.opal.service.legacy.LegacyMinorCreditorService;
 import uk.gov.hmcts.opal.service.opal.OpalMinorCreditorService;
-
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 class MinorCreditorServiceProxyTest extends ProxyTestsBase {
 
@@ -43,6 +46,21 @@ class MinorCreditorServiceProxyTest extends ProxyTestsBase {
 
     void testMode(MinorCreditorServiceInterface targetService, MinorCreditorServiceInterface otherService) {
         testPostSearchMinorCreditors(targetService, otherService);
+    }
+
+    void testHistoryMode(MinorCreditorServiceInterface targetService, MinorCreditorServiceInterface otherService) {
+        Long id = 123L;
+        LocalDate dateFrom = LocalDate.of(2026, 1, 1);
+        LocalDate dateTo = LocalDate.of(2026, 1, 31);
+        List<String> itemTypes = List.of("amendment");
+        GetMinorCreditorHistoryResponse response = GetMinorCreditorHistoryResponse.builder().build();
+        when(targetService.getMinorCreditorHistory(id, dateFrom, dateTo, itemTypes)).thenReturn(response);
+
+        GetMinorCreditorHistoryResponse result = serviceProxy.getMinorCreditorHistory(id, dateFrom, dateTo, itemTypes);
+
+        verify(targetService).getMinorCreditorHistory(id, dateFrom, dateTo, itemTypes);
+        verifyNoInteractions(otherService);
+        Assertions.assertEquals(response, result);
     }
 
     void testPostSearchMinorCreditors(MinorCreditorServiceInterface targetService,
@@ -75,6 +93,22 @@ class MinorCreditorServiceProxyTest extends ProxyTestsBase {
         setMode(LEGACY);
         // Then: the target service is called, but the other service is not
         testMode(legacyService, opalService);
+    }
+
+    @Test
+    void getMinorCreditorHistory_shouldUseOpalServiceWhenModeIsNotLegacy() {
+        // Given: app mode is set
+        setMode(OPAL);
+        // Then: the target service is called, but the other service is not
+        testHistoryMode(opalService, legacyService);
+    }
+
+    @Test
+    void getMinorCreditorHistory_shouldUseLegacyServiceWhenModeIsLegacy() {
+        // Given: app mode is set
+        setMode(LEGACY);
+        // Then: the target service is called, but the other service is not
+        testHistoryMode(legacyService, opalService);
     }
 
 }


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PO-2642

### Change description ###

- Endpoint to allow the user to view the account history for a minor creditor account.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
