### PR TITLE
PO-3860: Refactor StandardLetterEntity to use AssociatedRecordType enum

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/entity/StandardLetterEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/StandardLetterEntity.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -17,6 +18,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
+import uk.gov.hmcts.opal.entity.converter.AssociatedRecordTypeConverter;
 
 @Entity
 @Table(name = "standard_letters")
@@ -45,8 +47,10 @@ public class StandardLetterEntity {
     @Column(name = "standard_letter_name", length = 50, nullable = false)
     private String standardLetterName;
 
-    @Column(name = "associated_record_type", length = 30, nullable = false)
-    private String associatedRecordType;
+    @Convert(converter = AssociatedRecordTypeConverter.class)
+    @Column(name = "associated_record_type", length = 30, nullable = false,
+        columnDefinition = "t_associated_record_type_enum")
+    private AssociatedRecordType associatedRecordType;
 
     @Column(name = "user_entries")
     private String userEntries;

--- a/src/main/resources/db/migration/ddl/V1_190__alter_standard_letters_associated_record_type_to_enum.sql
+++ b/src/main/resources/db/migration/ddl/V1_190__alter_standard_letters_associated_record_type_to_enum.sql
@@ -1,0 +1,20 @@
+/**
+* OPAL Program
+*
+* MODULE      : alter_standard_letters_associated_record_type_to_enum.sql
+*
+* DESCRIPTION : Alter standard_letters.associated_record_type to use PostgreSQL enum
+*
+* VERSION HISTORY:
+*
+* Date          Author         Version     Nature of Change
+* ----------    -----------    --------    ----------------------------------------------------------------------------
+* 03/06/2026    TMc            1.0         PO-3847 - Update columns on STANDARD_LETTERS table to use PostgreSQL ENUM
+*
+**/
+
+ALTER TABLE standard_letters
+    ALTER COLUMN associated_record_type TYPE t_associated_record_type_enum
+    USING associated_record_type::text::t_associated_record_type_enum;
+
+COMMENT ON COLUMN standard_letters.associated_record_type IS 'The type of record for which this letter is generated. Specific values can be found in the DB LLD on Confluence.';


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-3860
BE - Database enum alignment - StandardLettersEntity
https://tools.hmcts.net/jira/browse/PO-3847 (DB)


### Change description ###
- Refactor `StandardLetterEntity.associatedRecordType` to use the `AssociatedRecordType` enum instead of a `String`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
