### PR TITLE
PO-7203: Document investigation into Spring test context memory growth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -312,8 +312,12 @@ tasks.register('integration', Test) {
   group = "Verification"
   testClassesDirs = sourceSets.integrationTest.output.classesDirs
   classpath = sourceSets.integrationTest.runtimeClasspath
+  systemProperty 'logging.level.org.springframework.test.context.cache', 'DEBUG'
+  jvmArgs '-XX:+HeapDumpOnOutOfMemoryError',
+    "-XX:HeapDumpPath=${layout.buildDirectory.dir('heap-dumps/integration').get().asFile.absolutePath}"
   exclude '**/ReportQueueConnectivityIntegrationTest.class'
   doFirst {
+    layout.buildDirectory.dir('heap-dumps/integration').get().asFile.mkdirs()
     pullLatestLegacyStubImageIfLocal()
   }
   finalizedBy 'packageIntegrationOutput'
@@ -452,6 +456,12 @@ tasks.register('packageIntegrationOutput', Copy) {
   into("${rootDir}/integration-output")
   from(layout.buildDirectory.dir("reports/tests/integration")) {
     into("report")
+  }
+  from(layout.buildDirectory.dir("test-results/integration")) {
+    into("test-results")
+  }
+  from(layout.buildDirectory.dir("heap-dumps/integration")) {
+    into("heap-dumps")
   }
 }
 tasks.register('mergeFunctionalResults', Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -298,7 +298,7 @@ tasks.withType(JavaExec).configureEach {
 tasks.withType(Test).configureEach {
   useJUnitPlatform()
 
-  systemProperty 'spring.test.context.cache.maxSize', 4
+  systemProperty 'spring.test.context.cache.maxSize', 8
 
   testLogging {
     exceptionFormat = 'full'

--- a/build.gradle
+++ b/build.gradle
@@ -307,23 +307,120 @@ tasks.withType(Test).configureEach {
   failFast = false
 }
 
+def integrationSourceFiles = fileTree('src/integrationTest/java') {
+  include '**/*Test.java'
+  include '**/*IT.java'
+}
+
+def integrationClassNameFor = { File file ->
+  rootDir.toPath()
+    .relativize(file.toPath())
+    .toString()
+    .replace("src${File.separator}integrationTest${File.separator}java${File.separator}", "")
+    .replace(File.separator, ".")
+    .replaceAll(/\.java$/, "")
+}
+
+def integrationTestClassesMatching = { Closure<Boolean> matcher ->
+  integrationSourceFiles.files.collectMany { File file ->
+    def source = file.getText('UTF-8')
+    def className = integrationClassNameFor(file)
+    if (source.contains('abstract class')) {
+      return []
+    }
+    matcher(source, className) ? [className] : []
+  }.sort()
+}
+
+def integrationSecurityTestClasses = integrationTestClassesMatching { String source, String className ->
+  source.contains('integration-with-spring-security') ||
+    source.contains('extends AbstractIntegrationWithSecurityTest')
+}
+
+def integrationLegacyTestClasses = integrationTestClassesMatching { String source, String className ->
+  source.contains('@ActiveProfiles({"integration", "legacy"})') ||
+    source.contains('@ActiveProfiles({"legacy"})') ||
+    source.contains('extends AbstractLegacyDefendantsIntegrationTest') ||
+    className.tokenize('.').last().startsWith('Legacy')
+}
+
+def integrationOpalTestClasses = integrationTestClassesMatching { String source, String className ->
+  source.contains('@ActiveProfiles({"integration", "opal"})') ||
+    source.contains('extends AbstractOpalDefendantsIntegrationTest') ||
+    className.tokenize('.').last().startsWith('Opal')
+}
+
+def integrationBaseTestClasses = integrationTestClassesMatching { String source, String className ->
+  !(integrationSecurityTestClasses.contains(className) ||
+    integrationLegacyTestClasses.contains(className) ||
+    integrationOpalTestClasses.contains(className))
+}
+
+def configureIntegrationDiagnostics = { Test task, String outputName ->
+  task.systemProperty 'logging.level.org.springframework.test.context.cache', 'DEBUG'
+  task.jvmArgs '-XX:+HeapDumpOnOutOfMemoryError',
+    "-XX:HeapDumpPath=${layout.buildDirectory.dir("heap-dumps/${outputName}").get().asFile.absolutePath}",
+    "-Xlog:gc*,safepoint:file=${layout.buildDirectory.file("logs/${outputName}-gc.log").get().asFile.absolutePath}:time,uptime,level,tags:filecount=3,filesize=20M"
+  task.doFirst {
+    layout.buildDirectory.dir("heap-dumps/${outputName}").get().asFile.mkdirs()
+    layout.buildDirectory.dir('logs').get().asFile.mkdirs()
+    pullLatestLegacyStubImageIfLocal()
+  }
+}
+
+def registerIntegrationFamilyTask = { String taskName, String descriptionText, List<String> testClasses ->
+  tasks.register(taskName, Test) {
+    description = descriptionText
+    group = "Verification"
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+    reports.html.getOutputLocation().set(layout.buildDirectory.dir("reports/tests/${taskName}"))
+    reports.junitXml.getOutputLocation().set(layout.buildDirectory.dir("test-results/${taskName}"))
+    configureIntegrationDiagnostics(delegate as Test, taskName)
+    exclude '**/ReportQueueConnectivityIntegrationTest.class'
+    filter {
+      testClasses.each { includeTestsMatching it }
+    }
+    doFirst {
+      logger.lifecycle("Running ${testClasses.size()} ${taskName} test classes.")
+    }
+    finalizedBy 'packageIntegrationOutput'
+  }
+}
+
 tasks.register('integration', Test) {
   description = "Runs integration tests"
   group = "Verification"
   testClassesDirs = sourceSets.integrationTest.output.classesDirs
   classpath = sourceSets.integrationTest.runtimeClasspath
-  systemProperty 'logging.level.org.springframework.test.context.cache', 'DEBUG'
-  jvmArgs '-XX:+HeapDumpOnOutOfMemoryError',
-    "-XX:HeapDumpPath=${layout.buildDirectory.dir('heap-dumps/integration').get().asFile.absolutePath}",
-    "-Xlog:gc*,safepoint:file=${layout.buildDirectory.file('logs/integration-gc.log').get().asFile.absolutePath}:time,uptime,level,tags:filecount=3,filesize=20M"
+  configureIntegrationDiagnostics(delegate as Test, 'integration')
   exclude '**/ReportQueueConnectivityIntegrationTest.class'
-  doFirst {
-    layout.buildDirectory.dir('heap-dumps/integration').get().asFile.mkdirs()
-    layout.buildDirectory.dir('logs').get().asFile.mkdirs()
-    pullLatestLegacyStubImageIfLocal()
-  }
   finalizedBy 'packageIntegrationOutput'
 }
+
+registerIntegrationFamilyTask(
+  'integrationBase',
+  'Runs integration tests that use the base integration Spring profile.',
+  integrationBaseTestClasses
+)
+
+registerIntegrationFamilyTask(
+  'integrationOpal',
+  'Runs integration tests that use the Opal Spring profile.',
+  integrationOpalTestClasses
+)
+
+registerIntegrationFamilyTask(
+  'integrationLegacy',
+  'Runs integration tests that use the Legacy Spring profile.',
+  integrationLegacyTestClasses
+)
+
+registerIntegrationFamilyTask(
+  'integrationSecurity',
+  'Runs integration tests that use the Spring Security integration profile.',
+  integrationSecurityTestClasses
+)
 
 tasks.register('checkTestJiraAnnotations', JavaExec) {
   description = "Checks runnable integration and functional tests have Jira story and epic annotations"
@@ -462,12 +559,24 @@ tasks.register('packageIntegrationOutput', Copy) {
   from(layout.buildDirectory.dir("test-results/integration")) {
     into("test-results")
   }
+  from(layout.buildDirectory.dir("reports/tests")) {
+    into("reports")
+    include("integrationBase/**", "integrationOpal/**", "integrationLegacy/**", "integrationSecurity/**")
+  }
+  from(layout.buildDirectory.dir("test-results")) {
+    into("test-results")
+    include("integrationBase/**", "integrationOpal/**", "integrationLegacy/**", "integrationSecurity/**")
+  }
   from(layout.buildDirectory.dir("heap-dumps/integration")) {
     into("heap-dumps")
   }
+  from(layout.buildDirectory.dir("heap-dumps")) {
+    into("heap-dumps")
+    include("integrationBase/**", "integrationOpal/**", "integrationLegacy/**", "integrationSecurity/**")
+  }
   from(layout.buildDirectory.dir("logs")) {
     into("logs")
-    include("integration-gc.log*")
+    include("integration*-gc.log*")
   }
 }
 tasks.register('mergeFunctionalResults', Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -314,10 +314,12 @@ tasks.register('integration', Test) {
   classpath = sourceSets.integrationTest.runtimeClasspath
   systemProperty 'logging.level.org.springframework.test.context.cache', 'DEBUG'
   jvmArgs '-XX:+HeapDumpOnOutOfMemoryError',
-    "-XX:HeapDumpPath=${layout.buildDirectory.dir('heap-dumps/integration').get().asFile.absolutePath}"
+    "-XX:HeapDumpPath=${layout.buildDirectory.dir('heap-dumps/integration').get().asFile.absolutePath}",
+    "-Xlog:gc*,safepoint:file=${layout.buildDirectory.file('logs/integration-gc.log').get().asFile.absolutePath}:time,uptime,level,tags:filecount=3,filesize=20M"
   exclude '**/ReportQueueConnectivityIntegrationTest.class'
   doFirst {
     layout.buildDirectory.dir('heap-dumps/integration').get().asFile.mkdirs()
+    layout.buildDirectory.dir('logs').get().asFile.mkdirs()
     pullLatestLegacyStubImageIfLocal()
   }
   finalizedBy 'packageIntegrationOutput'
@@ -462,6 +464,10 @@ tasks.register('packageIntegrationOutput', Copy) {
   }
   from(layout.buildDirectory.dir("heap-dumps/integration")) {
     into("heap-dumps")
+  }
+  from(layout.buildDirectory.dir("logs")) {
+    into("logs")
+    include("integration-gc.log*")
   }
 }
 tasks.register('mergeFunctionalResults', Copy) {

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -403,3 +403,35 @@ Conclusion:
   context when their inline properties are aligned.
 - The two Release 1B LaunchDarkly-enabled tests now reuse the same context:
   both XML reports end at `missCount = 9`.
+
+### 2026-06-25: Removed unused `AccessTokenService` mock beans
+
+Code changes:
+
+- Removed unused `@MockitoBean AccessTokenService` declarations from search and
+  impositions integration tests.
+- These mocks were not referenced by the tests; requests already use the shared
+  `userStateStub` or explicit `UserStateService` stubbing.
+
+Files changed:
+
+- `OpalDefendantsSearchIntegrationTest`
+- `LegacyDefendantsSearchIntegrationTest`
+- `LegacyDefendantAccountImpositionsIntegrationTest`
+
+Validation:
+
+| Task | Before misses | After misses | Result |
+| --- | ---: | ---: | --- |
+| `compileIntegrationTestJava` | n/a | n/a | Passed |
+| `integrationOpal` | 9 | 9 | Passed |
+| `integrationLegacy` | 10 | 10 | Passed |
+| `checkstyleIntegrationTest` | n/a | n/a | Passed |
+
+Conclusion:
+
+- The cleanup is safe and removes unnecessary bean override customizers, but it
+  does not merge contexts in the measured slices.
+- Remaining unique contexts are now more likely caused by still-required spies,
+  gateway/user-state mock combinations, SQL setup differences, or explicit
+  feature-flag properties.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -372,3 +372,34 @@ Conclusion:
 - The useful next fix is therefore not more default-value trimming; it should
   target remaining genuinely distinct context keys, especially tests with
   different LaunchDarkly-enabled settings or unique mock/spy bean customizers.
+
+### 2026-06-25: Aligned LaunchDarkly-enabled Release 1B tests
+
+Code changes:
+
+- Removed `launchdarkly.default-flag-values.release-1b` from both
+  LaunchDarkly-enabled Release 1B integration tests.
+- Kept `launchdarkly.enabled=true` and `launchdarkly.sdk-key=test-sdk-key` so
+  the tests still exercise the LaunchDarkly-enabled bean path.
+- The flag result remains controlled by the mocked `LDClientInterface`, so the
+  default fallback value is not part of the asserted behaviour.
+
+Files changed:
+
+- `Release1bFeatureToggleLaunchDarklyEnabledFlagFalseIntegrationTest`
+- `Release1bFeatureToggleLaunchDarklyEnabledFlagTrueIntegrationTest`
+
+Validation:
+
+| Task | Before misses | After misses | Result |
+| --- | ---: | ---: | --- |
+| `compileIntegrationTestJava` | n/a | n/a | Passed |
+| `integrationOpal` | 10 | 9 | Passed |
+| `checkstyleIntegrationTest` | n/a | n/a | Passed |
+
+Conclusion:
+
+- This confirms that equivalent LaunchDarkly-enabled tests can share one Spring
+  context when their inline properties are aligned.
+- The two Release 1B LaunchDarkly-enabled tests now reuse the same context:
+  both XML reports end at `missCount = 9`.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -283,3 +283,52 @@ Concrete high-churn candidates:
 - Legacy family: many tests repeat `launchdarkly.enabled=false` and
   `release-1b=true`; these should be a shared profile or composed annotation
   instead of per-class inline properties.
+
+### 2026-06-25: Removed redundant LaunchDarkly property overrides
+
+Code changes:
+
+- Removed redundant `@TestPropertySource` declarations from Opal tests where
+  `application-opal.yaml` already provides:
+  - `launchdarkly.enabled=false`
+  - `launchdarkly.default-flag-values.release-1b=true`
+- Removed redundant `@TestPropertySource` declarations from Legacy tests where
+  `application-legacy.yaml` plus `application-integration.yaml` already provide:
+  - `launchdarkly.enabled=false`
+  - `launchdarkly.default-flag-values.release-1b=true`
+
+Files changed:
+
+- `OpalMinorCreditorIntegrationTest`
+- `MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest`
+- `OpalDefendantAccountHistoryIntegrationTest`
+- `OpalMajorCreditorAccountAtAGlanceIntegrationTest`
+- `OpalMajorCreditorAccountHeaderSummaryIntegrationTest`
+- `LegacyMinorCreditorPatchStubIntegrationTest`
+- `LegacyDefendantAccountImpositionsIntegrationTest`
+- `LegacyMinorCreditorIntegrationTest`
+- `LegacyMinorCreditorPatchIntegrationTest`
+- `LegacyMajorCreditorAccountHeaderSummaryIntegrationTest`
+- `LegacyMajorCreditorAccountAtAGlanceIntegrationTest`
+- `LegacyDefendantsSearchIntegrationTest`
+
+Validation:
+
+| Task | Before misses | After misses | Result |
+| --- | ---: | ---: | --- |
+| `compileIntegrationTestJava` | n/a | n/a | Passed |
+| `integrationOpal` | 15 | 10 | Passed |
+| `integrationLegacy` | 11 | 10 | Passed |
+| `integration` | not previously captured | 55 | Passed |
+
+Conclusion:
+
+- Removing redundant inline properties measurably reduced context churn in the
+  Opal group and modestly reduced it in the Legacy group.
+- This confirms that per-class `@TestPropertySource` entries were contributing
+  to distinct Spring Test context keys even when they repeated profile defaults.
+- Remaining churn is now more likely from genuinely different feature-flag
+  values and per-class mock/spy bean customizers.
+- The full integration task now has a local Docker/Testcontainers baseline:
+  `missCount = 55`, `maxSize = 4`, `hitCount = 11915`, `failureCount = 0`,
+  99 XML suites, and no heap failure.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -601,3 +601,33 @@ Conclusion:
 - The base suite improved by one additional context miss.
 - The shared minor-creditor cleanup also reduced Legacy context churn by two
   misses while remaining neutral for Opal.
+
+### 2026-06-25: Converted shared draft and defendant schema validators
+
+Code changes:
+
+- Replaced direct-use `@MockitoSpyBean JsonSchemaValidationService` with
+  `@Autowired` in shared test base classes.
+
+Files changed:
+
+- `CommonDraftAccountControllerIntegrationTest`
+- `AbstractCommonDefendantsIntegrationTest`
+- `AbstractOpalDefendantsIntegrationTest`
+- `AbstractLegacyDefendantsIntegrationTest`
+
+Validation:
+
+| Task | Before misses | After misses | Result |
+| --- | ---: | ---: | --- |
+| `compileIntegrationTestJava` | n/a | n/a | Passed |
+| `integrationBase` | 23 | 23 | Passed |
+| `integrationOpal` | 9 | 9 | Passed |
+| `integrationLegacy` | 8 | 7 | Passed |
+| `checkstyleIntegrationTest` | n/a | n/a | Passed |
+
+Conclusion:
+
+- This is safe cleanup for the draft and defendant test hierarchy.
+- It reduced Legacy context churn by one additional miss, while Base and Opal
+  remained unchanged because other context-key differences still dominate there.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -702,3 +702,44 @@ Conclusion:
 - The remaining cache churn is no longer obviously caused by direct-use spies;
   the remaining spies are tied to stubbing, verification, or forced error
   paths and would need deliberate test redesign rather than mechanical removal.
+
+### 2026-06-25: Cache-size comparison reproduced resource exhaustion
+
+Experiment:
+
+- Ran `integration` with a temporary Gradle init script overriding
+  `spring.test.context.cache.maxSize=32`.
+- This did not change repository code.
+
+Result:
+
+| Variant | Cache max size | Outcome | Notable failure |
+| --- | ---: | --- | --- |
+| Current repo config | 4 | Passed | n/a |
+| Temporary large cache | 32 | Failed | `FATAL: sorry, too many clients already` |
+| Temporary large cache plus smaller Hikari pool | 32 | Failed | `FATAL: sorry, too many clients already` |
+
+Observed details:
+
+- Large-cache run failed after 713 tests completed, with 141 failures.
+- Large-cache plus small-pool run failed after 650 tests completed, with
+  166 failures.
+- After resetting the polluted reusable Testcontainers Postgres container, the
+  normal repo configuration passed again in 2m 25s with `missCount=44`,
+  `hitCount=11764`, and `maxSize=4`.
+- The failing contexts show full `WebMergedContextConfiguration` output,
+  including distinct active profiles, inline properties, and
+  `BeanOverrideContextCustomizer` entries.
+- Testcontainers Postgres is started with `max_connections=200`.
+- Main datasource defaults allow each Spring context to create a Hikari pool
+  with `minimumIdle=2` and `maximumPoolSize=10`.
+
+Conclusion:
+
+- Raising Spring's context cache size is not a sustainable fix in this suite.
+- The current low cache size avoids retaining too many live contexts at once,
+  but it also causes repeated context creation.
+- The root issue is the combination of many distinct Spring context keys and
+  heavy retained resources per context, especially datasource pools.
+- Sustainable fixes should continue reducing unique context keys and should
+  also consider explicit integration-test datasource pool limits.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -541,3 +541,34 @@ Conclusion:
 - The Opal and Legacy changes are behaviour-safe cleanup but do not reduce
   misses because those classes still have other unique context-key inputs:
   feature-flag properties or gateway/user-state mock combinations.
+
+### 2026-06-25: Removed additional base controller spy customizers
+
+Code changes:
+
+- Replaced direct-use `@MockitoSpyBean` dependencies with `@Autowired`
+  dependencies in base controller integration tests.
+- The converted dependencies are called directly by the tests and are not
+  stubbed or verified through Mockito.
+
+Files changed:
+
+- `BusinessUnitControllerIntegrationTest`
+- `CourtControllerIntegrationTest`
+- `LocalJusticeAreaControllerIntegrationTest`
+- `MajorCreditorControllerIntegrationTest`
+
+Validation:
+
+| Task | Before misses | After misses | Result |
+| --- | ---: | ---: | --- |
+| `compileIntegrationTestJava` | n/a | n/a | Passed |
+| `integrationBase` | 27 | 24 | Passed |
+| `checkstyleIntegrationTest` | n/a | n/a | Passed |
+
+Conclusion:
+
+- Removing unnecessary spy bean override customizers is now the highest-value
+  fix pattern for the base suite.
+- `integrationBase` has reduced from the original measured baseline of 30 misses
+  to 24 misses across the LaunchDarkly and spy-cleanup changes.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -332,3 +332,43 @@ Conclusion:
 - The full integration task now has a local Docker/Testcontainers baseline:
   `missCount = 55`, `maxSize = 4`, `hitCount = 11915`, `failureCount = 0`,
   99 XML suites, and no heap failure.
+
+### 2026-06-25: Removed further redundant test property entries
+
+Code changes:
+
+- Removed remaining inline feature-flag properties where the active test profile
+  already supplies the same default value.
+- Collapsed duplicate `@TestPropertySource` declarations on
+  `JwtControllerIntegrationTest`.
+
+Files changed:
+
+- `CentralFundControllerIntegrationTest`
+- `ResultControllerIntegrationTest`
+- `ResultControllerRelease1aDisabledIntegrationTest`
+- `ResultControllerRelease1bDisabledIntegrationTest`
+- `DefendantAccountSearchRelease1cDisabledIntegrationTest`
+- `JwtControllerIntegrationTest`
+- `OpalDefendantsSearchIntegrationTest`
+- `MinorCreditorApiControllerFeatureFlagIntegrationTest`
+- `DefendantAccountHistoryFeatureFlagIntegrationTest`
+
+Validation:
+
+| Task | Before misses | After misses | Result |
+| --- | ---: | ---: | --- |
+| `compileIntegrationTestJava` | n/a | n/a | Passed |
+| `integrationBase` | 30 | 30 | Passed |
+| `integrationOpal` | 10 | 10 | Passed |
+| `integrationSecurity` | 2 | 2 | Passed |
+| `checkstyleIntegrationTest` | n/a | n/a | Passed |
+
+Conclusion:
+
+- This cleanup is behaviour-safe and reduces misleading per-class configuration
+  noise, but it does not further reduce context creation in the measured split
+  tasks.
+- The useful next fix is therefore not more default-value trimming; it should
+  target remaining genuinely distinct context keys, especially tests with
+  different LaunchDarkly-enabled settings or unique mock/spy bean customizers.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -890,28 +890,3 @@ Conclusion:
   allows more release-1b disabled tests to reuse existing contexts.
 - Full-suite context misses are now down from 55 to 40 while the integration
   suite remains green.
-
-### 2026-06-25: Removed legacy feature-disabled gateway mock
-
-Code changes:
-
-- Removed `@MockitoBean GatewayService` from
-  `MajorCreditorAccountHeaderSummaryFeatureFlagIntegrationTest`.
-- Removed the corresponding `verifyNoInteractions` assertion.
-- The test still verifies the feature-disabled 404 response.
-
-Validation:
-
-| Task | Before misses | After misses | Result |
-| --- | ---: | ---: | --- |
-| Focused affected test | n/a | n/a | Passed |
-| `integrationLegacy` | 7 | 7 | Passed |
-| `integration` | 40 | 40 | Passed |
-| `checkstyleIntegrationTest` | n/a | n/a | Passed |
-
-Conclusion:
-
-- This did not reduce the measured miss count because the legacy
-  release-1b-disabled profile/property combination is still a distinct context.
-- It still removes an unnecessary Spring-level bean override from a
-  feature-disabled path and reduces retained mock/test customizer complexity.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -195,6 +195,8 @@ Ticket questions answered:
 - After bounding datasource pools, a moderate cache size of 8 was validated
   locally and reduced full-suite context misses further from 44 to 41 without
   reproducing the connection exhaustion seen at cache size 32.
+- Further release-1b feature-toggle cleanup reduced the full-suite miss count
+  to 40 and the Base split to 19.
 
 Remaining work before removing the Jenkins mitigations:
 
@@ -205,6 +207,18 @@ Remaining work before removing the Jenkins mitigations:
   `@SpringBootTest` coverage is not needed.
 - Re-test cache size after context-key reduction; do not simply restore Spring's
   default cache size while contexts remain this heavy.
+
+Team context:
+
+- Initial write-up was shared with Marc as a likely Spring test context
+  fragmentation issue.
+- Marc agreed the direction looked right from a brief review and asked for the
+  findings to be written up on the ticket/Confluence.
+- The requested next step is a branch that starts to fix the issue and shows
+  considerable measurable improvement, not just investigation notes.
+- Current branch now includes both evidence and first remediation steps:
+  context miss reduction, integration-test datasource pool limits, split test
+  tasks, diagnostics, and a validated moderate cache-size increase.
 
 ## Next validation step
 
@@ -839,3 +853,65 @@ Conclusion:
   at cache size 32.
 - This is still not a reason to restore Spring's default cache size; further
   context-key consolidation is needed before trying larger values.
+
+### 2026-06-25: Removed unnecessary release-1b disabled search mock
+
+Code changes:
+
+- Removed the `@MockitoBean DefendantAccountService` from
+  `DefendantAccountSearchRelease1bDisabledIntegrationTest`.
+- Removed the `verifyNoInteractions` assertion from that test; the feature
+  disabled 404 remains the behaviour under test.
+- Removed the redundant `release-1c=true` inline override from the same test.
+- Aligned `ResultControllerRelease1bDisabledIntegrationTest` property ordering
+  with the other release-1b-disabled tests.
+
+Validation:
+
+| Task | Before misses | After misses | Result |
+| --- | ---: | ---: | --- |
+| Focused affected tests | n/a | n/a | Passed |
+| `integrationBase` | 24 | 19 | Passed |
+| `integration` | 41 | 40 | Passed |
+| `checkstyleIntegrationTest` | n/a | n/a | Passed |
+
+Observed full-suite cache stats after the change:
+
+- Maximum `missCount`: 40
+- Maximum `hitCount`: 11768
+- Cache `maxSize`: 8
+
+Conclusion:
+
+- The release-1b disabled search test no longer creates its own Spring context
+  just to verify that a downstream service was not called.
+- This is a higher-value fix than the earlier direct-use spy removals because
+  it eliminates a Spring-level bean override from a feature-toggle path and
+  allows more release-1b disabled tests to reuse existing contexts.
+- Full-suite context misses are now down from 55 to 40 while the integration
+  suite remains green.
+
+### 2026-06-25: Removed legacy feature-disabled gateway mock
+
+Code changes:
+
+- Removed `@MockitoBean GatewayService` from
+  `MajorCreditorAccountHeaderSummaryFeatureFlagIntegrationTest`.
+- Removed the corresponding `verifyNoInteractions` assertion.
+- The test still verifies the feature-disabled 404 response.
+
+Validation:
+
+| Task | Before misses | After misses | Result |
+| --- | ---: | ---: | --- |
+| Focused affected test | n/a | n/a | Passed |
+| `integrationLegacy` | 7 | 7 | Passed |
+| `integration` | 40 | 40 | Passed |
+| `checkstyleIntegrationTest` | n/a | n/a | Passed |
+
+Conclusion:
+
+- This did not reduce the measured miss count because the legacy
+  release-1b-disabled profile/property combination is still a distinct context.
+- It still removes an unnecessary Spring-level bean override from a
+  feature-disabled path and reduces retained mock/test customizer complexity.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -487,3 +487,57 @@ Conclusion:
 - `CentralFundControllerIntegrationTest` now reuses the next standard
   integration context; `ResultControllerIntegrationTest` still creates a unique
   context because it has a `JsonSchemaValidationService` spy.
+
+### 2026-06-25: Removed JWT non-feature LaunchDarkly override
+
+Code changes:
+
+- Removed `launchdarkly.enabled=false` from `JwtControllerIntegrationTest`.
+- The test's feature-disabled scenario is driven by a mocked downstream
+  user-service response, not by the LaunchDarkly bean path.
+
+Validation:
+
+| Task | Before misses | After misses | Result |
+| --- | ---: | ---: | --- |
+| `compileIntegrationTestJava` | n/a | n/a | Passed |
+| `integrationSecurity` | 2 | 2 | Passed |
+| `checkstyleIntegrationTest` | n/a | n/a | Passed |
+
+Conclusion:
+
+- This is safe cleanup, but it does not reduce `integrationSecurity` context
+  misses because `JwtControllerIntegrationTest` and `UserStateClientServiceIT`
+  still require separate security contexts.
+
+### 2026-06-25: Replaced schema validation spies with autowired services
+
+Code changes:
+
+- Replaced `@MockitoSpyBean JsonSchemaValidationService` with `@Autowired`
+  `JsonSchemaValidationService` where the tests only call `validateOrError`
+  directly and do not use Mockito spy behaviour.
+
+Files changed:
+
+- `ResultControllerIntegrationTest`
+- `OpalDefendantsSearchIntegrationTest`
+- `LegacyDefendantAccountImpositionsIntegrationTest`
+
+Validation:
+
+| Task | Before misses | After misses | Result |
+| --- | ---: | ---: | --- |
+| `compileIntegrationTestJava` | n/a | n/a | Passed |
+| `integrationBase` | 29 | 27 | Passed |
+| `integrationOpal` | 9 | 9 | Passed |
+| `integrationLegacy` | 10 | 10 | Passed |
+| `checkstyleIntegrationTest` | n/a | n/a | Passed |
+
+Conclusion:
+
+- This produced a measurable base-suite improvement by removing unnecessary spy
+  bean override customizers from `ResultControllerIntegrationTest`.
+- The Opal and Legacy changes are behaviour-safe cleanup but do not reduce
+  misses because those classes still have other unique context-key inputs:
+  feature-flag properties or gateway/user-state mock combinations.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -891,3 +891,34 @@ Conclusion:
   allows more release-1b disabled tests to reuse existing contexts.
 - Full-suite context misses are now down from 55 to 40 while the integration
   suite remains green.
+
+### 2026-07-02: Removed two redundant profile-backed LaunchDarkly property sources
+
+Code changes:
+
+- Removed redundant inline `@TestPropertySource` from
+  `LegacyDefendantAccountHistoryIntegrationTest`.
+  - `launchdarkly.enabled=false` is already provided by the `legacy` profile.
+  - `launchdarkly.default-flag-values.release-1b=true` is already provided by
+    the `integration` profile.
+- Removed redundant inline `@TestPropertySource` from
+  `OpalMinorCreditorHistoryIntegrationTest`.
+  - `launchdarkly.enabled=false` is already provided by the `opal` profile.
+  - `launchdarkly.default-flag-values.release-1b=true` is already provided by
+    the `opal` profile.
+
+Expected impact:
+
+- Both classes no longer create distinct Spring context cache keys just to
+  repeat profile-backed LaunchDarkly defaults.
+- This should improve context reuse in the Legacy and Opal families without
+  changing the intended feature-flag state.
+
+Validation status:
+
+- Static diff check passed.
+- Local Gradle validation was attempted, but the wrapper could not download the
+  Gradle distribution in this session due to a network timeout. Re-run
+  `./gradlew checkstyleIntegrationTest --no-daemon` and the relevant integration
+  split tasks before relying on the measured miss-count impact of this final
+  cleanup.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -655,3 +655,27 @@ Conclusion:
   Opal context churn by one more miss.
 - Remaining Opal spies are more likely intentional test doubles and should not
   be removed without deeper test redesign.
+
+### 2026-06-25: Replaced Opal minor-creditor repository spies
+
+Code changes:
+
+- Replaced repository `@MockitoSpyBean` declarations with `@Autowired`
+  repositories in `OpalMinorCreditorIntegrationTest`.
+- The repositories are only used for direct database state assertions before
+  and after delete behaviour; they are not stubbed or verified with Mockito.
+
+Validation:
+
+| Task | Before misses | After misses | Result |
+| --- | ---: | ---: | --- |
+| `compileIntegrationTestJava` | n/a | n/a | Passed |
+| `integrationOpal` | 8 | 7 | Passed |
+| `checkstyleIntegrationTest` | n/a | n/a | Passed |
+
+Conclusion:
+
+- This removed four more bean override customizers and reduced Opal context
+  churn by one additional miss.
+- Remaining spies now appear to be deliberate test doubles for gateway/service
+  verification or forced error paths.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -8,9 +8,10 @@ integration base starts the full application with MockMvc, Flyway, Postgres,
 Redis, legacy gateway wiring, LaunchDarkly, Jackson, cache infrastructure, and
 the application bean graph.
 
-The current mitigation is visible in Gradle:
+The current branch keeps the Jenkins heap mitigation but has moved the Spring
+test context cache to a measured moderate value:
 
-- `spring.test.context.cache.maxSize=4`
+- `spring.test.context.cache.maxSize=8`
 - integration test JVM heap `maxHeapSize = "2g"`
 - Gradle daemon heap `org.gradle.jvmargs=-Xmx2g`
 
@@ -25,7 +26,7 @@ not by a single obviously broken test class.
 Current memory/cache settings:
 
 - `build.gradle`: all `Test` tasks set `spring.test.context.cache.maxSize` to
-  `4` and `maxHeapSize` to `2g`.
+  `8` and `maxHeapSize` to `2g`.
 - `gradle.properties`: Gradle itself also runs with `-Xmx2g`.
 
 Shared integration base:

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -172,6 +172,40 @@ Prioritize reducing distinct full Spring contexts before changing heap again:
    not be the long-term fix if it causes repeated rebuilding of the same heavy
    contexts.
 
+## Ticket status review
+
+PO-7203 is complete as a spike investigation if the expected outcome is root
+cause identification plus a sustainable-fix direction.
+
+Ticket questions answered:
+
+- Spring Test Context caching contributes to the problem. The cache is not
+  malfunctioning, but the suite creates more distinct full contexts than the
+  configured cache can retain.
+- No single abnormal bean graph was identified. The problem is context-key
+  fragmentation across full `@SpringBootTest` classes combined with heavy
+  resources retained by each context.
+- The exact Jenkins `Java heap space` failure was not reproduced locally, but
+  the same resource-retention failure mode was reproduced by increasing the
+  cache size: the suite exhausted Postgres connections while retaining many
+  contexts.
+- The current fixes show measurable improvement: full-suite context misses were
+  reduced from 55 to 44, and integration-test datasource pools are now bounded
+  so each retained context has a lower DB connection footprint.
+- After bounding datasource pools, a moderate cache size of 8 was validated
+  locally and reduced full-suite context misses further from 44 to 41 without
+  reproducing the connection exhaustion seen at cache size 32.
+
+Remaining work before removing the Jenkins mitigations:
+
+- Continue consolidating inline feature-flag properties.
+- Reduce remaining unique Mockito override sets where tests do not actually
+  need Spring-level bean replacement.
+- Move controller/error-path tests to narrower slices where full
+  `@SpringBootTest` coverage is not needed.
+- Re-test cache size after context-key reduction; do not simply restore Spring's
+  default cache size while contexts remain this heavy.
+
 ## Next validation step
 
 Run the full Jenkins-equivalent `integration` task with cache DEBUG logging and
@@ -775,3 +809,33 @@ Conclusion:
   integration-test context compared with production datasource defaults.
 - This directly addresses the resource-retention side of the OOM/root-cause
   investigation while keeping the full integration suite green.
+
+### 2026-06-25: Scoped `release-1c` default and raised cache size to 8
+
+Code changes:
+
+- Added `launchdarkly.default-flag-values.release-1c=true` to
+  `application-opal.yaml`.
+- Removed the redundant inline `release-1c=true` property from
+  `OpalDefendantsSearchIntegrationTest`.
+- Kept the base-profile search-disabled test override explicit so the Base
+  split does not inherit Opal-only defaults.
+- Changed `spring.test.context.cache.maxSize` from 4 to 8 in `build.gradle`.
+
+Validation:
+
+| Task | Before misses | After misses | Result |
+| --- | ---: | ---: | --- |
+| Focused affected tests | n/a | n/a | Passed |
+| `integrationOpal` | 7 | 6 | Passed |
+| `integration` with temporary cache size 8 | 44 | 41 | Passed |
+
+Conclusion:
+
+- The Opal profile no longer needs a one-off inline `release-1c=true` property
+  for the standard Opal defendant search tests.
+- With Hikari pools capped for integration tests, cache size 8 is a measured
+  improvement over 4 and did not reproduce the `too many clients` failure seen
+  at cache size 32.
+- This is still not a reason to restore Spring's default cache size; further
+  context-key consolidation is needed before trying larger values.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -572,3 +572,32 @@ Conclusion:
   fix pattern for the base suite.
 - `integrationBase` has reduced from the original measured baseline of 30 misses
   to 24 misses across the LaunchDarkly and spy-cleanup changes.
+
+### 2026-06-25: Converted further direct-use schema validation spies
+
+Code changes:
+
+- Replaced `@MockitoSpyBean JsonSchemaValidationService` with `@Autowired`
+  where the tests only call the real validation service directly.
+
+Files changed:
+
+- `ProsecutorControllerIntegrationTest`
+- `OffenceControllerIntegrationTest`
+- `MinorCreditorControllerIntegrationTest`
+
+Validation:
+
+| Task | Before misses | After misses | Result |
+| --- | ---: | ---: | --- |
+| `compileIntegrationTestJava` | n/a | n/a | Passed |
+| `integrationBase` | 24 | 23 | Passed |
+| `integrationOpal` | 9 | 9 | Passed |
+| `integrationLegacy` | 10 | 8 | Passed |
+| `checkstyleIntegrationTest` | n/a | n/a | Passed |
+
+Conclusion:
+
+- The base suite improved by one additional context miss.
+- The shared minor-creditor cleanup also reduced Legacy context churn by two
+  misses while remaining neutral for Opal.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -1,0 +1,180 @@
+# PO-7203 Spring test context memory investigation
+
+## Summary
+
+The integration test suite is creating many distinct full Spring Boot
+`ApplicationContext` instances. Each context is heavy because the shared
+integration base starts the full application with MockMvc, Flyway, Postgres,
+Redis, legacy gateway wiring, LaunchDarkly, Jackson, cache infrastructure, and
+the application bean graph.
+
+The current mitigation is visible in Gradle:
+
+- `spring.test.context.cache.maxSize=4`
+- integration test JVM heap `maxHeapSize = "2g"`
+- Gradle daemon heap `org.gradle.jvmargs=-Xmx2g`
+
+Local reproduction did not hit `OutOfMemoryError`, but cache diagnostics confirm
+the underlying shape: a small mixed subset produced six distinct Spring test
+contexts while the cache retained only four. This supports the hypothesis that
+Jenkins failures are caused by repeated creation and retention of heavy contexts,
+not by a single obviously broken test class.
+
+## Evidence
+
+Current memory/cache settings:
+
+- `build.gradle`: all `Test` tasks set `spring.test.context.cache.maxSize` to
+  `4` and `maxHeapSize` to `2g`.
+- `gradle.properties`: Gradle itself also runs with `-Xmx2g`.
+
+Shared integration base:
+
+- `AbstractIntegrationTest` uses full `@SpringBootTest(classes = Application.class)`.
+- It adds `@AutoConfigureMockMvc`, `@ContextConfiguration(TestContainerConfig)`,
+  `@Import(IntegrationSecurityConfiguration)`, and the Zephyr extension.
+- `TestContainerConfig` starts Postgres and Redis Testcontainers, and can start
+  the legacy stub container.
+- `application-integration.yaml` keeps LaunchDarkly enabled by default.
+
+Static context-key contributors found in `src/integrationTest/java`:
+
+- 106 integration test classes.
+- Active profile variants:
+  - 31 classes with `@ActiveProfiles({"integration"})`
+  - 17 classes with `@ActiveProfiles({"integration", "opal"})`
+  - 16 classes with `@ActiveProfiles({"integration", "legacy"})`
+  - 4 classes with `@ActiveProfiles("integration")`
+  - 1 class with `@ActiveProfiles({"legacy"})`
+  - 1 security profile with `inheritProfiles = false`
+- 33 classes with `@TestPropertySource`.
+- 18 classes with `@MockitoBean`, `@MockBean`, or `@SpyBean`.
+- 1 class with `@DirtiesContext`.
+- Additional per-class `@Import` customizations.
+
+These are Spring test context cache-key inputs. In particular, inline
+`@TestPropertySource` properties and `@MockitoBean` sets commonly force a new
+context even when the class extends the same abstract base.
+
+Representative examples:
+
+- `Release1bFeatureToggleLaunchDarklyEnabledFlagFalseIntegrationTest` changes
+  profiles, sets inline LaunchDarkly properties, and adds an `LDClientInterface`
+  Mockito bean.
+- `TestingSupportControllerIntegrationTest` adds four Mockito beans.
+- `GenericReportServiceTest` adds `@DirtiesContext`, imports test beans, and adds
+  two Mockito beans.
+- `GlobalExceptionIntegrationTest` imports a test controller.
+
+## Local measurement
+
+Commands used:
+
+```bash
+JAVA_TOOL_OPTIONS='-Dlogging.level.org.springframework.test.context.cache=DEBUG -Dspring.main.banner-mode=off' \
+  ./gradlew integration --no-daemon \
+  --tests 'uk.gov.hmcts.opal.controllers.ReportsApiControllerIntegrationTest'
+```
+
+Result:
+
+- Build succeeded.
+- Spring context cache: `size = 1`, `maxSize = 4`, `missCount = 1`.
+
+```bash
+JAVA_TOOL_OPTIONS='-Dlogging.level.org.springframework.test.context.cache=DEBUG -Dspring.main.banner-mode=off' \
+  ./gradlew integration --no-daemon \
+  --tests 'uk.gov.hmcts.opal.controllers.ReportsApiControllerIntegrationTest' \
+  --tests 'uk.gov.hmcts.opal.controllers.Release1bFeatureToggleLaunchDarklyEnabledFlagFalseIntegrationTest' \
+  --tests 'uk.gov.hmcts.opal.controllers.LegacyDefendantsSearchIntegrationTest' \
+  --tests 'uk.gov.hmcts.opal.controllers.JwtControllerIntegrationTest'
+```
+
+Result:
+
+- Build succeeded.
+- Spring context cache: `size = 4`, `maxSize = 4`, `missCount = 4`.
+
+```bash
+JAVA_TOOL_OPTIONS='-Dlogging.level.org.springframework.test.context.cache=DEBUG -Dspring.main.banner-mode=off' \
+  ./gradlew integration --no-daemon \
+  --tests 'uk.gov.hmcts.opal.controllers.ReportsApiControllerIntegrationTest' \
+  --tests 'uk.gov.hmcts.opal.controllers.Release1bFeatureToggleLaunchDarklyEnabledFlagFalseIntegrationTest' \
+  --tests 'uk.gov.hmcts.opal.controllers.LegacyDefendantsSearchIntegrationTest' \
+  --tests 'uk.gov.hmcts.opal.controllers.JwtControllerIntegrationTest' \
+  --tests 'uk.gov.hmcts.opal.controllers.TestingSupportControllerIntegrationTest' \
+  --tests 'uk.gov.hmcts.opal.controllers.OpalMajorCreditorAccountAtAGlanceIntegrationTest'
+```
+
+Result:
+
+- Build succeeded.
+- Spring context cache: `size = 4`, `maxSize = 4`, `missCount = 6`,
+  `hitCount = 932`, `failureCount = 0`.
+- Four LaunchDarkly clients were closed at JVM shutdown, consistent with four
+  live cached contexts at the end of the run.
+
+## Findings
+
+1. Context caching is a contributor, but not because the cache is malfunctioning.
+   It is doing what it was configured to do: retaining up to four contexts.
+   The suite naturally creates more than four distinct contexts, so Jenkins will
+   repeatedly build expensive contexts and evict older ones.
+
+2. The root cause is context-key fragmentation across full `@SpringBootTest`
+   integration tests. Profiles, inline property overrides, mock bean sets,
+   imports, and `@DirtiesContext` multiply cache keys.
+
+3. The contexts are heavy. A cache size of four still means four full application
+   contexts can be retained at once, including LaunchDarkly clients and the full
+   web/MVC infrastructure. The Jenkins failure during
+   `mvcContentNegotiationManager` creation is consistent with heap exhaustion
+   while another full MVC context is being built.
+
+4. Reducing `spring.test.context.cache.maxSize` lowers retained context count,
+   but it increases context rebuild churn. Increasing heap hides the pressure.
+   Neither addresses the number and weight of distinct contexts.
+
+5. Local reproduction of the exact Jenkins OOM was not achieved with the sampled
+   subsets. That is expected: the local machine only ran selected classes and
+   had enough memory for them. The measurable local result is cache-key churn,
+   not the OOM itself.
+
+## Recommended sustainable fix
+
+Prioritize reducing distinct full Spring contexts before changing heap again:
+
+1. Consolidate feature-toggle tests so they share a small number of common
+   profile/property configurations instead of many per-class inline
+   `@TestPropertySource` combinations.
+
+2. Replace per-class `@MockitoBean` usage with shared test configuration where
+   the same mocks are needed across multiple tests. If a test only validates a
+   controller/service slice, move it out of full `@SpringBootTest`.
+
+3. Review `@DirtiesContext` in `GenericReportServiceTest`. Keep it only if the
+   test mutates singleton state that cannot be reset directly.
+
+4. Split integration tests into more coherent Gradle tasks by context family,
+   for example base integration, opal profile, legacy profile, and security.
+   This reduces eviction/rebuild churn and makes memory behavior measurable per
+   family.
+
+5. Add temporary CI diagnostics while fixing:
+   - keep `org.springframework.test.context.cache=DEBUG` for integration runs
+     until the context count is understood;
+   - add `-XX:+HeapDumpOnOutOfMemoryError` and archive heap dumps on Jenkins
+     failures;
+   - optionally add GC logging for the integration test JVM.
+
+6. After reducing context count, re-test with a larger cache size such as the
+   Spring default of 32 or an empirically chosen value. A low cache size should
+   not be the long-term fix if it causes repeated rebuilding of the same heavy
+   contexts.
+
+## Next validation step
+
+Run the full Jenkins-equivalent `integration` task with cache DEBUG logging and
+heap-dump-on-OOM enabled. The key number to capture is the final or peak
+`missCount`, because that approximates how many distinct context keys the full
+suite creates in one forked test JVM.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -435,3 +435,55 @@ Conclusion:
 - Remaining unique contexts are now more likely caused by still-required spies,
   gateway/user-state mock combinations, SQL setup differences, or explicit
   feature-flag properties.
+
+### 2026-06-25: Reduced ReportInstances mock bean customizers
+
+Code changes:
+
+- Replaced Spring-level `@MockitoBean` declarations for `UserState` and
+  `BusinessUnitUser` in `ReportInstancesControllerIntegrationTest` with plain
+  test objects returned by the mocked `UserStateService`.
+- Kept the Spring-level mocks that are still needed:
+  - `UserStateService`
+  - `ReportQueuePublisherImpl`
+
+Validation:
+
+| Task | Before misses | After misses | Result |
+| --- | ---: | ---: | --- |
+| `compileIntegrationTestJava` | n/a | n/a | Passed |
+| `integrationBase` | 30 | 30 | Passed |
+
+Conclusion:
+
+- This removes unnecessary bean override customizers from one heavy base test,
+  but it does not merge the test with another existing base context.
+- It remains useful cleanup because mock domain objects do not need to be part
+  of the Spring ApplicationContext.
+
+### 2026-06-25: Removed non-feature LaunchDarkly disabled overrides
+
+Code changes:
+
+- Removed `launchdarkly.enabled=false` from tests that do not assert
+  feature-toggle behaviour:
+  - `CentralFundControllerIntegrationTest`
+  - `ResultControllerIntegrationTest`
+- These tests now use the standard integration profile LaunchDarkly setup, which
+  uses the local integration flag file.
+
+Validation:
+
+| Task | Before misses | After misses | Result |
+| --- | ---: | ---: | --- |
+| `compileIntegrationTestJava` | n/a | n/a | Passed |
+| `integrationBase` | 30 | 29 | Passed |
+| `checkstyleIntegrationTest` | n/a | n/a | Passed |
+
+Conclusion:
+
+- This confirms that some historical `launchdarkly.enabled=false` overrides were
+  unnecessary in non-feature tests and were creating avoidable context keys.
+- `CentralFundControllerIntegrationTest` now reuses the next standard
+  integration context; `ResultControllerIntegrationTest` still creates a unique
+  context because it has a `JsonSchemaValidationService` spy.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -743,3 +743,35 @@ Conclusion:
   heavy retained resources per context, especially datasource pools.
 - Sustainable fixes should continue reducing unique context keys and should
   also consider explicit integration-test datasource pool limits.
+
+### 2026-06-25: Added explicit integration-test Hikari pool limits
+
+Code changes:
+
+- Added integration-test datasource pool limits in:
+  - `src/integrationTest/resources/application-integration.yaml`
+  - `src/integrationTest/resources/application-integration-with-spring-security.yaml`
+- Set `spring.datasource.hikari.minimum-idle=0`.
+- Set `spring.datasource.hikari.maximum-pool-size=4`.
+
+Validation:
+
+| Task | Result | Notes |
+| --- | --- | --- |
+| `processIntegrationTestResources` | Passed | YAML processed successfully |
+| `integration` | Passed | 2m 20s |
+| `checkstyleIntegrationTest` | Passed | n/a |
+
+Observed cache stats after the change:
+
+- Maximum `missCount`: 44
+- Maximum `hitCount`: 11764
+- Cache `maxSize`: 4
+
+Conclusion:
+
+- This does not reduce the number of distinct Spring context keys.
+- It reduces the retained database connection footprint of each cached
+  integration-test context compared with production datasource defaults.
+- This directly addresses the resource-retention side of the OOM/root-cause
+  investigation while keeping the full integration suite green.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -178,3 +178,108 @@ Run the full Jenkins-equivalent `integration` task with cache DEBUG logging and
 heap-dump-on-OOM enabled. The key number to capture is the final or peak
 `missCount`, because that approximates how many distinct context keys the full
 suite creates in one forked test JVM.
+
+## Investigation log
+
+### 2026-06-24: Added diagnostics and split-task baseline
+
+Code changes started:
+
+- Added integration-test JVM diagnostics:
+  - Spring test context cache DEBUG logs.
+  - Heap dumps on OOM under `build/heap-dumps/<task>`.
+  - GC/safepoint logs under `build/logs/<task>-gc.log`.
+  - Diagnostic artifacts copied into `integration-output`.
+- Added opt-in split tasks without changing the existing CI `integration` task:
+  - `integrationBase`
+  - `integrationOpal`
+  - `integrationLegacy`
+  - `integrationSecurity`
+
+Local Docker/Testcontainers validation:
+
+| Task | Classes selected | Result | Max cache size | Context misses | Hits | Failures |
+| --- | ---: | --- | ---: | ---: | ---: | ---: |
+| `integrationBase` | 52 | Passed | 4 | 30 | 5608 | 0 |
+| `integrationOpal` | 26 | Passed | 4 | 15 | 4926 | 0 |
+| `integrationLegacy` | 17 | Passed | 4 | 11 | 1301 | 0 |
+| `integrationSecurity` | 3 selected / 2 XML suites | Passed | 2 | 2 | 76 | 0 |
+
+Notes:
+
+- The split tasks are useful for measurement and isolation, but they do not by
+  themselves remove context churn. Base, Opal, and Legacy still create many
+  distinct contexts inside each broad profile family.
+- LaunchDarkly clients closing at JVM shutdown are a useful proxy for how many
+  contexts were created over the run. The base, Opal, and Legacy runs each closed
+  more clients than the cache can retain at once.
+- `ReportQueueConnectivityIntegrationTest` remains excluded from the split tasks
+  to match the existing `integration` task.
+
+Current evidence for proposed fixes:
+
+- 33 integration classes use `@TestPropertySource`.
+- Many of those are feature-toggle tests with small inline property differences.
+  These are strong candidates for shared composed annotations or shared test
+  profiles.
+- 18 concrete classes use `@MockitoBean`, `@MockBean`, `@SpyBean`, or
+  `@MockitoSpyBean`; abstract superclass mock/spy declarations also affect their
+  subclasses. Repeated mock customizers should be consolidated or moved to
+  narrower tests where possible.
+- `GenericReportServiceTest` is still the only class with `@DirtiesContext`;
+  this remains a specific cleanup target.
+
+Proposed next code fixes:
+
+1. Create shared composed integration-test annotations for common context shapes,
+   starting with feature-toggle-enabled/disabled cases.
+2. Move repeated `@MockitoBean` or `@MockitoSpyBean` declarations from individual
+   classes into shared test configuration where the same replacements are used.
+3. Review and remove `@DirtiesContext` from `GenericReportServiceTest` if direct
+   cleanup/reset is enough.
+4. Consider disabling LaunchDarkly in the base integration profile by default and
+   enabling it only for tests that explicitly validate LaunchDarkly behaviour.
+
+### 2026-06-24: First proposed fixes validated
+
+Build/test changes:
+
+- Added `ReportQueueConnectivityIntegrationTest` exclusion to the new split
+  tasks so they match the existing `integration` task.
+- Removed `@DirtiesContext` from `GenericReportServiceTest`.
+
+Validation:
+
+- `./gradlew integration --no-daemon --tests 'uk.gov.hmcts.opal.service.GenericReportServiceTest'`
+  passed.
+- `./gradlew integrationBase --no-daemon` passed after the cleanup.
+- Base-family cache stats after the cleanup stayed at `missCount = 30`,
+  `maxSize = 4`, `hitCount = 5608`, `failureCount = 0`.
+
+Conclusion:
+
+- Removing `@DirtiesContext` is safe and removes one explicit context
+  invalidation, but it does not materially lower context count because
+  `GenericReportServiceTest` still has a unique context from `@Import` plus
+  `@MockitoBean` customizers.
+- A trial change to disable LaunchDarkly by default in
+  `application-integration.yaml` was validated and then reverted. It did not
+  reduce context misses and did not clearly reduce LaunchDarkly client shutdowns,
+  so it is not currently a justified fix.
+- The next high-value fix remains consolidating repeated `@TestPropertySource`
+  and mock customizer combinations.
+
+Concrete high-churn candidates:
+
+- Base family: feature-toggle tests and controller tests with inline
+  LaunchDarkly properties, plus `ReportInstancesControllerIntegrationTest`,
+  `TestingSupportControllerIntegrationTest`, `CommonDraftAccountControllerIntegrationTest`,
+  and `GenericReportServiceTest` due to multiple mock/import customizers.
+- Opal family: `Release1bFeatureToggleLaunchDarklyEnabledFlagTrueIntegrationTest`
+  and `Release1bFeatureToggleLaunchDarklyEnabledFlagFalseIntegrationTest` each
+  create LaunchDarkly-enabled contexts with mocked `LDClientInterface`; several
+  Opal controller tests repeat `launchdarkly.enabled=false` with only flag-value
+  differences.
+- Legacy family: many tests repeat `launchdarkly.enabled=false` and
+  `release-1b=true`; these should be a shared profile or composed annotation
+  instead of per-class inline properties.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -679,3 +679,26 @@ Conclusion:
   churn by one additional miss.
 - Remaining spies now appear to be deliberate test doubles for gateway/service
   verification or forced error paths.
+
+### 2026-06-25: Re-ran full integration suite after cleanup
+
+Validation:
+
+| Task | Earlier full-run misses | Current full-run misses | Result |
+| --- | ---: | ---: | --- |
+| `integration` | 55 | 44 | Passed |
+
+Observed cache stats:
+
+- Maximum `missCount`: 44
+- Maximum `hitCount`: 11764
+- Cache `maxSize`: 4
+- Failure count: 0
+
+Conclusion:
+
+- The accumulated context-key cleanup reduced the full integration suite from
+  55 to 44 context misses while keeping the suite green.
+- The remaining cache churn is no longer obviously caused by direct-use spies;
+  the remaining spies are tied to stubbing, verification, or forced error
+  paths and would need deliberate test redesign rather than mechanical removal.

--- a/docs/spikes/PO-7203-spring-test-context-memory.md
+++ b/docs/spikes/PO-7203-spring-test-context-memory.md
@@ -631,3 +631,27 @@ Conclusion:
 - This is safe cleanup for the draft and defendant test hierarchy.
 - It reduced Legacy context churn by one additional miss, while Base and Opal
   remained unchanged because other context-key differences still dominate there.
+
+### 2026-06-25: Converted Opal impositions schema validator
+
+Code changes:
+
+- Replaced direct-use `@MockitoSpyBean JsonSchemaValidationService` with
+  `@Autowired` in `OpalDefendantAccountImpositionsIntegrationTest`.
+- Left remaining repository and service spies unchanged where tests use Mockito
+  stubbing, verification, or forced error paths.
+
+Validation:
+
+| Task | Before misses | After misses | Result |
+| --- | ---: | ---: | --- |
+| `compileIntegrationTestJava` | n/a | n/a | Passed |
+| `integrationOpal` | 9 | 8 | Passed |
+| `checkstyleIntegrationTest` | n/a | n/a | Passed |
+
+Conclusion:
+
+- Removing the final direct-use schema validator spy in this Opal path reduced
+  Opal context churn by one more miss.
+- Remaining Opal spies are more likely intentional test doubles and should not
+  be removed without deeper test redesign.

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/AbstractCommonDefendantsIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/AbstractCommonDefendantsIntegrationTest.java
@@ -12,7 +12,6 @@ import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
@@ -39,7 +38,7 @@ abstract class AbstractCommonDefendantsIntegrationTest extends AbstractIntegrati
     @Autowired
     JdbcTemplate jdbcTemplate;
 
-    @MockitoSpyBean
+    @Autowired
     JsonSchemaValidationService jsonSchemaValidationService;
 
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/AbstractLegacyDefendantsIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/AbstractLegacyDefendantsIntegrationTest.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.opal.controllers;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.SchemaPaths;
 import uk.gov.hmcts.opal.controllers.util.DefendantAccountVersionUtil;
@@ -16,7 +16,7 @@ abstract class AbstractLegacyDefendantsIntegrationTest extends AbstractIntegrati
     protected static final String REMOVE_DEFENDANT_PARTY_RESPONSE_SCHEMA = SchemaPaths.DEFENDANT_ACCOUNT
         + "/removeDefendantAccountPartyResponse.json";
 
-    @MockitoSpyBean
+    @Autowired
     protected JsonSchemaValidationService jsonSchemaValidationService;
 
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/AbstractOpalDefendantsIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/AbstractOpalDefendantsIntegrationTest.java
@@ -4,9 +4,9 @@ import java.time.LocalDate;
 import java.time.Period;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.SchemaPaths;
@@ -35,7 +35,7 @@ abstract class AbstractOpalDefendantsIntegrationTest extends AbstractIntegration
         SchemaPaths.DEFENDANT_ACCOUNT + "/getDefendantAccountFixedPenaltyResponse.json";
     protected static final LocalDate ACCOUNT_77_BIRTH_DATE = LocalDate.of(1980, 2, 3);
 
-    @MockitoSpyBean
+    @Autowired
     protected JsonSchemaValidationService jsonSchemaValidationService;
 
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/BusinessUnitControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/BusinessUnitControllerIntegrationTest.java
@@ -15,9 +15,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
@@ -40,7 +40,7 @@ class BusinessUnitControllerIntegrationTest extends AbstractIntegrationTest {
     private static final String GET_BUNITS_REF_DATA_RESPONSE =
         SchemaPaths.REFERENCE_DATA + "/getBusinessUnitsRefDataResponse.json";
 
-    @MockitoSpyBean
+    @Autowired
     private JsonSchemaValidationService jsonSchemaValidationService;
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CentralFundControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CentralFundControllerIntegrationTest.java
@@ -23,7 +23,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import tools.jackson.databind.JsonNode;
@@ -34,9 +33,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration"})
-@TestPropertySource(properties = {
-    "launchdarkly.enabled=false"
-})
 @Sql(scripts = "classpath:db/insertData/insert_into_central_funds.sql", executionPhase = BEFORE_TEST_CLASS)
 @Sql(scripts = "classpath:db/deleteData/delete_from_central_funds.sql", executionPhase = AFTER_TEST_CLASS)
 @Slf4j(topic = "opal.CentralFundControllerIntegrationTest")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CentralFundControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CentralFundControllerIntegrationTest.java
@@ -35,8 +35,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration"})
 @TestPropertySource(properties = {
-    "launchdarkly.enabled=false",
-    "launchdarkly.default-flag-values.release-1b=true"
+    "launchdarkly.enabled=false"
 })
 @Sql(scripts = "classpath:db/insertData/insert_into_central_funds.sql", executionPhase = BEFORE_TEST_CLASS)
 @Sql(scripts = "classpath:db/deleteData/delete_from_central_funds.sql", executionPhase = AFTER_TEST_CLASS)

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CommonDraftAccountControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CommonDraftAccountControllerIntegrationTest.java
@@ -11,9 +11,9 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.SchemaPaths;
@@ -50,7 +50,7 @@ class CommonDraftAccountControllerIntegrationTest extends AbstractIntegrationTes
     @MockitoBean
     SecurityEventLoggingService securityEventLoggingService;
 
-    @MockitoSpyBean
+    @Autowired
     JsonSchemaValidationService jsonSchemaValidationService;
 
     @MockitoBean

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CourtControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CourtControllerIntegrationTest.java
@@ -11,9 +11,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
@@ -37,7 +37,7 @@ class CourtControllerIntegrationTest extends AbstractIntegrationTest {
     private static final String GET_COURTS_REF_DATA_RESPONSE =
         SchemaPaths.REFERENCE_DATA + "/getCourtsRefDataResponse.json";
 
-    @MockitoSpyBean
+    @Autowired
     private JsonSchemaValidationService jsonSchemaValidationService;
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountHistoryFeatureFlagIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountHistoryFeatureFlagIntegrationTest.java
@@ -17,7 +17,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "opal"})
 @TestPropertySource(properties = {
-    "launchdarkly.enabled=false",
     "launchdarkly.default-flag-values.release-1b=false"
 })
 @DisplayName("Defendant Account History Feature Flag Integration Test")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountSearchRelease1bDisabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountSearchRelease1bDisabledIntegrationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.opal.controllers;
 
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -11,9 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
-import uk.gov.hmcts.opal.service.DefendantAccountService;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
@@ -21,16 +18,12 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 @ActiveProfiles("integration")
 @TestPropertySource(properties = {
     "launchdarkly.enabled=false",
-    "launchdarkly.default-flag-values.release-1b=false",
-    "launchdarkly.default-flag-values.release-1c=true"
+    "launchdarkly.default-flag-values.release-1b=false"
 })
 @DisplayName("Defendant account search release-1b disabled Integration Test")
 class DefendantAccountSearchRelease1bDisabledIntegrationTest extends AbstractIntegrationTest {
 
     private static final String DEFENDANTS_SEARCH_URL = "/defendant-accounts/search";
-
-    @MockitoBean
-    private DefendantAccountService defendantAccountService;
 
     @Test
     @DisplayName("POST /defendant-accounts/search is unavailable when release-1b is disabled")
@@ -46,8 +39,6 @@ class DefendantAccountSearchRelease1bDisabledIntegrationTest extends AbstractInt
             .andExpect(status().isNotFound())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("$.title").value("Feature Disabled"));
-
-        verifyNoInteractions(defendantAccountService);
     }
 
     private String searchCriteria(boolean consolidationSearch) {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountSearchRelease1cDisabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountSearchRelease1cDisabledIntegrationTest.java
@@ -28,7 +28,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 @ActiveProfiles("integration")
 @TestPropertySource(properties = {
     "launchdarkly.enabled=false",
-    "launchdarkly.default-flag-values.release-1b=true",
     "launchdarkly.default-flag-values.release-1c=false"
 })
 @DisplayName("Defendant account search release-1c disabled Integration Test")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/JwtControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/JwtControllerIntegrationTest.java
@@ -17,21 +17,15 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.gov.hmcts.opal.AbstractIntegrationWithSecurityTest;
-import uk.gov.hmcts.opal.util.FeatureFlags;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @Slf4j(topic = "opal.JwtControllerIntegrationTest")
 @TestPropertySource(properties = {
-    "launchdarkly.enabled=false",
-    "launchdarkly.default-flag-values.release-1a=true"
+    "launchdarkly.enabled=false"
 })
 @DisplayName("JWT Controller Integration Tests")
-@TestPropertySource(properties = {
-    "launchdarkly.enabled=false",
-    FeatureFlags.RELEASE_1A_ENABLED_PROPERTY + "=true"
-})
 class JwtControllerIntegrationTest extends AbstractIntegrationWithSecurityTest {
 
     private static final String URL = "/business-units/5";

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/JwtControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/JwtControllerIntegrationTest.java
@@ -14,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.gov.hmcts.opal.AbstractIntegrationWithSecurityTest;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
@@ -22,9 +21,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @Slf4j(topic = "opal.JwtControllerIntegrationTest")
-@TestPropertySource(properties = {
-    "launchdarkly.enabled=false"
-})
 @DisplayName("JWT Controller Integration Tests")
 class JwtControllerIntegrationTest extends AbstractIntegrationWithSecurityTest {
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantAccountHistoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantAccountHistoryIntegrationTest.java
@@ -19,7 +19,6 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
@@ -32,10 +31,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "legacy"})
-@TestPropertySource(properties = {
-    "launchdarkly.enabled=false",
-    "launchdarkly.default-flag-values.release-1b=true"
-})
 @DisplayName("Legacy Defendant Account History Integration Tests")
 @Slf4j(topic = "opal.LegacyDefendantAccountHistoryIntegrationTest")
 class LegacyDefendantAccountHistoryIntegrationTest extends AbstractLegacyDefendantsIntegrationTest {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantAccountImpositionsIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantAccountImpositionsIntegrationTest.java
@@ -22,12 +22,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.client.HttpClientErrorException;
@@ -67,7 +67,7 @@ class LegacyDefendantAccountImpositionsIntegrationTest extends AbstractIntegrati
     @MockitoBean
     private GatewayService gatewayService;
 
-    @MockitoSpyBean
+    @Autowired
     private JsonSchemaValidationService jsonSchemaValidationService;
 
     @BeforeEach

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantAccountImpositionsIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantAccountImpositionsIntegrationTest.java
@@ -26,7 +26,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MvcResult;
@@ -55,10 +54,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "legacy"})
 @DisplayName("Legacy Defendant Account Impositions Integration Tests")
-@TestPropertySource(properties = {
-    "launchdarkly.enabled=false",
-    "launchdarkly.default-flag-values.release-1b=true"
-})
 class LegacyDefendantAccountImpositionsIntegrationTest extends AbstractIntegrationTest {
 
     private static final String URL_BASE = "/defendant-accounts";

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantAccountImpositionsIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantAccountImpositionsIntegrationTest.java
@@ -33,7 +33,6 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.client.HttpClientErrorException;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.common.legacy.service.GatewayService;
-import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
 import uk.gov.hmcts.opal.common.user.authorisation.client.service.UserStateClientService;
 import uk.gov.hmcts.opal.controllers.util.UserStateUtil;
 import uk.gov.hmcts.opal.dto.legacy.LegacyCourtReferenceCommon;
@@ -61,9 +60,6 @@ class LegacyDefendantAccountImpositionsIntegrationTest extends AbstractIntegrati
 
     @MockitoBean
     private UserStateService userStateService;
-
-    @MockitoBean
-    private AccessTokenService accessTokenService;
 
     @MockitoBean
     private UserStateClientService userStateClientService;

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantsSearchIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantsSearchIntegrationTest.java
@@ -12,11 +12,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
-import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
 import uk.gov.hmcts.opal.dto.ToJsonString;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
@@ -29,10 +27,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 class LegacyDefendantsSearchIntegrationTest extends AbstractIntegrationTest {
 
     private static final String DEFENDANTS_SEARCH_URL = "/defendant-accounts/search";
-
-
-    @MockitoBean
-    private AccessTokenService accessTokenService;
 
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantsSearchIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantsSearchIntegrationTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
@@ -24,7 +23,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "legacy"})
-@TestPropertySource(properties = "launchdarkly.default-flag-values.release-1b=true")
 @Sql(scripts = "classpath:db/insertData/insert_into_defendant_accounts.sql", executionPhase = BEFORE_TEST_CLASS)
 @Sql(scripts = "classpath:db/deleteData/delete_from_defendant_accounts.sql", executionPhase = AFTER_TEST_CLASS)
 @Slf4j(topic = "opal.LegacyDefendantsIntegrationTest01")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyMajorCreditorAccountAtAGlanceIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyMajorCreditorAccountAtAGlanceIntegrationTest.java
@@ -17,7 +17,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.server.ResponseStatusException;
@@ -30,10 +29,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "legacy"})
-@TestPropertySource(properties = {
-    "launchdarkly.enabled=false",
-    "launchdarkly.default-flag-values.release-1b=true"
-})
 @DisplayName("Major Creditor Account At A Glance Legacy Integration Tests")
 @Slf4j(topic = "opal.LegacyMajorCreditorAccountAtAGlanceIntegrationTest")
 class LegacyMajorCreditorAccountAtAGlanceIntegrationTest extends AbstractIntegrationTest {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyMajorCreditorAccountHeaderSummaryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyMajorCreditorAccountHeaderSummaryIntegrationTest.java
@@ -19,7 +19,6 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
@@ -33,10 +32,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "legacy"})
-@TestPropertySource(properties = {
-    "launchdarkly.enabled=false",
-    "launchdarkly.default-flag-values.release-1b=true"
-})
 @DisplayName("Major Creditor Account Header Summary Legacy Integration Tests")
 @Slf4j(topic = "opal.LegacyMajorCreditorAccountHeaderSummaryIntegrationTest")
 class LegacyMajorCreditorAccountHeaderSummaryIntegrationTest extends AbstractIntegrationTest {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyMinorCreditorIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyMinorCreditorIntegrationTest.java
@@ -6,17 +6,12 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TE
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "legacy"})
-@TestPropertySource(properties = {
-    "launchdarkly.enabled=false",
-    "launchdarkly.default-flag-values.release-1b=true"
-})
 @Slf4j(topic = "opal.LegacyDefendantsIntegrationTest01")
 @Sql(scripts = "classpath:db/insertData/insert_into_minor_creditors.sql", executionPhase = BEFORE_TEST_METHOD)
 @Sql(scripts = "classpath:db/deleteData/delete_from_minor_creditors.sql", executionPhase = AFTER_TEST_METHOD)

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyMinorCreditorPatchIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyMinorCreditorPatchIntegrationTest.java
@@ -20,7 +20,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
@@ -45,10 +44,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "legacy"})
-@TestPropertySource(properties = {
-    "launchdarkly.enabled=false",
-    "launchdarkly.default-flag-values.release-1b=true"
-})
 @Sql(scripts = "classpath:db/insertData/insert_into_minor_creditors.sql", executionPhase = BEFORE_TEST_METHOD)
 @Sql(scripts = "classpath:db/deleteData/delete_from_minor_creditors.sql", executionPhase = AFTER_TEST_METHOD)
 @Slf4j(topic = "opal.LegacyMinorCreditorPatchIntegrationTest")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyMinorCreditorPatchStubIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyMinorCreditorPatchStubIntegrationTest.java
@@ -15,7 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
@@ -30,10 +29,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "legacy"})
-@TestPropertySource(properties = {
-    "launchdarkly.enabled=false",
-    "launchdarkly.default-flag-values.release-1b=true"
-})
 @Sql(scripts = "classpath:db/insertData/insert_into_minor_creditors.sql", executionPhase = BEFORE_TEST_METHOD)
 @Sql(scripts = "classpath:db/deleteData/delete_from_minor_creditors.sql", executionPhase = AFTER_TEST_METHOD)
 @Slf4j(topic = "opal.LegacyMinorCreditorPatchStubIntegrationTest")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LocalJusticeAreaControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LocalJusticeAreaControllerIntegrationTest.java
@@ -9,10 +9,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -46,10 +46,10 @@ class LocalJusticeAreaControllerIntegrationTest extends AbstractIntegrationTest 
         SchemaPaths.REFERENCE_DATA + "/getLJARefDataResponse.json";
     public static final String LJA_TYPE_PARAM = "lja_type";
 
-    @MockitoSpyBean
+    @Autowired
     CacheManager cacheManager;
 
-    @MockitoSpyBean
+    @Autowired
     private JsonSchemaValidationService jsonSchemaValidationService;
 
     private static Stream<Arguments> testCasesForQueryParameterInput() {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MajorCreditorAccountHeaderSummaryFeatureFlagIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MajorCreditorAccountHeaderSummaryFeatureFlagIntegrationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.opal.controllers;
 
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -12,9 +11,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
-import uk.gov.hmcts.opal.common.legacy.service.GatewayService;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
@@ -26,9 +23,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 })
 @DisplayName("Major Creditor Account Header Summary Feature Flag Integration Tests")
 class MajorCreditorAccountHeaderSummaryFeatureFlagIntegrationTest extends AbstractIntegrationTest {
-
-    @MockitoBean
-    private GatewayService gatewayService;
 
     @Test
     @DisplayName("PO-2136 feature flag disabled returns 404")
@@ -43,7 +37,5 @@ class MajorCreditorAccountHeaderSummaryFeatureFlagIntegrationTest extends Abstra
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE))
             .andExpect(jsonPath("$.title").value("Feature Disabled"))
             .andExpect(jsonPath("$.detail").value("The requested feature is not currently available"));
-
-        verifyNoInteractions(gatewayService);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MajorCreditorAccountHeaderSummaryFeatureFlagIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MajorCreditorAccountHeaderSummaryFeatureFlagIntegrationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.controllers;
 
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -11,7 +12,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
+import uk.gov.hmcts.opal.common.legacy.service.GatewayService;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
@@ -23,6 +26,9 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 })
 @DisplayName("Major Creditor Account Header Summary Feature Flag Integration Tests")
 class MajorCreditorAccountHeaderSummaryFeatureFlagIntegrationTest extends AbstractIntegrationTest {
+
+    @MockitoBean
+    private GatewayService gatewayService;
 
     @Test
     @DisplayName("PO-2136 feature flag disabled returns 404")
@@ -37,5 +43,7 @@ class MajorCreditorAccountHeaderSummaryFeatureFlagIntegrationTest extends Abstra
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE))
             .andExpect(jsonPath("$.title").value("Feature Disabled"))
             .andExpect(jsonPath("$.detail").value("The requested feature is not currently available"));
+
+        verifyNoInteractions(gatewayService);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MajorCreditorControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MajorCreditorControllerIntegrationTest.java
@@ -5,9 +5,9 @@ import static org.hamcrest.Matchers.hasItem;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
@@ -37,7 +37,7 @@ class MajorCreditorControllerIntegrationTest extends AbstractIntegrationTest {
     private static final String GET_MAJOR_CREDS_REF_DATA_RESPONSE =
         SchemaPaths.REFERENCE_DATA + "/getMajorCredRefDataResponse.json";
 
-    @MockitoSpyBean
+    @Autowired
     private JsonSchemaValidationService jsonSchemaValidationService;
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagIntegrationTest.java
@@ -36,7 +36,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "opal"})
 @TestPropertySource(properties = {
-    "launchdarkly.enabled=false",
     "launchdarkly.default-flag-values.release-1b=false"
 })
 @Sql(scripts = "classpath:db/insertData/insert_into_minor_creditors.sql", executionPhase = BEFORE_TEST_METHOD)

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
@@ -34,10 +33,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "opal"})
-@TestPropertySource(properties = {
-    "launchdarkly.enabled=false",
-    "launchdarkly.default-flag-values.release-1b=true"
-})
 @Sql(scripts = "classpath:db/insertData/insert_into_minor_creditors.sql", executionPhase = BEFORE_TEST_METHOD)
 @Sql(scripts = "classpath:db/deleteData/delete_from_minor_creditors.sql", executionPhase = AFTER_TEST_METHOD)
 @Slf4j(topic = "opal.MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorControllerIntegrationTest.java
@@ -17,8 +17,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
@@ -50,7 +50,7 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
         "opal/minor-creditor/getMinorCreditorAccountHeaderSummaryResponse.json";
 
 
-    @MockitoSpyBean
+    @Autowired
     private JsonSchemaValidationService jsonSchemaValidationService;
 
     void postSearchMinorCreditorImpl_Success(Logger log) throws Exception {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OffenceControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OffenceControllerIntegrationTest.java
@@ -3,9 +3,9 @@ package uk.gov.hmcts.opal.controllers;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
@@ -41,7 +41,7 @@ class OffenceControllerIntegrationTest extends AbstractIntegrationTest {
         SchemaPaths.REFERENCE_DATA + "/postOffencesSearchResponse.json";
     private static final String URL_BASE = "/offences";
 
-    @MockitoSpyBean
+    @Autowired
     private JsonSchemaValidationService jsonSchemaValidationService;
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantAccountHistoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantAccountHistoryIntegrationTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.dto.ToJsonString;
@@ -25,10 +24,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "opal"})
-@TestPropertySource(properties = {
-    "launchdarkly.enabled=false",
-    "launchdarkly.default-flag-values.release-1b=true"
-})
 @DisplayName("Defendant Account History Controller Integration Tests")
 @Slf4j(topic = "opal.OpalDefendantAccountHistoryIntegrationTest")
 class OpalDefendantAccountHistoryIntegrationTest extends AbstractOpalDefendantsIntegrationTest {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantAccountImpositionsIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantAccountImpositionsIntegrationTest.java
@@ -14,9 +14,9 @@ import static uk.gov.hmcts.opal.SchemaPaths.GET_DEFENDANT_ACCOUNT_IMPOSITIONS_RE
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -41,7 +41,7 @@ class OpalDefendantAccountImpositionsIntegrationTest extends AbstractIntegration
     private static final String URL_BASE = "/defendant-accounts";
 
 
-    @MockitoSpyBean
+    @Autowired
     private JsonSchemaValidationService jsonSchemaValidationService;
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsSearchIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsSearchIntegrationTest.java
@@ -36,7 +36,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "opal"})
 @TestPropertySource(properties = {
-    "launchdarkly.default-flag-values.release-1b=true",
     "launchdarkly.default-flag-values.release-1c=true"
 })
 @Sql(scripts = "classpath:db/insertData/insert_into_defendant_accounts.sql", executionPhase = BEFORE_TEST_CLASS)

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsSearchIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsSearchIntegrationTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
@@ -33,9 +32,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "opal"})
-@TestPropertySource(properties = {
-    "launchdarkly.default-flag-values.release-1c=true"
-})
 @Sql(scripts = "classpath:db/insertData/insert_into_defendant_accounts.sql", executionPhase = BEFORE_TEST_CLASS)
 @Sql(scripts = "classpath:db/deleteData/delete_from_defendant_accounts.sql", executionPhase = AFTER_TEST_CLASS)
 @Slf4j(topic = "opal.OpalDefendantsIntegrationTest01")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsSearchIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsSearchIntegrationTest.java
@@ -18,10 +18,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
@@ -45,7 +45,7 @@ class OpalDefendantsSearchIntegrationTest extends AbstractIntegrationTest {
     private static final String DEFENDANTS_SEARCH_RESP_SCHEMA = SchemaPaths.DEFENDANT_ACCOUNT
         + "/postDefendantAccountsSearchResponse.json";
 
-    @MockitoSpyBean
+    @Autowired
     JsonSchemaValidationService jsonSchemaValidationService;
 
     @ParameterizedTest(name = "consolidated={0}")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsSearchIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsSearchIntegrationTest.java
@@ -21,13 +21,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.SchemaPaths;
-import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
 import uk.gov.hmcts.opal.dto.ToJsonString;
 import uk.gov.hmcts.opal.service.opal.JsonSchemaValidationService;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
@@ -49,9 +47,6 @@ class OpalDefendantsSearchIntegrationTest extends AbstractIntegrationTest {
 
     @MockitoSpyBean
     JsonSchemaValidationService jsonSchemaValidationService;
-
-    @MockitoBean
-    private AccessTokenService accessTokenService;
 
     @ParameterizedTest(name = "consolidated={0}")
     @ValueSource(booleans = {false, true})

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMajorCreditorAccountAtAGlanceIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMajorCreditorAccountAtAGlanceIntegrationTest.java
@@ -33,7 +33,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
@@ -52,10 +51,6 @@ import org.yaml.snakeyaml.Yaml;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "opal"})
-@TestPropertySource(properties = {
-    "launchdarkly.enabled=false",
-    "launchdarkly.default-flag-values.release-1b=true"
-})
 @Sql(
     scripts = "classpath:db/insertData/insert_into_major_creditor_at_a_glance_postcode.sql",
     executionPhase = BEFORE_TEST_CLASS

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMajorCreditorAccountHeaderSummaryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMajorCreditorAccountHeaderSummaryIntegrationTest.java
@@ -19,7 +19,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.ResultActions;
 import tools.jackson.databind.JsonNode;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
@@ -29,10 +28,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "opal"})
-@TestPropertySource(properties = {
-    "launchdarkly.enabled=false",
-    "launchdarkly.default-flag-values.release-1b=true"
-})
 @DisplayName("Major Creditor Account Header Summary Opal Integration Tests")
 @Slf4j(topic = "opal.OpalMajorCreditorAccountHeaderSummaryIntegrationTest")
 class OpalMajorCreditorAccountHeaderSummaryIntegrationTest extends AbstractIntegrationTest {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMinorCreditorHistoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMinorCreditorHistoryIntegrationTest.java
@@ -23,7 +23,6 @@ import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
@@ -37,10 +36,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "opal"})
-@TestPropertySource(properties = {
-    "launchdarkly.enabled=false",
-    "launchdarkly.default-flag-values.release-1b=true"
-})
 @Sql(scripts = {
     "classpath:db/deleteData/delete_from_po_2642_minor_creditor_history.sql",
     "classpath:db/insertData/insert_into_po_2642_minor_creditor_history.sql"

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMinorCreditorIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMinorCreditorIntegrationTest.java
@@ -13,10 +13,10 @@ import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.dto.ToJsonString;
@@ -40,16 +40,16 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 @Slf4j(topic = "opal.OpalMinorCreditorIntegrationTest")
 public class OpalMinorCreditorIntegrationTest extends MinorCreditorControllerIntegrationTest {
 
-    @MockitoSpyBean
+    @Autowired
     private ImpositionRepository impositionRepository;
 
-    @MockitoSpyBean
+    @Autowired
     private CreditorTransactionRepository creditorTransactionRepository;
 
-    @MockitoSpyBean
+    @Autowired
     private PartyRepository partyRepository;
 
-    @MockitoSpyBean
+    @Autowired
     private CreditorAccountRepository creditorAccountRepository;
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMinorCreditorIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMinorCreditorIntegrationTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
@@ -36,9 +35,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "opal"})
-@TestPropertySource(properties = {
-    "launchdarkly.default-flag-values.release-1b=true"
-})
 @Sql(scripts = "classpath:db/insertData/insert_into_minor_creditors.sql", executionPhase = BEFORE_TEST_METHOD)
 @Sql(scripts = "classpath:db/deleteData/delete_from_minor_creditors.sql", executionPhase = AFTER_TEST_METHOD)
 @Slf4j(topic = "opal.OpalMinorCreditorIntegrationTest")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ProsecutorControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ProsecutorControllerIntegrationTest.java
@@ -3,9 +3,9 @@ package uk.gov.hmcts.opal.controllers;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
@@ -30,7 +30,7 @@ class ProsecutorControllerIntegrationTest extends AbstractIntegrationTest {
 
     private static final String URL_BASE = "/prosecutors";
 
-    @MockitoSpyBean
+    @Autowired
     private JsonSchemaValidationService jsonSchemaValidationService;
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/Release1bFeatureToggleLaunchDarklyEnabledFlagFalseIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/Release1bFeatureToggleLaunchDarklyEnabledFlagFalseIntegrationTest.java
@@ -28,8 +28,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 @ActiveProfiles({"integration", "opal"})
 @TestPropertySource(properties = {
     "launchdarkly.enabled=true",
-    "launchdarkly.sdk-key=test-sdk-key",
-    "launchdarkly.default-flag-values.release-1b=true"
+    "launchdarkly.sdk-key=test-sdk-key"
 })
 class Release1bFeatureToggleLaunchDarklyEnabledFlagFalseIntegrationTest extends AbstractIntegrationTest {
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/Release1bFeatureToggleLaunchDarklyEnabledFlagTrueIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/Release1bFeatureToggleLaunchDarklyEnabledFlagTrueIntegrationTest.java
@@ -26,8 +26,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 @ActiveProfiles({"integration", "opal"})
 @TestPropertySource(properties = {
     "launchdarkly.enabled=true",
-    "launchdarkly.sdk-key=test-sdk-key",
-    "launchdarkly.default-flag-values.release-1b=false"
+    "launchdarkly.sdk-key=test-sdk-key"
 })
 class Release1bFeatureToggleLaunchDarklyEnabledFlagTrueIntegrationTest extends AbstractIntegrationTest {
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportInstancesControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportInstancesControllerIntegrationTest.java
@@ -57,15 +57,6 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     UserStateService userStateService;
 
     @MockitoBean
-    private UserState userState;
-
-    @MockitoBean
-    private BusinessUnitUser businessUnitUser1;
-
-    @MockitoBean
-    private BusinessUnitUser businessUnitUser2;
-
-    @MockitoBean
     private ReportQueuePublisherImpl reportQueuePublisher;
 
     @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
@@ -78,11 +69,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraEpic("PO-2248")
     @JiraTestKey("PO-7742")
     void createReportInstance_singleBU() throws Exception {
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
-        when(userState.getUserId()).thenReturn(USER_ID);
-        when(userState.getUserName()).thenReturn(USER_NAME);
-        when(businessUnitUser1.getBusinessUnitId()).thenReturn((short)1);
+        givenUserStateForBusinessUnits((short)1);
         Map<String, Object> parameterMap = Map.of(
             "date-param", "2026-05-26",
             "decimal-param", 5.0,
@@ -143,12 +130,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraEpic("PO-2248")
     @JiraTestKey("PO-7744")
     void createReportInstance_multiBUs() throws Exception {
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1, businessUnitUser2));
-        when(userState.getUserId()).thenReturn(USER_ID);
-        when(userState.getUserName()).thenReturn(USER_NAME);
-        when(businessUnitUser1.getBusinessUnitId()).thenReturn((short)1);
-        when(businessUnitUser2.getBusinessUnitId()).thenReturn((short)2);
+        givenUserStateForBusinessUnits((short)1, (short)2);
 
         CreateReportInstanceRequestReports request = CreateReportInstanceRequestReports.builder()
             .reportId(REPORT_2BUs_ID)
@@ -176,10 +158,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraEpic("PO-2248")
     @JiraTestKey("PO-7746")
     void createReportInstance_singleBU_fail2BUs_422() throws Exception {
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1, businessUnitUser2));
-        when(businessUnitUser1.getBusinessUnitId()).thenReturn((short)1);
-        when(businessUnitUser2.getBusinessUnitId()).thenReturn((short)2);
+        givenUserStateForBusinessUnits((short)1, (short)2);
 
         CreateReportInstanceRequestReports request = CreateReportInstanceRequestReports.builder()
             .reportId(REPORT_1BU_ID)
@@ -202,9 +181,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraEpic("PO-2248")
     @JiraTestKey("PO-7750")
     void createReportInstance_cannotManuallyCreate_422() throws Exception {
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
-        when(businessUnitUser1.getBusinessUnitId()).thenReturn((short)1);
+        givenUserStateForBusinessUnits((short)1);
 
         CreateReportInstanceRequestReports request = CreateReportInstanceRequestReports.builder()
             .reportId(REPORT_NO_MANUAL_CREATION)
@@ -227,9 +204,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraEpic("PO-2248")
     @JiraTestKey("PO-7743")
     void createReportInstance_wrongBU_403() throws Exception {
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
-        when(businessUnitUser1.getBusinessUnitId()).thenReturn((short)1);
+        givenUserStateForBusinessUnits((short)1);
 
         CreateReportInstanceRequestReports request = CreateReportInstanceRequestReports.builder()
             .reportId(REPORT_1BU_ID)
@@ -251,9 +226,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraEpic("PO-2248")
     @JiraTestKey("PO-7752")
     void createReportInstance_notAllBUs_403() throws Exception {
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
-        when(businessUnitUser1.getBusinessUnitId()).thenReturn((short)1);
+        givenUserStateForBusinessUnits((short)1);
 
         CreateReportInstanceRequestReports request = CreateReportInstanceRequestReports.builder()
             .reportId(REPORT_2BUs_ID)
@@ -364,11 +337,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
         doThrow(new IllegalArgumentException("Unable to publish report queue message"))
             .when(reportQueuePublisher).publish(anyLong());
 
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
-        when(userState.getUserId()).thenReturn(USER_ID);
-        when(userState.getUserName()).thenReturn(USER_NAME);
-        when(businessUnitUser1.getBusinessUnitId()).thenReturn((short)1);
+        givenUserStateForBusinessUnits((short)1);
 
         CreateReportInstanceRequestReports request = CreateReportInstanceRequestReports.builder()
             .reportId(REPORT_1BU_ID)
@@ -410,11 +379,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraEpic("PO-2248")
     @JiraTestKey("PO-7741")
     void createReportInstance_reportParameterValidation_mandatoryFieldsNotSuppliedFail() throws Exception {
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
-        when(userState.getUserId()).thenReturn(USER_ID);
-        when(userState.getUserName()).thenReturn(USER_NAME);
-        when(businessUnitUser1.getBusinessUnitId()).thenReturn((short)1);
+        givenUserStateForBusinessUnits((short)1);
 
         CreateReportInstanceRequestReports request = CreateReportInstanceRequestReports.builder()
             .reportId(REPORT_1BU_ID)
@@ -442,11 +407,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraEpic("PO-2248")
     @JiraTestKey("PO-7751")
     void createReportInstance_reportParameterValidation_unknownParameterFail() throws Exception {
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
-        when(userState.getUserId()).thenReturn(USER_ID);
-        when(userState.getUserName()).thenReturn(USER_NAME);
-        when(businessUnitUser1.getBusinessUnitId()).thenReturn((short)1);
+        givenUserStateForBusinessUnits((short)1);
 
         CreateReportInstanceRequestReports request = CreateReportInstanceRequestReports.builder()
             .reportId(REPORT_1BU_ID)
@@ -484,11 +445,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraEpic("PO-2248")
     @JiraTestKey("PO-7754")
     void createReportInstance_reportParameterValidation_parameterTypeMismatchFail() throws Exception {
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
-        when(userState.getUserId()).thenReturn(USER_ID);
-        when(userState.getUserName()).thenReturn(USER_NAME);
-        when(businessUnitUser1.getBusinessUnitId()).thenReturn((short)1);
+        givenUserStateForBusinessUnits((short)1);
 
         CreateReportInstanceRequestReports request = CreateReportInstanceRequestReports.builder()
             .reportId(REPORT_1BU_ID)
@@ -526,11 +483,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraEpic("PO-2248")
     @JiraTestKey("PO-7753")
     void createReportInstance_repeatSuccess() throws Exception {
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
-        when(userState.getUserId()).thenReturn(USER_ID);
-        when(userState.getUserName()).thenReturn(USER_NAME);
-        when(businessUnitUser1.getBusinessUnitId()).thenReturn((short)1);
+        givenUserStateForBusinessUnits((short)1);
 
         CreateReportInstanceRequestReports request = CreateReportInstanceRequestReports.builder()
             .reportId(REPORT_1BU_ID)
@@ -573,5 +526,18 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
         CreateReportInstanceResponseReports dto2 = objectMapper
             .readValue(body2, CreateReportInstanceResponseReports.class);
         assertNotEquals(dto1.getReportInstanceId(), dto2.getReportInstanceId());
+    }
+
+    private void givenUserStateForBusinessUnits(short... businessUnitIds) {
+        Set<BusinessUnitUser> businessUnitUsers = new java.util.HashSet<>();
+        for (short businessUnitId : businessUnitIds) {
+            businessUnitUsers.add(BusinessUnitUser.builder().businessUnitId(businessUnitId).build());
+        }
+
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(UserState.builder()
+            .userId(USER_ID)
+            .userName(USER_NAME)
+            .businessUnitUser(businessUnitUsers)
+            .build());
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
@@ -27,8 +27,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration"})
 @TestPropertySource(properties = {
-    "launchdarkly.default-flag-values.release-1a=true",
-    "launchdarkly.default-flag-values.release-1b=true",
     "launchdarkly.enabled=false"
 })
 @Slf4j(topic = "opal.ResultControllerIntegrationTest")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
@@ -11,9 +11,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
@@ -34,7 +34,7 @@ class ResultControllerIntegrationTest extends AbstractIntegrationTest {
     private static final String GET_RESULTS_REF_DATA_RESPONSE =
         SchemaPaths.REFERENCE_DATA + "/getResultsRefDataResponse.json";
 
-    @MockitoSpyBean
+    @Autowired
     private JsonSchemaValidationService jsonSchemaValidationService;
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
@@ -26,9 +25,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration"})
-@TestPropertySource(properties = {
-    "launchdarkly.enabled=false"
-})
 @Slf4j(topic = "opal.ResultControllerIntegrationTest")
 @Sql(scripts = "classpath:db/insertData/insert_into_results.sql", executionPhase = BEFORE_TEST_CLASS)
 @DisplayName("ResultController Integration Test")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerRelease1aDisabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerRelease1aDisabledIntegrationTest.java
@@ -18,7 +18,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 @ActiveProfiles({"integration"})
 @TestPropertySource(properties = {
     "launchdarkly.default-flag-values.release-1a=false",
-    "launchdarkly.default-flag-values.release-1b=true",
     "launchdarkly.enabled=false"
 })
 @DisplayName("ResultController release-1a disabled Integration Test")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerRelease1bDisabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerRelease1bDisabledIntegrationTest.java
@@ -19,8 +19,8 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration"})
 @TestPropertySource(properties = {
-    "launchdarkly.default-flag-values.release-1b=false",
-    "launchdarkly.enabled=false"
+    "launchdarkly.enabled=false",
+    "launchdarkly.default-flag-values.release-1b=false"
 })
 @DisplayName("ResultController release-1b disabled Integration Test")
 class ResultControllerRelease1bDisabledIntegrationTest extends AbstractIntegrationTest {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerRelease1bDisabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerRelease1bDisabledIntegrationTest.java
@@ -19,7 +19,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration"})
 @TestPropertySource(properties = {
-    "launchdarkly.default-flag-values.release-1a=true",
     "launchdarkly.default-flag-values.release-1b=false",
     "launchdarkly.enabled=false"
 })

--- a/src/integrationTest/java/uk/gov/hmcts/opal/service/GenericReportServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/service/GenericReportServiceTest.java
@@ -18,7 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
@@ -42,7 +41,6 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @Transactional
-@DirtiesContext
 @Import(GenericReportServiceTest.TestBeans.class)
 class GenericReportServiceTest extends AbstractIntegrationTest {
 

--- a/src/integrationTest/resources/application-integration-with-spring-security.yaml
+++ b/src/integrationTest/resources/application-integration-with-spring-security.yaml
@@ -4,6 +4,10 @@ spring:
     locations: classpath:db/migration/ddl, classpath:db/migration/data/allEnvs, classpath:db/migration/data/nle, classpath:db/migration/data/dev
     baseline-on-migrate: true
     ignoreMigrationPatterns: "*:missing"
+  datasource:
+    hikari:
+      minimum-idle: 0
+      maximum-pool-size: 4
   main:
     allow-bean-definition-overriding: true
   security:

--- a/src/integrationTest/resources/application-integration.yaml
+++ b/src/integrationTest/resources/application-integration.yaml
@@ -4,6 +4,10 @@ spring:
     locations: classpath:db/migration/ddl, classpath:db/migration/data/allEnvs, classpath:db/migration/data/nle, classpath:db/migration/data/dev
     baseline-on-migrate: true
     ignoreMigrationPatterns: "*:missing"
+  datasource:
+    hikari:
+      minimum-idle: 0
+      maximum-pool-size: 4
   main:
     allow-bean-definition-overriding: true
   security:

--- a/src/integrationTest/resources/application-opal.yaml
+++ b/src/integrationTest/resources/application-opal.yaml
@@ -3,3 +3,4 @@ launchdarkly:
   enabled: false
   default-flag-values:
     release-1b: true
+    release-1c: true


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-7203


### Change description ###
Investigated why Spring ApplicationContexts used by integration tests are consuming excessive heap and causing Jenkins pipeline failures with java.lang.OutOfMemoryError: Java heap space during mvcContentNegotiationManager creation.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
