### PR TITLE
PO-1939 update Jenkins pipelines and reporting

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -84,10 +84,33 @@ def ensureFunctionalReportOutputExists() {
   }
 }
 
+def ensureSmokeReportOutputExists() {
+  if (steps.fileExists('smoke-output/report/index.html')
+    || steps.fileExists('smoke-output/report/htmlReport/test-summary.html')) {
+    return
+  }
+
+  if (steps.fileExists('smoke-test-report/index.html')
+    || steps.fileExists('smoke-test-report/htmlReport/test-summary.html')) {
+    steps.sh '''
+      mkdir -p smoke-output
+      rm -rf smoke-output/report
+      cp -R smoke-test-report smoke-output/report
+    '''
+  }
+}
+
+def failBuildOnUnstableResults() {
+  if (currentBuild.result == 'UNSTABLE') {
+    currentBuild.result = 'FAILURE'
+  }
+}
+
 def publishFunctionalResults(String reportNameSuffix = '') {
   ensureFunctionalReportOutputExists()
 
   steps.junit allowEmptyResults: true, testResults: '**/test-results/functional/*.xml'
+  failBuildOnUnstableResults()
   steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/functional/*.xml'
   steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
   steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-test-report/**/*'
@@ -107,6 +130,33 @@ def publishFunctionalResults(String reportNameSuffix = '') {
       reportDir            : 'functional-output/report/htmlReport',
       reportFiles          : 'test-summary.html',
       reportName           : "Test Summary Report${reportNameSuffix}"
+  ]
+}
+
+def publishSmokeResults(String reportNameSuffix = '') {
+  ensureSmokeReportOutputExists()
+
+  steps.junit allowEmptyResults: true, testResults: '**/test-results/smoke/*.xml'
+  failBuildOnUnstableResults()
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/smoke/*.xml'
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-output/**/*'
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-test-report/**/*'
+
+  publishHTML target: [
+      allowMissing         : true,
+      alwaysLinkToLastBuild: true,
+      keepAll              : true,
+      reportDir            : 'smoke-output/report',
+      reportFiles          : 'index.html',
+      reportName           : "Serenity Smoke Test Report${reportNameSuffix}"
+  ]
+  publishHTML target: [
+      allowMissing         : true,
+      alwaysLinkToLastBuild: true,
+      keepAll              : true,
+      reportDir            : 'smoke-output/report/htmlReport',
+      reportFiles          : 'test-summary.html',
+      reportName           : "Smoke Test Summary Report${reportNameSuffix}"
   ]
 }
 
@@ -132,6 +182,7 @@ withPipeline(type, product, component) {
 
   afterAlways('test') {
     steps.junit '**/test-results/integration/*.xml'
+    failBuildOnUnstableResults()
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/integration/*.xml'
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'integration-output/**/*'
 
@@ -195,31 +246,13 @@ withPipeline(type, product, component) {
   }
 
   afterAlways('smoketest:dev') {
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-output/**/*'
-
-    publishHTML target: [
-        allowMissing         : true,
-        alwaysLinkToLastBuild: true,
-        keepAll              : true,
-        reportDir            : "smoke-output/report",
-        reportFiles          : "index.html",
-        reportName           : "Serenity Smoke Test Report"
-    ]
+    publishSmokeResults()
   }
 
   afterAlways('functionalTest:stg') {
     publishFunctionalResults()
   }
   afterAlways('smoketest:stg') {
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-output/**/*'
-
-    publishHTML target: [
-        allowMissing         : true,
-        alwaysLinkToLastBuild: true,
-        keepAll              : true,
-        reportDir            : "smoke-output/report",
-        reportFiles          : "index.html",
-        reportName           : "Serenity Smoke Test Report"
-    ]
+    publishSmokeResults()
   }
 }

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -7,7 +7,7 @@ properties([
     booleanParam(name: 'Integration', defaultValue: true, description: 'Run integration tests'),
     booleanParam(name: 'Functional', defaultValue: true, description: 'Run functional tests'),
     booleanParam(name: 'Smoke', defaultValue: true, description: 'Run smoke tests'),
-    booleanParam(name: 'Demo', defaultValue: true, description: 'Run R1A functional tests against demo'),
+    booleanParam(name: 'RunR1AOnly', defaultValue: true, description: 'Run R1A functional tests against demo'),
     booleanParam(name: 'RunR1AOff', defaultValue: false, description: 'Run R1AOff functional tests against demo'),
     booleanParam(name: 'ZephyrExecution', defaultValue: false, description: 'Create Zephyr Execution'),
   ])
@@ -84,12 +84,34 @@ def configureZephyrExecution = { testEnvironment ->
 
 def publishIntegrationResults = {
   steps.junit '**/test-results/integration/*.xml'
+  if (currentBuild.result == 'UNSTABLE') {
+    currentBuild.result = 'FAILURE'
+  }
   steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/integration/*.xml'
   steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'integration-output/**/*'
 }
 
-def publishFunctionalResults = { reportDirectory, reportNameSuffix ->
+def ensureFunctionalReportOutputExists = { reportDirectory, rawReportDirectory ->
+  if (steps.fileExists("${reportDirectory}/report/index.html")
+    || steps.fileExists("${reportDirectory}/report/htmlReport/test-summary.html")) {
+    return
+  }
+
+  if (steps.fileExists("${rawReportDirectory}/index.html")
+    || steps.fileExists("${rawReportDirectory}/htmlReport/test-summary.html")) {
+    steps.sh """
+      mkdir -p ${reportDirectory}
+      rm -rf ${reportDirectory}/report
+      cp -R ${rawReportDirectory} ${reportDirectory}/report
+    """
+  }
+}
+
+def publishFunctionalResults = { reportDirectory, rawReportDirectory, reportNameSuffix, junitPattern ->
+  ensureFunctionalReportOutputExists(reportDirectory, rawReportDirectory)
+
   steps.archiveArtifacts allowEmptyArchive: true, artifacts: "${reportDirectory}/**/*"
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: "${rawReportDirectory}/**/*"
   publishHTML target: [
     allowMissing         : true,
     alwaysLinkToLastBuild: true,
@@ -106,8 +128,11 @@ def publishFunctionalResults = { reportDirectory, reportNameSuffix ->
     reportFiles          : "test-summary.html",
     reportName           : "Test Summary Report${reportNameSuffix}"
   ]
-  steps.junit allowEmptyResults: true, testResults: '**/test-results/functional/*.xml'
-  steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/functional/*.xml'
+  steps.junit allowEmptyResults: true, testResults: junitPattern
+  if (currentBuild.result == 'UNSTABLE') {
+    currentBuild.result = 'FAILURE'
+  }
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: junitPattern
 }
 
 def publishSmokeResults = { reportNameSuffix ->
@@ -129,6 +154,9 @@ def publishSmokeResults = { reportNameSuffix ->
     reportName           : "Smoke Test Summary Report${reportNameSuffix}"
   ]
   steps.junit allowEmptyResults: true, testResults: '**/test-results/smoke/*.xml'
+  if (currentBuild.result == 'UNSTABLE') {
+    currentBuild.result = 'FAILURE'
+  }
   steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/smoke/*.xml'
 }
 
@@ -138,7 +166,8 @@ def runIntegrationStage = { stageName, gradleTask ->
       try {
         builder.gradle(gradleTask)
       } catch (error) {
-        steps.echo "${stageName} failed, but continuing with the pipeline. Error: " + error.message
+        currentBuild.result = 'FAILURE'
+        steps.echo "${stageName} failed. Marking build as FAILURE. Error: " + error.message
       } finally {
         publishIntegrationResults()
       }
@@ -156,12 +185,19 @@ def runFunctionalStage = { stageName, shouldRunWithZephyr, reportNameSuffix ->
           builder.gradle('functional')
         }
       } catch (error) {
-        steps.echo "${stageName} failed, but continuing with the pipeline. Error: " + error.message
+        currentBuild.result = 'FAILURE'
+        steps.echo "${stageName} failed. Marking build as FAILURE. Error: " + error.message
       } finally {
         try {
-          publishFunctionalResults('functional-output', reportNameSuffix)
+          publishFunctionalResults(
+            'functional-output',
+            'functional-test-report',
+            reportNameSuffix,
+            'build/test-results/functional/*.xml'
+          )
         } catch (publishError) {
-          steps.echo "${stageName} result publication failed, but continuing with the pipeline. Error: " + publishError.message
+          currentBuild.result = 'FAILURE'
+          steps.echo "${stageName} result publication failed. Marking build as FAILURE. Error: " + publishError.message
         }
       }
     }
@@ -174,12 +210,14 @@ def runSmokeStage = { stageName, reportNameSuffix ->
       try {
         builder.gradle('smoke')
       } catch (error) {
-        steps.echo "${stageName} failed, but continuing with the pipeline. Error: " + error.message
+        currentBuild.result = 'FAILURE'
+        steps.echo "${stageName} failed. Marking build as FAILURE. Error: " + error.message
       } finally {
         try {
           publishSmokeResults(reportNameSuffix)
         } catch (publishError) {
-          steps.echo "${stageName} result publication failed, but continuing with the pipeline. Error: " + publishError.message
+          currentBuild.result = 'FAILURE'
+          steps.echo "${stageName} result publication failed. Marking build as FAILURE. Error: " + publishError.message
         }
       }
     }
@@ -194,16 +232,23 @@ def runTaggedFunctionalStage = { enabled, stageName, shouldRunWithZephyr, report
           if (shouldRunWithZephyr) {
             builder.gradle('clearReports functionalOpalTagsWithZephyrExecution')
           } else {
-            builder.gradle('clearReports functionalOpalTags aggregate copyDemoFunctionalReport mergeFunctionalOpalTagsResults generateDemoTestSummary packageDemoFunctionalOutput')
+            builder.gradle('clearReports functionalOpalTags aggregate copyDemoFunctionalReport generateTaggedDemoTestSummary copyOpalTagsCucumberJson packageTaggedDemoFunctionalOutput')
           }
         }
       } catch (error) {
-        steps.echo "${stageName} failed, but continuing with the pipeline. Error: " + error.message
+        currentBuild.result = 'FAILURE'
+        steps.echo "${stageName} failed. Marking build as FAILURE. Error: " + error.message
       } finally {
         try {
-          publishFunctionalResults('functional-output-demo', reportNameSuffix)
+          publishFunctionalResults(
+            'functional-output-demo',
+            'functional-test-report-demo',
+            reportNameSuffix,
+            'build/test-results/functional/opal-tags/*.xml'
+          )
         } catch (publishError) {
-          steps.echo "${stageName} result publication failed, but continuing with the pipeline. Error: " + publishError.message
+          currentBuild.result = 'FAILURE'
+          steps.echo "${stageName} result publication failed. Marking build as FAILURE. Error: " + publishError.message
         }
       }
     }
@@ -219,7 +264,7 @@ withNightlyPipeline(type, product, component) {
     echo 'Integration:' + params.Integration
     echo 'Functional:' + params.Functional
     echo 'Smoke:' + params.Smoke
-    echo 'Demo:' + params.Demo
+    echo 'RunR1AOnly:' + params.RunR1AOnly
     echo 'RunR1AOff:' + params.RunR1AOff
 
     def today = ZonedDateTime.now().getDayOfWeek()
@@ -233,13 +278,13 @@ withNightlyPipeline(type, product, component) {
     runFunctionalStage('Functional Tests', shouldRunWithZephyr, testEnvironments.staging.reportNameSuffix)
     runSmokeStage('Smoke Tests', testEnvironments.staging.reportNameSuffix)
 
-    if (params.Demo) {
+    if (params.RunR1AOnly) {
       configureTestEnvironment(testEnvironments.demo)
       if (shouldRunWithZephyr) {
         configureZephyrExecution(testEnvironments.demo)
       }
       runTaggedFunctionalStage(
-        params.Demo,
+        params.RunR1AOnly,
         'Demo R1A Functional Tests',
         shouldRunWithZephyr,
         testEnvironments.demo.reportNameSuffix,

--- a/README.md
+++ b/README.md
@@ -262,11 +262,11 @@ Nightly parameters:
 | Parameter | Default | Purpose |
 |-----------|---------|---------|
 | `Integration` | `true` | Runs the staging integration-test stage. |
-| `Functional` | `true` | Runs the staging functional-test stage and enables the demo R1A functional stage when `Demo` is also enabled. |
-| `Demo` | `true` | Runs the demo R1A functional stage against the demo environment. |
+| `Functional` | `true` | Runs the staging functional-test stage. |
+| `Smoke` | `true` | Runs the staging smoke-test stage. |
+| `RunR1AOnly` | `true` | Runs the demo R1A functional stage against the demo environment. |
 | `RunR1AOff` | `false` | Runs the optional demo R1A-off functional stage. |
 | `ZephyrExecution` | `false` | Creates Zephyr executions; this also runs automatically on Fridays. |
-| `LEGACY_URL` | `PRE-PROD` | Existing legacy URL selector retained for legacy-mode test configuration. |
 
 Nightly environments:
 
@@ -281,16 +281,44 @@ Nightly stages:
 |-------|-------------|---------------|------------------|
 | `Integration Tests` | `staging` | `Integration` | `Integration` |
 | `Functional Tests` | `staging` | `Functional` | `functional` or `functionalWithZephyrExecution` |
-| `Demo R1A Functional Tests` | `demo` | `Demo` and `Functional` | `functionalOpalTags` or `functionalOpalTagsWithZephyrExecution` with the R1A manual-account-creation tag filter |
+| `Smoke Tests` | `staging` | `Smoke` | `smoke` |
+| `Demo R1A Functional Tests` | `demo` | `RunR1AOnly` | `functionalOpalTags` or `functionalOpalTagsWithZephyrExecution` with the R1A manual-account-creation tag filter |
 | `R1AOff Demo Functional Tests` | `demo` | `RunR1AOff` | `functionalOpalTags` or `functionalOpalTagsWithZephyrExecution` with `@R1AOff and not @Ignore` |
 
 The demo R1A stage is intentionally limited to manual-account-creation scenarios and
 excludes R1A-off, R1B, R1B-off, R1C, and R1C-off style release-tagged scenarios. It
 does not run the full backend functional suite.
 
-All functional stages publish JUnit XML from `build/test-results/functional`, archive the
-functional test XMLs, and publish the Serenity report plus the generated test-summary
-HTML. The integration stage publishes and archives JUnit XML from `build/test-results/integration`.
+Nightly reports and artifacts:
+
+- Staging functional publishes `Serenity Functional Test Report` and `Test Summary Report`.
+- Staging smoke publishes `Serenity Smoke Test Report` and `Smoke Test Summary Report`.
+- Demo R1A publishes `Serenity Functional Test Report (Demo)` and `Test Summary Report (Demo)`.
+- Demo R1AOff publishes `Serenity Functional Test Report (Demo R1AOff)` and `Test Summary Report (Demo R1AOff)`.
+- Archived output folders are `integration-output`, `functional-output`, `functional-output-demo`, and `smoke-output`.
+- Functional and smoke outputs are published from `*/report` with Zephyr payloads under `*/zephyr`. Integration publishes `integration-output/report` and archives `integration-output/zephyr` when the integration Zephyr JSON is generated.
+
+Failure handling:
+
+- A Gradle stage failure marks the nightly build `FAILURE`.
+- JUnit-reported test failures for integration, functional, smoke, demo R1A, and demo R1AOff are promoted from `UNSTABLE` to `FAILURE`.
+- The demo R1A and R1AOff stages currently share `functional-output-demo` / `functional-test-report-demo`, so when both run in the same build the later demo-tagged run can overwrite the shared demo artifact contents even though Jenkins publishes separate report links.
+
+### CNP Jenkins pipeline
+
+`Jenkinsfile_CNP` uses the standard HMCTS pipeline wrapper for PR and branch builds.
+This repo-local Jenkinsfile does not declare its own job parameters.
+
+CNP outputs:
+
+- Integration publishes JUnit XML from `build/test-results/integration`, archives `integration-output/**/*`, and publishes `Integration Tests Report` from `integration-output/report`.
+- Functional publishes JUnit XML from `build/test-results/functional`, archives both `functional-output/**/*` and `functional-test-report/**/*`, and publishes `Serenity Functional Test Report` plus `Test Summary Report`.
+- Smoke publishes JUnit XML from `build/test-results/smoke`, archives both `smoke-output/**/*` and `smoke-test-report/**/*`, and publishes `Serenity Smoke Test Report` plus `Smoke Test Summary Report`.
+
+CNP failure handling:
+
+- JUnit-reported failures for integration, functional, and smoke are promoted from `UNSTABLE` to `FAILURE`.
+- Functional and smoke publication rebuild `functional-output/report` and `smoke-output/report` from the raw Serenity output if the packaged report directory is missing.
 
 ### Zephyr tasks
 

--- a/build.gradle
+++ b/build.gradle
@@ -371,6 +371,13 @@ tasks.register('packageDemoFunctionalOutput', Copy) {
     into("report")
   }
 }
+tasks.register('packageTaggedDemoFunctionalOutput', Copy) {
+  dependsOn 'copyDemoFunctionalReport', 'generateTaggedDemoTestSummary', 'copyOpalTagsCucumberJson'
+  into("${rootDir}/functional-output-demo")
+  from("${rootDir}/functional-test-report-demo") {
+    into("report")
+  }
+}
 tasks.register('copyIntegrationJunit5Report', Copy) {
   from("target/zephyr-reports/Junit5Report-IntegrationTest.json")
   into("${rootDir}/integration-output/zephyr")
@@ -425,6 +432,19 @@ tasks.register('generateDemoTestSummary', JavaExec) {
   args = [
     "--integration-dir=${layout.buildDirectory.dir('test-results/functional-empty').get().asFile.absolutePath}",
     "--functional-dir=${layout.buildDirectory.dir('test-results/functional').get().asFile.absolutePath}",
+    "--output-dir=${file('functional-test-report-demo').absolutePath}",
+    "--title=Test Summary Report (Demo)"
+  ]
+}
+tasks.register('generateTaggedDemoTestSummary', JavaExec) {
+  group = "Reporting"
+  description = "Generate an HTML summary for the tagged demo functional run"
+  dependsOn 'copyDemoFunctionalReport'
+  classpath = sourceSets.functionalTest.runtimeClasspath
+  mainClass = 'uk.gov.hmcts.opal.scripts.TestReportSummaryGenerator'
+  args = [
+    "--integration-dir=${layout.buildDirectory.dir('test-results/functional-empty').get().asFile.absolutePath}",
+    "--functional-dir=${layout.buildDirectory.dir('test-results/functional/opal-tags').get().asFile.absolutePath}",
     "--output-dir=${file('functional-test-report-demo').absolutePath}",
     "--title=Test Summary Report (Demo)"
   ]
@@ -1158,15 +1178,14 @@ tasks.register('functionalOpalTagsWithZephyrExecution') {
   description = "Runs functionalOpalTags then creates the Zephyr execution from the cucumber report"
 
   dependsOn('functionalOpalTags', 'copyOpalTagsCucumberJson', 'createJiraExecutionFromOpalTagsCucumberReport',
-          'aggregate', 'copyDemoFunctionalReport', 'mergeFunctionalOpalTagsResults', 'generateDemoTestSummary')
+          'aggregate', 'copyDemoFunctionalReport', 'generateTaggedDemoTestSummary')
 
   tasks.copyOpalTagsCucumberJson.mustRunAfter functionalOpalTags
   tasks.createJiraExecutionFromOpalTagsCucumberReport.mustRunAfter copyOpalTagsCucumberJson
-  tasks.mergeFunctionalOpalTagsResults.mustRunAfter createJiraExecutionFromOpalTagsCucumberReport
   tasks.aggregate.mustRunAfter createJiraExecutionFromOpalTagsCucumberReport
   tasks.copyDemoFunctionalReport.mustRunAfter aggregate
-  tasks.generateDemoTestSummary.mustRunAfter copyDemoFunctionalReport
-  finalizedBy 'packageDemoFunctionalOutput'
+  tasks.generateTaggedDemoTestSummary.mustRunAfter copyDemoFunctionalReport
+  finalizedBy 'packageTaggedDemoFunctionalOutput'
 }
 
 tasks.register('functionalLegacyWithZephyrExecution') {


### PR DESCRIPTION
### JIRA link (if applicable) ###

n/a

### Change description ###

Updates the Jenkins pipeline and reporting behaviour for opal-fines-service.
This change:
•improves CNP report publication for integration, functional, and smoke
•makes JUnit-reported test failures fail the build in both CNP and nightly
•updates nightly demo parameter naming and documentation
•fixes nightly demo tagged functional summary/report publication
•documents the current pipeline behaviour in README.md

Changes
CNP pipeline
•Added shared functional and smoke publish helpers in Jenkinsfile_CNP
•Rebuilds functional-output/report from functional-test-report if the packaged report is missing
•Rebuilds smoke-output/report from smoke-test-report if the packaged report is missing
•Publishes and archives:
◦functional JUnit XML
◦smoke JUnit XML
◦functional-output/**/*
◦smoke-output/**/*
◦raw Serenity output directories
•Integration now archives integration-output/**/* and publishes Integration Tests Report from integration-output/report

Failure handling
•In both Jenkinsfile_CNP and Jenkinsfile_nightly, JUnit-reported failures now promote UNSTABLE to FAILURE
•This applies to:
◦integration
◦functional
◦smoke
◦nightly demo tagged functional runs
•Nightly stage execution failures are also explicitly marked as FAILURE

Nightly pipeline
•Renamed nightly parameter:
◦Demo -> RunR1AOnly
•Retained optional:
◦RunR1AOff
•Nightly now documents and supports:
◦staging integration
◦staging functional
◦staging smoke
◦demo R1A-only tagged functional
◦optional demo R1A-off tagged functional

Demo report generation
•Added dedicated tagged demo report generation path in build.gradle
•Added:
◦generateTaggedDemoTestSummary
◦packageTaggedDemoFunctionalOutput
•Updated functionalOpalTagsWithZephyrExecution to use the tagged demo summary/output flow
•Demo tagged report publication now reads build/test-results/functional/opal-tags/*.xml directly

Documentation
•Updated README.md to reflect:
◦current nightly parameters
◦current nightly stages
◦CNP outputs
◦report/artifact layout
◦UNSTABLE to FAILURE behaviour
◦current demo artifact caveat when both RunR1AOnly and RunR1AOff run in the same nightly build

Notes
•The nightly RunR1AOnly and RunR1AOff stages currently share functional-output-demo / functional-test-report-demo, so the later demo-tagged run can overwrite the shared demo artifact contents in the same build.
•Legacy functional scenarios remain ignored; no active legacy execution was added by this change.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
