### PR TITLE
Make Serenity reports wait for test results

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -484,6 +484,42 @@ tasks.register('smoke') {
 
 }
 
+// Jenkins sometimes invokes Serenity-producing tasks as separate top-level tasks.
+// Keep the execution order deterministic and aggregate against the JUnit XML roots
+// that the functional and smoke suites actually generate.
+tasks.named('clearReports') {
+  doLast {
+    delete(layout.buildDirectory.dir("test-results"))
+  }
+}
+
+tasks.named('aggregate') {
+  testRoot = layout.buildDirectory.dir("test-results").get().asFile.absolutePath
+  mustRunAfter(
+    tasks.named('functionalOpal'),
+    tasks.named('functionalLegacy'),
+    tasks.named('functionalOpalTags'),
+    tasks.named('smokeOpal'),
+    tasks.named('mergeFunctionalResults'),
+    tasks.named('mergeFunctionalWithTagsResults'),
+    tasks.named('mergeFunctionalOpalTagsResults')
+  )
+}
+
+tasks.configureEach {
+  if (name in ['copyFunctionalReport', 'copyDemoFunctionalReport', 'copySmokeReport']) {
+    mustRunAfter tasks.named('aggregate')
+  } else if (name == 'copyOpalCucumberJson') {
+    mustRunAfter tasks.named('functionalOpal')
+  } else if (name == 'copyOpalTagsCucumberJson') {
+    mustRunAfter tasks.named('functionalOpalTags')
+  } else if (name == 'copyLegacyCucumberJson') {
+    mustRunAfter tasks.named('functionalLegacy')
+  } else if (name == 'copySmokeCucumberJson') {
+    mustRunAfter tasks.named('smokeOpal')
+  }
+}
+
 def coverageExclusions = [
   '**/uk/gov/hmcts/opal/**/model/**',
   '**/uk/gov/hmcts/opal/**/config/**',


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Fixes blank Serenity reports in CI by wiring aggregate to the generated JUnit test results and tightening task ordering for functional and smoke report publication. Also clears stale build/test-results data during report runs so old results do not leak into new reports

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
