### PR TITLE
PO-2257 exclude manual report queue integration helper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -270,6 +270,7 @@ tasks.register('integration', Test) {
   group = "Verification"
   testClassesDirs = sourceSets.integrationTest.output.classesDirs
   classpath = sourceSets.integrationTest.runtimeClasspath
+  exclude '**/ReportQueueConnectivityIntegrationTest.class'
   doFirst {
     pullLatestLegacyStubImageIfLocal()
   }


### PR DESCRIPTION
### Change description ###

Excludes ReportQueueConnectivityIntegrationTest from the Gradle integration task.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
