### PR TITLE
PO-5757 Add Defendant Account Controls

### DIFF
--- a/src/functionalTest/resources/features/opalMode/manualAccountCreation/draftAccounts/accountJson/adultAccount.json
+++ b/src/functionalTest/resources/features/opalMode/manualAccountCreation/draftAccounts/accountJson/adultAccount.json
@@ -71,7 +71,7 @@
         {
           "result_id": "FO",
           "amount_imposed": 500,
-          "amount_paid": 200,
+          "amount_paid": 800,
           "major_creditor_id": 650000000021,
           "minor_creditor": null
         }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantEnforcementIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantEnforcementIntegrationTest.java
@@ -18,6 +18,7 @@ import uk.gov.hmcts.opal.dto.ToJsonString;
 import uk.gov.hmcts.opal.dto.common.InstalmentPeriod;
 import uk.gov.hmcts.opal.dto.common.PaymentTermsType;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -132,6 +133,12 @@ abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTe
     }
 
     void postEnforcementImpl_fullRequest_blockedByAccountControls(Logger log) throws Exception {
+        final Integer versionBeforeRequest = getCurrentDefendantAccountVersion(SCRIPTED_DEFENDANT_ACCOUNT_ID);
+        final Integer enforcementCountBeforeRequest =
+            countEnforcementsForDefendantAccount(SCRIPTED_DEFENDANT_ACCOUNT_ID);
+        final Integer paymentTermCountBeforeRequest =
+            countPaymentTermsForDefendantAccount(SCRIPTED_DEFENDANT_ACCOUNT_ID);
+
         AddDefendantAccountEnforcementRequest request = AddDefendantAccountEnforcementRequest.builder()
             .resultId(ResultId.ABDC)
             .enforcementResultResponses(scriptedFullResponses)
@@ -153,9 +160,20 @@ abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTe
             ))
             .andExpect(jsonPath("retriable").value(false));
 
+        assertEquals(versionBeforeRequest, getCurrentDefendantAccountVersion(SCRIPTED_DEFENDANT_ACCOUNT_ID));
+        assertEquals(enforcementCountBeforeRequest,
+                     countEnforcementsForDefendantAccount(SCRIPTED_DEFENDANT_ACCOUNT_ID));
+        assertEquals(paymentTermCountBeforeRequest,
+                     countPaymentTermsForDefendantAccount(SCRIPTED_DEFENDANT_ACCOUNT_ID));
     }
 
     void postEnforcementImpl_minimumRequest_blockedByAccountControls(Logger log) throws Exception {
+        final Integer versionBeforeRequest = getCurrentDefendantAccountVersion(SCRIPTED_DEFENDANT_ACCOUNT_ID);
+        final Integer enforcementCountBeforeRequest =
+            countEnforcementsForDefendantAccount(SCRIPTED_DEFENDANT_ACCOUNT_ID);
+        final Integer paymentTermCountBeforeRequest =
+            countPaymentTermsForDefendantAccount(SCRIPTED_DEFENDANT_ACCOUNT_ID);
+
         AddDefendantAccountEnforcementRequest request = AddDefendantAccountEnforcementRequest.builder()
             .resultId(ResultId.ABDC)
             .enforcementResultResponses(Collections.emptyList())
@@ -177,6 +195,11 @@ abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTe
             ))
             .andExpect(jsonPath("retriable").value(false));
 
+        assertEquals(versionBeforeRequest, getCurrentDefendantAccountVersion(SCRIPTED_DEFENDANT_ACCOUNT_ID));
+        assertEquals(enforcementCountBeforeRequest,
+                     countEnforcementsForDefendantAccount(SCRIPTED_DEFENDANT_ACCOUNT_ID));
+        assertEquals(paymentTermCountBeforeRequest,
+                     countPaymentTermsForDefendantAccount(SCRIPTED_DEFENDANT_ACCOUNT_ID));
     }
 
     void postEnforcementImpl_invalidDefendant_Failure(Logger log) throws Exception {
@@ -270,6 +293,22 @@ abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTe
 
     private Integer getCurrentDefendantAccountVersion(Long defendantAccountId) {
         return defendantAccountVersionFor(defendantAccountId);
+    }
+
+    private Integer countEnforcementsForDefendantAccount(Long defendantAccountId) {
+        return jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM enforcements WHERE defendant_account_id = ?",
+            Integer.class,
+            defendantAccountId
+        );
+    }
+
+    private Integer countPaymentTermsForDefendantAccount(Long defendantAccountId) {
+        return jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM payment_terms WHERE defendant_account_id = ?",
+            Integer.class,
+            defendantAccountId
+        );
     }
 
     private ResultActions postScriptedEnforcement(AddDefendantAccountEnforcementRequest request) throws Exception {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantEnforcementIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantEnforcementIntegrationTest.java
@@ -32,6 +32,8 @@ abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTe
     protected static final Long COLLO_BUSINESS_UNIT_ID = 77L;
     protected static final Long COLLO_DEFENDANT_ACCOUNT_ID = 99000000000007L;
     protected static final Long INVALID_DEFENDANT_ACCOUNT_ID = 404L;
+    protected static final Long SCRIPTED_BUSINESS_UNIT_ID = 78L;
+    protected static final Long SCRIPTED_DEFENDANT_ACCOUNT_ID = 77L;
 
     protected static final List<ResultResponse> fullResponses = List.of(
         ResultResponse.builder().parameterName("reason").response("test reason").build(),
@@ -44,6 +46,13 @@ abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTe
         ResultResponse.builder().parameterName("reason").response("a").build(),
         ResultResponse.builder().parameterName("collectiontype").response("Wages").build(),
         ResultResponse.builder().parameterName("reserveterms").response("aa").build()
+    );
+
+    protected static final List<ResultResponse> scriptedFullResponses = List.of(
+        ResultResponse.builder().parameterName("reason").response("test reason").build(),
+        ResultResponse.builder().parameterName("jail_days").response("14").build(),
+        ResultResponse.builder().parameterName("enforcer_id").response("780000000021").build(),
+        ResultResponse.builder().parameterName("earliest_release_date").response("2026-05-01T00:00:00").build()
     );
 
     protected static final PaymentTerms paymentTerms = PaymentTerms.builder()
@@ -120,6 +129,54 @@ abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTe
             .andExpect(jsonPath("defendant_account_id").value("99000000000006"))
             .andExpect(jsonPath("version").exists())
             .andExpect(jsonPath("enforcement_id").exists());
+    }
+
+    void postEnforcementImpl_fullRequest_blockedByAccountControls(Logger log) throws Exception {
+        AddDefendantAccountEnforcementRequest request = AddDefendantAccountEnforcementRequest.builder()
+            .resultId(ResultId.ABDC)
+            .enforcementResultResponses(scriptedFullResponses)
+            .paymentTerms(paymentTerms)
+            .build();
+
+        ResultActions resultActions = postScriptedEnforcement(request);
+        String body = resultActions.andReturn().getResponse().getContentAsString();
+
+        log.info(":testPostEnforcementImpl_fullRequest_blockedByAccountControls: Response body: \n{}",
+                 ToJsonString.toPrettyJson(body));
+
+        resultActions.andExpect(status().isUnprocessableEntity())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("title").value("Unprocessable Content"))
+            .andExpect(jsonPath("status").value(422))
+            .andExpect(jsonPath("detail").value(
+                "Defendant account update blocked: Zero balance check failed because account_balance is -500.58."
+            ))
+            .andExpect(jsonPath("retriable").value(false));
+
+    }
+
+    void postEnforcementImpl_minimumRequest_blockedByAccountControls(Logger log) throws Exception {
+        AddDefendantAccountEnforcementRequest request = AddDefendantAccountEnforcementRequest.builder()
+            .resultId(ResultId.ABDC)
+            .enforcementResultResponses(Collections.emptyList())
+            .paymentTerms(paymentTerms)
+            .build();
+
+        ResultActions resultActions = postScriptedEnforcement(request);
+        String body = resultActions.andReturn().getResponse().getContentAsString();
+
+        log.info(":testPostEnforcementImpl_minimumRequest_blockedByAccountControls: Response body: \n{}",
+                 ToJsonString.toPrettyJson(body));
+
+        resultActions.andExpect(status().isUnprocessableEntity())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("title").value("Unprocessable Content"))
+            .andExpect(jsonPath("status").value(422))
+            .andExpect(jsonPath("detail").value(
+                "Defendant account update blocked: Zero balance check failed because account_balance is -500.58."
+            ))
+            .andExpect(jsonPath("retriable").value(false));
+
     }
 
     void postEnforcementImpl_invalidDefendant_Failure(Logger log) throws Exception {
@@ -214,4 +271,16 @@ abstract class DefendantEnforcementIntegrationTest extends AbstractIntegrationTe
     private Integer getCurrentDefendantAccountVersion(Long defendantAccountId) {
         return defendantAccountVersionFor(defendantAccountId);
     }
+
+    private ResultActions postScriptedEnforcement(AddDefendantAccountEnforcementRequest request) throws Exception {
+        return mockMvc.perform(
+            post(URL_BASE + "/" + SCRIPTED_DEFENDANT_ACCOUNT_ID + "/enforcements")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("Authorization", userStateStub.getBearerToken())
+                .header("Business-Unit-ID", SCRIPTED_BUSINESS_UNIT_ID.toString())
+                .header("IF-MATCH", "0")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON));
+    }
+
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantPartyDeleteIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantPartyDeleteIntegrationTest.java
@@ -65,7 +65,7 @@ class DefendantPartyDeleteIntegrationTest extends AbstractOpalDefendantsIntegrat
 
         assertEquals(currentVersion, versionFor(defendantAccountId));
         long dapId = 9077L;
-        assertEquals(1, getAssociationCountForDAP(defendantAccountId, dapId));
+        assertEquals(1, partyAssociationCountFor(defendantAccountId, dapId));
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantPartyDeleteIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantPartyDeleteIntegrationTest.java
@@ -22,6 +22,53 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 class DefendantPartyDeleteIntegrationTest extends AbstractOpalDefendantsIntegrationTest {
 
     @Test
+    @DisplayName("OPAL: DELETE Remove DAP - account controls return 422 for blocked account status")
+    @JiraStory("PO-5757")
+    @JiraEpic("PO-2990")
+    void delete_removeParty_returns422_whenBlockedByAccountControls() throws Exception {
+        // Arrange
+        long defendantAccountId = 9077L;
+        Integer currentVersion = versionFor(defendantAccountId);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(userStateStub.getBearerToken());
+        headers.add("Business-Unit-Id", "78");
+        headers.add(HttpHeaders.IF_MATCH, "\"" + currentVersion + "\"");
+
+        String body = """
+            {
+              "party_details": {
+                "party_id": "77"
+              }
+            }
+            """;
+
+        // Act
+        ResultActions res = mockMvc.perform(
+            delete("/defendant-accounts/9077/defendant-account-parties/9077")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .headers(headers)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+        );
+
+        log.info("DELETE DAP account controls response:\n{}", res.andReturn().getResponse().getContentAsString());
+
+        // Assert
+        res.andExpect(status().isUnprocessableEntity())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.title").value("Unprocessable Content"))
+            .andExpect(jsonPath("$.status").value(422))
+            .andExpect(jsonPath("$.detail").value(
+                "Defendant account update blocked: Account Status Check failed because account_status is CS."))
+            .andExpect(jsonPath("$.retriable").value(false));
+
+        assertEquals(currentVersion, versionFor(defendantAccountId));
+        long dapId = 9077L;
+        assertEquals(1, getAssociationCountForDAP(defendantAccountId, dapId));
+    }
+
+    @Test
     @DisplayName("OPAL: DELETE Remove DAP - Happy path (removed association + bumps version")
     @JiraStory("PO-1897")
     @JiraEpic("PO-1970")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantPartyPostIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantPartyPostIntegrationTest.java
@@ -66,6 +66,51 @@ class DefendantPartyPostIntegrationTest extends AbstractOpalDefendantsIntegratio
     }
 
     @Test
+    @DisplayName("POST Add DAP - account controls return 422 for blocked account status")
+    @JiraStory("PO-5757")
+    @JiraEpic("PO-2990")
+    void post_addParty_returns422_whenBlockedByAccountControls() throws Exception {
+        // Arrange
+        long defendantAccountId = 9077L;
+        Integer currentVersion = versionFor(defendantAccountId);
+
+        HttpHeaders headers = buildHttpHeaders("78", "\"" + currentVersion + "\"");
+
+        String body = """
+            {
+                "defendant_account_party": {
+                    "defendant_account_party_type": "Parent/Guardian",
+                    "is_debtor": false,
+                    %s,
+                    %s
+                }
+            }
+            """.formatted(validIndividualDetails("BlockedStatus"), validCommonFields());
+
+        // Act
+        ResultActions res = mockMvc.perform(
+            post(URL_BASE + "/" + defendantAccountId + "/defendant-account-parties")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .headers(headers)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+        );
+
+        log.info("POST DAP account controls resp:\n{}", res.andReturn().getResponse().getContentAsString());
+
+        // Assert
+        res.andExpect(status().isUnprocessableEntity())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.title").value("Unprocessable Content"))
+            .andExpect(jsonPath("$.status").value(422))
+            .andExpect(jsonPath("$.detail").value(
+                "Defendant account update blocked: Account Status Check failed because account_status is CS."))
+            .andExpect(jsonPath("$.retriable").value(false));
+
+        assertEquals(currentVersion, versionFor(defendantAccountId));
+    }
+
+    @Test
     @DisplayName("POST Add DAP - 404 when account not in header BU")
     @JiraStory("PO-1896")
     @JiraEpic("PO-1970")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantPartyPutIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantPartyPutIntegrationTest.java
@@ -35,6 +35,60 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 class DefendantPartyPutIntegrationTest extends AbstractOpalDefendantsIntegrationTest {
 
     @Test
+    @Sql(
+        scripts = "classpath:db/insertData/update_into_parties.sql",
+        executionPhase = BEFORE_TEST_METHOD
+    )
+    @DisplayName("OPAL: PUT Replace DAP - account controls return 422 for P/G replacement")
+    @JiraStory("PO-5757")
+    @JiraEpic("PO-2990")
+    void put_replaceParentGuardian_returns422_whenBlockedByAccountControls() throws Exception {
+        long defendantAccountId = 20010L;
+        Integer currentVersion = versionFor(defendantAccountId);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(userStateStub.getBearerToken());
+        headers.add("Business-Unit-Id", "78");
+        headers.add(HttpHeaders.IF_MATCH, "\"" + currentVersion + "\"");
+
+        String body = """
+            {
+                "defendant_account_party_type": "Parent/Guardian",
+                "is_debtor": true,
+                "party_details": {
+                    "party_id": "920010",
+                    "organisation_flag": false,
+                    "individual_details": {
+                        "title": "Mr",
+                        "forenames": "Blocked",
+                        "surname": "Guardian"
+                    }
+                }
+            }
+            """;
+
+        ResultActions res = mockMvc.perform(
+            put("/defendant-accounts/20010/defendant-account-parties/920011")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .headers(headers)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+        );
+
+        log.info("PUT DAP account controls resp:\n{}", res.andReturn().getResponse().getContentAsString());
+
+        res.andExpect(status().isUnprocessableEntity())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.title").value("Unprocessable Content"))
+            .andExpect(jsonPath("$.status").value(422))
+            .andExpect(jsonPath("$.detail").value(
+                "Defendant account update blocked: Account Status Check failed because account_status is CS."))
+            .andExpect(jsonPath("$.retriable").value(false));
+
+        assertEquals(currentVersion, versionFor(defendantAccountId));
+    }
+
+    @Test
     @DisplayName("OPAL: PUT Replace DAP – Not Found (account not in BU)")
     @JiraStory("PO-1963")
     @JiraEpic("PO-1970")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantEnforcementIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantEnforcementIntegrationTest.java
@@ -1,30 +1,35 @@
 package uk.gov.hmcts.opal.controllers;
 
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
+
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "opal"})
+@Sql(scripts = "classpath:db/insertData/insert_into_enforcements.sql", executionPhase = BEFORE_TEST_METHOD)
+@Sql(scripts = "classpath:db/deleteData/delete_from_enforcements.sql", executionPhase = AFTER_TEST_METHOD)
 @Slf4j(topic = "opal.OpalDefendantEnforcementIntegrationTest")
 public class OpalDefendantEnforcementIntegrationTest extends DefendantEnforcementIntegrationTest {
 
     @Test
-    @JiraStory("PO-1774")
-    @JiraEpic("PO-1675")
-    @JiraTestKey("PO-5998")
-    public void testAddEnforcement_whenGivenAllFields_addsEnforcement() throws Exception {
-        super.postEnforcementImpl_fullRequest_Success(log);
+    @JiraStory("PO-5757")
+    @JiraEpic("PO-2990")
+    public void testAddEnforcement_withFullRequestAndBlockedAccountControls_returns422AndRollsBack() throws Exception {
+        super.postEnforcementImpl_fullRequest_blockedByAccountControls(log);
     }
 
     @Test
-    @JiraStory("PO-1774")
-    @JiraEpic("PO-1675")
-    @JiraTestKey("PO-5999")
-    public void testAddEnforcement_whenGivenMinimumFields_addsEnforcement() throws Exception {
-        super.postEnforcementImpl_minimumRequest_Success(log);
+    @JiraStory("PO-5757")
+    @JiraEpic("PO-2990")
+    public void testAddEnforcement_withMinimumRequestAndBlockedAccountControls_returns422AndRollsBack()
+        throws Exception {
+        super.postEnforcementImpl_minimumRequest_blockedByAccountControls(log);
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsPatchIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsPatchIntegrationTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.opal.controllers;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -24,6 +25,45 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @Slf4j(topic = "opal.OpalDefendantsPatchIntegrationTest")
 class OpalDefendantsPatchIntegrationTest extends AbstractOpalDefendantsIntegrationTest {
+
+    @Test
+    @DisplayName("OPAL: PATCH Update Defendant Account - account controls return 422 for protected field change")
+    @JiraStory("PO-5757")
+    @JiraEpic("PO-2990")
+    void patch_updateProtectedField_returns422_whenBlockedByAccountControls() throws Exception {
+        // Arrange
+        long defendantAccountId = 9077L;
+        Integer currentVersion = versionFor(defendantAccountId);
+        HttpHeaders headers = authorisedHeaders("good_token", "78", "\"" + currentVersion + "\"");
+
+        // Act
+        ResultActions result = mockMvc.perform(
+            patch(URL_BASE + "/9077")
+                .headers(headers)
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "collection_order": {
+                        "collection_order_flag": false
+                      }
+                    }
+                    """));
+
+        log.info(":patch_updateProtectedField_accountControls body:\n{}",
+                 ToJsonString.toPrettyJson(result.andReturn().getResponse().getContentAsString()));
+
+        // Assert
+        result.andExpect(status().isUnprocessableEntity())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.title").value("Unprocessable Content"))
+            .andExpect(jsonPath("$.status").value(422))
+            .andExpect(jsonPath("$.detail").value(
+                "Defendant account update blocked: Account Status Check failed because account_status is CS."))
+            .andExpect(jsonPath("$.retriable").value(false));
+
+        assertEquals(currentVersion, versionFor(defendantAccountId));
+    }
 
     @Test
     @DisplayName("OPAL: PATCH Update Defendant Account - Happy Path [@PO-1565]")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsPaymentCardIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsPaymentCardIntegrationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.controllers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -18,6 +19,46 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @Slf4j(topic = "opal.OpalDefendantsPaymentCardIntegrationTest")
 class OpalDefendantsPaymentCardIntegrationTest extends AbstractOpalDefendantsIntegrationTest {
+
+    @Test
+    @DisplayName("OPAL: Add Payment Card Request - account controls return 422 for blocked last enforcement")
+    @JiraStory("PO-5757")
+    @JiraEpic("PO-2990")
+    void opalAddPaymentCardRequest_returns422_whenBlockedByAccountControls() throws Exception {
+        // Arrange
+        long defendantAccountId = 991199L;
+        Integer currentVersion = versionFor(defendantAccountId);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.AUTHORIZATION, userStateStub.getBearerToken());
+        headers.add("Business-Unit-Id", "78");
+        headers.add("Business-Unit-User-Id", "TEST_USER_123");
+        headers.add(HttpHeaders.IF_MATCH, "\"" + currentVersion + "\"");
+
+        // Act
+        ResultActions result = mockMvc.perform(
+            post("/defendant-accounts/991199/payment-card-request")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .headers(headers)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}")
+        );
+
+        log.info(":opalAddPaymentCardRequest_accountControls body:\n{}",
+                 ToJsonString.toPrettyJson(result.andReturn().getResponse().getContentAsString()));
+
+        // Assert
+        result.andExpect(status().isUnprocessableEntity())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.title").value("Unprocessable Content"))
+            .andExpect(jsonPath("$.status").value(422))
+            .andExpect(jsonPath("$.detail").value(
+                "Defendant account update blocked: Payment card request last enforcement check failed because "
+                    + "last_enforcement is ABDC."))
+            .andExpect(jsonPath("$.retriable").value(false));
+
+        assertEquals(currentVersion, versionFor(defendantAccountId));
+    }
 
     @Test
     @DisplayName("OPAL: Add Payment Card Request – Happy Path [@PO-1719]")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsPaymentTermsIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsPaymentTermsIntegrationTest.java
@@ -90,6 +90,73 @@ class OpalDefendantsPaymentTermsIntegrationTest extends AbstractOpalDefendantsIn
     }
 
     @Test
+    @DisplayName("OPAL: Add Payment Terms - account controls return 422 with all failed checks")
+    @JiraStory("PO-5757")
+    @JiraEpic("PO-2990")
+    void test_Opal_AddPaymentTerms_returns422_withAllAccountControlFailures() throws Exception {
+        // Arrange
+        authorise((short) 78, FinesPermission.AMEND_PAYMENT_TERMS);
+
+        long defendantAccountId = 575700L;
+        Integer currentVersion = versionFor(defendantAccountId);
+        HttpHeaders headers = authorisedHeaders(userStateStub.getBearerToken(), "78", "\"" + currentVersion + "\"");
+
+        String requestJson = """
+            {
+              "payment_terms": {
+                "days_in_default": 30,
+                "date_days_in_default_imposed": "2025-11-05",
+                "extension": true,
+                "reason_for_extension": "extn reason text",
+                "effective_date": "2025-11-01",
+                "payment_terms_type": {
+                  "payment_terms_type_code": "B",
+                  "payment_terms_type_display_name": "By date"
+                },
+                "instalment_period": {
+                  "instalment_period_code": "W",
+                  "instalment_period_display_name": "Weekly"
+                },
+                "lump_sum_amount": 120.00,
+                "instalment_amount": 10.00,
+                "posted_details": {
+                  "posted_by": "clerk1",
+                  "posted_date": "2025-02-02T10:11:12",
+                  "posted_by_name": "aa"
+                }
+              },
+              "request_payment_card": false,
+              "generate_payment_terms_change_letter": false
+            }
+            """;
+
+        // Act
+        ResultActions result = mockMvc.perform(
+            post("/defendant-accounts/575700/payment-terms")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .headers(headers)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+        );
+
+        log.info(":opalAddPaymentTerms_allAccountControlFailures response body:\n{}",
+                 ToJsonString.toPrettyJson(result.andReturn().getResponse().getContentAsString()));
+
+        // Assert
+        result.andExpect(status().isUnprocessableEntity())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.title").value("Unprocessable Content"))
+            .andExpect(jsonPath("$.status").value(422))
+            .andExpect(jsonPath("$.detail").value(
+                "Defendant account update blocked: Account Status Check failed because account_status is CS; "
+                    + "Payment terms last enforcement check failed because last_enforcement is MPSO; "
+                    + "Zero balance check failed because account_balance is 0.00."))
+            .andExpect(jsonPath("$.retriable").value(false));
+
+        assertEquals(currentVersion, versionFor(defendantAccountId));
+    }
+
+    @Test
     @DisplayName("OPAL: Add Payment Terms – Happy Path [@PO-1718]")
     @JiraStory("PO-1718")
     @JiraEpic("PO-977")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsPaymentTermsIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsPaymentTermsIntegrationTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.opal.controllers;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -21,6 +22,72 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @Slf4j(topic = "opal.OpalDefendantsPaymentTermsIntegrationTest")
 class OpalDefendantsPaymentTermsIntegrationTest extends AbstractOpalDefendantsIntegrationTest {
+
+    @Test
+    @DisplayName("OPAL: Add Payment Terms - account controls return 422 for blocked last enforcement")
+    @JiraStory("PO-5757")
+    @JiraEpic("PO-2990")
+    void test_Opal_AddPaymentTerms_returns422_whenBlockedByAccountControls() throws Exception {
+        // Arrange
+        authorise((short) 78, FinesPermission.AMEND_PAYMENT_TERMS);
+
+        long defendantAccountId = 78L;
+        Integer currentVersion = versionFor(defendantAccountId);
+        HttpHeaders headers = authorisedHeaders(userStateStub.getBearerToken(), "78", "\"" + currentVersion + "\"");
+
+        String requestJson = """
+            {
+              "payment_terms": {
+                "days_in_default": 30,
+                "date_days_in_default_imposed": "2025-11-05",
+                "extension": true,
+                "reason_for_extension": "extn reason text",
+                "effective_date": "2025-11-01",
+                "payment_terms_type": {
+                  "payment_terms_type_code": "B",
+                  "payment_terms_type_display_name": "By date"
+                },
+                "instalment_period": {
+                  "instalment_period_code": "W",
+                  "instalment_period_display_name": "Weekly"
+                },
+                "lump_sum_amount": 120.00,
+                "instalment_amount": 10.00,
+                "posted_details": {
+                  "posted_by": "clerk1",
+                  "posted_date": "2025-02-02T10:11:12",
+                  "posted_by_name": "aa"
+                }
+              },
+              "request_payment_card": false,
+              "generate_payment_terms_change_letter": false
+            }
+            """;
+
+        // Act
+        ResultActions result = mockMvc.perform(
+            post("/defendant-accounts/78/payment-terms")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .headers(headers)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestJson)
+        );
+
+        log.info(":opalAddPaymentTerms_accountControls response body:\n{}",
+                 ToJsonString.toPrettyJson(result.andReturn().getResponse().getContentAsString()));
+
+        // Assert
+        result.andExpect(status().isUnprocessableEntity())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.title").value("Unprocessable Content"))
+            .andExpect(jsonPath("$.status").value(422))
+            .andExpect(jsonPath("$.detail").value(
+                "Defendant account update blocked: Payment terms last enforcement check failed because "
+                    + "last_enforcement is MPSO."))
+            .andExpect(jsonPath("$.retriable").value(false));
+
+        assertEquals(currentVersion, versionFor(defendantAccountId));
+    }
 
     @Test
     @DisplayName("OPAL: Add Payment Terms – Happy Path [@PO-1718]")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/RemoveEnforcementHoldIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/RemoveEnforcementHoldIntegrationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.controllers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -26,6 +27,43 @@ class RemoveEnforcementHoldIntegrationTest extends AbstractOpalDefendantsIntegra
 
     @MockitoBean
     private ReportEntryService reportEntryService;
+
+    @Test
+    @DisplayName("Remove enforcement hold returns 422 when blocked by account controls")
+    @JiraStory("PO-5757")
+    @JiraEpic("PO-2990")
+    void removeEnforcementHold_returns422_whenBlockedByAccountControls() throws Exception {
+        // Arrange
+        long defendantAccountId = 9077L;
+        String ifMatch = "\"" + versionFor(defendantAccountId) + "\"";
+
+        // Act
+        ResultActions resultActions = mockMvc.perform(
+            patch(URL_BASE + "/{defendantAccountId}/remove-enf-hold", defendantAccountId)
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .header("Business-Unit-Id", 78)
+                .header("If-Match", ifMatch)
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_PROBLEM_JSON)
+                .content("""
+                    {
+                      "reason": "remove hold reason"
+                    }
+                    """)
+        );
+
+        // Assert
+        resultActions.andExpect(status().isUnprocessableEntity())
+            .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.title").value("Unprocessable Content"))
+            .andExpect(jsonPath("$.status").value(422))
+            .andExpect(jsonPath("$.detail").value(
+                "Defendant account update blocked: Account Status Check failed because account_status is CS."))
+            .andExpect(jsonPath("$.retriable").value(false));
+
+        assertEquals(ifMatch, "\"" + versionFor(defendantAccountId) + "\"");
+    }
 
     @Test
     @DisplayName("Remove enforcement hold returns 200 and updates the defendant account")

--- a/src/integrationTest/resources/db/deleteData/delete_from_defendant_accounts.sql
+++ b/src/integrationTest/resources/db/deleteData/delete_from_defendant_accounts.sql
@@ -247,3 +247,13 @@ WHERE party_id IN (990001, 990002);
 DELETE
 FROM defendant_accounts
 WHERE defendant_account_id = 990001;
+
+-- PO-5757 account controls multi-failure seed data
+DELETE FROM payment_terms
+WHERE defendant_account_id = 575700;
+
+DELETE FROM enforcements
+WHERE defendant_account_id = 575700;
+
+DELETE FROM defendant_accounts
+WHERE defendant_account_id = 575700;

--- a/src/integrationTest/resources/db/insertData/insert_into_defendant_accounts.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_defendant_accounts.sql
@@ -1313,3 +1313,15 @@ INSERT INTO defendant_transactions
 VALUES (990001, 990001, 'CONSOL',
         'defendant_accounts', '2023-11-03 16:05:10', '01000000A');
 -- END TEST DATA: PO-1896 - Seed data for DefendantAccountHeaderSummary
+
+-- PO-5757 account controls multi-failure seed data
+INSERT INTO defendant_accounts
+( defendant_account_id, version_number, business_unit_id, account_number,
+  amount_paid, account_balance, amount_imposed, account_status, last_enforcement,
+  prosecutor_case_reference, allow_writeoffs, allow_cheques, account_type,
+  collection_order, payment_card_requested )
+VALUES (575700, 0, 78, '575700A',
+        0.00, 0.00, 0.00, 'CS', 'MPSO',
+        '575700PCR', 'N', 'N', 'Fine',
+        'N', 'N')
+ON CONFLICT (defendant_account_id) DO NOTHING;

--- a/src/integrationTest/resources/db/insertData/update_into_parties.sql
+++ b/src/integrationTest/resources/db/insertData/update_into_parties.sql
@@ -131,3 +131,7 @@ ON CONFLICT (defendant_account_party_id) DO UPDATE
         party_id = EXCLUDED.party_id,
         association_type = EXCLUDED.association_type,
         debtor = EXCLUDED.debtor;
+
+UPDATE defendant_accounts
+SET account_status = 'CS'
+WHERE defendant_account_id = 20010;

--- a/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
@@ -251,8 +251,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ProblemDetail> handleUnprocessableException(UnprocessableException ex) {
         ProblemDetail problemDetail = createProblemDetail(
             HttpStatus.UNPROCESSABLE_CONTENT,
-            "Unprocessable Entity",
-            "The request could not be processed",
+            "Unprocessable Content",
+            ex.getDetailedReason(),
             "unprocessable-entity",
             ex.isRetriable(),
             ex

--- a/src/main/java/uk/gov/hmcts/opal/entity/defendantaccount/DefendantAccountEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/defendantaccount/DefendantAccountEntity.java
@@ -257,4 +257,10 @@ public class DefendantAccountEntity implements Versioned {
     public BigInteger getVersion() {
         return Optional.ofNullable(versionNumber).map(BigInteger::valueOf).orElse(null);
     }
+
+    public boolean isInBusinessUnit(String businessUnitId) {
+        return businessUnit != null
+            && businessUnit.getBusinessUnitId() != null
+            && String.valueOf(businessUnit.getBusinessUnitId()).equals(businessUnitId);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/DefendantAccountControlValidator.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/DefendantAccountControlValidator.java
@@ -3,11 +3,19 @@ package uk.gov.hmcts.opal.service.opal;
 import java.math.BigDecimal;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.opal.dto.UpdateDefendantAccountRequest;
+import uk.gov.hmcts.opal.entity.court.CourtEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountStatus;
 import uk.gov.hmcts.opal.exception.UnprocessableException;
+import uk.gov.hmcts.opal.generated.model.CollectionOrderCommon;
+import uk.gov.hmcts.opal.generated.model.EnforcementCourtDefendantAccount;
+import uk.gov.hmcts.opal.generated.model.EnforcementOverrideDefendantAccount;
+import uk.gov.hmcts.opal.generated.model.UpdateDefendantAccountRequestPayload;
 
 @Component
 public class DefendantAccountControlValidator {
@@ -45,8 +53,57 @@ public class DefendantAccountControlValidator {
         validate(account, Check.ACCOUNT_STATUS);
     }
 
+    public boolean isProtectedUpdate(UpdateDefendantAccountRequest request, DefendantAccountEntity account) {
+        UpdateDefendantAccountRequestPayload payload = request.getPayload();
+        return isEnforcementCourtChange(payload.getEnforcementCourt(), account)
+            || isCollectionOrderChange(payload.getCollectionOrder(), account)
+            || isEnforcementOverrideChange(payload.getEnforcementOverride(), account);
+    }
+
     public void validateCanRemoveEnforcementHold(DefendantAccountEntity account) {
         validate(account, Check.ACCOUNT_STATUS);
+    }
+
+    private boolean isEnforcementCourtChange(EnforcementCourtDefendantAccount enforcementCourt,
+                                             DefendantAccountEntity account) {
+        if (enforcementCourt == null) {
+            return false;
+        }
+        Long currentCourtId = Optional.ofNullable(account.getEnforcingCourt())
+            .map(CourtEntity::getCourtId)
+            .orElse(null);
+        return !Objects.equals(enforcementCourt.getCourtId(), currentCourtId);
+    }
+
+    private boolean isCollectionOrderChange(CollectionOrderCommon collectionOrder, DefendantAccountEntity account) {
+        if (collectionOrder == null) {
+            return false;
+        }
+        return !Objects.equals(collectionOrder.getCollectionOrderFlag(), account.getCollectionOrder())
+            || !Objects.equals(collectionOrder.getCollectionOrderDate(), account.getCollectionOrderEffectiveDate());
+    }
+
+    private boolean isEnforcementOverrideChange(EnforcementOverrideDefendantAccount enforcementOverride,
+                                                DefendantAccountEntity account) {
+        if (enforcementOverride == null) {
+            return false;
+        }
+        String requestedResultId = enforcementOverride.getEnforcementOverrideResult() == null
+            ? null
+            : enforcementOverride.getEnforcementOverrideResult().getEnforcementOverrideResultId();
+        Long requestedEnforcerId = enforcementOverride.getEnforcer() == null
+            ? null
+            : enforcementOverride.getEnforcer().getEnforcerId();
+        Integer requestedLjaId = enforcementOverride.getLja() == null
+            ? null
+            : enforcementOverride.getLja().getLjaId();
+        Integer currentLjaId = Optional.ofNullable(account.getEnforcementOverrideTfoLjaId())
+            .map(Short::intValue)
+            .orElse(null);
+
+        return !Objects.equals(requestedResultId, account.getEnforcementOverrideResultId())
+            || !Objects.equals(requestedEnforcerId, account.getEnforcementOverrideEnforcerId())
+            || !Objects.equals(requestedLjaId, currentLjaId);
     }
 
     private void validate(DefendantAccountEntity account, Check... checks) {

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/DefendantAccountControlValidator.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/DefendantAccountControlValidator.java
@@ -94,16 +94,13 @@ public class DefendantAccountControlValidator {
         Long requestedEnforcerId = enforcementOverride.getEnforcer() == null
             ? null
             : enforcementOverride.getEnforcer().getEnforcerId();
-        Integer requestedLjaId = enforcementOverride.getLja() == null
+        Short requestedLjaId = enforcementOverride.getLja() == null
             ? null
             : enforcementOverride.getLja().getLjaId();
-        Integer currentLjaId = Optional.ofNullable(account.getEnforcementOverrideTfoLjaId())
-            .map(Short::intValue)
-            .orElse(null);
 
         return !Objects.equals(requestedResultId, account.getEnforcementOverrideResultId())
             || !Objects.equals(requestedEnforcerId, account.getEnforcementOverrideEnforcerId())
-            || !Objects.equals(requestedLjaId, currentLjaId);
+            || !Objects.equals(requestedLjaId, account.getEnforcementOverrideTfoLjaId());
     }
 
     private void validate(DefendantAccountEntity account, Check... checks) {

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/DefendantAccountControlValidator.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/DefendantAccountControlValidator.java
@@ -1,0 +1,110 @@
+package uk.gov.hmcts.opal.service.opal;
+
+import java.math.BigDecimal;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
+import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountStatus;
+import uk.gov.hmcts.opal.exception.UnprocessableException;
+
+@Component
+public class DefendantAccountControlValidator {
+
+    private static final Set<DefendantAccountStatus> BLOCKED_ACCOUNT_STATUSES = EnumSet.of(
+        DefendantAccountStatus.ACCOUNT_CONSOLIDATED,
+        DefendantAccountStatus.ACCOUNT_WRITTEN_OFF,
+        DefendantAccountStatus.TRANSFER_OUT_PENDING,
+        DefendantAccountStatus.TRANSFER_OUT_ACKNOWLEDGED,
+        DefendantAccountStatus.TRANSFER_OUT_TO_NI_SCOTLAND
+    );
+
+    private static final Set<String> PAYMENT_TERMS_BLOCKED_LAST_ENFORCEMENTS = Set.of(
+        "EO", "BWTD", "BWTU", "CLAMPO", "CONF", "CW", "CWN", "DW", "NBWT", "REW", "S136", "SC", "SUMM",
+        "UPWO", "MPSO"
+    );
+
+    private static final Set<String> PAYMENT_CARD_BLOCKED_LAST_ENFORCEMENTS = Set.of(
+        "ABDC", "AEO", "AEOC", "BWTD", "BWTU", "CLAMPO", "CW", "DW", "NBWT", "S136"
+    );
+
+    public void validateCanMutateParty(DefendantAccountEntity account) {
+        validate(account, Check.ACCOUNT_STATUS);
+    }
+
+    public void validateCanAddPaymentTerms(DefendantAccountEntity account) {
+        validate(account, Check.ACCOUNT_STATUS, Check.PAYMENT_TERMS_LAST_ENFORCEMENT, Check.ZERO_BALANCE);
+    }
+
+    public void validateCanAddPaymentCardRequest(DefendantAccountEntity account) {
+        validate(account, Check.ACCOUNT_STATUS, Check.PAYMENT_CARD_LAST_ENFORCEMENT, Check.ZERO_BALANCE);
+    }
+
+    public void validateCanUpdateProtectedFields(DefendantAccountEntity account) {
+        validate(account, Check.ACCOUNT_STATUS);
+    }
+
+    public void validateCanRemoveEnforcementHold(DefendantAccountEntity account) {
+        validate(account, Check.ACCOUNT_STATUS);
+    }
+
+    private void validate(DefendantAccountEntity account, Check... checks) {
+        List<String> failures = List.of(checks).stream()
+            .map(check -> check.failureMessage(account))
+            .filter(message -> message != null)
+            .toList();
+
+        if (!failures.isEmpty()) {
+            throw new UnprocessableException("Defendant account update blocked: " + String.join("; ", failures)
+                + ".");
+        }
+    }
+
+    private enum Check {
+        ACCOUNT_STATUS {
+            @Override
+            String failureMessage(DefendantAccountEntity account) {
+                DefendantAccountStatus accountStatus = account.getAccountStatus();
+                if (accountStatus != null && BLOCKED_ACCOUNT_STATUSES.contains(accountStatus)) {
+                    return "Account Status Check failed because account_status is " + accountStatus.getLabel();
+                }
+                return null;
+            }
+        },
+        PAYMENT_TERMS_LAST_ENFORCEMENT {
+            @Override
+            String failureMessage(DefendantAccountEntity account) {
+                String lastEnforcement = account.getLastEnforcement();
+                if (lastEnforcement != null && PAYMENT_TERMS_BLOCKED_LAST_ENFORCEMENTS.contains(lastEnforcement)) {
+                    return "Payment terms last enforcement check failed because last_enforcement is "
+                        + lastEnforcement;
+                }
+                return null;
+            }
+        },
+        PAYMENT_CARD_LAST_ENFORCEMENT {
+            @Override
+            String failureMessage(DefendantAccountEntity account) {
+                String lastEnforcement = account.getLastEnforcement();
+                if (lastEnforcement != null && PAYMENT_CARD_BLOCKED_LAST_ENFORCEMENTS.contains(lastEnforcement)) {
+                    return "Payment card request last enforcement check failed because last_enforcement is "
+                        + lastEnforcement;
+                }
+                return null;
+            }
+        },
+        ZERO_BALANCE {
+            @Override
+            String failureMessage(DefendantAccountEntity account) {
+                BigDecimal accountBalance = account.getAccountBalance();
+                if (accountBalance != null && accountBalance.compareTo(BigDecimal.ZERO) <= 0) {
+                    return "Zero balance check failed because account_balance is " + accountBalance;
+                }
+                return null;
+            }
+        };
+
+        abstract String failureMessage(DefendantAccountEntity account);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service.opal;
 
+import jakarta.persistence.EntityManager;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 import java.time.Clock;
@@ -8,6 +9,8 @@ import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -40,7 +43,6 @@ import uk.gov.hmcts.opal.service.persistence.LocalJusticeAreaRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.ResultRepositoryService;
 import uk.gov.hmcts.opal.service.proxy.NotesProxy;
 import uk.gov.hmcts.opal.util.VersionUtils;
-import java.util.Objects;
 
 import static uk.gov.hmcts.opal.service.opal.OpalDefendantAccountBuilders.buildEnforcementAction;
 import static uk.gov.hmcts.opal.service.opal.OpalDefendantAccountBuilders.buildEnforcementOverrideResult;
@@ -79,7 +81,12 @@ public class OpalDefendantAccountEnforcementService
 
     private final ObjectMapper objectMapper;
 
+    private final DefendantAccountControlValidator defendantAccountControlValidator;
+
+    private final EntityManager entityManager;
+
     @Override
+    @Transactional
     public AddEnforcementResponse addEnforcement(
         Long defendantAccountId,
         Short businessUnitId,
@@ -132,6 +139,8 @@ public class OpalDefendantAccountEnforcementService
             VersionUtils.extractBigInteger(ifMatch).longValue()
         );
 
+        clearPersistenceContext();
+
         if (request.getPaymentTerms() != null) {
             DefendantAccountEntity defendantEntity = defendantAccountRepositoryService.findById(defendantAccountId);
             opalDefendantAccountService.addPaymentTermsPreservingLastEnforcement(
@@ -173,6 +182,10 @@ public class OpalDefendantAccountEnforcementService
         return resultResponsesMap;
     }
 
+    private void clearPersistenceContext() {
+        Optional.ofNullable(entityManager).ifPresent(EntityManager::clear);
+    }
+
     @Override
     @Transactional
     public RemoveDefendantAccountEnforcementHoldResponse removeEnforcementHold(
@@ -198,6 +211,7 @@ public class OpalDefendantAccountEnforcementService
         }
 
         VersionUtils.verifyIfMatch(defendantEntity, ifMatch, defendantAccountId, "removeEnforcementHold");
+        defendantAccountControlValidator.validateCanRemoveEnforcementHold(defendantEntity);
 
         if (defendantEntity.getLastEnforcement() == null) {
             throw new ResourceConflictException(

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementService.java
@@ -10,7 +10,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -139,7 +138,9 @@ public class OpalDefendantAccountEnforcementService
             VersionUtils.extractBigInteger(ifMatch).longValue()
         );
 
-        clearPersistenceContext();
+        // The stored procedure updates defendant_accounts outside Hibernate. Refresh the managed account so chained
+        // payment terms and the response use the latest version and enforcement state.
+        entityManager.refresh(defendant);
 
         if (request.getPaymentTerms() != null) {
             DefendantAccountEntity defendantEntity = defendantAccountRepositoryService.findById(defendantAccountId);
@@ -180,10 +181,6 @@ public class OpalDefendantAccountEnforcementService
         }
 
         return resultResponsesMap;
-    }
-
-    private void clearPersistenceContext() {
-        Optional.ofNullable(entityManager).ifPresent(EntityManager::clear);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementService.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.opal.service.opal;
 
-import jakarta.persistence.EntityManager;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 import java.time.Clock;
@@ -82,8 +81,6 @@ public class OpalDefendantAccountEnforcementService
 
     private final DefendantAccountControlValidator defendantAccountControlValidator;
 
-    private final EntityManager entityManager;
-
     @Override
     @Transactional
     public AddEnforcementResponse addEnforcement(
@@ -140,7 +137,7 @@ public class OpalDefendantAccountEnforcementService
 
         // The stored procedure updates defendant_accounts outside Hibernate. Refresh the managed account so chained
         // payment terms and the response use the latest version and enforcement state.
-        entityManager.refresh(defendant);
+        defendantAccountRepositoryService.refresh(defendant);
 
         if (request.getPaymentTerms() != null) {
             DefendantAccountEntity defendantEntity = defendantAccountRepositoryService.findById(defendantAccountId);

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyService.java
@@ -128,8 +128,7 @@ public class OpalDefendantAccountPartyService implements DefendantAccountPartySe
         log.debug(":addDefendantAccountParty: Opal mode: accountId={}, buId={}, postedBy={}, businessUserId={}",
             accountId, businessUnitId, postedBy, businessUserId);
 
-        // Verify the defendant account exists in the business unit.
-        defendantAccountRepositoryService.validateAccountExistsInBusinessUnit(account, businessUnitId);
+        validateAccountExistsInBusinessUnit(account, businessUnitId);
 
         VersionUtils.verifyIfMatch(account, ifMatch, accountId, "addDefendantAccountParty");
         defendantAccountControlValidator.validateCanMutateParty(account);
@@ -234,7 +233,7 @@ public class OpalDefendantAccountPartyService implements DefendantAccountPartySe
         log.debug(":replaceDefendantAccountParty: Opal mode: accountId={}, dapId={}, buId={}, postedBy={}, "
                 + "businessUserId={}", accountId, dapId, businessUnitId, postedBy, businessUserId);
 
-        defendantAccountRepositoryService.validateAccountExistsInBusinessUnit(account, businessUnitId);
+        validateAccountExistsInBusinessUnit(account, businessUnitId);
 
         VersionUtils.verifyIfMatch(account, ifMatch, accountId, "replaceDefendantAccountParty");
 
@@ -350,7 +349,7 @@ public class OpalDefendantAccountPartyService implements DefendantAccountPartySe
         log.debug(":removeDefendantAccountParty: accountId={}, dapId={}, buId={}, postedBy={}",
             defendantAccountId, defendantAccountPartyId, businessUnitId, postedBy);
 
-        defendantAccountRepositoryService.validateAccountExistsInBusinessUnit(account, String.valueOf(businessUnitId));
+        validateAccountExistsInBusinessUnit(account, String.valueOf(businessUnitId));
 
         VersionUtils.verifyIfMatch(account, ifMatch, defendantAccountId, "removeDefendantAccountParty");
         defendantAccountControlValidator.validateCanMutateParty(account);
@@ -616,6 +615,12 @@ public class OpalDefendantAccountPartyService implements DefendantAccountPartySe
         log.debug("replaceDebtorDetail: post-change debtor: {}", debtor);
 
         debtorDetailRepositoryService.save(debtor);
+    }
+
+    private void validateAccountExistsInBusinessUnit(DefendantAccountEntity account, String businessUnitId) {
+        if (!account.isInBusinessUnit(businessUnitId)) {
+            throw new EntityNotFoundException("Defendant Account not found in business unit " + businessUnitId);
+        }
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyService.java
@@ -73,6 +73,8 @@ public class OpalDefendantAccountPartyService implements DefendantAccountPartySe
 
     private final DefendantAccountPartiesRepository defendantAccountPartiesRepository;
 
+    private final DefendantAccountControlValidator defendantAccountControlValidator;
+
     @Override
     @Transactional(readOnly = true)
     public GetDefendantAccountPartyResponse getDefendantAccountParty(Long defendantAccountId,
@@ -130,6 +132,7 @@ public class OpalDefendantAccountPartyService implements DefendantAccountPartySe
         defendantAccountRepositoryService.validateAccountExistsInBusinessUnit(account, businessUnitId);
 
         VersionUtils.verifyIfMatch(account, ifMatch, accountId, "addDefendantAccountParty");
+        defendantAccountControlValidator.validateCanMutateParty(account);
         amendmentRepositoryService.auditInitialiseStoredProc(accountId, RecordType.DEFENDANT_ACCOUNTS);
 
         // Save the party record
@@ -231,20 +234,21 @@ public class OpalDefendantAccountPartyService implements DefendantAccountPartySe
         log.debug(":replaceDefendantAccountParty: Opal mode: accountId={}, dapId={}, buId={}, postedBy={}, "
                 + "businessUserId={}", accountId, dapId, businessUnitId, postedBy, businessUserId);
 
-        if (account.getBusinessUnit() == null
-            || account.getBusinessUnit().getBusinessUnitId() == null
-            || !String.valueOf(account.getBusinessUnit().getBusinessUnitId()).equals(businessUnitId)) {
-            throw new EntityNotFoundException("Defendant Account not found in business unit " + businessUnitId);
-        }
+        defendantAccountRepositoryService.validateAccountExistsInBusinessUnit(account, businessUnitId);
 
         VersionUtils.verifyIfMatch(account, ifMatch, accountId, "replaceDefendantAccountParty");
-        amendmentRepositoryService.auditInitialiseStoredProc(accountId, RecordType.DEFENDANT_ACCOUNTS);
 
         DefendantAccountPartiesEntity dap = account.getParties().stream()
             .filter(p -> p.getDefendantAccountPartyId().equals(dapId))
             .findFirst()
             .orElseThrow(() -> new EntityNotFoundException(
                 "Defendant Account Party not found for accountId=" + accountId + ", partyId=" + dapId));
+
+        if (isParentGuardianReplacement(dap)) {
+            defendantAccountControlValidator.validateCanMutateParty(account);
+        }
+
+        amendmentRepositoryService.auditInitialiseStoredProc(accountId, RecordType.DEFENDANT_ACCOUNTS);
 
         PartyEntity party = dap.getParty();
 
@@ -346,15 +350,10 @@ public class OpalDefendantAccountPartyService implements DefendantAccountPartySe
         log.debug(":removeDefendantAccountParty: accountId={}, dapId={}, buId={}, postedBy={}",
             defendantAccountId, defendantAccountPartyId, businessUnitId, postedBy);
 
-        if (account.getBusinessUnit() == null
-            || account.getBusinessUnit().getBusinessUnitId() == null
-            || !Objects.equals(account.getBusinessUnit().getBusinessUnitId(), businessUnitId)) {
-            throw new EntityNotFoundException("Defendant Account not found in business unit."
-                + " Defendant Account: " + defendantAccountId
-                + " Business Unit: " + businessUnitId);
-        }
+        defendantAccountRepositoryService.validateAccountExistsInBusinessUnit(account, String.valueOf(businessUnitId));
 
         VersionUtils.verifyIfMatch(account, ifMatch, defendantAccountId, "removeDefendantAccountParty");
+        defendantAccountControlValidator.validateCanMutateParty(account);
         amendmentRepositoryService.auditInitialiseStoredProc(defendantAccountId, RecordType.DEFENDANT_ACCOUNTS);
 
         // Verify the DAP association is valid for this Defendant Account
@@ -391,6 +390,10 @@ public class OpalDefendantAccountPartyService implements DefendantAccountPartySe
             && Boolean.TRUE.equals(Optional.ofNullable(partyDetails)
                 .map(PartyDetails::getOrganisationFlag)
                 .orElse(null));
+    }
+
+    private boolean isParentGuardianReplacement(DefendantAccountPartiesEntity dap) {
+        return AssociationType.PARENT_GUARDIAN.equals(dap.getAssociationType());
     }
 
     private void removeParentGuardianParties(DefendantAccountEntity account, Long dapId) {

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPaymentTermsService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPaymentTermsService.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.opal.service.opal;
 
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -34,6 +33,8 @@ public class OpalDefendantAccountPaymentTermsService implements DefendantAccount
 
     private final PaymentCardRequestRepositoryService paymentCardRequestRepositoryService;
 
+    private final DefendantAccountControlValidator defendantAccountControlValidator;
+
     @Override
     @Transactional(readOnly = true)
     public GetDefendantAccountPaymentTermsResponse getPaymentTerms(Long defendantAccountId) {
@@ -58,6 +59,7 @@ public class OpalDefendantAccountPaymentTermsService implements DefendantAccount
 
         DefendantAccountEntity account = loadAndValidateAccount(defendantAccountId, businessUnitId);
         VersionUtils.verifyIfMatch(account, ifMatch, account.getDefendantAccountId(), "addPaymentCardRequest");
+        defendantAccountControlValidator.validateCanAddPaymentCardRequest(account);
 
         amendmentRepositoryService.auditInitialiseStoredProc(defendantAccountId, RecordType.DEFENDANT_ACCOUNTS);
 
@@ -74,16 +76,8 @@ public class OpalDefendantAccountPaymentTermsService implements DefendantAccount
 
     private DefendantAccountEntity loadAndValidateAccount(Long accountId, String buId) {
         DefendantAccountEntity account = defendantAccountRepositoryService.findById(accountId);
-        validateBusinessUnitPresent(account, buId);
+        defendantAccountRepositoryService.validateAccountExistsInBusinessUnit(account, buId);
         return account;
-    }
-
-    private void validateBusinessUnitPresent(DefendantAccountEntity account, String buId) {
-        if (account.getBusinessUnit() == null
-            || account.getBusinessUnit().getBusinessUnitId() == null
-            || !String.valueOf(account.getBusinessUnit().getBusinessUnitId()).equals(buId)) {
-            throw new EntityNotFoundException("Defendant Account not found in business unit " + buId);
-        }
     }
 
     private void ensureNoExistingPaymentCardRequest(Long accountId) {

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPaymentTermsService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPaymentTermsService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service.opal;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -76,8 +77,14 @@ public class OpalDefendantAccountPaymentTermsService implements DefendantAccount
 
     private DefendantAccountEntity loadAndValidateAccount(Long accountId, String buId) {
         DefendantAccountEntity account = defendantAccountRepositoryService.findById(accountId);
-        defendantAccountRepositoryService.validateAccountExistsInBusinessUnit(account, buId);
+        validateAccountExistsInBusinessUnit(account, buId);
         return account;
+    }
+
+    private void validateAccountExistsInBusinessUnit(DefendantAccountEntity account, String businessUnitId) {
+        if (!account.isInBusinessUnit(businessUnitId)) {
+            throw new EntityNotFoundException("Defendant Account not found in business unit " + businessUnitId);
+        }
     }
 
     private void ensureNoExistingPaymentCardRequest(Long accountId) {

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
@@ -822,6 +822,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
         }
 
         VersionUtils.verifyIfMatch(defAccount, ifMatch, defendantAccountId, "addPaymentTerms");
+        defendantAccountControlValidator.validateCanAddPaymentTerms(defAccount);
 
         amendmentService.auditInitialiseStoredProc(defendantAccountId, RecordType.DEFENDANT_ACCOUNTS);
 

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
@@ -67,11 +67,9 @@ import uk.gov.hmcts.opal.entity.search.SearchConsolidatedEntity;
 import uk.gov.hmcts.opal.entity.search.SearchDefendantAccount;
 import uk.gov.hmcts.opal.exception.DefendantAccountNotFoundException;
 import uk.gov.hmcts.opal.exception.UnprocessableException;
-import uk.gov.hmcts.opal.generated.model.CollectionOrderCommon;
 import uk.gov.hmcts.opal.generated.model.CommentsAndNotesCommon;
 import uk.gov.hmcts.opal.generated.model.EnforcementCourtDefendantAccount;
 import uk.gov.hmcts.opal.generated.model.EnforcementOverrideDefendantAccount;
-import uk.gov.hmcts.opal.generated.model.UpdateDefendantAccountRequestPayload;
 import uk.gov.hmcts.opal.generated.model.UpdateDefendantAccountResponsePayload;
 import uk.gov.hmcts.opal.mapper.ConsolidatedAccountMapper;
 import uk.gov.hmcts.opal.mapper.DefendantAccountHeaderSummaryMapper;
@@ -356,7 +354,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
 
         VersionUtils.verifyIfMatch(entity, request.getVersion(), defendantAccountId, "updateDefendantAccount");
 
-        if (isProtectedUpdate(request, entity)) {
+        if (defendantAccountControlValidator.isProtectedUpdate(request, entity)) {
             defendantAccountControlValidator.validateCanUpdateProtectedFields(entity);
         }
 
@@ -409,55 +407,6 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
             )
             .version(newVersion)
             .build();
-    }
-
-    private boolean isProtectedUpdate(UpdateDefendantAccountRequest request, DefendantAccountEntity entity) {
-        UpdateDefendantAccountRequestPayload payload = request.getPayload();
-        return isEnforcementCourtChange(payload.getEnforcementCourt(), entity)
-            || isCollectionOrderChange(payload.getCollectionOrder(), entity)
-            || isEnforcementOverrideChange(payload.getEnforcementOverride(), entity);
-    }
-
-    private boolean isEnforcementCourtChange(EnforcementCourtDefendantAccount enforcementCourt,
-                                             DefendantAccountEntity entity) {
-        if (enforcementCourt == null) {
-            return false;
-        }
-        Long currentCourtId = Optional.ofNullable(entity.getEnforcingCourt())
-            .map(CourtEntity::getCourtId)
-            .orElse(null);
-        return !Objects.equals(enforcementCourt.getCourtId(), currentCourtId);
-    }
-
-    private boolean isCollectionOrderChange(CollectionOrderCommon collectionOrder, DefendantAccountEntity entity) {
-        if (collectionOrder == null) {
-            return false;
-        }
-        return !Objects.equals(collectionOrder.getCollectionOrderFlag(), entity.getCollectionOrder())
-            || !Objects.equals(collectionOrder.getCollectionOrderDate(), entity.getCollectionOrderEffectiveDate());
-    }
-
-    private boolean isEnforcementOverrideChange(EnforcementOverrideDefendantAccount enforcementOverride,
-                                                DefendantAccountEntity entity) {
-        if (enforcementOverride == null) {
-            return false;
-        }
-        String requestedResultId = enforcementOverride.getEnforcementOverrideResult() == null
-            ? null
-            : enforcementOverride.getEnforcementOverrideResult().getEnforcementOverrideResultId();
-        Long requestedEnforcerId = enforcementOverride.getEnforcer() == null
-            ? null
-            : enforcementOverride.getEnforcer().getEnforcerId();
-        Integer requestedLjaId = enforcementOverride.getLja() == null
-            ? null
-            : enforcementOverride.getLja().getLjaId();
-        Integer currentLjaId = Optional.ofNullable(entity.getEnforcementOverrideTfoLjaId())
-            .map(Short::intValue)
-            .orElse(null);
-
-        return !Objects.equals(requestedResultId, entity.getEnforcementOverrideResultId())
-            || !Objects.equals(requestedEnforcerId, entity.getEnforcementOverrideEnforcerId())
-            || !Objects.equals(requestedLjaId, currentLjaId);
     }
 
     /**

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
@@ -67,9 +67,11 @@ import uk.gov.hmcts.opal.entity.search.SearchConsolidatedEntity;
 import uk.gov.hmcts.opal.entity.search.SearchDefendantAccount;
 import uk.gov.hmcts.opal.exception.DefendantAccountNotFoundException;
 import uk.gov.hmcts.opal.exception.UnprocessableException;
+import uk.gov.hmcts.opal.generated.model.CollectionOrderCommon;
 import uk.gov.hmcts.opal.generated.model.CommentsAndNotesCommon;
 import uk.gov.hmcts.opal.generated.model.EnforcementCourtDefendantAccount;
 import uk.gov.hmcts.opal.generated.model.EnforcementOverrideDefendantAccount;
+import uk.gov.hmcts.opal.generated.model.UpdateDefendantAccountRequestPayload;
 import uk.gov.hmcts.opal.generated.model.UpdateDefendantAccountResponsePayload;
 import uk.gov.hmcts.opal.mapper.ConsolidatedAccountMapper;
 import uk.gov.hmcts.opal.mapper.DefendantAccountHeaderSummaryMapper;
@@ -164,6 +166,8 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
     private final PaymentTermsMapper paymentTermsMapper;
 
     private final Clock clock;
+
+    private final DefendantAccountControlValidator defendantAccountControlValidator;
 
     @Override
     @Transactional(readOnly = true)
@@ -352,6 +356,10 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
 
         VersionUtils.verifyIfMatch(entity, request.getVersion(), defendantAccountId, "updateDefendantAccount");
 
+        if (isProtectedUpdate(request, entity)) {
+            defendantAccountControlValidator.validateCanUpdateProtectedFields(entity);
+        }
+
         amendmentService.auditInitialiseStoredProc(defendantAccountId, RecordType.DEFENDANT_ACCOUNTS);
 
         if (request.getPayload().getCommentAndNotes() != null) {
@@ -403,6 +411,55 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
             .build();
     }
 
+    private boolean isProtectedUpdate(UpdateDefendantAccountRequest request, DefendantAccountEntity entity) {
+        UpdateDefendantAccountRequestPayload payload = request.getPayload();
+        return isEnforcementCourtChange(payload.getEnforcementCourt(), entity)
+            || isCollectionOrderChange(payload.getCollectionOrder(), entity)
+            || isEnforcementOverrideChange(payload.getEnforcementOverride(), entity);
+    }
+
+    private boolean isEnforcementCourtChange(EnforcementCourtDefendantAccount enforcementCourt,
+                                             DefendantAccountEntity entity) {
+        if (enforcementCourt == null) {
+            return false;
+        }
+        Long currentCourtId = Optional.ofNullable(entity.getEnforcingCourt())
+            .map(CourtEntity::getCourtId)
+            .orElse(null);
+        return !Objects.equals(enforcementCourt.getCourtId(), currentCourtId);
+    }
+
+    private boolean isCollectionOrderChange(CollectionOrderCommon collectionOrder, DefendantAccountEntity entity) {
+        if (collectionOrder == null) {
+            return false;
+        }
+        return !Objects.equals(collectionOrder.getCollectionOrderFlag(), entity.getCollectionOrder())
+            || !Objects.equals(collectionOrder.getCollectionOrderDate(), entity.getCollectionOrderEffectiveDate());
+    }
+
+    private boolean isEnforcementOverrideChange(EnforcementOverrideDefendantAccount enforcementOverride,
+                                                DefendantAccountEntity entity) {
+        if (enforcementOverride == null) {
+            return false;
+        }
+        String requestedResultId = enforcementOverride.getEnforcementOverrideResult() == null
+            ? null
+            : enforcementOverride.getEnforcementOverrideResult().getEnforcementOverrideResultId();
+        Long requestedEnforcerId = enforcementOverride.getEnforcer() == null
+            ? null
+            : enforcementOverride.getEnforcer().getEnforcerId();
+        Integer requestedLjaId = enforcementOverride.getLja() == null
+            ? null
+            : enforcementOverride.getLja().getLjaId();
+        Integer currentLjaId = Optional.ofNullable(entity.getEnforcementOverrideTfoLjaId())
+            .map(Short::intValue)
+            .orElse(null);
+
+        return !Objects.equals(requestedResultId, entity.getEnforcementOverrideResultId())
+            || !Objects.equals(requestedEnforcerId, entity.getEnforcementOverrideEnforcerId())
+            || !Objects.equals(requestedLjaId, currentLjaId);
+    }
+
     /**
      * This method adds a payment card request to a defendant account.
      *
@@ -416,12 +473,16 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
         String businessUnitId,
         String businessUnitUserId,
         String ifMatch,
-        String displayName) {
+        String displayName,
+        boolean validatePaymentCardControls) {
 
         log.debug(":addPaymentCard (Opal): accountId={}, bu={}", defendantAccountId, businessUnitId);
 
         DefendantAccountEntity account = loadAndValidateAccount(defendantAccountId, businessUnitId);
         VersionUtils.verifyIfMatch(account, ifMatch, account.getDefendantAccountId(), "addPaymentCard");
+        if (validatePaymentCardControls) {
+            defendantAccountControlValidator.validateCanAddPaymentCardRequest(account);
+        }
 
         ensureNoExistingPaymentCardRequest(defendantAccountId);
 
@@ -573,7 +634,8 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
             businessUnitId,
             businessUnitUserId,
             ifMatch,
-            postedByName
+            postedByName,
+            true
         );
 
         auditComplete(defendantAccountId, account, businessUnitUserId, postedByName);
@@ -673,6 +735,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
         }
 
         VersionUtils.verifyIfMatch(defAccount, ifMatch, defendantAccountId, "addPaymentTerms");
+        defendantAccountControlValidator.validateCanAddPaymentTerms(defAccount);
 
         amendmentService.auditInitialiseStoredProc(defendantAccountId, RecordType.DEFENDANT_ACCOUNTS);
 
@@ -706,7 +769,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
         if (Boolean.TRUE.equals(addPaymentTermsRequest.getRequestPaymentCard())) {
             log.debug(":addPaymentTerms: Request Payment Card flag is TRUE for account {}",
                 defAccount.getDefendantAccountId());
-            addPaymentCard(defendantAccountId, businessUnitId, businessUnitUserId, ifMatch, postedByName);
+            addPaymentCard(defendantAccountId, businessUnitId, businessUnitUserId, ifMatch, postedByName, false);
         }
 
         // if generate_payment_terms_change_letter is true
@@ -781,7 +844,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
         if (Boolean.TRUE.equals(addPaymentTermsRequest.getRequestPaymentCard())) {
             log.debug(":addPaymentTermsPreservingLastEnforcement: Request Payment Card flag is TRUE for account {}",
                 defAccount.getDefendantAccountId());
-            addPaymentCard(defendantAccountId, businessUnitId, businessUnitUserId, ifMatch, postedByName);
+            addPaymentCard(defendantAccountId, businessUnitId, businessUnitUserId, ifMatch, postedByName, false);
         }
 
         if (Boolean.TRUE.equals(addPaymentTermsRequest.getGeneratePaymentTermsChangeLetter())) {

--- a/src/main/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountRepositoryService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountRepositoryService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service.persistence;
 
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Optional;
@@ -16,6 +17,8 @@ import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
 public class DefendantAccountRepositoryService {
 
     private final DefendantAccountRepository defendantAccountRepository;
+
+    private final EntityManager entityManager;
 
     @Transactional(readOnly = true)
     public DefendantAccountEntity findById(long defendantAccountId) {
@@ -63,5 +66,9 @@ public class DefendantAccountRepositoryService {
         return defendantAccountRepository.findByDefendantAccountIdForUpdate(defendantAccountId)
             .orElseThrow(() -> new EntityNotFoundException(
                 "Defendant Account not found with id: " + defendantAccountId));
+    }
+
+    public void refresh(DefendantAccountEntity defendantAccountEntity) {
+        entityManager.refresh(defendantAccountEntity);
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/persistence/EnforcementRepositoryService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/persistence/EnforcementRepositoryService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.postgresql.util.PGobject;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.common.exceptions.standard.InternalServerErrorException;
@@ -72,9 +73,9 @@ public class EnforcementRepositoryService {
         String sql =
             "CALL p_add_defendant_account_enforcement(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CAST(? AS timestamp), ?, ?)";
 
-        try (Connection connection = dataSource.getConnection();
-             CallableStatement cs = connection.prepareCall(sql)) {
+        Connection connection = DataSourceUtils.getConnection(dataSource);
 
+        try (CallableStatement cs = connection.prepareCall(sql)) {
             cs.setString(1, resultId);
             cs.setLong(2, defendantAccountId);
             cs.setShort(3, businessUnitId);
@@ -97,6 +98,8 @@ public class EnforcementRepositoryService {
         } catch (Exception e) {
             throw new InternalServerErrorException("Failed to call stored procedure",
                                                    "p_add_defendant_account_enforcement", e);
+        } finally {
+            DataSourceUtils.releaseConnection(connection, dataSource);
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
@@ -494,6 +494,8 @@ class GlobalExceptionHandlerTest {
 
         assertEquals(HttpStatus.UNPROCESSABLE_CONTENT, r.getStatusCode());
         ProblemDetail pd = r.getBody();
+        assertEquals("Unprocessable Content", pd.getTitle());
+        assertEquals("Too many results", pd.getDetail());
         assertEquals(false, pd.getProperties().get("retriable"));
         assertEquals("Too many results", pd.getProperties().get("unprocessableReason"));
         assertNull(r.getHeaders().getETag());

--- a/src/test/java/uk/gov/hmcts/opal/entity/DefendantAccountEntityTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/entity/DefendantAccountEntityTest.java
@@ -13,6 +13,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -132,5 +133,32 @@ public class DefendantAccountEntityTest {
 
         // Test toString method
         assertNotNull(defendantAccount1.toString());
+    }
+
+    @Test
+    void isInBusinessUnit_returnsTrueWhenBusinessUnitMatches() {
+        DefendantAccountEntity defendantAccount = DefendantAccountEntity.builder()
+            .businessUnit(BusinessUnitEntity.builder().businessUnitId((short) 78).build())
+            .build();
+
+        assertTrue(defendantAccount.isInBusinessUnit("78"));
+    }
+
+    @Test
+    void isInBusinessUnit_returnsFalseWhenBusinessUnitDoesNotMatch() {
+        DefendantAccountEntity defendantAccount = DefendantAccountEntity.builder()
+            .businessUnit(BusinessUnitEntity.builder().businessUnitId((short) 77).build())
+            .build();
+
+        assertFalse(defendantAccount.isInBusinessUnit("78"));
+    }
+
+    @Test
+    void isInBusinessUnit_returnsFalseWhenBusinessUnitIsMissing() {
+        DefendantAccountEntity defendantAccount = DefendantAccountEntity.builder()
+            .businessUnit(null)
+            .build();
+
+        assertFalse(defendantAccount.isInBusinessUnit("78"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/DefendantAccountControlValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/DefendantAccountControlValidatorTest.java
@@ -1,0 +1,89 @@
+package uk.gov.hmcts.opal.service.opal;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
+import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountStatus;
+import uk.gov.hmcts.opal.exception.UnprocessableException;
+
+class DefendantAccountControlValidatorTest {
+
+    private final DefendantAccountControlValidator validator = new DefendantAccountControlValidator();
+
+    @ParameterizedTest
+    @EnumSource(value = DefendantAccountStatus.class, names = {
+        "ACCOUNT_CONSOLIDATED",
+        "ACCOUNT_WRITTEN_OFF",
+        "TRANSFER_OUT_PENDING",
+        "TRANSFER_OUT_ACKNOWLEDGED",
+        "TRANSFER_OUT_TO_NI_SCOTLAND"
+    })
+    void validateCanMutateParty_blocksConfiguredAccountStatuses(DefendantAccountStatus status) {
+        DefendantAccountEntity account = DefendantAccountEntity.builder()
+            .accountStatus(status)
+            .build();
+
+        UnprocessableException exception = assertThrows(
+            UnprocessableException.class,
+            () -> validator.validateCanMutateParty(account)
+        );
+
+        assertEquals("Defendant account update blocked: Account Status Check failed because account_status is "
+                         + status.getLabel() + ".",
+                     exception.getDetailedReason());
+    }
+
+    @Test
+    void validateCanAddPaymentTerms_collectsAllFailures() {
+        DefendantAccountEntity account = DefendantAccountEntity.builder()
+            .accountStatus(DefendantAccountStatus.TRANSFER_OUT_ACKNOWLEDGED)
+            .lastEnforcement("EO")
+            .accountBalance(BigDecimal.ZERO.setScale(2))
+            .build();
+
+        UnprocessableException exception = assertThrows(
+            UnprocessableException.class,
+            () -> validator.validateCanAddPaymentTerms(account)
+        );
+
+        assertEquals("Defendant account update blocked: Account Status Check failed because account_status is TA; "
+                         + "Payment terms last enforcement check failed because last_enforcement is EO; "
+                         + "Zero balance check failed because account_balance is 0.00.",
+                     exception.getDetailedReason());
+    }
+
+    @Test
+    void validateCanAddPaymentCardRequest_usesPaymentCardLastEnforcementList() {
+        DefendantAccountEntity account = DefendantAccountEntity.builder()
+            .accountStatus(DefendantAccountStatus.LIVE)
+            .lastEnforcement("AEO")
+            .accountBalance(BigDecimal.TEN)
+            .build();
+
+        UnprocessableException exception = assertThrows(
+            UnprocessableException.class,
+            () -> validator.validateCanAddPaymentCardRequest(account)
+        );
+
+        assertEquals("Defendant account update blocked: Payment card request last enforcement check failed because "
+                         + "last_enforcement is AEO.",
+                     exception.getDetailedReason());
+    }
+
+    @Test
+    void validateCanUpdateProtectedFields_allowsLiveAccount() {
+        DefendantAccountEntity account = DefendantAccountEntity.builder()
+            .accountStatus(DefendantAccountStatus.LIVE)
+            .lastEnforcement("AEO")
+            .accountBalance(BigDecimal.TEN)
+            .build();
+
+        assertDoesNotThrow(() -> validator.validateCanUpdateProtectedFields(account));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/DefendantAccountControlValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/DefendantAccountControlValidatorTest.java
@@ -2,15 +2,23 @@ package uk.gov.hmcts.opal.service.opal;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import uk.gov.hmcts.opal.dto.UpdateDefendantAccountRequest;
+import uk.gov.hmcts.opal.entity.court.CourtEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountStatus;
 import uk.gov.hmcts.opal.exception.UnprocessableException;
+import uk.gov.hmcts.opal.generated.model.CollectionOrderCommon;
+import uk.gov.hmcts.opal.generated.model.CommentsAndNotesCommon;
+import uk.gov.hmcts.opal.generated.model.UpdateDefendantAccountRequestPayload;
 
 class DefendantAccountControlValidatorTest {
 
@@ -85,5 +93,56 @@ class DefendantAccountControlValidatorTest {
             .build();
 
         assertDoesNotThrow(() -> validator.validateCanUpdateProtectedFields(account));
+    }
+
+    @Test
+    void isProtectedUpdate_returnsTrueWhenProtectedFieldChanges() {
+        DefendantAccountEntity account = DefendantAccountEntity.builder()
+            .collectionOrder(false)
+            .collectionOrderEffectiveDate(LocalDate.of(2025, 1, 1))
+            .build();
+        UpdateDefendantAccountRequest request = UpdateDefendantAccountRequest.builder()
+            .payload(UpdateDefendantAccountRequestPayload.builder()
+                .collectionOrder(CollectionOrderCommon.builder()
+                    .collectionOrderFlag(true)
+                    .collectionOrderDate(LocalDate.of(2025, 1, 1))
+                    .build())
+                .build())
+            .build();
+
+        assertTrue(validator.isProtectedUpdate(request, account));
+    }
+
+    @Test
+    void isProtectedUpdate_returnsFalseWhenProtectedFieldIsUnchanged() {
+        DefendantAccountEntity account = DefendantAccountEntity.builder()
+            .enforcingCourt(CourtEntity.builder().courtId(100L).build())
+            .collectionOrder(true)
+            .collectionOrderEffectiveDate(LocalDate.of(2025, 1, 1))
+            .build();
+        UpdateDefendantAccountRequest request = UpdateDefendantAccountRequest.builder()
+            .payload(UpdateDefendantAccountRequestPayload.builder()
+                .collectionOrder(CollectionOrderCommon.builder()
+                    .collectionOrderFlag(true)
+                    .collectionOrderDate(LocalDate.of(2025, 1, 1))
+                    .build())
+                .build())
+            .build();
+
+        assertFalse(validator.isProtectedUpdate(request, account));
+    }
+
+    @Test
+    void isProtectedUpdate_returnsFalseWhenOnlyCommentsChange() {
+        DefendantAccountEntity account = DefendantAccountEntity.builder().build();
+        UpdateDefendantAccountRequest request = UpdateDefendantAccountRequest.builder()
+            .payload(UpdateDefendantAccountRequestPayload.builder()
+                .commentAndNotes(CommentsAndNotesCommon.builder()
+                    .accountComment("comment only")
+                    .build())
+                .build())
+            .build();
+
+        assertFalse(validator.isProtectedUpdate(request, account));
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service.opal;
 
+import jakarta.persistence.EntityManager;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -133,6 +134,9 @@ public class OpalDefendantAccountEnforcementServiceTest {
 
     @Mock
     private DefendantAccountControlValidator defendantAccountControlValidator;
+
+    @Mock
+    private EntityManager entityManager;
 
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
@@ -1019,6 +1023,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
         assertEquals(String.valueOf(DEFENDANT_ACCOUNT_ID), response.getDefendantAccountId());
         assertEquals(0, response.getVersion());
         assertEquals(String.valueOf(ENFORCEMENT_ID), response.getEnforcementId());
+        verify(entityManager).refresh(ArgumentMatchers.any(DefendantAccountEntity.class));
     }
 
     private void mockAuthorisedUser() {

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.opal.service.opal;
 
-import jakarta.persistence.EntityManager;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -134,9 +133,6 @@ public class OpalDefendantAccountEnforcementServiceTest {
 
     @Mock
     private DefendantAccountControlValidator defendantAccountControlValidator;
-
-    @Mock
-    private EntityManager entityManager;
 
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
@@ -1023,7 +1019,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
         assertEquals(String.valueOf(DEFENDANT_ACCOUNT_ID), response.getDefendantAccountId());
         assertEquals(0, response.getVersion());
         assertEquals(String.valueOf(ENFORCEMENT_ID), response.getEnforcementId());
-        verify(entityManager).refresh(ArgumentMatchers.any(DefendantAccountEntity.class));
+        verify(defendantAccountRepositoryService).refresh(ArgumentMatchers.any(DefendantAccountEntity.class));
     }
 
     private void mockAuthorisedUser() {

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
@@ -40,6 +40,7 @@ import uk.gov.hmcts.opal.entity.defendantaccount.AssociationType;
 import uk.gov.hmcts.opal.entity.debtordetail.DebtorDetailEntity;
 import uk.gov.hmcts.opal.entity.result.ResultEntity;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
+import uk.gov.hmcts.opal.exception.UnprocessableException;
 import uk.gov.hmcts.opal.service.AccountNoteContext;
 import uk.gov.hmcts.opal.service.UserStateService;
 import uk.gov.hmcts.opal.service.persistence.DebtorDetailRepositoryService;
@@ -129,6 +130,9 @@ public class OpalDefendantAccountEnforcementServiceTest {
 
     @Mock
     private OpalDefendantAccountService opalDefendantAccountService;
+
+    @Mock
+    private DefendantAccountControlValidator defendantAccountControlValidator;
 
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
@@ -796,6 +800,58 @@ public class OpalDefendantAccountEnforcementServiceTest {
         verify(defendantAccountRepositoryService).findById(defendantAccountId);
         verifyNoInteractions(amendmentService, reportEntryService, notesProxy);
         verifyNoMoreInteractions(defendantAccountRepositoryService);
+    }
+
+    @Test
+    void removeEnforcementHold_whenAccountControlsFail_throwsBeforeMutation() {
+        Long defendantAccountId = 77L;
+        Short businessUnitId = 10;
+        String businessUnitUserId = "BU-USER-1";
+        String ifMatch = "\"7\"";
+
+        RemoveDefendantAccountEnforcementHoldRequest request =
+            RemoveDefendantAccountEnforcementHoldRequest.builder()
+                .reason("remove hold reason")
+                .build();
+
+        DefendantAccountEntity defendantEntity = DefendantAccountEntity.builder()
+            .defendantAccountId(defendantAccountId)
+            .lastEnforcement("NOENF")
+            .versionNumber(7L)
+            .build();
+        UnprocessableException exception = new UnprocessableException("blocked");
+
+        UserState userState = allPermissionsUser();
+
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
+        when(defendantAccountRepositoryService.findById(defendantAccountId)).thenReturn(defendantEntity);
+        doThrow(exception).when(defendantAccountControlValidator).validateCanRemoveEnforcementHold(defendantEntity);
+
+        try (MockedStatic<VersionUtils> versionUtils = mockStatic(VersionUtils.class)) {
+            versionUtils.when(() -> VersionUtils.verifyIfMatch(
+                defendantEntity,
+                ifMatch,
+                defendantAccountId,
+                "removeEnforcementHold"
+            )).thenAnswer(invocation -> null);
+
+            UnprocessableException result = assertThrows(
+                UnprocessableException.class,
+                () -> service.removeEnforcementHold(
+                    defendantAccountId,
+                    businessUnitId,
+                    businessUnitUserId,
+                    ifMatch,
+                    request
+                )
+            );
+
+            assertEquals(exception, result);
+            verify(defendantAccountControlValidator).validateCanRemoveEnforcementHold(defendantEntity);
+            verifyNoInteractions(amendmentService, reportEntryService, notesProxy);
+            verify(defendantAccountRepositoryService, org.mockito.Mockito.never()).saveAndFlush(defendantEntity);
+            assertEquals("NOENF", defendantEntity.getLastEnforcement());
+        }
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyServiceAddPartyTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyServiceAddPartyTest.java
@@ -41,6 +41,7 @@ import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
 import uk.gov.hmcts.opal.entity.debtordetail.DebtorDetailEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.AssociationType;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
+import uk.gov.hmcts.opal.exception.UnprocessableException;
 import uk.gov.hmcts.opal.repository.DefendantAccountPartiesRepository;
 import uk.gov.hmcts.opal.service.persistence.AliasRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.AmendmentRepositoryService;
@@ -69,6 +70,9 @@ class OpalDefendantAccountPartyServiceAddPartyTest {
 
     @Mock
     private PartyRepositoryService partyRepositoryService;
+
+    @Mock
+    private DefendantAccountControlValidator defendantAccountControlValidator;
 
     // Service under test
     @InjectMocks
@@ -210,6 +214,25 @@ class OpalDefendantAccountPartyServiceAddPartyTest {
         assertEquals("Defendant Account not found in business unit " + businessUnitId, exception.getMessage());
         verify(defendantAccountRepositoryService).findById(accountId);
         verify(defendantAccountRepositoryService).validateAccountExistsInBusinessUnit(account, businessUnitId);
+        verifyNoAddSideEffects();
+    }
+
+    @Test
+    void addDefendantAccountParty_whenAccountControlsFail_throwsBeforeMutation() {
+        Long accountId = 100L;
+        String businessUnitId = "10";
+        DefendantAccountEntity account = defendantAccount(accountId, Short.parseShort(businessUnitId), 1L);
+        UnprocessableException exception = new UnprocessableException("blocked");
+
+        when(defendantAccountRepositoryService.findById(accountId)).thenReturn(account);
+        doThrow(exception).when(defendantAccountControlValidator).validateCanMutateParty(account);
+
+        UnprocessableException result = assertThrows(UnprocessableException.class, () ->
+            service.addDefendantAccountParty(
+                accountId, businessUnitId, "bu-user-1", "tester", "\"1\"", validOrganisationRequest()));
+
+        assertEquals(exception, result);
+        verify(defendantAccountControlValidator).validateCanMutateParty(account);
         verifyNoAddSideEffects();
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyServiceAddPartyTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyServiceAddPartyTest.java
@@ -203,8 +203,6 @@ class OpalDefendantAccountPartyServiceAddPartyTest {
             .defendantAccountId(accountId).businessUnit(buWrong).versionNumber(1L).build();
 
         when(defendantAccountRepositoryService.findById(accountId)).thenReturn(account);
-        doThrow(new EntityNotFoundException("Defendant Account not found in business unit " + businessUnitId))
-            .when(defendantAccountRepositoryService).validateAccountExistsInBusinessUnit(account, businessUnitId);
         AddDefendantAccountPartyRequest request = validOrganisationRequest();
 
         EntityNotFoundException exception = assertThrows(EntityNotFoundException.class, () ->
@@ -213,7 +211,6 @@ class OpalDefendantAccountPartyServiceAddPartyTest {
 
         assertEquals("Defendant Account not found in business unit " + businessUnitId, exception.getMessage());
         verify(defendantAccountRepositoryService).findById(accountId);
-        verify(defendantAccountRepositoryService).validateAccountExistsInBusinessUnit(account, businessUnitId);
         verifyNoAddSideEffects();
     }
 
@@ -307,7 +304,6 @@ class OpalDefendantAccountPartyServiceAddPartyTest {
 
         assertEquals("Defendant Account not found with id: " + accountId, exception.getMessage());
         verify(defendantAccountRepositoryService).findById(accountId);
-        verify(defendantAccountRepositoryService, never()).validateAccountExistsInBusinessUnit(any(), any());
         verifyNoAddSideEffects();
     }
 
@@ -325,7 +321,6 @@ class OpalDefendantAccountPartyServiceAddPartyTest {
                 accountId, businessUnitId, "bu-user-1", "tester", "Tester Name", "\"4\"", request));
 
         verify(defendantAccountRepositoryService).findById(accountId);
-        verify(defendantAccountRepositoryService).validateAccountExistsInBusinessUnit(account, businessUnitId);
         verifyNoAddSideEffects();
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyServiceRemovePartyTests.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyServiceRemovePartyTests.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.opal.service.opal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -24,6 +25,7 @@ import uk.gov.hmcts.opal.entity.PartyEntity;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountPartiesEntity;
+import uk.gov.hmcts.opal.exception.UnprocessableException;
 import uk.gov.hmcts.opal.service.persistence.AmendmentRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
 
@@ -35,6 +37,9 @@ class OpalDefendantAccountPartyServiceRemovePartyTests {
 
     @Mock
     private AmendmentRepositoryService amendmentRepositoryService;
+
+    @Mock
+    private DefendantAccountControlValidator defendantAccountControlValidator;
 
 
     @InjectMocks
@@ -122,16 +127,35 @@ class OpalDefendantAccountPartyServiceRemovePartyTests {
     @Test
     void removeDefendantAccountParty_whenBusinessUnitMismatch_throwsEntityNotFoundException() {
         when(defendantAccountRepositoryService.findById(1L)).thenReturn(account);
+        doThrow(new EntityNotFoundException("Defendant Account not found in business unit 11"))
+            .when(defendantAccountRepositoryService).validateAccountExistsInBusinessUnit(account, "11");
 
         EntityNotFoundException exception = assertThrows(EntityNotFoundException.class, () ->
             service.removeDefendantAccountParty(
                 1L, 5L, (short) 11, "businessUser", "posted", "Posted User", "1", null));
 
-        assertEquals("Defendant Account not found in business unit. Defendant Account: 1 Business Unit: 11",
+        assertEquals("Defendant Account not found in business unit 11",
             exception.getMessage());
         verify(defendantAccountRepositoryService).findById(1L);
         verify(amendmentRepositoryService, never()).auditInitialiseStoredProc(1L, RecordType.DEFENDANT_ACCOUNTS);
         verify(defendantAccountRepositoryService, never()).saveAndFlush(account);
+    }
+
+    @Test
+    void removeDefendantAccountParty_whenAccountControlsFail_throwsBeforeMutation() {
+        UnprocessableException exception = new UnprocessableException("blocked");
+
+        when(defendantAccountRepositoryService.findById(1L)).thenReturn(account);
+        doThrow(exception).when(defendantAccountControlValidator).validateCanMutateParty(account);
+
+        UnprocessableException result = assertThrows(UnprocessableException.class, () ->
+            service.removeDefendantAccountParty(1L, 5L, (short) 10, "businessUser", "posted", "1", null));
+
+        assertEquals(exception, result);
+        verify(defendantAccountControlValidator).validateCanMutateParty(account);
+        verify(amendmentRepositoryService, never()).auditInitialiseStoredProc(1L, RecordType.DEFENDANT_ACCOUNTS);
+        verify(defendantAccountRepositoryService, never()).saveAndFlush(account);
+        assertEquals(1, account.getParties().size());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyServiceRemovePartyTests.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyServiceRemovePartyTests.java
@@ -127,8 +127,6 @@ class OpalDefendantAccountPartyServiceRemovePartyTests {
     @Test
     void removeDefendantAccountParty_whenBusinessUnitMismatch_throwsEntityNotFoundException() {
         when(defendantAccountRepositoryService.findById(1L)).thenReturn(account);
-        doThrow(new EntityNotFoundException("Defendant Account not found in business unit 11"))
-            .when(defendantAccountRepositoryService).validateAccountExistsInBusinessUnit(account, "11");
 
         EntityNotFoundException exception = assertThrows(EntityNotFoundException.class, () ->
             service.removeDefendantAccountParty(

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceAddPaymentTermsTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceAddPaymentTermsTest.java
@@ -1,10 +1,13 @@
 package uk.gov.hmcts.opal.service.opal;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -25,6 +28,7 @@ import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
 import uk.gov.hmcts.opal.entity.enforcement.EnforcementEntity;
 import uk.gov.hmcts.opal.entity.paymentterms.PaymentTermsEntity;
 import uk.gov.hmcts.opal.entity.result.ResultEntity;
+import uk.gov.hmcts.opal.exception.UnprocessableException;
 import uk.gov.hmcts.opal.mapper.request.PaymentTermsMapper;
 import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
 import uk.gov.hmcts.opal.repository.EnforcementRepository;
@@ -49,6 +53,9 @@ public class OpalDefendantAccountServiceAddPaymentTermsTest {
     private ResultService resultService;
     @Mock
     private ReportEntryService reportEntryService;
+
+    @Mock
+    private DefendantAccountControlValidator defendantAccountControlValidator;
 
     @InjectMocks
     private OpalDefendantAccountService defendantAccountService;
@@ -211,7 +218,6 @@ public class OpalDefendantAccountServiceAddPaymentTermsTest {
         account.setBusinessUnit(bu);
         account.setLastEnforcement("55");
         account.setVersionNumber(1L);
-
         PaymentTerms paymentTermsDto = new PaymentTerms();
         AddDefendantAccountPaymentTermsRequest request = new AddDefendantAccountPaymentTermsRequest();
         request.setPaymentTerms(paymentTermsDto);
@@ -252,5 +258,37 @@ public class OpalDefendantAccountServiceAddPaymentTermsTest {
         assertEquals("55", savedAccount.getLastEnforcement(),
             "Expected lastEnforcement to be preserved for enforcement-driven payment terms");
         verify(reportEntryService).createExtendTtpReportEntry(any(Long.class), any(short.class));
+    }
+
+    @Test
+    void addPaymentTerms_whenAccountControlsFail_throwsBeforeCreatingPaymentTerms() {
+        final Long defendantAccountId = 1L;
+        final String businessUnitId = "10";
+        final String businessUnitUserId = "userX";
+        final String ifMatch = "\"1\"";
+
+        DefendantAccountEntity account = DefendantAccountEntity.builder()
+            .defendantAccountId(defendantAccountId)
+            .businessUnit(BusinessUnitEntity.builder().businessUnitId((short) 10).build())
+            .versionNumber(1L)
+            .build();
+        UnprocessableException exception = new UnprocessableException("blocked");
+
+        when(defendantAccountRepository.findByDefendantAccountIdForUpdate(defendantAccountId))
+            .thenReturn(Optional.of(account));
+        doThrow(exception).when(defendantAccountControlValidator).validateCanAddPaymentTerms(account);
+
+        PaymentTerms paymentTermsDto = new PaymentTerms();
+        AddDefendantAccountPaymentTermsRequest request = new AddDefendantAccountPaymentTermsRequest();
+        request.setPaymentTerms(paymentTermsDto);
+
+        UnprocessableException result = assertThrows(UnprocessableException.class, () ->
+            defendantAccountService.addPaymentTerms(
+                defendantAccountId, businessUnitId, businessUnitUserId, ifMatch, request));
+
+        assertEquals(exception, result);
+        verify(defendantAccountControlValidator).validateCanAddPaymentTerms(account);
+        verify(paymentTermsService, never()).addPaymentTerm(any());
+        verify(defendantAccountRepository, never()).save(any());
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceAddPaymentTermsTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceAddPaymentTermsTest.java
@@ -274,8 +274,8 @@ public class OpalDefendantAccountServiceAddPaymentTermsTest {
             .build();
         UnprocessableException exception = new UnprocessableException("blocked");
 
-        when(defendantAccountRepository.findByDefendantAccountIdForUpdate(defendantAccountId))
-            .thenReturn(Optional.of(account));
+        when(defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(defendantAccountId))
+            .thenReturn(account);
         doThrow(exception).when(defendantAccountControlValidator).validateCanAddPaymentTerms(account);
 
         PaymentTerms paymentTermsDto = new PaymentTerms();
@@ -284,7 +284,7 @@ public class OpalDefendantAccountServiceAddPaymentTermsTest {
 
         UnprocessableException result = assertThrows(UnprocessableException.class, () ->
             defendantAccountService.addPaymentTerms(
-                defendantAccountId, businessUnitId, businessUnitUserId, ifMatch, request));
+                defendantAccountId, businessUnitId, businessUnitUserId, "Tester Name", ifMatch, request));
 
         assertEquals(exception, result);
         verify(defendantAccountControlValidator).validateCanAddPaymentTerms(account);

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServicePaymentCardTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServicePaymentCardTest.java
@@ -182,7 +182,7 @@ class OpalDefendantAccountServicePaymentCardTest {
         doThrow(exception).when(defendantAccountControlValidator).validateCanAddPaymentCardRequest(account);
 
         UnprocessableException result = assertThrows(UnprocessableException.class, () ->
-            service.addPaymentCardRequest(1L, "10", "BU-USER-123", "\"1\""));
+            service.addPaymentCardRequest(1L, "10", "BU-USER-123", "John Smith", "\"1\""));
 
         assertEquals(exception, result);
         verify(defendantAccountControlValidator).validateCanAddPaymentCardRequest(account);

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServicePaymentCardTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServicePaymentCardTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -30,6 +31,7 @@ import uk.gov.hmcts.opal.dto.RecordType;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.entity.PaymentCardRequestEntity;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
+import uk.gov.hmcts.opal.exception.UnprocessableException;
 import uk.gov.hmcts.opal.service.DefendantAccountPaymentTermsService;
 import uk.gov.hmcts.opal.service.UserStateService;
 import uk.gov.hmcts.opal.service.persistence.AmendmentRepositoryService;
@@ -46,6 +48,8 @@ class OpalDefendantAccountServicePaymentCardTest {
     PaymentCardRequestRepositoryService paymentCardRequestRepositoryService;
     @Mock
     AmendmentRepositoryService amendmentRepositoryService;
+    @Mock
+    DefendantAccountControlValidator defendantAccountControlValidator;
     @Mock UserStateService userStateService;
 
     @InjectMocks
@@ -110,6 +114,8 @@ class OpalDefendantAccountServicePaymentCardTest {
             .build();
 
         when(defendantAccountRepositoryService.findById(1L)).thenReturn(account);
+        doThrow(new EntityNotFoundException("Defendant Account not found in business unit 10"))
+            .when(defendantAccountRepositoryService).validateAccountExistsInBusinessUnit(account, "10");
 
         assertThrows(EntityNotFoundException.class, () ->
             service.addPaymentCardRequest(1L, "10", null, "John Smith", "\"1\"")
@@ -157,6 +163,8 @@ class OpalDefendantAccountServicePaymentCardTest {
             .build();
 
         when(defendantAccountRepositoryService.findById(1L)).thenReturn(account);
+        doThrow(new EntityNotFoundException("Defendant Account not found in business unit 10"))
+            .when(defendantAccountRepositoryService).validateAccountExistsInBusinessUnit(account, "10");
 
         assertThrows(EntityNotFoundException.class, () ->
             service.addPaymentCardRequest(1L, "10", "BU-USER-123", "John Smith", "\"1\"")
@@ -165,6 +173,26 @@ class OpalDefendantAccountServicePaymentCardTest {
         verify(defendantAccountRepositoryService, never()).save(any());
     }
 
+    @Test
+    void addPaymentCardRequest_whenAccountControlsFail_throwsBeforeMutation() {
+        DefendantAccountEntity account = DefendantAccountEntity.builder()
+            .defendantAccountId(1L)
+            .businessUnit(BusinessUnitEntity.builder().businessUnitId((short) 10).build())
+            .versionNumber(1L)
+            .build();
+        UnprocessableException exception = new UnprocessableException("blocked");
+
+        when(defendantAccountRepositoryService.findById(1L)).thenReturn(account);
+        doThrow(exception).when(defendantAccountControlValidator).validateCanAddPaymentCardRequest(account);
+
+        UnprocessableException result = assertThrows(UnprocessableException.class, () ->
+            service.addPaymentCardRequest(1L, "10", "BU-USER-123", "\"1\""));
+
+        assertEquals(exception, result);
+        verify(defendantAccountControlValidator).validateCanAddPaymentCardRequest(account);
+        verify(paymentCardRequestRepositoryService, never()).save(any());
+        verify(defendantAccountRepositoryService, never()).save(any());
+    }
 
     @Test
     void addPaymentCardRequest_newSignature_succeedsWhenBusinessUnitMatches() {

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServicePaymentCardTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServicePaymentCardTest.java
@@ -114,8 +114,6 @@ class OpalDefendantAccountServicePaymentCardTest {
             .build();
 
         when(defendantAccountRepositoryService.findById(1L)).thenReturn(account);
-        doThrow(new EntityNotFoundException("Defendant Account not found in business unit 10"))
-            .when(defendantAccountRepositoryService).validateAccountExistsInBusinessUnit(account, "10");
 
         assertThrows(EntityNotFoundException.class, () ->
             service.addPaymentCardRequest(1L, "10", null, "John Smith", "\"1\"")
@@ -163,8 +161,6 @@ class OpalDefendantAccountServicePaymentCardTest {
             .build();
 
         when(defendantAccountRepositoryService.findById(1L)).thenReturn(account);
-        doThrow(new EntityNotFoundException("Defendant Account not found in business unit 10"))
-            .when(defendantAccountRepositoryService).validateAccountExistsInBusinessUnit(account, "10");
 
         assertThrows(EntityNotFoundException.class, () ->
             service.addPaymentCardRequest(1L, "10", "BU-USER-123", "John Smith", "\"1\"")

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceTest03.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceTest03.java
@@ -158,8 +158,6 @@ class OpalDefendantAccountServiceTest03 {
             .defendantAccountId(accountId).businessUnit(buWrong).versionNumber(1L).build();
 
         when(defendantAccountRepositoryService.findById(accountId)).thenReturn(account);
-        doThrow(new EntityNotFoundException("Defendant Account not found in business unit 10"))
-            .when(defendantAccountRepositoryService).validateAccountExistsInBusinessUnit(account, "10");
 
         assertThrows(EntityNotFoundException.class, () ->
             service.replaceDefendantAccountParty(accountId, 1L,

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceTest03.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceTest03.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -45,6 +46,7 @@ import uk.gov.hmcts.opal.entity.debtordetail.DebtorDetailEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.AssociationType;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountPartiesEntity;
+import uk.gov.hmcts.opal.exception.UnprocessableException;
 import uk.gov.hmcts.opal.repository.DefendantAccountPartiesRepository;
 import uk.gov.hmcts.opal.service.persistence.AliasRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.AmendmentRepositoryService;
@@ -73,6 +75,9 @@ class OpalDefendantAccountServiceTest03 {
 
     @Mock
     private PartyRepositoryService partyRepositoryService;
+
+    @Mock
+    private DefendantAccountControlValidator defendantAccountControlValidator;
 
     // Service under test
     @InjectMocks
@@ -153,12 +158,55 @@ class OpalDefendantAccountServiceTest03 {
             .defendantAccountId(accountId).businessUnit(buWrong).versionNumber(1L).build();
 
         when(defendantAccountRepositoryService.findById(accountId)).thenReturn(account);
+        doThrow(new EntityNotFoundException("Defendant Account not found in business unit 10"))
+            .when(defendantAccountRepositoryService).validateAccountExistsInBusinessUnit(account, "10");
 
         assertThrows(EntityNotFoundException.class, () ->
             service.replaceDefendantAccountParty(accountId, 1L,
                 DefendantAccountParty.builder().build(), "\"1\"", "10", "tester", "Tester Name", null));
 
         verify(defendantAccountRepositoryService, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void replaceDefendantAccountParty_whenParentGuardianAccountControlsFail_throwsBeforeMutation() {
+        Long accountId = 100L;
+        Long dapId = 200L;
+
+        BusinessUnitEntity buEnt = BusinessUnitEntity.builder()
+            .businessUnitId((short) 10).build();
+
+        DefendantAccountPartiesEntity dap = DefendantAccountPartiesEntity.builder()
+            .defendantAccountPartyId(dapId)
+            .associationType(AssociationType.PARENT_GUARDIAN)
+            .party(PartyEntity.builder().partyId(300L).build())
+            .build();
+
+        DefendantAccountEntity account = DefendantAccountEntity.builder()
+            .defendantAccountId(accountId)
+            .businessUnit(buEnt)
+            .parties(List.of(dap))
+            .versionNumber(1L)
+            .build();
+        UnprocessableException exception = new UnprocessableException("blocked");
+
+        when(defendantAccountRepositoryService.findById(accountId)).thenReturn(account);
+        doThrow(exception).when(defendantAccountControlValidator).validateCanMutateParty(account);
+
+        try (MockedStatic<VersionUtils> vs = mockStatic(VersionUtils.class)) {
+            vs.when(() -> VersionUtils.verifyIfMatch(any(), anyString(), anyLong(), anyString()))
+                .thenAnswer(i -> null);
+
+            UnprocessableException result = assertThrows(UnprocessableException.class, () ->
+                service.replaceDefendantAccountParty(
+                    accountId, dapId, DefendantAccountParty.builder().build(), "\"1\"", "10", "tester", null));
+
+            assertEquals(exception, result);
+            verify(defendantAccountControlValidator).validateCanMutateParty(account);
+            verify(amendmentRepositoryService, never())
+                .auditInitialiseStoredProc(accountId, RecordType.DEFENDANT_ACCOUNTS);
+            verify(defendantAccountRepositoryService, never()).saveAndFlush(any());
+        }
     }
 
     @Test
@@ -372,7 +420,10 @@ class OpalDefendantAccountServiceTest03 {
         when(partyProxy.getPartyId()).thenReturn(300L);
 
         DefendantAccountPartiesEntity dap = DefendantAccountPartiesEntity.builder()
-            .defendantAccountPartyId(dapId).party(partyProxy).build();
+            .defendantAccountPartyId(dapId)
+            .party(partyProxy)
+            .associationType(AssociationType.DEFENDANT)
+            .build();
 
         DefendantAccountEntity account = DefendantAccountEntity.builder()
             .defendantAccountId(accountId).businessUnit(buEnt).parties(List.of(dap)).versionNumber(1L).build();
@@ -403,6 +454,7 @@ class OpalDefendantAccountServiceTest03 {
             verify(partyRepositoryService, times(2)).findById(300L); // main + aliases
             verify(defendantAccountRepositoryService).saveAndFlush(account);
             verify(aliasRepoService, times(2)).findByPartyId(300L);
+            verify(defendantAccountControlValidator, never()).validateCanMutateParty(account);
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountUpdateTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountUpdateTest.java
@@ -306,6 +306,7 @@ class OpalDefendantAccountUpdateTest {
                 .build())
             .version(BigInteger.ZERO)
             .build();
+        when(defendantAccountControlValidator.isProtectedUpdate(req, entity)).thenReturn(true);
 
         UnprocessableException result = assertThrows(UnprocessableException.class,
             () -> service.updateDefendantAccount(77L, "78", req, "tester"));

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountUpdateTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountUpdateTest.java
@@ -6,8 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -39,6 +41,7 @@ import uk.gov.hmcts.opal.entity.NoteEntity;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
 import uk.gov.hmcts.opal.entity.court.CourtEntity;
 import uk.gov.hmcts.opal.entity.result.ResultEntity;
+import uk.gov.hmcts.opal.exception.UnprocessableException;
 import uk.gov.hmcts.opal.generated.model.CollectionOrderCommon;
 import uk.gov.hmcts.opal.generated.model.CommentsAndNotesCommon;
 import uk.gov.hmcts.opal.generated.model.EnforcementCourtDefendantAccount;
@@ -88,6 +91,9 @@ class OpalDefendantAccountUpdateTest {
 
     @Mock
     private DefendantAccountRepositoryService defendantAccountRepositoryService;
+
+    @Mock
+    private DefendantAccountControlValidator defendantAccountControlValidator;
 
     @Spy
     private Clock clock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
@@ -274,6 +280,104 @@ class OpalDefendantAccountUpdateTest {
         assertThrows(ObjectOptimisticLockingFailureException.class,
             () -> service.updateDefendantAccount(77L, "78", req, "tester", "Tester Name"));
         verify(defendantAccountRepository, never()).save(any());
+    }
+
+    @Test
+    void updateDefendantAccount_whenProtectedUpdateAccountControlsFail_throwsBeforeMutation() {
+        var bu = BusinessUnitEntity.builder()
+            .businessUnitId((short) 78)
+            .build();
+
+        var entity = DefendantAccountEntity.builder()
+            .defendantAccountId(77L)
+            .businessUnit(bu)
+            .versionNumber(0L)
+            .build();
+        UnprocessableException exception = new UnprocessableException("blocked");
+
+        when(defendantAccountRepository.findById(77L)).thenReturn(Optional.of(entity));
+        doThrow(exception).when(defendantAccountControlValidator).validateCanUpdateProtectedFields(entity);
+
+        var req = UpdateDefendantAccountRequest.builder()
+            .payload(UpdateDefendantAccountRequestPayload.builder()
+                .collectionOrder(CollectionOrderCommon.builder()
+                    .collectionOrderFlag(true)
+                    .build())
+                .build())
+            .version(BigInteger.ZERO)
+            .build();
+
+        UnprocessableException result = assertThrows(UnprocessableException.class,
+            () -> service.updateDefendantAccount(77L, "78", req, "tester"));
+
+        assertEquals(exception, result);
+        verify(defendantAccountControlValidator).validateCanUpdateProtectedFields(entity);
+        verify(amendmentService, never()).auditInitialiseStoredProc(anyLong(), any());
+        verify(defendantAccountRepository, never()).save(any());
+    }
+
+    @Test
+    void updateDefendantAccount_whenOnlyCommentsChanged_doesNotRunAccountControls() {
+        var bu = BusinessUnitEntity.builder()
+            .businessUnitId((short) 78)
+            .build();
+
+        var entity = DefendantAccountEntity.builder()
+            .defendantAccountId(77L)
+            .businessUnit(bu)
+            .versionNumber(0L)
+            .build();
+
+        when(defendantAccountRepository.findById(77L)).thenReturn(Optional.of(entity));
+        when(noteRepository.save(any())).thenReturn(null);
+        doNothing().when(entityManager).lock(any(), any());
+
+        var req = UpdateDefendantAccountRequest.builder()
+            .payload(UpdateDefendantAccountRequestPayload.builder()
+                .commentAndNotes(CommentsAndNotesCommon.builder()
+                    .accountComment("comment only")
+                    .build())
+                .build())
+            .version(BigInteger.ZERO)
+            .build();
+
+        service.updateDefendantAccount(77L, "78", req, "tester");
+
+        verify(defendantAccountControlValidator, never()).validateCanUpdateProtectedFields(any());
+        verify(defendantAccountRepository).save(entity);
+    }
+
+    @Test
+    void updateDefendantAccount_whenProtectedFieldsAreUnchanged_doesNotRunAccountControls() {
+        var bu = BusinessUnitEntity.builder()
+            .businessUnitId((short) 78)
+            .build();
+
+        var entity = DefendantAccountEntity.builder()
+            .defendantAccountId(77L)
+            .businessUnit(bu)
+            .collectionOrder(true)
+            .collectionOrderEffectiveDate(LocalDate.of(2025, 1, 1))
+            .versionNumber(0L)
+            .build();
+
+        when(defendantAccountRepository.findById(77L)).thenReturn(Optional.of(entity));
+        doNothing().when(entityManager).lock(any(), any());
+
+        var req = UpdateDefendantAccountRequest.builder()
+            .payload(UpdateDefendantAccountRequestPayload.builder()
+                .collectionOrder(CollectionOrderCommon.builder()
+                    .collectionOrderFlag(true)
+                    .collectionOrderDate(LocalDate.of(2025, 1, 1))
+                    .build())
+                .build())
+            .version(BigInteger.ZERO)
+            .build();
+
+        service.updateDefendantAccount(77L, "78", req, "tester");
+
+        verify(defendantAccountControlValidator, never()).validateCanUpdateProtectedFields(any());
+        verify(defendantAccountRepository).save(entity);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountUpdateTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountUpdateTest.java
@@ -295,7 +295,7 @@ class OpalDefendantAccountUpdateTest {
             .build();
         UnprocessableException exception = new UnprocessableException("blocked");
 
-        when(defendantAccountRepository.findById(77L)).thenReturn(Optional.of(entity));
+        when(defendantAccountRepositoryService.findById(77L)).thenReturn(entity);
         doThrow(exception).when(defendantAccountControlValidator).validateCanUpdateProtectedFields(entity);
 
         var req = UpdateDefendantAccountRequest.builder()
@@ -329,7 +329,7 @@ class OpalDefendantAccountUpdateTest {
             .versionNumber(0L)
             .build();
 
-        when(defendantAccountRepository.findById(77L)).thenReturn(Optional.of(entity));
+        when(defendantAccountRepositoryService.findById(77L)).thenReturn(entity);
         when(noteRepository.save(any())).thenReturn(null);
         doNothing().when(entityManager).lock(any(), any());
 
@@ -362,7 +362,7 @@ class OpalDefendantAccountUpdateTest {
             .versionNumber(0L)
             .build();
 
-        when(defendantAccountRepository.findById(77L)).thenReturn(Optional.of(entity));
+        when(defendantAccountRepositoryService.findById(77L)).thenReturn(entity);
         doNothing().when(entityManager).lock(any(), any());
 
         var req = UpdateDefendantAccountRequest.builder()

--- a/src/test/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountRepositoryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountRepositoryServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,9 @@ class DefendantAccountRepositoryServiceTest {
 
     @Mock
     private DefendantAccountRepository defendantAccountRepository;
+
+    @Mock
+    private EntityManager entityManager;
 
     @InjectMocks
     private DefendantAccountRepositoryService service;
@@ -209,5 +213,19 @@ class DefendantAccountRepositoryServiceTest {
             "Defendant Account not found with id: 77",
             exception.getMessage()
         );
+    }
+
+    @Test
+    void refresh_refreshesEntityManagerState() {
+        // arrange
+        DefendantAccountEntity account = DefendantAccountEntity.builder()
+            .defendantAccountId(5L)
+            .build();
+
+        // act
+        service.refresh(account);
+
+        // assert
+        verify(entityManager).refresh(account);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PO-5757

### Change description ###

- Added reusable account-control validation for blocked status, last enforcement, and balance checks.
- Applied controls across affected defendant account update APIs.
- Added 422 problem JSON handling for blocked updates.
- Added unit and integration coverage for PO-5757 scenarios.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
