### PR TITLE
Align Jenkins artifacts and report publishing

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -88,6 +88,20 @@ def ensureFunctionalReportOutputExists() {
   }
 }
 
+def ensureIntegrationReportOutputExists() {
+  if (steps.fileExists('integration-output/report/index.html')) {
+    return
+  }
+
+  if (steps.fileExists('build/reports/tests/integration/index.html')) {
+    steps.sh '''
+      mkdir -p integration-output
+      rm -rf integration-output/report
+      cp -R build/reports/tests/integration integration-output/report
+    '''
+  }
+}
+
 def ensureSmokeReportOutputExists() {
   if (steps.fileExists('smoke-output/report/index.html')
     || steps.fileExists('smoke-output/report/htmlReport/test-summary.html')) {
@@ -115,9 +129,7 @@ def publishFunctionalResults(String reportNameSuffix = '') {
 
   steps.junit allowEmptyResults: true, testResults: '**/test-results/functional/*.xml'
   failBuildOnUnstableResults()
-  steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/functional/*.xml'
   steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
-  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-test-report/**/*'
 
   publishHTML target: [
       allowMissing         : true,
@@ -127,14 +139,6 @@ def publishFunctionalResults(String reportNameSuffix = '') {
       reportFiles          : 'index.html',
       reportName           : "Serenity Functional Test Report${reportNameSuffix}"
   ]
-  publishHTML target: [
-      allowMissing         : true,
-      alwaysLinkToLastBuild: true,
-      keepAll              : true,
-      reportDir            : 'functional-output/report/htmlReport',
-      reportFiles          : 'test-summary.html',
-      reportName           : "Test Summary Report${reportNameSuffix}"
-  ]
 }
 
 def publishSmokeResults(String reportNameSuffix = '') {
@@ -142,9 +146,7 @@ def publishSmokeResults(String reportNameSuffix = '') {
 
   steps.junit allowEmptyResults: true, testResults: '**/test-results/smoke/*.xml'
   failBuildOnUnstableResults()
-  steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/smoke/*.xml'
   steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-output/**/*'
-  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-test-report/**/*'
 
   publishHTML target: [
       allowMissing         : true,
@@ -153,14 +155,6 @@ def publishSmokeResults(String reportNameSuffix = '') {
       reportDir            : 'smoke-output/report',
       reportFiles          : 'index.html',
       reportName           : "Serenity Smoke Test Report${reportNameSuffix}"
-  ]
-  publishHTML target: [
-      allowMissing         : true,
-      alwaysLinkToLastBuild: true,
-      keepAll              : true,
-      reportDir            : 'smoke-output/report/htmlReport',
-      reportFiles          : 'test-summary.html',
-      reportName           : "Smoke Test Summary Report${reportNameSuffix}"
   ]
 }
 
@@ -194,7 +188,7 @@ withPipeline(type, product, component) {
   afterAlways('test') {
     steps.junit '**/test-results/integration/*.xml'
     failBuildOnUnstableResults()
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/integration/*.xml'
+    ensureIntegrationReportOutputExists()
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'integration-output/**/*'
 
     publishHTML target: [

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -182,11 +182,15 @@ def publishSmokeResults = { reportNameSuffix ->
   }
 }
 
-def runIntegrationStage = { stageName, gradleTask ->
+def runIntegrationStage = { stageName, shouldRunWithZephyr ->
   if (params.Integration) {
     stage(stageName) {
       try {
-        builder.gradle(gradleTask)
+        if (shouldRunWithZephyr) {
+          builder.gradle('integrationTestWithZephyrExecution')
+        } else {
+          builder.gradle('Integration')
+        }
       } catch (error) {
         currentBuild.result = 'FAILURE'
         steps.echo "${stageName} failed. Marking build as FAILURE. Error: " + error.message
@@ -227,11 +231,15 @@ def runFunctionalStage = { stageName, shouldRunWithZephyr, reportNameSuffix ->
   }
 }
 
-def runSmokeStage = { stageName, reportNameSuffix ->
+def runSmokeStage = { stageName, shouldRunWithZephyr, reportNameSuffix ->
   if (params.Smoke) {
     stage(stageName) {
       try {
-        builder.gradle('smoke')
+        if (shouldRunWithZephyr) {
+          builder.gradle('smokeWithZephyrExecution')
+        } else {
+          builder.gradle('smoke')
+        }
       } catch (error) {
         currentBuild.result = 'FAILURE'
         steps.echo "${stageName} failed. Marking build as FAILURE. Error: " + error.message
@@ -298,9 +306,9 @@ withNightlyPipeline(type, product, component) {
     if (shouldRunWithZephyr) {
       configureZephyrExecution(testEnvironments.staging)
     }
-    runIntegrationStage('Integration Tests', 'Integration')
+    runIntegrationStage('Integration Tests', shouldRunWithZephyr)
     runFunctionalStage('Functional Tests', shouldRunWithZephyr, testEnvironments.staging.reportNameSuffix)
-    runSmokeStage('Smoke Tests', testEnvironments.staging.reportNameSuffix)
+    runSmokeStage('Smoke Tests', shouldRunWithZephyr, testEnvironments.staging.reportNameSuffix)
 
     if (params.RunR1AOnly) {
       configureTestEnvironment(testEnvironments.demo)

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -43,7 +43,7 @@ def testEnvironments = [
         testUrl              : 'https://opal-fines-service.demo.platform.hmcts.net',
         userServiceApiUrl    : 'https://opal-user-service.demo.platform.hmcts.net',
         loggingServiceApiUrl : 'https://opal-logging-service.demo.platform.hmcts.net',
-        reportNameSuffix     : ' (Demo)',
+        reportNameSuffix     : ' (Demo R1AOn Only)',
     ],
 ]
 
@@ -87,8 +87,30 @@ def publishIntegrationResults = {
   if (currentBuild.result == 'UNSTABLE') {
     currentBuild.result = 'FAILURE'
   }
-  steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/integration/*.xml'
+  ensureIntegrationReportOutputExists()
   steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'integration-output/**/*'
+  publishHTML target: [
+    allowMissing         : true,
+    alwaysLinkToLastBuild: true,
+    keepAll              : true,
+    reportDir            : 'integration-output/report',
+    reportFiles          : 'index.html',
+    reportName           : 'Integration Tests Report'
+  ]
+}
+
+def ensureIntegrationReportOutputExists() {
+  if (steps.fileExists('integration-output/report/index.html')) {
+    return
+  }
+
+  if (steps.fileExists('build/reports/tests/integration/index.html')) {
+    steps.sh '''
+      mkdir -p integration-output
+      rm -rf integration-output/report
+      cp -R build/reports/tests/integration integration-output/report
+    '''
+  }
 }
 
 def ensureFunctionalReportOutputExists = { reportDirectory, rawReportDirectory ->
@@ -107,11 +129,29 @@ def ensureFunctionalReportOutputExists = { reportDirectory, rawReportDirectory -
   }
 }
 
-def publishFunctionalResults = { reportDirectory, rawReportDirectory, reportNameSuffix, junitPattern ->
-  ensureFunctionalReportOutputExists(reportDirectory, rawReportDirectory)
+def packageFunctionalReportOutput = { reportDirectory, rawReportDirectory, sourceOutputDirectory ->
+  if (reportDirectory == sourceOutputDirectory) {
+    ensureFunctionalReportOutputExists(reportDirectory, rawReportDirectory)
+    return
+  }
+
+  steps.sh """
+    mkdir -p ${reportDirectory}
+    rm -rf ${reportDirectory}/report
+    rm -rf ${reportDirectory}/zephyr
+    if [ -d "${rawReportDirectory}" ]; then
+      cp -R ${rawReportDirectory} ${reportDirectory}/report
+    fi
+    if [ -d "${sourceOutputDirectory}/zephyr" ]; then
+      cp -R ${sourceOutputDirectory}/zephyr ${reportDirectory}/zephyr
+    fi
+  """
+}
+
+def publishFunctionalResults = { reportDirectory, rawReportDirectory, sourceOutputDirectory, reportNameSuffix, junitPattern ->
+  packageFunctionalReportOutput(reportDirectory, rawReportDirectory, sourceOutputDirectory)
 
   steps.archiveArtifacts allowEmptyArchive: true, artifacts: "${reportDirectory}/**/*"
-  steps.archiveArtifacts allowEmptyArchive: true, artifacts: "${rawReportDirectory}/**/*"
   publishHTML target: [
     allowMissing         : true,
     alwaysLinkToLastBuild: true,
@@ -120,19 +160,10 @@ def publishFunctionalResults = { reportDirectory, rawReportDirectory, reportName
     reportFiles          : "index.html",
     reportName           : "Serenity Functional Test Report${reportNameSuffix}"
   ]
-  publishHTML target: [
-    allowMissing         : true,
-    alwaysLinkToLastBuild: true,
-    keepAll              : true,
-    reportDir            : "${reportDirectory}/report/htmlReport",
-    reportFiles          : "test-summary.html",
-    reportName           : "Test Summary Report${reportNameSuffix}"
-  ]
   steps.junit allowEmptyResults: true, testResults: junitPattern
   if (currentBuild.result == 'UNSTABLE') {
     currentBuild.result = 'FAILURE'
   }
-  steps.archiveArtifacts allowEmptyArchive: true, artifacts: junitPattern
 }
 
 def publishSmokeResults = { reportNameSuffix ->
@@ -145,19 +176,10 @@ def publishSmokeResults = { reportNameSuffix ->
     reportFiles          : "index.html",
     reportName           : "Serenity Smoke Test Report${reportNameSuffix}"
   ]
-  publishHTML target: [
-    allowMissing         : true,
-    alwaysLinkToLastBuild: true,
-    keepAll              : true,
-    reportDir            : "smoke-output/report/htmlReport",
-    reportFiles          : "test-summary.html",
-    reportName           : "Smoke Test Summary Report${reportNameSuffix}"
-  ]
   steps.junit allowEmptyResults: true, testResults: '**/test-results/smoke/*.xml'
   if (currentBuild.result == 'UNSTABLE') {
     currentBuild.result = 'FAILURE'
   }
-  steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/test-results/smoke/*.xml'
 }
 
 def runIntegrationStage = { stageName, gradleTask ->
@@ -192,6 +214,7 @@ def runFunctionalStage = { stageName, shouldRunWithZephyr, reportNameSuffix ->
           publishFunctionalResults(
             'functional-output',
             'functional-test-report',
+            'functional-output',
             reportNameSuffix,
             'build/test-results/functional/*.xml'
           )
@@ -224,7 +247,7 @@ def runSmokeStage = { stageName, reportNameSuffix ->
   }
 }
 
-def runTaggedFunctionalStage = { enabled, stageName, shouldRunWithZephyr, reportNameSuffix, tagFilter ->
+def runTaggedFunctionalStage = { enabled, stageName, shouldRunWithZephyr, reportDirectory, reportNameSuffix, tagFilter ->
   if (enabled) {
     stage(stageName) {
       try {
@@ -232,7 +255,7 @@ def runTaggedFunctionalStage = { enabled, stageName, shouldRunWithZephyr, report
           if (shouldRunWithZephyr) {
             builder.gradle('clearReports functionalOpalTagsWithZephyrExecution')
           } else {
-            builder.gradle('clearReports functionalOpalTags aggregate copyDemoFunctionalReport generateTaggedDemoTestSummary copyOpalTagsCucumberJson packageTaggedDemoFunctionalOutput')
+            builder.gradle('clearReports functionalOpalTags aggregate copyDemoFunctionalReport copyOpalTagsCucumberJson packageTaggedDemoFunctionalOutput')
           }
         }
       } catch (error) {
@@ -241,8 +264,9 @@ def runTaggedFunctionalStage = { enabled, stageName, shouldRunWithZephyr, report
       } finally {
         try {
           publishFunctionalResults(
-            'functional-output-demo',
+            reportDirectory,
             'functional-test-report-demo',
+            'functional-output-demo',
             reportNameSuffix,
             'build/test-results/functional/opal-tags/*.xml'
           )
@@ -287,6 +311,7 @@ withNightlyPipeline(type, product, component) {
         params.RunR1AOnly,
         'Demo R1A Functional Tests',
         shouldRunWithZephyr,
+        'functional-output-r1a-only-demo',
         testEnvironments.demo.reportNameSuffix,
         r1ATagFilter
       )
@@ -301,6 +326,7 @@ withNightlyPipeline(type, product, component) {
         params.RunR1AOff,
         'R1AOff Demo Functional Tests',
         shouldRunWithZephyr,
+        'functional-output-r1a-off-demo',
         ' (Demo R1AOff)',
         r1AOffTagFilter
       )

--- a/README.md
+++ b/README.md
@@ -291,18 +291,19 @@ does not run the full backend functional suite.
 
 Nightly reports and artifacts:
 
-- Staging functional publishes `Serenity Functional Test Report` and `Test Summary Report`.
-- Staging smoke publishes `Serenity Smoke Test Report` and `Smoke Test Summary Report`.
-- Demo R1A publishes `Serenity Functional Test Report (Demo)` and `Test Summary Report (Demo)`.
-- Demo R1AOff publishes `Serenity Functional Test Report (Demo R1AOff)` and `Test Summary Report (Demo R1AOff)`.
-- Archived output folders are `integration-output`, `functional-output`, `functional-output-demo`, and `smoke-output`.
+- Staging integration publishes `Integration Tests Report`.
+- Staging functional publishes `Serenity Functional Test Report`.
+- Staging smoke publishes `Serenity Smoke Test Report`.
+- Demo R1A publishes `Serenity Functional Test Report (Demo R1AOn Only)`.
+- Demo R1AOff publishes `Serenity Functional Test Report (Demo R1AOff)`.
+- Archived output folders are `integration-output`, `functional-output`, `functional-output-r1a-only-demo`, `functional-output-r1a-off-demo`, and `smoke-output`.
 - Functional and smoke outputs are published from `*/report` with Zephyr payloads under `*/zephyr`. Integration publishes `integration-output/report` and archives `integration-output/zephyr` when the integration Zephyr JSON is generated.
 
 Failure handling:
 
 - A Gradle stage failure marks the nightly build `FAILURE`.
 - JUnit-reported test failures for integration, functional, smoke, demo R1A, and demo R1AOff are promoted from `UNSTABLE` to `FAILURE`.
-- The demo R1A and R1AOff stages currently share `functional-output-demo` / `functional-test-report-demo`, so when both run in the same build the later demo-tagged run can overwrite the shared demo artifact contents even though Jenkins publishes separate report links.
+- The demo R1A and R1AOff stages publish to separate artifact directories so the later demo-tagged run cannot overwrite the earlier one.
 
 ### CNP Jenkins pipeline
 
@@ -312,8 +313,8 @@ This repo-local Jenkinsfile does not declare its own job parameters.
 CNP outputs:
 
 - Integration publishes JUnit XML from `build/test-results/integration`, archives `integration-output/**/*`, and publishes `Integration Tests Report` from `integration-output/report`.
-- Functional publishes JUnit XML from `build/test-results/functional`, archives both `functional-output/**/*` and `functional-test-report/**/*`, and publishes `Serenity Functional Test Report` plus `Test Summary Report`.
-- Smoke publishes JUnit XML from `build/test-results/smoke`, archives both `smoke-output/**/*` and `smoke-test-report/**/*`, and publishes `Serenity Smoke Test Report` plus `Smoke Test Summary Report`.
+- Functional archives `functional-output/**/*` and publishes `Serenity Functional Test Report`.
+- Smoke archives `smoke-output/**/*` and publishes `Serenity Smoke Test Report`.
 
 CNP failure handling:
 

--- a/README.md
+++ b/README.md
@@ -279,9 +279,9 @@ Nightly stages:
 
 | Stage | Environment | Controlled by | Gradle task flow |
 |-------|-------------|---------------|------------------|
-| `Integration Tests` | `staging` | `Integration` | `Integration` |
+| `Integration Tests` | `staging` | `Integration` | `Integration` or `integrationTestWithZephyrExecution` |
 | `Functional Tests` | `staging` | `Functional` | `functional` or `functionalWithZephyrExecution` |
-| `Smoke Tests` | `staging` | `Smoke` | `smoke` |
+| `Smoke Tests` | `staging` | `Smoke` | `smoke` or `smokeWithZephyrExecution` |
 | `Demo R1A Functional Tests` | `demo` | `RunR1AOnly` | `functionalOpalTags` or `functionalOpalTagsWithZephyrExecution` with the R1A manual-account-creation tag filter |
 | `R1AOff Demo Functional Tests` | `demo` | `RunR1AOff` | `functionalOpalTags` or `functionalOpalTagsWithZephyrExecution` with `@R1AOff and not @Ignore` |
 
@@ -298,6 +298,7 @@ Nightly reports and artifacts:
 - Demo R1AOff publishes `Serenity Functional Test Report (Demo R1AOff)`.
 - Archived output folders are `integration-output`, `functional-output`, `functional-output-r1a-only-demo`, `functional-output-r1a-off-demo`, and `smoke-output`.
 - Functional and smoke outputs are published from `*/report` with Zephyr payloads under `*/zephyr`. Integration publishes `integration-output/report` and archives `integration-output/zephyr` when the integration Zephyr JSON is generated.
+- When `ZephyrExecution=true` or the nightly run is on Friday, integration, functional, smoke, demo R1A, and demo R1AOff all use their Zephyr-enabled Gradle flows.
 
 Failure handling:
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
 //Should we fail fast on test failures?
 //Defaults to true if env is not present
 var failFast = System.getenv('FAIL_FAST') == null || System.getenv('FAIL_FAST').toBoolean()
-var skipSonar = System.getenv('SKIP_SONAR') != null && System.getenv('SKIP_SONAR').toBoolean();
+var skipSonar = System.getenv('SKIP_SONAR') != null && System.getenv('SKIP_SONAR').toBoolean()
 def defaultLegacyStubImage = 'hmctsprod.azurecr.io/opal/legacy-db-stub:latest'
 def legacyStubImage = System.getenv('OPAL_LEGACY_STUB_IMAGE') ?: defaultLegacyStubImage
 def legacyStubPort = 4553
@@ -359,21 +359,21 @@ tasks.register('copyDemoFunctionalReport', Copy) {
   logger.quiet("Demo Functional Test Report available at - file://${rootDir}/functional-test-report-demo/index.html")
 }
 tasks.register('packageFunctionalOutput', Copy) {
-  dependsOn 'copyFunctionalReport', 'generateTestSummary', 'copyOpalCucumberJson', 'copyLegacyCucumberJson'
+  dependsOn 'copyFunctionalReport', 'copyOpalCucumberJson', 'copyLegacyCucumberJson'
   into("${rootDir}/functional-output")
   from("${rootDir}/functional-test-report") {
     into("report")
   }
 }
 tasks.register('packageDemoFunctionalOutput', Copy) {
-  dependsOn 'copyDemoFunctionalReport', 'generateDemoTestSummary', 'copyOpalTagsCucumberJson'
+  dependsOn 'copyDemoFunctionalReport', 'copyOpalTagsCucumberJson'
   into("${rootDir}/functional-output-demo")
   from("${rootDir}/functional-test-report-demo") {
     into("report")
   }
 }
 tasks.register('packageTaggedDemoFunctionalOutput', Copy) {
-  dependsOn 'copyDemoFunctionalReport', 'generateTaggedDemoTestSummary', 'copyOpalTagsCucumberJson'
+  dependsOn 'copyDemoFunctionalReport', 'copyOpalTagsCucumberJson'
   into("${rootDir}/functional-output-demo")
   from("${rootDir}/functional-test-report-demo") {
     into("report")
@@ -411,70 +411,16 @@ tasks.register('mergeFunctionalOpalTagsResults', Copy) {
   into layout.buildDirectory.dir("test-results/functional")
   include '*.xml'
 }
-tasks.register('generateTestSummary', JavaExec) {
-  group = "Reporting"
-  description = "Generate an HTML summary from test result XMLs"
-  dependsOn 'copyFunctionalReport'
-  classpath = sourceSets.functionalTest.runtimeClasspath
-  mainClass = 'uk.gov.hmcts.opal.scripts.TestReportSummaryGenerator'
-  args = [
-    "--integration-dir=${layout.buildDirectory.dir('test-results/integration').get().asFile.absolutePath}",
-    "--functional-dir=${layout.buildDirectory.dir('test-results/functional').get().asFile.absolutePath}",
-    "--output-dir=${file('functional-test-report').absolutePath}",
-    "--title=Test Summary Report"
-  ]
-}
-tasks.register('generateDemoTestSummary', JavaExec) {
-  group = "Reporting"
-  description = "Generate an HTML summary for the demo tagged functional run"
-  dependsOn 'copyDemoFunctionalReport'
-  classpath = sourceSets.functionalTest.runtimeClasspath
-  mainClass = 'uk.gov.hmcts.opal.scripts.TestReportSummaryGenerator'
-  args = [
-    "--integration-dir=${layout.buildDirectory.dir('test-results/functional-empty').get().asFile.absolutePath}",
-    "--functional-dir=${layout.buildDirectory.dir('test-results/functional').get().asFile.absolutePath}",
-    "--output-dir=${file('functional-test-report-demo').absolutePath}",
-    "--title=Test Summary Report (Demo)"
-  ]
-}
-tasks.register('generateTaggedDemoTestSummary', JavaExec) {
-  group = "Reporting"
-  description = "Generate an HTML summary for the tagged demo functional run"
-  dependsOn 'copyDemoFunctionalReport'
-  classpath = sourceSets.functionalTest.runtimeClasspath
-  mainClass = 'uk.gov.hmcts.opal.scripts.TestReportSummaryGenerator'
-  args = [
-    "--integration-dir=${layout.buildDirectory.dir('test-results/functional-empty').get().asFile.absolutePath}",
-    "--functional-dir=${layout.buildDirectory.dir('test-results/functional/opal-tags').get().asFile.absolutePath}",
-    "--output-dir=${file('functional-test-report-demo').absolutePath}",
-    "--title=Test Summary Report (Demo)"
-  ]
-}
-tasks.register('generateSmokeTestSummary', JavaExec) {
-  group = "Reporting"
-  description = "Generate an HTML summary for the smoke run"
-  dependsOn 'copySmokeReport'
-  classpath = sourceSets.functionalTest.runtimeClasspath
-  mainClass = 'uk.gov.hmcts.opal.scripts.TestReportSummaryGenerator'
-  args = [
-    "--integration-dir=${layout.buildDirectory.dir('test-results/functional-empty').get().asFile.absolutePath}",
-    "--functional-dir=${layout.buildDirectory.dir('test-results/smoke').get().asFile.absolutePath}",
-    "--output-dir=${file('smoke-test-report').absolutePath}",
-    "--title=Smoke Test Summary Report"
-  ]
-}
-
 tasks.register('functional') {
   description = "Runs functional tests"
   group = "Verification"
   gradle.startParameter.continueOnFailure = true
-  dependsOn('clearReports', 'functionalOpal', 'functionalLegacy', 'aggregate', 'copyFunctionalReport', 'mergeFunctionalResults', 'generateTestSummary')
+  dependsOn('clearReports', 'functionalOpal', 'functionalLegacy', 'aggregate', 'copyFunctionalReport', 'mergeFunctionalResults')
   tasks.functionalOpal.mustRunAfter clearReports
   tasks.functionalLegacy.mustRunAfter functionalOpal
   tasks.mergeFunctionalResults.mustRunAfter functionalLegacy
   tasks.aggregate.mustRunAfter functionalLegacy
   tasks.copyFunctionalReport.mustRunAfter aggregate
-  tasks.generateTestSummary.mustRunAfter copyFunctionalReport
   finalizedBy 'packageFunctionalOutput'
 }
 
@@ -483,13 +429,12 @@ tasks.register('functionalWithTags') {
   group = "Verification"
   gradle.startParameter.continueOnFailure = true
   dependsOn('clearReports', 'functionalOpal', 'functionalOpalTags', 'aggregate', 'copyDemoFunctionalReport',
-    'mergeFunctionalWithTagsResults', 'generateDemoTestSummary')
+    'mergeFunctionalWithTagsResults')
   tasks.functionalOpal.mustRunAfter clearReports
   tasks.functionalOpalTags.mustRunAfter functionalOpal
   tasks.mergeFunctionalWithTagsResults.mustRunAfter functionalOpalTags
   tasks.aggregate.mustRunAfter functionalOpalTags
   tasks.copyDemoFunctionalReport.mustRunAfter aggregate
-  tasks.generateDemoTestSummary.mustRunAfter copyDemoFunctionalReport
   finalizedBy 'packageDemoFunctionalOutput'
 }
 
@@ -520,7 +465,7 @@ tasks.register('copySmokeCucumberJson', Copy) {
   outputs.upToDateWhen { false }
 }
 tasks.register('packageSmokeOutput', Copy) {
-  dependsOn 'copySmokeReport', 'generateSmokeTestSummary', 'copySmokeCucumberJson'
+  dependsOn 'copySmokeReport', 'copySmokeCucumberJson'
   into("${rootDir}/smoke-output")
   from("${rootDir}/smoke-test-report") {
     into("report")
@@ -531,11 +476,10 @@ tasks.register('smoke') {
   description = "Runs Smoke Tests"
   group = "Verification"
   gradle.startParameter.continueOnFailure = true
-  dependsOn('clearReports', 'smokeOpal', 'aggregate', 'copySmokeReport', 'generateSmokeTestSummary')
+  dependsOn('clearReports', 'smokeOpal', 'aggregate', 'copySmokeReport')
   tasks.smokeOpal.mustRunAfter clearReports
   tasks.aggregate.mustRunAfter smokeOpal
   tasks.copySmokeReport.mustRunAfter aggregate
-  tasks.generateSmokeTestSummary.mustRunAfter copySmokeReport
   finalizedBy 'packageSmokeOutput'
 
 }
@@ -893,7 +837,7 @@ tasks.register('functionalWithZephyrExecution') {
   dependsOn('clearReports',
           'functionalOpal','copyOpalCucumberJson', 'createJiraExecutionFromOpalCucumberReport',
           'functionalLegacy','copyLegacyCucumberJson', 'createJiraExecutionFromLegacyCucumberReport',
-          'aggregate', 'copyFunctionalReport', 'mergeFunctionalResults', 'generateTestSummary')
+          'aggregate', 'copyFunctionalReport', 'mergeFunctionalResults')
 
   tasks.functionalOpal.mustRunAfter clearReports
   tasks.copyOpalCucumberJson.mustRunAfter functionalOpal
@@ -905,7 +849,6 @@ tasks.register('functionalWithZephyrExecution') {
   tasks.mergeFunctionalResults.mustRunAfter createJiraExecutionFromLegacyCucumberReport
   tasks.aggregate.mustRunAfter createJiraExecutionFromLegacyCucumberReport
   tasks.copyFunctionalReport.mustRunAfter aggregate
-  tasks.generateTestSummary.mustRunAfter copyFunctionalReport
   finalizedBy 'packageFunctionalOutput'
 }
 
@@ -917,7 +860,7 @@ tasks.register('functionalWithTagsWithZephyrExecution') {
   dependsOn('clearReports',
           'functionalOpal', 'copyOpalCucumberJson', 'createJiraExecutionFromOpalCucumberReport',
           'functionalOpalTags', 'copyOpalTagsCucumberJson', 'createJiraExecutionFromOpalTagsCucumberReport',
-          'aggregate', 'copyDemoFunctionalReport', 'mergeFunctionalWithTagsResults', 'generateDemoTestSummary')
+          'aggregate', 'copyDemoFunctionalReport', 'mergeFunctionalWithTagsResults')
 
   tasks.functionalOpal.mustRunAfter clearReports
   tasks.copyOpalCucumberJson.mustRunAfter functionalOpal
@@ -929,7 +872,6 @@ tasks.register('functionalWithTagsWithZephyrExecution') {
   tasks.mergeFunctionalWithTagsResults.mustRunAfter createJiraExecutionFromOpalTagsCucumberReport
   tasks.aggregate.mustRunAfter createJiraExecutionFromOpalTagsCucumberReport
   tasks.copyDemoFunctionalReport.mustRunAfter aggregate
-  tasks.generateDemoTestSummary.mustRunAfter copyDemoFunctionalReport
   finalizedBy 'packageDemoFunctionalOutput'
 }
 
@@ -1182,13 +1124,12 @@ tasks.register('functionalOpalTagsWithZephyrExecution') {
   description = "Runs functionalOpalTags then creates the Zephyr execution from the cucumber report"
 
   dependsOn('functionalOpalTags', 'copyOpalTagsCucumberJson', 'createJiraExecutionFromOpalTagsCucumberReport',
-          'aggregate', 'copyDemoFunctionalReport', 'generateTaggedDemoTestSummary')
+          'aggregate', 'copyDemoFunctionalReport')
 
   tasks.copyOpalTagsCucumberJson.mustRunAfter functionalOpalTags
   tasks.createJiraExecutionFromOpalTagsCucumberReport.mustRunAfter copyOpalTagsCucumberJson
   tasks.aggregate.mustRunAfter createJiraExecutionFromOpalTagsCucumberReport
   tasks.copyDemoFunctionalReport.mustRunAfter aggregate
-  tasks.generateTaggedDemoTestSummary.mustRunAfter copyDemoFunctionalReport
   finalizedBy 'packageTaggedDemoFunctionalOutput'
 }
 
@@ -1207,13 +1148,12 @@ tasks.register('smokeWithZephyrExecution') {
   description = "Runs smoke then creates the Zephyr execution from the cucumber report"
 
   dependsOn('smokeOpal', 'copySmokeCucumberJson', 'createJiraExecutionFromSmokeCucumberReport',
-          'aggregate', 'copySmokeReport', 'generateSmokeTestSummary')
+          'aggregate', 'copySmokeReport')
 
   tasks.copySmokeCucumberJson.mustRunAfter smokeOpal
   tasks.createJiraExecutionFromSmokeCucumberReport.mustRunAfter copySmokeCucumberJson
   tasks.aggregate.mustRunAfter createJiraExecutionFromSmokeCucumberReport
   tasks.copySmokeReport.mustRunAfter aggregate
-  tasks.generateSmokeTestSummary.mustRunAfter copySmokeReport
   finalizedBy 'packageSmokeOutput'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
 //Should we fail fast on test failures?
 //Defaults to true if env is not present
 var failFast = System.getenv('FAIL_FAST') == null || System.getenv('FAIL_FAST').toBoolean()
-var skipSonar = System.getenv('SKIP_SONAR') != null && System.getenv('SKIP_SONAR').toBoolean();
+var skipSonar = System.getenv('SKIP_SONAR') != null && System.getenv('SKIP_SONAR').toBoolean()
 def defaultLegacyStubImage = 'hmctsprod.azurecr.io/opal/legacy-db-stub:latest'
 def legacyStubImage = System.getenv('OPAL_LEGACY_STUB_IMAGE') ?: defaultLegacyStubImage
 def legacyStubPort = 4553
@@ -360,21 +360,21 @@ tasks.register('copyDemoFunctionalReport', Copy) {
   logger.quiet("Demo Functional Test Report available at - file://${rootDir}/functional-test-report-demo/index.html")
 }
 tasks.register('packageFunctionalOutput', Copy) {
-  dependsOn 'copyFunctionalReport', 'generateTestSummary', 'copyOpalCucumberJson', 'copyLegacyCucumberJson'
+  dependsOn 'copyFunctionalReport', 'copyOpalCucumberJson', 'copyLegacyCucumberJson'
   into("${rootDir}/functional-output")
   from("${rootDir}/functional-test-report") {
     into("report")
   }
 }
 tasks.register('packageDemoFunctionalOutput', Copy) {
-  dependsOn 'copyDemoFunctionalReport', 'generateDemoTestSummary', 'copyOpalTagsCucumberJson'
+  dependsOn 'copyDemoFunctionalReport', 'copyOpalTagsCucumberJson'
   into("${rootDir}/functional-output-demo")
   from("${rootDir}/functional-test-report-demo") {
     into("report")
   }
 }
 tasks.register('packageTaggedDemoFunctionalOutput', Copy) {
-  dependsOn 'copyDemoFunctionalReport', 'generateTaggedDemoTestSummary', 'copyOpalTagsCucumberJson'
+  dependsOn 'copyDemoFunctionalReport', 'copyOpalTagsCucumberJson'
   into("${rootDir}/functional-output-demo")
   from("${rootDir}/functional-test-report-demo") {
     into("report")
@@ -412,70 +412,16 @@ tasks.register('mergeFunctionalOpalTagsResults', Copy) {
   into layout.buildDirectory.dir("test-results/functional")
   include '*.xml'
 }
-tasks.register('generateTestSummary', JavaExec) {
-  group = "Reporting"
-  description = "Generate an HTML summary from test result XMLs"
-  dependsOn 'copyFunctionalReport'
-  classpath = sourceSets.functionalTest.runtimeClasspath
-  mainClass = 'uk.gov.hmcts.opal.scripts.TestReportSummaryGenerator'
-  args = [
-    "--integration-dir=${layout.buildDirectory.dir('test-results/integration').get().asFile.absolutePath}",
-    "--functional-dir=${layout.buildDirectory.dir('test-results/functional').get().asFile.absolutePath}",
-    "--output-dir=${file('functional-test-report').absolutePath}",
-    "--title=Test Summary Report"
-  ]
-}
-tasks.register('generateDemoTestSummary', JavaExec) {
-  group = "Reporting"
-  description = "Generate an HTML summary for the demo tagged functional run"
-  dependsOn 'copyDemoFunctionalReport'
-  classpath = sourceSets.functionalTest.runtimeClasspath
-  mainClass = 'uk.gov.hmcts.opal.scripts.TestReportSummaryGenerator'
-  args = [
-    "--integration-dir=${layout.buildDirectory.dir('test-results/functional-empty').get().asFile.absolutePath}",
-    "--functional-dir=${layout.buildDirectory.dir('test-results/functional').get().asFile.absolutePath}",
-    "--output-dir=${file('functional-test-report-demo').absolutePath}",
-    "--title=Test Summary Report (Demo)"
-  ]
-}
-tasks.register('generateTaggedDemoTestSummary', JavaExec) {
-  group = "Reporting"
-  description = "Generate an HTML summary for the tagged demo functional run"
-  dependsOn 'copyDemoFunctionalReport'
-  classpath = sourceSets.functionalTest.runtimeClasspath
-  mainClass = 'uk.gov.hmcts.opal.scripts.TestReportSummaryGenerator'
-  args = [
-    "--integration-dir=${layout.buildDirectory.dir('test-results/functional-empty').get().asFile.absolutePath}",
-    "--functional-dir=${layout.buildDirectory.dir('test-results/functional/opal-tags').get().asFile.absolutePath}",
-    "--output-dir=${file('functional-test-report-demo').absolutePath}",
-    "--title=Test Summary Report (Demo)"
-  ]
-}
-tasks.register('generateSmokeTestSummary', JavaExec) {
-  group = "Reporting"
-  description = "Generate an HTML summary for the smoke run"
-  dependsOn 'copySmokeReport'
-  classpath = sourceSets.functionalTest.runtimeClasspath
-  mainClass = 'uk.gov.hmcts.opal.scripts.TestReportSummaryGenerator'
-  args = [
-    "--integration-dir=${layout.buildDirectory.dir('test-results/functional-empty').get().asFile.absolutePath}",
-    "--functional-dir=${layout.buildDirectory.dir('test-results/smoke').get().asFile.absolutePath}",
-    "--output-dir=${file('smoke-test-report').absolutePath}",
-    "--title=Smoke Test Summary Report"
-  ]
-}
-
 tasks.register('functional') {
   description = "Runs functional tests"
   group = "Verification"
   gradle.startParameter.continueOnFailure = true
-  dependsOn('clearReports', 'functionalOpal', 'functionalLegacy', 'aggregate', 'copyFunctionalReport', 'mergeFunctionalResults', 'generateTestSummary')
+  dependsOn('clearReports', 'functionalOpal', 'functionalLegacy', 'aggregate', 'copyFunctionalReport', 'mergeFunctionalResults')
   tasks.functionalOpal.mustRunAfter clearReports
   tasks.functionalLegacy.mustRunAfter functionalOpal
   tasks.mergeFunctionalResults.mustRunAfter functionalLegacy
   tasks.aggregate.mustRunAfter functionalLegacy
   tasks.copyFunctionalReport.mustRunAfter aggregate
-  tasks.generateTestSummary.mustRunAfter copyFunctionalReport
   finalizedBy 'packageFunctionalOutput'
 }
 
@@ -484,13 +430,12 @@ tasks.register('functionalWithTags') {
   group = "Verification"
   gradle.startParameter.continueOnFailure = true
   dependsOn('clearReports', 'functionalOpal', 'functionalOpalTags', 'aggregate', 'copyDemoFunctionalReport',
-    'mergeFunctionalWithTagsResults', 'generateDemoTestSummary')
+    'mergeFunctionalWithTagsResults')
   tasks.functionalOpal.mustRunAfter clearReports
   tasks.functionalOpalTags.mustRunAfter functionalOpal
   tasks.mergeFunctionalWithTagsResults.mustRunAfter functionalOpalTags
   tasks.aggregate.mustRunAfter functionalOpalTags
   tasks.copyDemoFunctionalReport.mustRunAfter aggregate
-  tasks.generateDemoTestSummary.mustRunAfter copyDemoFunctionalReport
   finalizedBy 'packageDemoFunctionalOutput'
 }
 
@@ -521,7 +466,7 @@ tasks.register('copySmokeCucumberJson', Copy) {
   outputs.upToDateWhen { false }
 }
 tasks.register('packageSmokeOutput', Copy) {
-  dependsOn 'copySmokeReport', 'generateSmokeTestSummary', 'copySmokeCucumberJson'
+  dependsOn 'copySmokeReport', 'copySmokeCucumberJson'
   into("${rootDir}/smoke-output")
   from("${rootDir}/smoke-test-report") {
     into("report")
@@ -532,11 +477,10 @@ tasks.register('smoke') {
   description = "Runs Smoke Tests"
   group = "Verification"
   gradle.startParameter.continueOnFailure = true
-  dependsOn('clearReports', 'smokeOpal', 'aggregate', 'copySmokeReport', 'generateSmokeTestSummary')
+  dependsOn('clearReports', 'smokeOpal', 'aggregate', 'copySmokeReport')
   tasks.smokeOpal.mustRunAfter clearReports
   tasks.aggregate.mustRunAfter smokeOpal
   tasks.copySmokeReport.mustRunAfter aggregate
-  tasks.generateSmokeTestSummary.mustRunAfter copySmokeReport
   finalizedBy 'packageSmokeOutput'
 
 }
@@ -894,7 +838,7 @@ tasks.register('functionalWithZephyrExecution') {
   dependsOn('clearReports',
           'functionalOpal','copyOpalCucumberJson', 'createJiraExecutionFromOpalCucumberReport',
           'functionalLegacy','copyLegacyCucumberJson', 'createJiraExecutionFromLegacyCucumberReport',
-          'aggregate', 'copyFunctionalReport', 'mergeFunctionalResults', 'generateTestSummary')
+          'aggregate', 'copyFunctionalReport', 'mergeFunctionalResults')
 
   tasks.functionalOpal.mustRunAfter clearReports
   tasks.copyOpalCucumberJson.mustRunAfter functionalOpal
@@ -906,7 +850,6 @@ tasks.register('functionalWithZephyrExecution') {
   tasks.mergeFunctionalResults.mustRunAfter createJiraExecutionFromLegacyCucumberReport
   tasks.aggregate.mustRunAfter createJiraExecutionFromLegacyCucumberReport
   tasks.copyFunctionalReport.mustRunAfter aggregate
-  tasks.generateTestSummary.mustRunAfter copyFunctionalReport
   finalizedBy 'packageFunctionalOutput'
 }
 
@@ -918,7 +861,7 @@ tasks.register('functionalWithTagsWithZephyrExecution') {
   dependsOn('clearReports',
           'functionalOpal', 'copyOpalCucumberJson', 'createJiraExecutionFromOpalCucumberReport',
           'functionalOpalTags', 'copyOpalTagsCucumberJson', 'createJiraExecutionFromOpalTagsCucumberReport',
-          'aggregate', 'copyDemoFunctionalReport', 'mergeFunctionalWithTagsResults', 'generateDemoTestSummary')
+          'aggregate', 'copyDemoFunctionalReport', 'mergeFunctionalWithTagsResults')
 
   tasks.functionalOpal.mustRunAfter clearReports
   tasks.copyOpalCucumberJson.mustRunAfter functionalOpal
@@ -930,7 +873,6 @@ tasks.register('functionalWithTagsWithZephyrExecution') {
   tasks.mergeFunctionalWithTagsResults.mustRunAfter createJiraExecutionFromOpalTagsCucumberReport
   tasks.aggregate.mustRunAfter createJiraExecutionFromOpalTagsCucumberReport
   tasks.copyDemoFunctionalReport.mustRunAfter aggregate
-  tasks.generateDemoTestSummary.mustRunAfter copyDemoFunctionalReport
   finalizedBy 'packageDemoFunctionalOutput'
 }
 
@@ -1183,13 +1125,12 @@ tasks.register('functionalOpalTagsWithZephyrExecution') {
   description = "Runs functionalOpalTags then creates the Zephyr execution from the cucumber report"
 
   dependsOn('functionalOpalTags', 'copyOpalTagsCucumberJson', 'createJiraExecutionFromOpalTagsCucumberReport',
-          'aggregate', 'copyDemoFunctionalReport', 'generateTaggedDemoTestSummary')
+          'aggregate', 'copyDemoFunctionalReport')
 
   tasks.copyOpalTagsCucumberJson.mustRunAfter functionalOpalTags
   tasks.createJiraExecutionFromOpalTagsCucumberReport.mustRunAfter copyOpalTagsCucumberJson
   tasks.aggregate.mustRunAfter createJiraExecutionFromOpalTagsCucumberReport
   tasks.copyDemoFunctionalReport.mustRunAfter aggregate
-  tasks.generateTaggedDemoTestSummary.mustRunAfter copyDemoFunctionalReport
   finalizedBy 'packageTaggedDemoFunctionalOutput'
 }
 
@@ -1208,13 +1149,12 @@ tasks.register('smokeWithZephyrExecution') {
   description = "Runs smoke then creates the Zephyr execution from the cucumber report"
 
   dependsOn('smokeOpal', 'copySmokeCucumberJson', 'createJiraExecutionFromSmokeCucumberReport',
-          'aggregate', 'copySmokeReport', 'generateSmokeTestSummary')
+          'aggregate', 'copySmokeReport')
 
   tasks.copySmokeCucumberJson.mustRunAfter smokeOpal
   tasks.createJiraExecutionFromSmokeCucumberReport.mustRunAfter copySmokeCucumberJson
   tasks.aggregate.mustRunAfter createJiraExecutionFromSmokeCucumberReport
   tasks.copySmokeReport.mustRunAfter aggregate
-  tasks.generateSmokeTestSummary.mustRunAfter copySmokeReport
   finalizedBy 'packageSmokeOutput'
 }
 


### PR DESCRIPTION
### Change description ###

Align Jenkins report publishing and archived artifacts for both nightly and CNP pipelines.

Changes

- add nightly publishing for Integration Tests Report
- rename nightly demo artifact outputs to:

functional-output-r1a-only-demo
functional-output-r1a-off-demo

- rename the nightly demo R1A report label to Serenity Functional Test Report (Demo R1AOn Only)
- stop publishing functional and smoke summary report links in both pipelines
- stop archiving duplicate raw outputs:

build/test-results/...
functional-test-report/...
smoke-test-report/...

- ensure nightly demo artifact folders contain the Serenity report as well as Zephyr output
- remove unused summary-generation tasks from build.gradle
- update README pipeline documentation to match the new behavior

Result
Nightly now produces:
- Integration Tests Report
- Serenity Functional Test Report
- Serenity Functional Test Report (Demo R1AOn Only)
- Serenity Functional Test Report (Demo R1AOff) when enabled
- Serenity Smoke Test Report

CNP now produces:
- Integration Tests Report
- Serenity Functional Test Report
- Serenity Smoke Test Report

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
