### PR TITLE
updates to the pipelines for the structure of the test reports.

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -7,11 +7,6 @@ def type = "java"
 def product = "opal"
 def component = "fines-service"
 
-def archiveZephyrReports = {
-  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'target/zephyr/**/*.json'
-  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'target/zephyr-reports/**/*.json'
-}
-
 def determineDevEnvironmentDeployment() {
   env.TEST_URL = "https://opal-fines-service-pr-${env.CHANGE_ID}.dev.platform.hmcts.net"
 
@@ -96,7 +91,7 @@ withPipeline(type, product, component) {
   afterAlways('test') {
     steps.junit '**/test-results/integration/*.xml'
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/integration/*.xml'
-    archiveZephyrReports()
+    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'integration-output/**/*'
 
     publishHTML target: [
         allowMissing         : true,
@@ -147,21 +142,20 @@ withPipeline(type, product, component) {
         allowMissing         : true,
         alwaysLinkToLastBuild: true,
         keepAll              : true,
-        reportDir            : "build/reports/tests/integration",
+        reportDir            : "integration-output/report",
         reportFiles          : "index.html",
         reportName           : "Integration Tests Report"
     ]
   }
 
   afterAlways('functionalTest:dev') {
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-test-report/**/*'
-    archiveZephyrReports()
+    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
 
     publishHTML target: [
         allowMissing         : true,
         alwaysLinkToLastBuild: true,
         keepAll              : true,
-        reportDir            : "functional-test-report/",
+        reportDir            : "functional-output/report",
         reportFiles          : "index.html",
         reportName           : "Serenity Functional Test Report"
     ]
@@ -169,35 +163,33 @@ withPipeline(type, product, component) {
         allowMissing         : true,
         alwaysLinkToLastBuild: true,
         keepAll              : true,
-        reportDir            : "functional-test-report/htmlReport/",
+        reportDir            : "functional-output/report/htmlReport",
         reportFiles          : "test-summary.html",
         reportName           : "Test Summary Report"
     ]
   }
 
   afterAlways('smoketest:dev') {
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-test-report/**/*'
-    archiveZephyrReports()
+    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-output/**/*'
 
     publishHTML target: [
         allowMissing         : true,
         alwaysLinkToLastBuild: true,
         keepAll              : true,
-        reportDir            : "smoke-test-report/",
+        reportDir            : "smoke-output/report",
         reportFiles          : "index.html",
         reportName           : "Serenity Smoke Test Report"
     ]
   }
 
   afterAlways('functionalTest:stg') {
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-test-report/**/*'
-    archiveZephyrReports()
+    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
 
     publishHTML target: [
         allowMissing         : true,
         alwaysLinkToLastBuild: true,
         keepAll              : true,
-        reportDir            : "functional-test-report/",
+        reportDir            : "functional-output/report",
         reportFiles          : "index.html",
         reportName           : "Serenity Functional Test Report"
     ]
@@ -205,20 +197,19 @@ withPipeline(type, product, component) {
         allowMissing         : true,
         alwaysLinkToLastBuild: true,
         keepAll              : true,
-        reportDir            : "functional-test-report/htmlReport/",
+        reportDir            : "functional-output/report/htmlReport",
         reportFiles          : "test-summary.html",
         reportName           : "Test Summary Report"
     ]
   }
   afterAlways('smoketest:stg') {
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-test-report/**/*'
-    archiveZephyrReports()
+    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-output/**/*'
 
     publishHTML target: [
         allowMissing         : true,
         alwaysLinkToLastBuild: true,
         keepAll              : true,
-        reportDir            : "smoke-test-report/",
+        reportDir            : "smoke-output/report",
         reportFiles          : "index.html",
         reportName           : "Serenity Smoke Test Report"
     ]

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -6,6 +6,7 @@ properties([
   parameters([
     booleanParam(name: 'Integration', defaultValue: true, description: 'Run integration tests'),
     booleanParam(name: 'Functional', defaultValue: true, description: 'Run functional tests'),
+    booleanParam(name: 'Smoke', defaultValue: true, description: 'Run smoke tests'),
     booleanParam(name: 'Demo', defaultValue: true, description: 'Run R1A functional tests against demo'),
     booleanParam(name: 'RunR1AOff', defaultValue: false, description: 'Run R1AOff functional tests against demo'),
     booleanParam(name: 'ZephyrExecution', defaultValue: false, description: 'Create Zephyr Execution'),
@@ -84,16 +85,16 @@ def configureZephyrExecution = { testEnvironment ->
 def publishIntegrationResults = {
   steps.junit '**/test-results/integration/*.xml'
   steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/integration/*.xml'
-  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'target/zephyr-reports/**/*.json'
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'integration-output/**/*'
 }
 
-def publishFunctionalResults = { reportNameSuffix ->
-  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-test-report/**/*'
+def publishFunctionalResults = { reportDirectory, reportNameSuffix ->
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: "${reportDirectory}/**/*"
   publishHTML target: [
     allowMissing         : true,
     alwaysLinkToLastBuild: true,
     keepAll              : true,
-    reportDir            : "functional-test-report/",
+    reportDir            : "${reportDirectory}/report",
     reportFiles          : "index.html",
     reportName           : "Serenity Functional Test Report${reportNameSuffix}"
   ]
@@ -101,13 +102,34 @@ def publishFunctionalResults = { reportNameSuffix ->
     allowMissing         : true,
     alwaysLinkToLastBuild: true,
     keepAll              : true,
-    reportDir            : "functional-test-report/htmlReport/",
+    reportDir            : "${reportDirectory}/report/htmlReport",
     reportFiles          : "test-summary.html",
     reportName           : "Test Summary Report${reportNameSuffix}"
   ]
   steps.junit allowEmptyResults: true, testResults: '**/test-results/functional/*.xml'
   steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/functional/*.xml'
-  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'target/zephyr/**/*.json'
+}
+
+def publishSmokeResults = { reportNameSuffix ->
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-output/**/*'
+  publishHTML target: [
+    allowMissing         : true,
+    alwaysLinkToLastBuild: true,
+    keepAll              : true,
+    reportDir            : "smoke-output/report",
+    reportFiles          : "index.html",
+    reportName           : "Serenity Smoke Test Report${reportNameSuffix}"
+  ]
+  publishHTML target: [
+    allowMissing         : true,
+    alwaysLinkToLastBuild: true,
+    keepAll              : true,
+    reportDir            : "smoke-output/report/htmlReport",
+    reportFiles          : "test-summary.html",
+    reportName           : "Smoke Test Summary Report${reportNameSuffix}"
+  ]
+  steps.junit allowEmptyResults: true, testResults: '**/test-results/smoke/*.xml'
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/smoke/*.xml'
 }
 
 def runIntegrationStage = { stageName, gradleTask ->
@@ -137,7 +159,25 @@ def runFunctionalStage = { stageName, shouldRunWithZephyr, reportNameSuffix ->
         steps.echo "${stageName} failed, but continuing with the pipeline. Error: " + error.message
       } finally {
         try {
-          publishFunctionalResults(reportNameSuffix)
+          publishFunctionalResults('functional-output', reportNameSuffix)
+        } catch (publishError) {
+          steps.echo "${stageName} result publication failed, but continuing with the pipeline. Error: " + publishError.message
+        }
+      }
+    }
+  }
+}
+
+def runSmokeStage = { stageName, reportNameSuffix ->
+  if (params.Smoke) {
+    stage(stageName) {
+      try {
+        builder.gradle('smoke')
+      } catch (error) {
+        steps.echo "${stageName} failed, but continuing with the pipeline. Error: " + error.message
+      } finally {
+        try {
+          publishSmokeResults(reportNameSuffix)
         } catch (publishError) {
           steps.echo "${stageName} result publication failed, but continuing with the pipeline. Error: " + publishError.message
         }
@@ -154,14 +194,14 @@ def runTaggedFunctionalStage = { enabled, stageName, shouldRunWithZephyr, report
           if (shouldRunWithZephyr) {
             builder.gradle('clearReports functionalOpalTagsWithZephyrExecution')
           } else {
-            builder.gradle('clearReports functionalOpalTags aggregate copyFunctionalReport mergeFunctionalOpalTagsResults generateTestSummary')
+            builder.gradle('clearReports functionalOpalTags aggregate copyDemoFunctionalReport mergeFunctionalOpalTagsResults generateDemoTestSummary packageDemoFunctionalOutput')
           }
         }
       } catch (error) {
         steps.echo "${stageName} failed, but continuing with the pipeline. Error: " + error.message
       } finally {
         try {
-          publishFunctionalResults(reportNameSuffix)
+          publishFunctionalResults('functional-output-demo', reportNameSuffix)
         } catch (publishError) {
           steps.echo "${stageName} result publication failed, but continuing with the pipeline. Error: " + publishError.message
         }
@@ -178,6 +218,7 @@ withNightlyPipeline(type, product, component) {
   afterAlways('DependencyCheckNightly') {
     echo 'Integration:' + params.Integration
     echo 'Functional:' + params.Functional
+    echo 'Smoke:' + params.Smoke
     echo 'Demo:' + params.Demo
     echo 'RunR1AOff:' + params.RunR1AOff
 
@@ -190,6 +231,7 @@ withNightlyPipeline(type, product, component) {
     }
     runIntegrationStage('Integration Tests', 'Integration')
     runFunctionalStage('Functional Tests', shouldRunWithZephyr, testEnvironments.staging.reportNameSuffix)
+    runSmokeStage('Smoke Tests', testEnvironments.staging.reportNameSuffix)
 
     if (params.Demo) {
       configureTestEnvironment(testEnvironments.demo)

--- a/README.md
+++ b/README.md
@@ -307,22 +307,32 @@ Run the matching functional or integration suite first if the report is not alre
 | --- | --- |
 | `functionalWithZephyrExecution` | Runs the default Opal functional suite, creates an Opal Cucumber report copy, creates an Opal Zephyr execution, then runs the Legacy functional suite and creates a Legacy Zephyr execution. |
 | `functionalWithTagsWithZephyrExecution` | Runs the default Opal functional suite and the tagged Opal functional suite selected by `TAGS` or `-Ptags`, then creates Zephyr executions for both reports. |
-| `functionalOpalWithZephyrExecution` | Runs only `functionalOpal`, copies its Cucumber report to `target/zephyr/cucumber-opal.json`, and creates the Opal Zephyr execution. |
-| `functionalOpalTagsWithZephyrExecution` | Runs only `functionalOpalTags`, copies its Cucumber report to `target/zephyr/cucumber-opal-tags.json`, and creates the tagged Opal Zephyr execution. |
-| `functionalLegacyWithZephyrExecution` | Runs only `functionalLegacy`, copies its Cucumber report to `target/zephyr/cucumber-legacy.json`, and creates the Legacy Zephyr execution. |
+| `functionalOpalWithZephyrExecution` | Runs only `functionalOpal`, copies its Cucumber report to `functional-output/zephyr/cucumber-opal.json`, and creates the Opal Zephyr execution. |
+| `functionalOpalTagsWithZephyrExecution` | Runs only `functionalOpalTags`, copies its Cucumber report to `functional-output-demo/zephyr/cucumber-opal-tags.json`, and creates the tagged Opal Zephyr execution. |
+| `functionalLegacyWithZephyrExecution` | Runs only `functionalLegacy`, copies its Cucumber report to `functional-output/zephyr/cucumber-legacy.json`, and creates the Legacy Zephyr execution. |
+| `smokeWithZephyrExecution` | Runs `smokeOpal`, copies its Cucumber report to `smoke-output/zephyr/cucumber-smoke.json`, and creates the smoke Zephyr execution. |
 
 | `createJiraTicketsFromCucumberReport` | Creates and links Jira test tickets from `target/cucumber.json`. |
 | `updateJiraTicketsFromCucumberReport` | Updates Jira test tickets from `target/cucumber.json`. |
+| `createJiraTicketsFromOpalCucumberReport` | Creates and links Jira test tickets from `functional-output/zephyr/cucumber-opal.json`. |
+| `updateJiraTicketsFromOpalCucumberReport` | Updates Jira test tickets from `functional-output/zephyr/cucumber-opal.json`. |
+| `createJiraTicketsFromOpalTagsCucumberReport` | Creates and links Jira test tickets from `functional-output-demo/zephyr/cucumber-opal-tags.json`. |
+| `updateJiraTicketsFromOpalTagsCucumberReport` | Updates Jira test tickets from `functional-output-demo/zephyr/cucumber-opal-tags.json`. |
+| `createJiraTicketsFromLegacyCucumberReport` | Creates and links Jira test tickets from `functional-output/zephyr/cucumber-legacy.json`. |
+| `updateJiraTicketsFromLegacyCucumberReport` | Updates Jira test tickets from `functional-output/zephyr/cucumber-legacy.json`. |
+| `createJiraTicketsFromSmokeCucumberReport` | Creates and links Jira test tickets from `smoke-output/zephyr/cucumber-smoke.json`. |
+| `updateJiraTicketsFromSmokeCucumberReport` | Updates Jira test tickets from `smoke-output/zephyr/cucumber-smoke.json`. |
 
 | `createJiraExecutionFromCucumberReport` | Creates a Zephyr execution from `target/cucumber.json`. |
-| `createJiraExecutionFromOpalCucumberReport` | Creates a Zephyr execution from `target/zephyr/cucumber-opal.json`. |
-| `createJiraExecutionFromOpalTagsCucumberReport` | Creates a Zephyr execution from `target/zephyr/cucumber-opal-tags.json`. |
-| `createJiraExecutionFromLegacyCucumberReport` | Creates a Zephyr execution from `target/zephyr/cucumber-legacy.json`. |
+| `createJiraExecutionFromOpalCucumberReport` | Creates a Zephyr execution from `functional-output/zephyr/cucumber-opal.json`. |
+| `createJiraExecutionFromOpalTagsCucumberReport` | Creates a Zephyr execution from `functional-output-demo/zephyr/cucumber-opal-tags.json`. |
+| `createJiraExecutionFromLegacyCucumberReport` | Creates a Zephyr execution from `functional-output/zephyr/cucumber-legacy.json`. |
+| `createJiraExecutionFromSmokeCucumberReport` | Creates a Zephyr execution from `smoke-output/zephyr/cucumber-smoke.json`. |
 
 | `integrationTestWithZephyrExecution` | Runs `integration`, then creates a Zephyr execution from the generated JUnit5 integration report. |
-| `createJiraTicketsFromJUnit5ReportIntegrationTest` | Creates and links Jira test tickets from `target/zephyr-reports/Junit5Report-IntegrationTest.json`. |
-| `updateJiraTicketsFromJUnit5ReportIntegrationTest` | Updates Jira test tickets from `target/zephyr-reports/Junit5Report-IntegrationTest.json`. |
-| `createJiraExecutionFromJUnit5ReportIntegrationTest` | Creates a Zephyr execution from `target/zephyr-reports/Junit5Report-IntegrationTest.json`. |
+| `createJiraTicketsFromJUnit5ReportIntegrationTest` | Creates and links Jira test tickets from `integration-output/zephyr/Junit5Report-IntegrationTest.json`. |
+| `updateJiraTicketsFromJUnit5ReportIntegrationTest` | Updates Jira test tickets from `integration-output/zephyr/Junit5Report-IntegrationTest.json`. |
+| `createJiraExecutionFromJUnit5ReportIntegrationTest` | Creates a Zephyr execution from `integration-output/zephyr/Junit5Report-IntegrationTest.json`. |
 
 ## Manual api testing (Postman)
 

--- a/build.gradle
+++ b/build.gradle
@@ -358,7 +358,7 @@ tasks.register('copyDemoFunctionalReport', Copy) {
   logger.quiet("Demo Functional Test Report available at - file://${rootDir}/functional-test-report-demo/index.html")
 }
 tasks.register('packageFunctionalOutput', Sync) {
-  dependsOn 'copyFunctionalReport', 'generateTestSummary'
+  dependsOn 'copyFunctionalReport', 'generateTestSummary', 'copyOpalCucumberJson', 'copyLegacyCucumberJson'
   into("${rootDir}/functional-output")
   from("${rootDir}/functional-test-report") {
     into("report")
@@ -369,7 +369,7 @@ tasks.register('packageFunctionalOutput', Sync) {
   }
 }
 tasks.register('packageDemoFunctionalOutput', Sync) {
-  dependsOn 'copyDemoFunctionalReport', 'generateDemoTestSummary'
+  dependsOn 'copyDemoFunctionalReport', 'generateDemoTestSummary', 'copyOpalTagsCucumberJson'
   into("${rootDir}/functional-output-demo")
   from("${rootDir}/functional-test-report-demo") {
     into("report")

--- a/build.gradle
+++ b/build.gradle
@@ -357,36 +357,30 @@ tasks.register('copyDemoFunctionalReport', Copy) {
   into("${rootDir}/functional-test-report-demo")
   logger.quiet("Demo Functional Test Report available at - file://${rootDir}/functional-test-report-demo/index.html")
 }
-tasks.register('packageFunctionalOutput', Sync) {
+tasks.register('packageFunctionalOutput', Copy) {
   dependsOn 'copyFunctionalReport', 'generateTestSummary', 'copyOpalCucumberJson', 'copyLegacyCucumberJson'
   into("${rootDir}/functional-output")
   from("${rootDir}/functional-test-report") {
     into("report")
   }
-  from("target/zephyr") {
-    include "cucumber-opal.json", "cucumber-legacy.json"
-    into("zephyr")
-  }
 }
-tasks.register('packageDemoFunctionalOutput', Sync) {
+tasks.register('packageDemoFunctionalOutput', Copy) {
   dependsOn 'copyDemoFunctionalReport', 'generateDemoTestSummary', 'copyOpalTagsCucumberJson'
   into("${rootDir}/functional-output-demo")
   from("${rootDir}/functional-test-report-demo") {
     into("report")
   }
-  from("target/zephyr") {
-    include "cucumber-opal-tags.json"
-    into("zephyr")
-  }
 }
-tasks.register('packageIntegrationOutput', Sync) {
+tasks.register('copyIntegrationJunit5Report', Copy) {
+  from("target/zephyr-reports/Junit5Report-IntegrationTest.json")
+  into("${rootDir}/integration-output/zephyr")
+  outputs.upToDateWhen { false }
+}
+tasks.register('packageIntegrationOutput', Copy) {
+  dependsOn 'copyIntegrationJunit5Report'
   into("${rootDir}/integration-output")
   from(layout.buildDirectory.dir("reports/tests/integration")) {
     into("report")
-  }
-  from("target/zephyr-reports") {
-    include "Junit5Report-IntegrationTest.json"
-    into("zephyr")
   }
 }
 tasks.register('mergeFunctionalResults', Copy) {
@@ -500,19 +494,15 @@ tasks.register('copySmokeReport', Copy) {
 }
 tasks.register('copySmokeCucumberJson', Copy) {
   from("target/cucumber.json")
-  into("target/zephyr")
+  into("${rootDir}/smoke-output/zephyr")
   rename { "cucumber-smoke.json" }
   outputs.upToDateWhen { false }
 }
-tasks.register('packageSmokeOutput', Sync) {
+tasks.register('packageSmokeOutput', Copy) {
   dependsOn 'copySmokeReport', 'generateSmokeTestSummary', 'copySmokeCucumberJson'
   into("${rootDir}/smoke-output")
   from("${rootDir}/smoke-test-report") {
     into("report")
-  }
-  from("target/zephyr") {
-    include "cucumber-smoke.json"
-    into("zephyr")
   }
 }
 
@@ -921,21 +911,21 @@ tasks.register('functionalWithTagsWithZephyrExecution') {
 
 tasks.register('copyOpalCucumberJson', Copy) {
   from("target/cucumber.json")
-  into("target/zephyr")
+  into("${rootDir}/functional-output/zephyr")
   rename { "cucumber-opal.json" }
   outputs.upToDateWhen { false }
 }
 
 tasks.register('copyOpalTagsCucumberJson', Copy) {
   from("target/cucumber.json")
-  into("target/zephyr")
+  into("${rootDir}/functional-output-demo/zephyr")
   rename { "cucumber-opal-tags.json" }
   outputs.upToDateWhen { false }
 }
 
 tasks.register('copyLegacyCucumberJson', Copy) {
   from("target/cucumber.json")
-  into("target/zephyr")
+  into("${rootDir}/functional-output/zephyr")
   rename { "cucumber-legacy.json" }
   outputs.upToDateWhen { false }
 }
@@ -964,11 +954,107 @@ tasks.register('updateJiraTicketsFromCucumberReport', JavaExec) {
   args = zephyrArgs("CUCUMBER_JSON_REPORT", "UPDATE_TICKETS", "functionalTest/resources", cucumberJson.absolutePath)
 }
 
+tasks.register('createJiraTicketsFromOpalCucumberReport', JavaExec) {
+  group = "Zephyr Reporting - Cucumber"
+  description = "Processes cucumber-opal.json to create and link Jira tickets to each test"
+  def opalCucumberJson = file("functional-output/zephyr/cucumber-opal.json")
+
+  inputs.file(opalCucumberJson)
+
+  classpath = configurations.zephyrCucumberReportProcessor
+  mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
+  args = zephyrArgs("CUCUMBER_JSON_REPORT", "CREATE_TICKETS", "functionalTest/resources", opalCucumberJson.absolutePath)
+}
+
+tasks.register('updateJiraTicketsFromOpalCucumberReport', JavaExec) {
+  group = "Zephyr Reporting - Cucumber"
+  description = "Processes cucumber-opal.json to update Jira tickets"
+  def opalCucumberJson = file("functional-output/zephyr/cucumber-opal.json")
+
+  inputs.file(opalCucumberJson)
+
+  classpath = configurations.zephyrCucumberReportProcessor
+  mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
+  args = zephyrArgs("CUCUMBER_JSON_REPORT", "UPDATE_TICKETS", "functionalTest/resources", opalCucumberJson.absolutePath)
+}
+
+tasks.register('createJiraTicketsFromOpalTagsCucumberReport', JavaExec) {
+  group = "Zephyr Reporting - Cucumber"
+  description = "Processes cucumber-opal-tags.json to create and link Jira tickets to each test"
+  def opalTagsCucumberJson = file("functional-output-demo/zephyr/cucumber-opal-tags.json")
+
+  inputs.file(opalTagsCucumberJson)
+
+  classpath = configurations.zephyrCucumberReportProcessor
+  mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
+  args = zephyrArgs("CUCUMBER_JSON_REPORT", "CREATE_TICKETS", "functionalTest/resources", opalTagsCucumberJson.absolutePath)
+}
+
+tasks.register('updateJiraTicketsFromOpalTagsCucumberReport', JavaExec) {
+  group = "Zephyr Reporting - Cucumber"
+  description = "Processes cucumber-opal-tags.json to update Jira tickets"
+  def opalTagsCucumberJson = file("functional-output-demo/zephyr/cucumber-opal-tags.json")
+
+  inputs.file(opalTagsCucumberJson)
+
+  classpath = configurations.zephyrCucumberReportProcessor
+  mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
+  args = zephyrArgs("CUCUMBER_JSON_REPORT", "UPDATE_TICKETS", "functionalTest/resources", opalTagsCucumberJson.absolutePath)
+}
+
+tasks.register('createJiraTicketsFromLegacyCucumberReport', JavaExec) {
+  group = "Zephyr Reporting - Cucumber"
+  description = "Processes cucumber-legacy.json to create and link Jira tickets to each test"
+  def legacyCucumberJson = file("functional-output/zephyr/cucumber-legacy.json")
+
+  inputs.file(legacyCucumberJson)
+
+  classpath = configurations.zephyrCucumberReportProcessor
+  mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
+  args = zephyrArgs("CUCUMBER_JSON_REPORT", "CREATE_TICKETS", "functionalTest/resources", legacyCucumberJson.absolutePath)
+}
+
+tasks.register('updateJiraTicketsFromLegacyCucumberReport', JavaExec) {
+  group = "Zephyr Reporting - Cucumber"
+  description = "Processes cucumber-legacy.json to update Jira tickets"
+  def legacyCucumberJson = file("functional-output/zephyr/cucumber-legacy.json")
+
+  inputs.file(legacyCucumberJson)
+
+  classpath = configurations.zephyrCucumberReportProcessor
+  mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
+  args = zephyrArgs("CUCUMBER_JSON_REPORT", "UPDATE_TICKETS", "functionalTest/resources", legacyCucumberJson.absolutePath)
+}
+
+tasks.register('createJiraTicketsFromSmokeCucumberReport', JavaExec) {
+  group = "Zephyr Reporting - Cucumber"
+  description = "Processes cucumber-smoke.json to create and link Jira tickets to each test"
+  def smokeCucumberJson = file("smoke-output/zephyr/cucumber-smoke.json")
+
+  inputs.file(smokeCucumberJson)
+
+  classpath = configurations.zephyrCucumberReportProcessor
+  mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
+  args = zephyrArgs("CUCUMBER_JSON_REPORT", "CREATE_TICKETS", "functionalTest/resources", smokeCucumberJson.absolutePath)
+}
+
+tasks.register('updateJiraTicketsFromSmokeCucumberReport', JavaExec) {
+  group = "Zephyr Reporting - Cucumber"
+  description = "Processes cucumber-smoke.json to update Jira tickets"
+  def smokeCucumberJson = file("smoke-output/zephyr/cucumber-smoke.json")
+
+  inputs.file(smokeCucumberJson)
+
+  classpath = configurations.zephyrCucumberReportProcessor
+  mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
+  args = zephyrArgs("CUCUMBER_JSON_REPORT", "UPDATE_TICKETS", "functionalTest/resources", smokeCucumberJson.absolutePath)
+}
+
 
 tasks.register('createJiraTicketsFromJUnit5ReportIntegrationTest', JavaExec) {
   group = "Zephyr Reporting - JUnit5"
   description = "Processes Junit5Report-IntegrationTest.json to create and link Jira tickets to each test"
-  def junit5ReportJson = file("target/zephyr-reports/Junit5Report-IntegrationTest.json")
+  def junit5ReportJson = file("integration-output/zephyr/Junit5Report-IntegrationTest.json")
 
   inputs.file(junit5ReportJson)
 
@@ -981,7 +1067,7 @@ tasks.register('updateJiraTicketsFromJUnit5ReportIntegrationTest', JavaExec) {
   group = "Zephyr Reporting - JUnit5"
 
   description = "Processes Junit5Report-IntegrationTest.json to update Jira tickets"
-  def junit5ReportJson = file("target/zephyr-reports/Junit5Report-IntegrationTest.json")
+  def junit5ReportJson = file("integration-output/zephyr/Junit5Report-IntegrationTest.json")
 
   inputs.file(junit5ReportJson)
 
@@ -994,7 +1080,7 @@ tasks.register('createJiraExecutionFromJUnit5ReportIntegrationTest', JavaExec) {
   group = "Zephyr Reporting - JUnit5"
 
   description = "Processes Junit5Report-IntegrationTest.json to create Zephyr executions"
-  def junit5ReportJson = file("target/zephyr-reports/Junit5Report-IntegrationTest.json")
+  def junit5ReportJson = file("integration-output/zephyr/Junit5Report-IntegrationTest.json")
 
   inputs.file(junit5ReportJson)
 
@@ -1021,7 +1107,7 @@ tasks.register('createJiraExecutionFromLegacyCucumberReport', JavaExec) {
   group = "Zephyr Reporting - Cucumber"
   classpath = configurations.zephyrCucumberReportProcessor
   mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-  def legacyCucumberJson = file("target/zephyr/cucumber-legacy.json")
+  def legacyCucumberJson = file("functional-output/zephyr/cucumber-legacy.json")
   inputs.file(legacyCucumberJson)
 
   args = zephyrArgs("CUCUMBER_JSON_REPORT", "CREATE_EXECUTION", "functionalTest/resources", legacyCucumberJson.absolutePath)
@@ -1031,7 +1117,7 @@ tasks.register('createJiraExecutionFromOpalCucumberReport', JavaExec) {
   group = "Zephyr Reporting - Cucumber"
   classpath = configurations.zephyrCucumberReportProcessor
   mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-  def opalCucumberJson = file("target/zephyr/cucumber-opal.json")
+  def opalCucumberJson = file("functional-output/zephyr/cucumber-opal.json")
   inputs.file(opalCucumberJson)
 
   args = zephyrArgs("CUCUMBER_JSON_REPORT", "CREATE_EXECUTION", "functionalTest/resources", opalCucumberJson.absolutePath)
@@ -1041,10 +1127,20 @@ tasks.register('createJiraExecutionFromOpalTagsCucumberReport', JavaExec) {
   group = "Zephyr Reporting - Cucumber"
   classpath = configurations.zephyrCucumberReportProcessor
   mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-  def opalTagsCucumberJson = file("target/zephyr/cucumber-opal-tags.json")
+  def opalTagsCucumberJson = file("functional-output-demo/zephyr/cucumber-opal-tags.json")
   inputs.file(opalTagsCucumberJson)
 
   args = zephyrArgs("CUCUMBER_JSON_REPORT", "CREATE_EXECUTION", "functionalTest/resources", opalTagsCucumberJson.absolutePath)
+}
+
+tasks.register('createJiraExecutionFromSmokeCucumberReport', JavaExec) {
+  group = "Zephyr Reporting - Cucumber"
+  classpath = configurations.zephyrCucumberReportProcessor
+  mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
+  def smokeCucumberJson = file("smoke-output/zephyr/cucumber-smoke.json")
+  inputs.file(smokeCucumberJson)
+
+  args = zephyrArgs("CUCUMBER_JSON_REPORT", "CREATE_EXECUTION", "functionalTest/resources", smokeCucumberJson.absolutePath)
 }
 
 tasks.register('functionalOpalWithZephyrExecution') {
@@ -1081,6 +1177,21 @@ tasks.register('functionalLegacyWithZephyrExecution') {
 
   tasks.copyLegacyCucumberJson.mustRunAfter functionalLegacy
   tasks.createJiraExecutionFromLegacyCucumberReport.mustRunAfter copyLegacyCucumberJson
+}
+
+tasks.register('smokeWithZephyrExecution') {
+  group = "Zephyr Reporting - Cucumber"
+  description = "Runs smoke then creates the Zephyr execution from the cucumber report"
+
+  dependsOn('smokeOpal', 'copySmokeCucumberJson', 'createJiraExecutionFromSmokeCucumberReport',
+          'aggregate', 'copySmokeReport', 'generateSmokeTestSummary')
+
+  tasks.copySmokeCucumberJson.mustRunAfter smokeOpal
+  tasks.createJiraExecutionFromSmokeCucumberReport.mustRunAfter copySmokeCucumberJson
+  tasks.aggregate.mustRunAfter createJiraExecutionFromSmokeCucumberReport
+  tasks.copySmokeReport.mustRunAfter aggregate
+  tasks.generateSmokeTestSummary.mustRunAfter copySmokeReport
+  finalizedBy 'packageSmokeOutput'
 }
 
 tasks.register('integrationTestWithZephyrExecution') {

--- a/build.gradle
+++ b/build.gradle
@@ -273,6 +273,7 @@ tasks.register('integration', Test) {
   doFirst {
     pullLatestLegacyStubImageIfLocal()
   }
+  finalizedBy 'packageIntegrationOutput'
 }
 
 tasks.register('checkTestJiraAnnotations', JavaExec) {
@@ -350,6 +351,44 @@ tasks.register('copyFunctionalReport', Copy) {
   into("${rootDir}/functional-test-report")
   logger.quiet("Functional Test Report available at - file://${rootDir}/functional-test-report/index.html")
 }
+tasks.register('copyDemoFunctionalReport', Copy) {
+  dependsOn 'aggregate'
+  from("${rootDir}/target/site/serenity")
+  into("${rootDir}/functional-test-report-demo")
+  logger.quiet("Demo Functional Test Report available at - file://${rootDir}/functional-test-report-demo/index.html")
+}
+tasks.register('packageFunctionalOutput', Sync) {
+  dependsOn 'copyFunctionalReport', 'generateTestSummary'
+  into("${rootDir}/functional-output")
+  from("${rootDir}/functional-test-report") {
+    into("report")
+  }
+  from("target/zephyr") {
+    include "cucumber-opal.json", "cucumber-legacy.json"
+    into("zephyr")
+  }
+}
+tasks.register('packageDemoFunctionalOutput', Sync) {
+  dependsOn 'copyDemoFunctionalReport', 'generateDemoTestSummary'
+  into("${rootDir}/functional-output-demo")
+  from("${rootDir}/functional-test-report-demo") {
+    into("report")
+  }
+  from("target/zephyr") {
+    include "cucumber-opal-tags.json"
+    into("zephyr")
+  }
+}
+tasks.register('packageIntegrationOutput', Sync) {
+  into("${rootDir}/integration-output")
+  from(layout.buildDirectory.dir("reports/tests/integration")) {
+    into("report")
+  }
+  from("target/zephyr-reports") {
+    include "Junit5Report-IntegrationTest.json"
+    into("zephyr")
+  }
+}
 tasks.register('mergeFunctionalResults', Copy) {
   dependsOn 'functionalOpal', 'functionalLegacy'
   from layout.buildDirectory.dir("test-results/functional/opal")
@@ -376,6 +415,38 @@ tasks.register('generateTestSummary', JavaExec) {
   dependsOn 'copyFunctionalReport'
   classpath = sourceSets.functionalTest.runtimeClasspath
   mainClass = 'uk.gov.hmcts.opal.scripts.TestReportSummaryGenerator'
+  args = [
+    "--integration-dir=${layout.buildDirectory.dir('test-results/integration').get().asFile.absolutePath}",
+    "--functional-dir=${layout.buildDirectory.dir('test-results/functional').get().asFile.absolutePath}",
+    "--output-dir=${file('functional-test-report').absolutePath}",
+    "--title=Test Summary Report"
+  ]
+}
+tasks.register('generateDemoTestSummary', JavaExec) {
+  group = "Reporting"
+  description = "Generate an HTML summary for the demo tagged functional run"
+  dependsOn 'copyDemoFunctionalReport'
+  classpath = sourceSets.functionalTest.runtimeClasspath
+  mainClass = 'uk.gov.hmcts.opal.scripts.TestReportSummaryGenerator'
+  args = [
+    "--integration-dir=${layout.buildDirectory.dir('test-results/functional-empty').get().asFile.absolutePath}",
+    "--functional-dir=${layout.buildDirectory.dir('test-results/functional').get().asFile.absolutePath}",
+    "--output-dir=${file('functional-test-report-demo').absolutePath}",
+    "--title=Test Summary Report (Demo)"
+  ]
+}
+tasks.register('generateSmokeTestSummary', JavaExec) {
+  group = "Reporting"
+  description = "Generate an HTML summary for the smoke run"
+  dependsOn 'copySmokeReport'
+  classpath = sourceSets.functionalTest.runtimeClasspath
+  mainClass = 'uk.gov.hmcts.opal.scripts.TestReportSummaryGenerator'
+  args = [
+    "--integration-dir=${layout.buildDirectory.dir('test-results/functional-empty').get().asFile.absolutePath}",
+    "--functional-dir=${layout.buildDirectory.dir('test-results/smoke').get().asFile.absolutePath}",
+    "--output-dir=${file('smoke-test-report').absolutePath}",
+    "--title=Smoke Test Summary Report"
+  ]
 }
 
 tasks.register('functional') {
@@ -389,20 +460,22 @@ tasks.register('functional') {
   tasks.aggregate.mustRunAfter functionalLegacy
   tasks.copyFunctionalReport.mustRunAfter aggregate
   tasks.generateTestSummary.mustRunAfter copyFunctionalReport
+  finalizedBy 'packageFunctionalOutput'
 }
 
 tasks.register('functionalWithTags') {
   description = "Runs functional tests with the default Opal suite plus tagged Opal scenarios"
   group = "Verification"
   gradle.startParameter.continueOnFailure = true
-  dependsOn('clearReports', 'functionalOpal', 'functionalOpalTags', 'aggregate', 'copyFunctionalReport',
-    'mergeFunctionalWithTagsResults', 'generateTestSummary')
+  dependsOn('clearReports', 'functionalOpal', 'functionalOpalTags', 'aggregate', 'copyDemoFunctionalReport',
+    'mergeFunctionalWithTagsResults', 'generateDemoTestSummary')
   tasks.functionalOpal.mustRunAfter clearReports
   tasks.functionalOpalTags.mustRunAfter functionalOpal
   tasks.mergeFunctionalWithTagsResults.mustRunAfter functionalOpalTags
   tasks.aggregate.mustRunAfter functionalOpalTags
-  tasks.copyFunctionalReport.mustRunAfter aggregate
-  tasks.generateTestSummary.mustRunAfter copyFunctionalReport
+  tasks.copyDemoFunctionalReport.mustRunAfter aggregate
+  tasks.generateDemoTestSummary.mustRunAfter copyDemoFunctionalReport
+  finalizedBy 'packageDemoFunctionalOutput'
 }
 
 
@@ -416,6 +489,7 @@ tasks.register('smokeOpal', Test) {
   gradle.startParameter.continueOnFailure = true
 
   include '**/SmokeTestRunner.class'
+  finalizedBy 'copySmokeCucumberJson'
 
 }
 tasks.register('copySmokeReport', Copy) {
@@ -424,15 +498,34 @@ tasks.register('copySmokeReport', Copy) {
   into("${rootDir}/smoke-test-report")
   logger.quiet("Smoke Test Report available at - file://${rootDir}/smoke-test-report/index.html")
 }
+tasks.register('copySmokeCucumberJson', Copy) {
+  from("target/cucumber.json")
+  into("target/zephyr")
+  rename { "cucumber-smoke.json" }
+  outputs.upToDateWhen { false }
+}
+tasks.register('packageSmokeOutput', Sync) {
+  dependsOn 'copySmokeReport', 'generateSmokeTestSummary', 'copySmokeCucumberJson'
+  into("${rootDir}/smoke-output")
+  from("${rootDir}/smoke-test-report") {
+    into("report")
+  }
+  from("target/zephyr") {
+    include "cucumber-smoke.json"
+    into("zephyr")
+  }
+}
 
 tasks.register('smoke') {
   description = "Runs Smoke Tests"
   group = "Verification"
   gradle.startParameter.continueOnFailure = true
-  dependsOn('clearReports', 'smokeOpal', 'aggregate', 'copySmokeReport')
+  dependsOn('clearReports', 'smokeOpal', 'aggregate', 'copySmokeReport', 'generateSmokeTestSummary')
   tasks.smokeOpal.mustRunAfter clearReports
   tasks.aggregate.mustRunAfter smokeOpal
   tasks.copySmokeReport.mustRunAfter aggregate
+  tasks.generateSmokeTestSummary.mustRunAfter copySmokeReport
+  finalizedBy 'packageSmokeOutput'
 
 }
 
@@ -799,6 +892,7 @@ tasks.register('functionalWithZephyrExecution') {
   tasks.aggregate.mustRunAfter createJiraExecutionFromLegacyCucumberReport
   tasks.copyFunctionalReport.mustRunAfter aggregate
   tasks.generateTestSummary.mustRunAfter copyFunctionalReport
+  finalizedBy 'packageFunctionalOutput'
 }
 
 tasks.register('functionalWithTagsWithZephyrExecution') {
@@ -809,7 +903,7 @@ tasks.register('functionalWithTagsWithZephyrExecution') {
   dependsOn('clearReports',
           'functionalOpal', 'copyOpalCucumberJson', 'createJiraExecutionFromOpalCucumberReport',
           'functionalOpalTags', 'copyOpalTagsCucumberJson', 'createJiraExecutionFromOpalTagsCucumberReport',
-          'aggregate', 'copyFunctionalReport', 'mergeFunctionalWithTagsResults', 'generateTestSummary')
+          'aggregate', 'copyDemoFunctionalReport', 'mergeFunctionalWithTagsResults', 'generateDemoTestSummary')
 
   tasks.functionalOpal.mustRunAfter clearReports
   tasks.copyOpalCucumberJson.mustRunAfter functionalOpal
@@ -820,8 +914,9 @@ tasks.register('functionalWithTagsWithZephyrExecution') {
   tasks.createJiraExecutionFromOpalTagsCucumberReport.mustRunAfter copyOpalTagsCucumberJson
   tasks.mergeFunctionalWithTagsResults.mustRunAfter createJiraExecutionFromOpalTagsCucumberReport
   tasks.aggregate.mustRunAfter createJiraExecutionFromOpalTagsCucumberReport
-  tasks.copyFunctionalReport.mustRunAfter aggregate
-  tasks.generateTestSummary.mustRunAfter copyFunctionalReport
+  tasks.copyDemoFunctionalReport.mustRunAfter aggregate
+  tasks.generateDemoTestSummary.mustRunAfter copyDemoFunctionalReport
+  finalizedBy 'packageDemoFunctionalOutput'
 }
 
 tasks.register('copyOpalCucumberJson', Copy) {
@@ -967,14 +1062,15 @@ tasks.register('functionalOpalTagsWithZephyrExecution') {
   description = "Runs functionalOpalTags then creates the Zephyr execution from the cucumber report"
 
   dependsOn('functionalOpalTags', 'copyOpalTagsCucumberJson', 'createJiraExecutionFromOpalTagsCucumberReport',
-          'aggregate', 'copyFunctionalReport', 'mergeFunctionalOpalTagsResults', 'generateTestSummary')
+          'aggregate', 'copyDemoFunctionalReport', 'mergeFunctionalOpalTagsResults', 'generateDemoTestSummary')
 
   tasks.copyOpalTagsCucumberJson.mustRunAfter functionalOpalTags
   tasks.createJiraExecutionFromOpalTagsCucumberReport.mustRunAfter copyOpalTagsCucumberJson
   tasks.mergeFunctionalOpalTagsResults.mustRunAfter createJiraExecutionFromOpalTagsCucumberReport
   tasks.aggregate.mustRunAfter createJiraExecutionFromOpalTagsCucumberReport
-  tasks.copyFunctionalReport.mustRunAfter aggregate
-  tasks.generateTestSummary.mustRunAfter copyFunctionalReport
+  tasks.copyDemoFunctionalReport.mustRunAfter aggregate
+  tasks.generateDemoTestSummary.mustRunAfter copyDemoFunctionalReport
+  finalizedBy 'packageDemoFunctionalOutput'
 }
 
 tasks.register('functionalLegacyWithZephyrExecution') {
@@ -994,4 +1090,5 @@ tasks.register('integrationTestWithZephyrExecution') {
   dependsOn('integration', 'createJiraExecutionFromJUnit5ReportIntegrationTest')
 
   tasks.createJiraExecutionFromJUnit5ReportIntegrationTest.mustRunAfter integration
+  finalizedBy 'packageIntegrationOutput'
 }

--- a/src/functionalTest/java/uk/gov/hmcts/opal/scripts/TestReportSummaryGenerator.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/scripts/TestReportSummaryGenerator.java
@@ -15,32 +15,17 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 public class TestReportSummaryGenerator {
     private static final Logger log = LoggerFactory.getLogger(TestReportSummaryGenerator.class);
 
     public static void main(String[] args) throws Exception {
-        List<Path> xmlIntegrationPaths = new ArrayList<>();
-        List<Path> xmlFunctionalPaths = new ArrayList<>();
+        ReportOptions options = ReportOptions.fromArgs(args);
+        List<Path> xmlIntegrationPaths = listXmlFiles(options.integrationDir());
+        List<Path> xmlFunctionalPaths = listXmlFiles(options.functionalDir());
 
         final String reportDate = LocalDate.now().format(DateTimeFormatter.ofPattern("dd/MM/yyyy"));
-
-
-        Path integrationDir = Paths.get("build/test-results/integration");
-        Path functionalDir = Paths.get("target/site/serenity");
-
-        if (Files.exists(integrationDir)) {
-            xmlIntegrationPaths.addAll(Files.list(integrationDir)
-                                           .filter(p -> p.toString().endsWith(".xml"))
-                                           .toList());
-        }
-
-        if (Files.exists(functionalDir)) {
-            xmlFunctionalPaths.addAll(Files.list(functionalDir)
-                                          .filter(p -> p.getFileName().toString().startsWith("SERENITY-JUNIT"))
-                                          .filter(p -> p.toString().endsWith(".xml"))
-                                          .toList());
-        }
 
         List<String> integrationRows = new ArrayList<>();
         List<String> functionalRows = new ArrayList<>();
@@ -168,13 +153,14 @@ public class TestReportSummaryGenerator {
         Path sourceScript = Path.of("src/functionalTest/java/uk/gov/hmcts/opal/scripts/script.js");
         String scriptContent = Files.readString(sourceScript, StandardCharsets.UTF_8);
 
-        Path output = Paths.get("functional-test-report/htmlReport/test-summary.html");
+        Path output = options.outputDir().resolve("htmlReport/test-summary.html");
         Files.createDirectories(output.getParent());
         Files.writeString(
             output, String.format(
                 """
                         <html>
                         <head>
+                            <title>%s</title>
                             <style>
                             %s
                             </style>
@@ -183,7 +169,7 @@ public class TestReportSummaryGenerator {
                             </script>
                         </head>
                         <body>
-                        <h1>Test Summary Report</h1>
+                        <h1>%s</h1>
                         <p> Report generated data: %s</p>
                         <div class="summaries">
                         <div class="overall">
@@ -249,8 +235,10 @@ public class TestReportSummaryGenerator {
 
                         </body></html>
                     """,
+                options.title(),
                 cssContent,
                 scriptContent,
+                options.title(),
                 reportDate,
                 totalAll,
                 passedAll,
@@ -273,5 +261,48 @@ public class TestReportSummaryGenerator {
         );
 
         log.info("HTML test summary written to: {}", output.toAbsolutePath());
+    }
+
+    private static List<Path> listXmlFiles(Path directory) throws Exception {
+        if (!Files.exists(directory)) {
+            return List.of();
+        }
+
+        try (Stream<Path> files = Files.list(directory)) {
+            return files
+                .filter(path -> path.toString().endsWith(".xml"))
+                .sorted()
+                .toList();
+        }
+    }
+
+    private record ReportOptions(Path integrationDir, Path functionalDir, Path outputDir, String title) {
+        private static final String DEFAULT_TITLE = "Test Summary Report";
+
+        private static ReportOptions fromArgs(String[] args) {
+            Path integrationDir = Paths.get("build/test-results/integration");
+            Path functionalDir = Paths.get("build/test-results/functional");
+            Path outputDir = Paths.get("functional-test-report");
+            String title = DEFAULT_TITLE;
+
+            for (String arg : args) {
+                String[] parts = arg.split("=", 2);
+                if (parts.length != 2) {
+                    continue;
+                }
+
+                switch (parts[0]) {
+                    case "--integration-dir" -> integrationDir = Paths.get(parts[1]);
+                    case "--functional-dir" -> functionalDir = Paths.get(parts[1]);
+                    case "--output-dir" -> outputDir = Paths.get(parts[1]);
+                    case "--title" -> title = parts[1];
+                    default -> {
+                        // Ignore unknown options to keep the generator backward compatible.
+                    }
+                }
+            }
+
+            return new ReportOptions(integrationDir, functionalDir, outputDir, title);
+        }
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Standardise test artifacts into stage output folders and add nightly smoke reporting
Summary :
This changes the test reporting layout so CI publishes stage-specific output folders instead of relying on raw target artifacts.
The pipeline now produces:
•integration-output/report and integration-output/zephyr
•functional-output/report and functional-output/zephyr
•functional-output-demo/report and functional-output-demo/zephyr
•smoke-output/report and smoke-output/zephyr

It also fixes the demo functional reporting path and adds smoke execution/reporting to the nightly pipeline.
Changes:
•Updated the functional summary generator to accept explicit input/output directories and titles.
•Split normal functional and demo functional report output so they do not overwrite each other.
•Added packaging tasks to assemble stage-specific output folders containing:
◦report/ for HTML reports
◦zephyr/ for cucumber/JUnit5 JSON inputs
•Added smoke cucumber JSON packaging as smoke-output/zephyr/cucumber-smoke.json.
•Updated Jenkinsfile_CNP to archive/publish from integration-output, functional-output, and smoke-output.
•Updated Jenkinsfile_nightly to:
◦add a Smoke parameter
◦run smoke tests on staging
◦archive/publish smoke output
◦publish demo functional results from functional-output-demo

Why
The previous layout mixed report roots and raw target/zephyr* artifacts, which made the Zephyr inputs harder to find and allowed report content from different stages to bleed together.

This change aligns the backend pipeline output more closely with the front end pattern:
•one artifact folder per stage
•report and Zephyr inputs grouped together
•no need to hunt through target/ for the JSON used by Jira create/update scripts

Expected artifact locations
•Integration: integration-output/zephyr/Junit5Report-IntegrationTest.json
•Functional: functional-output/zephyr/cucumber-opal.json
•Demo functional: functional-output-demo/zephyr/cucumber-opal-tags.json
•Smoke: smoke-output/zephyr/cucumber-smoke.json

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
