### PR TITLE
PO-7270_PO-7274 Add SQL scripts for operational report configuration and permissions updates

### DIFF
--- a/src/functionalTest/resources/features/opalMode/referenceData/Reports.feature
+++ b/src/functionalTest/resources/features/opalMode/referenceData/Reports.feature
@@ -23,7 +23,7 @@ Feature: Report Definition Reference Data
 
   @JIRA-STORY:PO-2250 @JIRA-EPIC:PO-2248 @JIRA-TEST-KEY:PO-7861
   Scenario: Seeded report definition forbidden responses match the standard error contract
-    Given I am testing as the "opal-test@dev.platform.hmcts.net" user
+    Given I am testing as the "opal-test-2@dev.platform.hmcts.net" user
     When I make a request to the seeded report definition api
     Then the request is rejected as forbidden
     And the latest report definition error response matches the standard problem detail contract for status 403

--- a/src/main/resources/db/migration/data/allEnvs/V1_150__insert_operational_report_bu_warning_threshold_configuration_item.sql
+++ b/src/main/resources/db/migration/data/allEnvs/V1_150__insert_operational_report_bu_warning_threshold_configuration_item.sql
@@ -1,0 +1,29 @@
+/**
+* OPAL Program
+*
+* MODULE      : insert_operational_report_bu_warning_threshold_configuration_item.sql
+*
+* DESCRIPTION : Insert operational report business unit warning threshold configuration item
+*
+* VERSION HISTORY:
+*
+* Date          Author      Version     Nature of Change
+* ----------    --------    --------    ------------------------------------------------------------------------------------------------------
+* 19/06/2026    C Cho       1.0         PO-7270 - Add operational report business unit warning threshold configuration item.
+*
+**/
+
+INSERT INTO public.configuration_items (
+    configuration_item_id,
+    item_name,
+    business_unit_id,
+    item_value,
+    item_values
+)
+VALUES (
+    NEXTVAL('configuration_item_id_seq'),
+    'OPERATIONAL_REPORT_BU_WARNING_THRESHOLD',
+    NULL,
+    '10',
+    NULL
+);

--- a/src/main/resources/db/migration/data/allEnvs/V1_155__update_operational_report_permissions.sql
+++ b/src/main/resources/db/migration/data/allEnvs/V1_155__update_operational_report_permissions.sql
@@ -1,0 +1,21 @@
+/**
+* OPAL Program
+*
+* MODULE      : update_operational_report_permissions.sql
+*
+* DESCRIPTION : Update operational report permissions
+*
+* VERSION HISTORY:
+*
+* Date          Author      Version     Nature of Change
+* ----------    --------    --------    ------------------------------------------------------------------------------------------------------
+* 19/06/2026    C Cho       1.0         PO-7274 - Set operational report permissions to search and view accounts.
+*
+**/
+
+UPDATE public.reports
+   SET permission = 'SEARCH_AND_VIEW_ACCOUNTS'
+ WHERE report_id IN (
+           'operational_report_enforcement',
+           'operational_report_payment'
+       );


### PR DESCRIPTION
JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/PO-7270
https://tools.hmcts.net/jira/browse/PO-7274

Change description
PO-7270 - Created a new system parameter for the operational report business unit warning threshold.
PO-7274 - Updated operational reports reference data to set the permission to SEARCH_AND_VIEW_ACCOUNTS.

Does this PR introduce a breaking change?** (check one with "x")

[ ] Yes
[x] No