### PR TITLE
PO-3870: BE enum alignment with DB - SuspenseItemEntity

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/entity/PaymentMethod.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/PaymentMethod.java
@@ -14,4 +14,5 @@ public enum PaymentMethod {
     PaymentMethod(String displayName) {
         this.displayName = displayName;
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/opal/entity/SuspenseItemEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/SuspenseItemEntity.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -20,6 +22,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import uk.gov.hmcts.opal.util.LocalDateTimeAdapter;
 
 import java.time.LocalDateTime;
@@ -50,15 +54,19 @@ public class SuspenseItemEntity {
     @Column(name = "suspense_item_number", nullable = false)
     private Short suspenseItemNumber;
 
-    @Column(name = "suspense_item_type", length = 2, nullable = false)
-    private String suspenseItemType;
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "suspense_item_type", length = 2, nullable = false,
+        columnDefinition = "t_suspense_item_type_enum")
+    private SuspenseItemType suspenseItemType;
 
     @Column(name = "created_date", nullable = false)
     @XmlJavaTypeAdapter(LocalDateTimeAdapter.class)
     private LocalDateTime createdDate;
 
     @Column(name = "payment_method", length = 2)
-    private String paymentMethod;
+    @Enumerated(EnumType.STRING)
+    private PaymentMethod paymentMethod;
 
     @Column(name = "court_fee_id")
     private Long courtFeeId;

--- a/src/main/java/uk/gov/hmcts/opal/entity/SuspenseItemEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/SuspenseItemEntity.java
@@ -64,8 +64,9 @@ public class SuspenseItemEntity {
     @XmlJavaTypeAdapter(LocalDateTimeAdapter.class)
     private LocalDateTime createdDate;
 
-    @Column(name = "payment_method", length = 2)
     @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "payment_method", length = 2, columnDefinition = "t_payment_method_enum")
     private PaymentMethod paymentMethod;
 
     @Column(name = "court_fee_id")

--- a/src/main/java/uk/gov/hmcts/opal/entity/SuspenseItemType.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/SuspenseItemType.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.opal.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum SuspenseItemType {
+    CC("Cancelled cheque (Fines)"),
+    CF("Court Fee"),
+    FA("Fines payment in advance"),
+    FB("Cancelled BACS (Fines)"),
+    IN("Adjustment"),
+    LA("Legal aid payment"),
+    MA("Maintenance payment"),
+    MB("Cancelled BACS (Maintenance)"),
+    MC("Cancelled cheque (Maintenance)"),
+    MS("Miscellaneous"),
+    OM("Overpayment (Maintenance)"),
+    OC("Overpayment (Court Fees)"),
+    OF("Overpayment (Fines)"),
+    UN("Unidentified");
+
+    private final String description;
+
+    SuspenseItemType(final String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/mapper/history/DefendantTransactionEntityHistoryMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/mapper/history/DefendantTransactionEntityHistoryMapper.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.opal.dto.history.DefendantTransactionTypeReference;
 import uk.gov.hmcts.opal.dto.history.PaymentMethodReference;
 import uk.gov.hmcts.opal.dto.history.WriteOffTypeReference;
 import uk.gov.hmcts.opal.entity.AssociatedRecordType;
+import uk.gov.hmcts.opal.entity.PaymentMethod;
 import uk.gov.hmcts.opal.entity.defendanttransaction.DefendantTransactionEntity;
 import uk.gov.hmcts.opal.entity.PaymentMethod;
 import uk.gov.hmcts.opal.entity.defendanttransaction.DefendantTransactionStatus;

--- a/src/main/java/uk/gov/hmcts/opal/service/report/CashListReportAssembler.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/CashListReportAssembler.java
@@ -85,7 +85,7 @@ public class CashListReportAssembler {
 
         return baseEntry(entryNumber, payment)
             .type(SUSPENSE_REPORT_TYPE)
-            .suspense(suspenseItem.getSuspenseItemType())
+            .suspense(suspenseItem.getSuspenseItemType().name())
             .accountNumber(SUSPENSE_ACCOUNT_NUMBER)
             .name(String.valueOf(suspenseItem.getSuspenseItemNumber()))
             .nameAdditionalInformation(toAdditionalInformation(payment))

--- a/src/main/resources/db/migration/ddl/V1_195__alter_suspense_items_enum_columns.sql
+++ b/src/main/resources/db/migration/ddl/V1_195__alter_suspense_items_enum_columns.sql
@@ -1,0 +1,23 @@
+/**
+* OPAL Program
+*
+* MODULE      : alter_suspense_items_enum_columns.sql
+*
+* DESCRIPTION : Alter suspense_items enum-backed columns
+*
+* VERSION HISTORY:
+*
+* Date          Author         Version     Nature of Change
+* ----------    -----------    --------    ----------------------------------------------------------------------------
+* 03/06/2026    TMc            1.0         PO-3848 - Update columns on SUSPENSE_ITEMS table to use PostgreSQL ENUM
+*
+**/
+
+ALTER TABLE suspense_items
+    ALTER COLUMN suspense_item_type TYPE t_suspense_item_type_enum
+        USING suspense_item_type::text::t_suspense_item_type_enum,
+    ALTER COLUMN payment_method TYPE t_payment_method_enum
+        USING payment_method::text::t_payment_method_enum;
+
+COMMENT ON COLUMN suspense_items.suspense_item_type IS 'Type of this suspense item. Specific values can be found in the DB LLD on Confluence.';
+COMMENT ON COLUMN suspense_items.payment_method IS 'The method of payment. Specific values can be found in the DB LLD on Confluence.';

--- a/src/test/java/uk/gov/hmcts/opal/entity/SuspenseItemTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/entity/SuspenseItemTypeTest.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.opal.entity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class SuspenseItemTypeTest {
+
+    @Test
+    void given_enumValues_when_getDescription_then_expectedDescriptionsReturned() {
+        assertEquals("Cancelled cheque (Fines)", SuspenseItemType.CC.getDescription());
+        assertEquals("Court Fee", SuspenseItemType.CF.getDescription());
+        assertEquals("Fines payment in advance", SuspenseItemType.FA.getDescription());
+        assertEquals("Cancelled BACS (Fines)", SuspenseItemType.FB.getDescription());
+        assertEquals("Adjustment", SuspenseItemType.IN.getDescription());
+        assertEquals("Legal aid payment", SuspenseItemType.LA.getDescription());
+        assertEquals("Maintenance payment", SuspenseItemType.MA.getDescription());
+        assertEquals("Cancelled BACS (Maintenance)", SuspenseItemType.MB.getDescription());
+        assertEquals("Cancelled cheque (Maintenance)", SuspenseItemType.MC.getDescription());
+        assertEquals("Miscellaneous", SuspenseItemType.MS.getDescription());
+        assertEquals("Overpayment (Maintenance)", SuspenseItemType.OM.getDescription());
+        assertEquals("Overpayment (Court Fees)", SuspenseItemType.OC.getDescription());
+        assertEquals("Overpayment (Fines)", SuspenseItemType.OF.getDescription());
+        assertEquals("Unidentified", SuspenseItemType.UN.getDescription());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/report/CashListReportAssemblerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/CashListReportAssemblerTest.java
@@ -16,9 +16,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.opal.entity.AssociatedRecordType;
 import uk.gov.hmcts.opal.entity.DestinationType;
 import uk.gov.hmcts.opal.entity.PartyEntity;
+import uk.gov.hmcts.opal.entity.PaymentMethod;
 import uk.gov.hmcts.opal.entity.PaymentInEntity;
 import uk.gov.hmcts.opal.entity.SuspenseAccountEntity;
 import uk.gov.hmcts.opal.entity.SuspenseItemEntity;
+import uk.gov.hmcts.opal.entity.SuspenseItemType;
 import uk.gov.hmcts.opal.entity.TillEntity;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.AssociationType;
@@ -95,7 +97,7 @@ class CashListReportAssemblerTest {
         CashListReportData.CashListEntry secondEntry = data.getEntries().getLast();
         assertThat(secondEntry.getEntry()).isEqualTo(2);
         assertThat(secondEntry.getType()).isEqualTo("SA");
-        assertThat(secondEntry.getSuspense()).isEqualTo("PA");
+        assertThat(secondEntry.getSuspense()).isEqualTo("FA");
         assertThat(secondEntry.getAccountNumber()).isEqualTo("Suspense Ref");
         assertThat(secondEntry.getName()).isEqualTo("1");
         assertThat(secondEntry.getNameAdditionalInformation()).isEqualTo("Manual - Suspense payment");
@@ -287,9 +289,9 @@ class CashListReportAssemblerTest {
             .suspenseItemId(SUSPENSE_ITEM_ID)
             .suspenseAccount(suspenseAccount)
             .suspenseItemNumber((short) 1)
-            .suspenseItemType("PA")
+            .suspenseItemType(SuspenseItemType.FA)
             .createdDate(LocalDateTime.of(2026, 5, 26, 15, 0))
-            .paymentMethod("CA")
+            .paymentMethod(PaymentMethod.CQ)
             .courtFeeId(99000000032000L)
             .build();
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-3870
https://tools.hmcts.net/jira/browse/PO-3848 (DB)


### Change description ###
Update SuspenseItemEntity to support the new source column as a Java enum, aligned with the database enum definition


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
