### PR TITLE
PO-3859: Refactor ReportEntryEntity to use AssociatedRecordType enum

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/entity/ReportEntryEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/ReportEntryEntity.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,7 +18,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnTransformer;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
+import uk.gov.hmcts.opal.entity.converter.AssociatedRecordTypeConverter;
 
 @Entity
 @Table(name = "report_entries")
@@ -48,8 +51,10 @@ public class ReportEntryEntity {
     @Column(name = "reported_timestamp")
     private LocalDateTime reportedTimestamp;
 
-    @Column(name = "associated_record_type", length = 30)
-    private String associatedRecordType;
+    @Convert(converter = AssociatedRecordTypeConverter.class)
+    @ColumnTransformer(write = "?::t_associated_record_type_enum")
+    @Column(name = "associated_record_type", length = 30, columnDefinition = "t_associated_record_type_enum")
+    private AssociatedRecordType associatedRecordType;
 
     @Column(name = "associated_record_id", length = 30)
     private String associatedRecordId;

--- a/src/main/java/uk/gov/hmcts/opal/service/iface/ReportEntryServiceInterface.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/iface/ReportEntryServiceInterface.java
@@ -2,5 +2,5 @@ package uk.gov.hmcts.opal.service.iface;
 
 public interface ReportEntryServiceInterface {
 
-    public void createExtendTtpReportEntry(Long paymentTermsId, short businessUnitId);
+    public void createExtendTtpReportEntry(Long defendantAccountId, short businessUnitId);
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
@@ -1121,7 +1121,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
         }
 
         // Create report entry for the Extension of Time to Pay report
-        reportEntryService.createExtendTtpReportEntry(savedPaymentTerms.getPaymentTermsId(),
+        reportEntryService.createExtendTtpReportEntry(defAccount.getDefendantAccountId(),
             defAccount.getBusinessUnit().getBusinessUnitId());
 
         log.debug(":addPaymentTerms: saved payment terms id={} for account {}",

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/ReportEntryService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/ReportEntryService.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.opal.service.opal;
 
-import static uk.gov.hmcts.opal.util.RecordTypeConstants.PAYMENT_TERMS;
 import static uk.gov.hmcts.opal.util.ReportIdConstants.LIST_EXTEND_TTP;
 
 import java.time.Clock;
@@ -9,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.opal.entity.AssociatedRecordType;
 import uk.gov.hmcts.opal.entity.ReportEntryEntity;
 import uk.gov.hmcts.opal.repository.ReportEntryRepository;
 import uk.gov.hmcts.opal.service.iface.ReportEntryServiceInterface;
@@ -29,18 +29,18 @@ public class ReportEntryService implements ReportEntryServiceInterface {
      * Create a report_entries record for the Extension of Time to Pay report.
      *
      */
-    public void createExtendTtpReportEntry(Long paymentTermsId, short businessUnitId) {
+    public void createExtendTtpReportEntry(Long defendantAccountId, short businessUnitId) {
         ReportEntryEntity reportEntry = ReportEntryEntity.builder()
             .businessUnit(businessUnitService.getBusinessUnit(businessUnitId))
             .reportId(LIST_EXTEND_TTP)
             .entryTimestamp(LocalDateTime.now(clock))
-            .associatedRecordId(String.valueOf(paymentTermsId))
-            .associatedRecordType(PAYMENT_TERMS)
+            .associatedRecordId(String.valueOf(defendantAccountId))
+            .associatedRecordType(AssociatedRecordType.DEFENDANT_ACCOUNTS)
             .build();
 
         reportEntryRepository.save(reportEntry);
 
-        log.debug(":createExtendTtpReportEntry: created report entry for paymentTermsId={} BU={}",
-            paymentTermsId, businessUnitId);
+        log.debug(":createExtendTtpReportEntry: created report entry for defendantAccountId={} BU={}",
+            defendantAccountId, businessUnitId);
     }
 }

--- a/src/main/resources/db/migration/ddl/V1_185__alter_report_entries_associated_record_type_to_enum.sql
+++ b/src/main/resources/db/migration/ddl/V1_185__alter_report_entries_associated_record_type_to_enum.sql
@@ -1,0 +1,20 @@
+/**
+* OPAL Program
+*
+* MODULE      : alter_report_entries_associated_record_type_to_enum.sql
+*
+* DESCRIPTION : Alter report_entries.associated_record_type to use PostgreSQL enum
+*
+* VERSION HISTORY:
+*
+* Date          Author         Version     Nature of Change
+* ----------    -----------    --------    ----------------------------------------------------------------------------
+* 03/06/2026    TMc            1.0         PO-3844 - Update columns on REPORT_ENTRIES table to use PostgreSQL ENUM
+*
+**/
+
+ALTER TABLE report_entries
+    ALTER COLUMN associated_record_type TYPE t_associated_record_type_enum
+    USING associated_record_type::text::t_associated_record_type_enum;
+
+COMMENT ON COLUMN report_entries.associated_record_type IS 'Type of record identified by associated_record_id. Specific values can be found in the DB LLD on Confluence.';

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/ReportEntryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/ReportEntryServiceTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.opal.util.RecordTypeConstants.PAYMENT_TERMS;
 import static uk.gov.hmcts.opal.util.ReportIdConstants.LIST_EXTEND_TTP;
 
 import java.time.Clock;
@@ -20,6 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.opal.entity.AssociatedRecordType;
 import uk.gov.hmcts.opal.entity.ReportEntryEntity;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
 import uk.gov.hmcts.opal.repository.ReportEntryRepository;
@@ -44,7 +44,7 @@ class ReportEntryServiceTest {
 
     @Test
     void createExtendTtpReportEntry_savesExpectedReportEntry() {
-        Long paymentTermsId = 77L;
+        Long defendantAccountId = 77L;
         short businessUnitId = 10;
         BusinessUnitEntity businessUnit = BusinessUnitEntity.builder()
             .businessUnitId(businessUnitId)
@@ -53,7 +53,7 @@ class ReportEntryServiceTest {
 
         when(businessUnitService.getBusinessUnit(businessUnitId)).thenReturn(businessUnit);
 
-        reportEntryService.createExtendTtpReportEntry(paymentTermsId, businessUnitId);
+        reportEntryService.createExtendTtpReportEntry(defendantAccountId, businessUnitId);
 
         verify(businessUnitService).getBusinessUnit(businessUnitId);
         verify(reportEntryRepository).save(reportEntryCaptor.capture());
@@ -62,8 +62,8 @@ class ReportEntryServiceTest {
         assertNotNull(savedEntry);
         assertEquals(businessUnit, savedEntry.getBusinessUnit());
         assertEquals(LIST_EXTEND_TTP, savedEntry.getReportId());
-        assertEquals(String.valueOf(paymentTermsId), savedEntry.getAssociatedRecordId());
-        assertEquals(PAYMENT_TERMS, savedEntry.getAssociatedRecordType());
+        assertEquals(String.valueOf(defendantAccountId), savedEntry.getAssociatedRecordId());
+        assertEquals(AssociatedRecordType.DEFENDANT_ACCOUNTS, savedEntry.getAssociatedRecordType());
         assertEquals(LocalDateTime.of(2026, 4, 22, 9, 15), savedEntry.getEntryTimestamp());
         assertNull(savedEntry.getReportedTimestamp());
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-3859
BE - Database enum alignment - ReportEntriesEntity
https://tools.hmcts.net/jira/browse/PO-3844 (DB)

### Change description ###
- Refactor ReportEntryEntity.associatedRecordType to use the `AssociatedRecordType` enum instead of a `String`
- Update extend TTP report entries to use `AssociatedRecordType.DEFENDANT_ACCOUNTS `with the `defendantAccountId` instead of a `paymentTermsId`, aligning `ReportEntryEntity` usage with the existing DB enum contract

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
