### PR TITLE
rebuild functional-output report path before CNP publish

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -68,6 +68,48 @@ def determineDevEnvironmentDeployment() {
   echo "Deploying Opal logging service (${env.OPAL_LOGGING_SERVICE_API_URL} - ${env.DEV_OPAL_LOGGING_SERVICE_IMAGE_SUFFIX}) instance in PR environment"
 }
 
+def ensureFunctionalReportOutputExists() {
+  if (steps.fileExists('functional-output/report/index.html')
+    || steps.fileExists('functional-output/report/htmlReport/test-summary.html')) {
+    return
+  }
+
+  if (steps.fileExists('functional-test-report/index.html')
+    || steps.fileExists('functional-test-report/htmlReport/test-summary.html')) {
+    steps.sh '''
+      mkdir -p functional-output
+      rm -rf functional-output/report
+      cp -R functional-test-report functional-output/report
+    '''
+  }
+}
+
+def publishFunctionalResults(String reportNameSuffix = '') {
+  ensureFunctionalReportOutputExists()
+
+  steps.junit allowEmptyResults: true, testResults: '**/test-results/functional/*.xml'
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/functional/*.xml'
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-test-report/**/*'
+
+  publishHTML target: [
+      allowMissing         : true,
+      alwaysLinkToLastBuild: true,
+      keepAll              : true,
+      reportDir            : 'functional-output/report',
+      reportFiles          : 'index.html',
+      reportName           : "Serenity Functional Test Report${reportNameSuffix}"
+  ]
+  publishHTML target: [
+      allowMissing         : true,
+      alwaysLinkToLastBuild: true,
+      keepAll              : true,
+      reportDir            : 'functional-output/report/htmlReport',
+      reportFiles          : 'test-summary.html',
+      reportName           : "Test Summary Report${reportNameSuffix}"
+  ]
+}
+
 withPipeline(type, product, component) {
   env.FAIL_FAST = true
   env.STAGING_DB_SCHEMA = 'public'
@@ -149,24 +191,7 @@ withPipeline(type, product, component) {
   }
 
   afterAlways('functionalTest:dev') {
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
-
-    publishHTML target: [
-        allowMissing         : true,
-        alwaysLinkToLastBuild: true,
-        keepAll              : true,
-        reportDir            : "functional-output/report",
-        reportFiles          : "index.html",
-        reportName           : "Serenity Functional Test Report"
-    ]
-    publishHTML target: [
-        allowMissing         : true,
-        alwaysLinkToLastBuild: true,
-        keepAll              : true,
-        reportDir            : "functional-output/report/htmlReport",
-        reportFiles          : "test-summary.html",
-        reportName           : "Test Summary Report"
-    ]
+    publishFunctionalResults()
   }
 
   afterAlways('smoketest:dev') {
@@ -183,24 +208,7 @@ withPipeline(type, product, component) {
   }
 
   afterAlways('functionalTest:stg') {
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
-
-    publishHTML target: [
-        allowMissing         : true,
-        alwaysLinkToLastBuild: true,
-        keepAll              : true,
-        reportDir            : "functional-output/report",
-        reportFiles          : "index.html",
-        reportName           : "Serenity Functional Test Report"
-    ]
-    publishHTML target: [
-        allowMissing         : true,
-        alwaysLinkToLastBuild: true,
-        keepAll              : true,
-        reportDir            : "functional-output/report/htmlReport",
-        reportFiles          : "test-summary.html",
-        reportName           : "Test Summary Report"
-    ]
+    publishFunctionalResults()
   }
   afterAlways('smoketest:stg') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-output/**/*'


### PR DESCRIPTION
## What changed

Updated `Jenkinsfile_CNP` so functional test report publishing uses the canonical
`functional-output/report` path consistently, matching the nightly pipeline behavior.

When that packaged path is missing on a failed functional run, the pipeline now
recreates `functional-output/report` from `functional-test-report` before Jenkins
publishes the HTML reports.

Also consolidated the duplicated functional report publishing logic for both
`functionalTest:dev` and `functionalTest:stg`.

## Why

CNP build `#1876` failed functional tests, but the left-menu `Serenity Functional Test Report`
was missing because Jenkins tried to publish from:

- `functional-output/report`
- `functional-output/report/htmlReport`

and those directories did not exist for that failed run.

The generated report content was present under `functional-test-report`, so the issue
was the missing packaged output path rather than missing Serenity output.

This change keeps `functional-output/report` as the only published location and repairs
that path before publishing when required.

## Impact

- Restores the left-menu functional report links in failing CNP runs
- Keeps CNP aligned with nightly report publishing expectations
- Avoids publishing from an alternate path directly


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
