### PR TITLE
PO-7246 : removing config to skip sonar in pipeline

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,10 +1,6 @@
 #!groovy
 import uk.gov.hmcts.contino.GithubAPI
-properties([
-        parameters([
-                booleanParam(name: 'SKIP_SONAR', defaultValue: false, description: 'Skip sonar'),
-        ])
-])
+
 @Library("Infrastructure@master")
 
 def type = "java"
@@ -28,7 +24,7 @@ def determineDevEnvironmentDeployment() {
   env.OPAL_LOGGING_SERVICE_API_URL = "https://opal-logging-service.staging.platform.hmcts.net"
   env.DEV_OPAL_LOGGING_SERVICE_IMAGE_SUFFIX = "latest"
 
-  env.SKIP_SONAR = params.SKIP_SONAR
+
   env.APP_MODE = "opal"
 
   def githubApi = new GithubAPI(this)
@@ -178,13 +174,6 @@ withPipeline(type, product, component) {
     steps.sh './gradlew checkTestJiraAnnotations'
   }
 
-  afterAlways("helmReleaseUninstall:${params.environment}") {
-    if(params.SKIP_SONAR) {
-      stage('SKIP_SONAR IS TRUE') {
-        error("Build can not fully complete when SKIP_SONAR is set to true")
-      }
-    }
-  }
   afterAlways('test') {
     steps.junit '**/test-results/integration/*.xml'
     failBuildOnUnstableResults()

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,6 @@ ext {
 //Should we fail fast on test failures?
 //Defaults to true if env is not present
 var failFast = System.getenv('FAIL_FAST') == null || System.getenv('FAIL_FAST').toBoolean()
-var skipSonar = System.getenv('SKIP_SONAR') != null && System.getenv('SKIP_SONAR').toBoolean()
 def defaultLegacyStubImage = 'hmctsprod.azurecr.io/opal/legacy-db-stub:latest'
 def legacyStubImage = System.getenv('OPAL_LEGACY_STUB_IMAGE') ?: defaultLegacyStubImage
 def legacyStubPort = 4553
@@ -538,9 +537,6 @@ sonarqube {
     property "sonar.exclusions", coverageExclusions.join(', ')
     property 'sonar.coverage.exclusions', "**/entity/**,**/model/*,**/exception/*,**/config/**,**/repository/jpa/*,**/opal/dto/*"
     property 'sonar.cpd.exclusions', "**/entity/**,**/opal/dto/**,**/service/DefendantAccountService.java,**/service/legacy/LegacyDefendantAccountService.java,**/service/opal/OpalDefendantAccountService.java"
-    if (skipSonar) {
-      property 'sonar.exclusions', "**/**"
-    }
   }
 }
 


### PR DESCRIPTION
For https://tools.hmcts.net/jira/browse/PO-7246 we need to skip SonarQube scanning in the pipeline.
This PR reverts the config change.