### PR TITLE
PO-3864: BE alignment with DB - ImpositionCategoriesEntity

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/entity/ImpositionCategoriesEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/ImpositionCategoriesEntity.java
@@ -1,0 +1,37 @@
+package uk.gov.hmcts.opal.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "imposition_categories",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "ic_imposition_category_uk", columnNames = "imposition_category")
+    }
+)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+public class ImpositionCategoriesEntity {
+
+    @Id
+    @Column(name = "imposition_category_id", length = 10, nullable = false)
+    private String impositionCategoryId;
+
+    @Column(name = "imposition_category", length = 40, nullable = false)
+    private String impositionCategory;
+
+    @Column(name = "item_number", nullable = false)
+    private Short itemNumber;
+}

--- a/src/main/resources/db/migration/ddl/V1_215__alter_imposition_categories.sql
+++ b/src/main/resources/db/migration/ddl/V1_215__alter_imposition_categories.sql
@@ -1,0 +1,47 @@
+/**
+* OPAL Program
+*
+* MODULE      : alter_imposition_categories.sql
+*
+* DESCRIPTION : Alter imposition category reference table
+*
+* VERSION HISTORY:
+*
+* Date          Author         Version     Nature of Change
+* ----------    -----------    --------    ----------------------------------------------------------------------------
+* 03/06/2026    TMc            1.0         PO-3842 - Amend IMPOSITION_CATEGORY_ITEM_NUMBER table.
+*                                          Rename table to IMPOSITION_CATEGORIES and add coded primary key
+*
+**/
+
+ALTER TABLE imposition_category_item_number
+    DROP CONSTRAINT IF EXISTS imposition_category_item_number_pk;
+
+ALTER TABLE imposition_category_item_number
+    RENAME TO imposition_categories;
+
+ALTER TABLE imposition_categories
+    ADD COLUMN imposition_category_id varchar(10);
+
+COMMENT ON COLUMN imposition_categories.imposition_category_id IS 'Unique coded value for imposition_category.';
+
+UPDATE imposition_categories
+    SET imposition_category_id = CASE imposition_category
+                                    WHEN 'Compensation'            THEN 'COMP'
+                                    WHEN 'Costs'                   THEN 'COST'
+                                    WHEN 'Court Charge'            THEN 'CC'
+                                    WHEN 'Crown Prosecution Costs' THEN 'CPC'
+                                    WHEN 'Fines'                   THEN 'FINE'
+                                    WHEN 'Legal Aid'               THEN 'LA'
+                                    WHEN 'Victim Surcharge'        THEN 'VS'
+                                    WHEN 'Witness Expenses & Central Fund' THEN 'WECF'
+                                 END;
+
+ALTER TABLE imposition_categories
+    ALTER COLUMN imposition_category_id SET NOT NULL;
+
+ALTER TABLE imposition_categories
+    ADD CONSTRAINT imposition_category_pk PRIMARY KEY (imposition_category_id);
+
+ALTER TABLE imposition_categories
+    ADD CONSTRAINT ic_imposition_category_uk UNIQUE (imposition_category);

--- a/src/main/resources/db/migration/ddl/V1_216__p_get_creditor_account.sql
+++ b/src/main/resources/db/migration/ddl/V1_216__p_get_creditor_account.sql
@@ -1,0 +1,170 @@
+CREATE OR REPLACE PROCEDURE p_get_creditor_account(
+    IN pi_business_unit_id            draft_accounts.business_unit_id%TYPE, 
+    IN pi_imposition_json             JSON, 
+    OUT po_creditor_account_id        creditor_accounts.creditor_account_id%TYPE, 
+    OUT po_is_minor_creditor          BOOLEAN, 
+    OUT po_results_mapped_item_number control_totals.item_number%TYPE)
+LANGUAGE plpgsql
+AS $$
+/**
+* OPAL Program
+*
+* MODULE      : p_get_creditor_account.sql
+*
+* DESCRIPTION : Retrieves or Creates the CREDITOR_ACCOUNT details, including minor_creditor PARTIES record(s).
+*
+* PARAMETERS  : pi_business_unit_id           - The business unit id from the DRAFT_ACCOUNTS table to be passed in by the backend
+*               pi_imposition_json            - The offence -> impositions -> imposition Json object
+*               po_creditor_account_id        - The found or newly created creditor_account_id
+*               po_is_minor_creditor          - Whether or not the creditor account is for a minor creditor
+*               po_results_mapped_item_number - The resutls.imposition_category mapped to an item_number and returned
+*
+* VERSION HISTORY:
+*
+* Date          Author      Version     Nature of Change
+* ----------    --------    --------    --------------------------------------------------------------------------------------------------------
+* 29/07/2025    TMc         1.0         PO-1043 - Retrieves or Creates the CREDITOR_ACCOUNT details, including minor_creditor PARTIES record(s).
+* 27/08/2025    TMc         2.0         PO-2082 - Replaced item_number logic to retrieve it from the new IMPOSITION_CATEGORY_ITEM_NUMBER table.
+* 03/06/2026    TMc         3.0         PO-3842 - Amend IMPOSITION_CATEGORY_ITEM_NUMBER table.
+*                                                 Renamed table in select statement for item_number lookup
+*
+**/
+DECLARE
+    v_pg_exception_detail  TEXT;
+    v_result_id             results.result_id%TYPE;
+    v_major_creditor_id     creditor_accounts.major_creditor_id%TYPE;
+    v_minor_creditor_json   JSON;
+
+    v_results_imposition_creditor   results.imposition_creditor%TYPE;
+BEGIN
+    po_is_minor_creditor := FALSE;
+
+    --Extract details from Impositions Json object
+    v_result_id           := pi_imposition_json ->> 'result_id';
+    v_major_creditor_id   := (pi_imposition_json ->> 'major_creditor_id')::BIGINT;
+    v_minor_creditor_json := json_extract_path(pi_imposition_json, 'minor_creditor');
+
+    --Retrieve the RESULTS record and map to an item_number
+    BEGIN
+        SELECT r.imposition_creditor
+             , ic.item_number
+        INTO STRICT v_results_imposition_creditor, po_results_mapped_item_number
+          FROM results r
+          JOIN imposition_categories ic
+            ON r.imposition_category = ic.imposition_category
+         WHERE result_id = v_result_id
+           AND imposition = TRUE;
+    EXCEPTION
+        --When NO_DATA_FOUND or TOO_MANY_ROWS raise custom exception otherwise re-raise the original
+        WHEN SQLSTATE 'P0002' OR SQLSTATE 'P0003' THEN
+            RAISE EXCEPTION 'Result % is not valid', v_result_id
+                USING ERRCODE = 'P2004'
+                    , DETAIL = 'p_get_creditor_account: result_id = ' || v_result_id;
+        WHEN OTHERS THEN
+            RAISE;
+    END;
+
+    --Retrieve the CREDITOR_ACCOUNT record, if possible
+    BEGIN
+        IF v_results_imposition_creditor = 'CF' THEN
+
+            SELECT creditor_account_id
+            INTO STRICT po_creditor_account_id
+              FROM creditor_accounts
+             WHERE business_unit_id      = pi_business_unit_id
+               AND creditor_account_type = 'CF';
+
+        ELSIF v_results_imposition_creditor = 'CPS' THEN
+
+            SELECT creditor_account_id
+            INTO STRICT po_creditor_account_id
+              FROM creditor_accounts
+             WHERE business_unit_id      = pi_business_unit_id
+               AND creditor_account_type = 'MJ'
+               AND prosecution_service   = TRUE;
+
+        ELSIF v_results_imposition_creditor = '!CPS' THEN
+
+            IF v_major_creditor_id IS NULL THEN
+                --New minor creditor account & parties will be created
+                po_creditor_account_id := NULL;
+            ELSE
+                SELECT creditor_account_id
+                INTO STRICT po_creditor_account_id
+                  FROM creditor_accounts
+                 WHERE business_unit_id      = pi_business_unit_id
+                   AND creditor_account_type = 'MJ'
+                   AND prosecution_service   = FALSE
+                   AND major_creditor_id     = v_major_creditor_id;
+            END IF;
+
+        ELSIF v_results_imposition_creditor = 'Any' THEN
+
+            IF v_major_creditor_id IS NULL THEN
+                --New minor creditor account & parties will be created
+                po_creditor_account_id := NULL;
+            ELSE
+                SELECT creditor_account_id
+                INTO STRICT po_creditor_account_id
+                  FROM creditor_accounts
+                 WHERE business_unit_id      = pi_business_unit_id
+                   AND creditor_account_type = 'MJ'
+                   AND major_creditor_id     = v_major_creditor_id;
+            END IF;
+
+        ELSE
+            -- Should not happen but raise exception if it does
+            RAISE EXCEPTION 'Result % is not valid', v_result_id
+                USING ERRCODE = 'P2004'
+                    , DETAIL = 'p_get_creditor_account: result_id = ' || v_result_id;
+        END IF;
+    EXCEPTION
+        --When NO_DATA_FOUND or TOO_MANY_ROWS raise custom exception otherwise re-raise the original
+        WHEN SQLSTATE 'P0002' OR SQLSTATE 'P0003' THEN
+            IF v_major_creditor_id IS NULL THEN
+                RAISE EXCEPTION 'Creditor not found'
+                    USING ERRCODE = 'P2006'
+                        , DETAIL = 'p_get_creditor_account: result_id = ' || v_result_id || ', imposition_creditor = ' || v_results_imposition_creditor;
+            ELSE
+                RAISE EXCEPTION 'Creditor % not found', v_major_creditor_id
+                    USING ERRCODE = 'P2006'
+                        , DETAIL = 'p_get_creditor_account: result_id = ' || v_result_id || ', imposition_creditor = ' || v_results_imposition_creditor;
+            END IF;
+        WHEN OTHERS THEN
+            RAISE;
+    END;
+
+    IF po_creditor_account_id IS NULL THEN
+        --Create new minor creditor account & parties, if passed minor_creditor Json is present
+        IF v_minor_creditor_json IS NULL OR JSON_TYPEOF(v_minor_creditor_json) = 'null' THEN
+            --Raise custom exception
+            RAISE EXCEPTION 'Missing creditor'
+                USING ERRCODE = 'P2005'
+                    , DETAIL = 'p_get_creditor_account: result_id = ' || v_result_id || ', imposition_creditor = ' || v_results_imposition_creditor;
+        ELSE
+            po_is_minor_creditor := TRUE;
+
+            CALL p_create_minor_creditor ( pi_business_unit_id,
+                                           v_minor_creditor_json,
+                                           po_creditor_account_id
+            );
+
+            RAISE INFO 'p_get_creditor_account: Created creditor_account_id = % - result_id = %, imposition_creditor = %', po_creditor_account_id, v_result_id, v_results_imposition_creditor;
+        END IF;
+    ELSE
+        RAISE INFO 'p_get_creditor_account: Found creditor_account_id = % - result_id = %, imposition_creditor = %', po_creditor_account_id, v_result_id, v_results_imposition_creditor;
+    END IF;
+
+EXCEPTION
+    WHEN SQLSTATE 'P2004' OR SQLSTATE 'P2005' OR SQLSTATE 'P2006' OR SQLSTATE 'P2010' THEN
+        --When custom exceptions just re-raise it so it's not manipulated
+        RAISE NOTICE 'Error in p_get_creditor_account: % - %', SQLSTATE, SQLERRM;
+        RAISE;
+    WHEN OTHERS THEN
+        GET STACKED DIAGNOSTICS v_pg_exception_detail = PG_EXCEPTION_DETAIL;
+        RAISE NOTICE 'Error in p_get_creditor_account: % - %', SQLSTATE, SQLERRM;
+        RAISE NOTICE 'Error details: %', v_pg_exception_detail;
+        RAISE EXCEPTION 'Error in p_get_creditor_account: % - %', SQLSTATE, SQLERRM
+            USING DETAIL = v_pg_exception_detail;
+END;
+$$;

--- a/src/test/java/uk/gov/hmcts/opal/entity/ImpositionCategoriesEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/entity/ImpositionCategoriesEntityTest.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.opal.entity;
+
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ImpositionCategoriesEntityTest {
+
+    @Test
+    void gettersAndSettersExposeMappedFields() {
+        ImpositionCategoriesEntity entity = new ImpositionCategoriesEntity();
+
+        entity.setImpositionCategoryId("COMP");
+        entity.setImpositionCategory("Compensation");
+        entity.setItemNumber((short) 7);
+
+        assertEquals("COMP", entity.getImpositionCategoryId());
+        assertEquals("Compensation", entity.getImpositionCategory());
+        assertEquals(Short.valueOf((short) 7), entity.getItemNumber());
+    }
+
+    @Test
+    void tableAnnotationDeclaresNamedUniqueConstraintForImpositionCategory() {
+        Table table = ImpositionCategoriesEntity.class.getAnnotation(Table.class);
+
+        assertNotNull(table);
+        assertEquals("imposition_categories", table.name());
+        assertEquals(1, table.uniqueConstraints().length);
+
+        UniqueConstraint uniqueConstraint = table.uniqueConstraints()[0];
+        assertEquals("ic_imposition_category_uk", uniqueConstraint.name());
+        assertArrayEquals(new String[]{"imposition_category"}, uniqueConstraint.columnNames());
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-3864
https://tools.hmcts.net/jira/browse/PO-3842 (DB)

### Change description ###
Aligns the backend and database for the new `imposition_categories` reference table.

- Added `ImpositionCategoriesEntity.java` to map the new `imposition_categories` table, including the new coded primary key `imposition_category_id`, the category name, and `item_number`.
- Added `V1_215__alter_imposition_categories.sql` to:
  - rename `imposition_category_item_number` to `imposition_categories`
  - add and backfill `imposition_category_id`
  - make the new ID non-null and the primary key
  - enforce uniqueness on `imposition_category`
- Added `V1_216__p_get_creditor_account.sql` to create/update the creditor account procedure so item number lookup now uses `imposition_categories`.


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
