### PR TITLE
PO-7911 - fix transaction logic in opal draft account publish

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountPublishTransactionIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountPublishTransactionIntegrationTest.java
@@ -22,6 +22,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.SqlConfig;
+import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
@@ -38,52 +39,49 @@ class DraftAccountPublishTransactionIntegrationTest extends AbstractIntegrationT
     @JiraStory("PO-7911")
     @JiraEpic("PO-973")
     @Test
-    @DraftAccountPublishRetryFixture
+    @DraftAccountPublishDbUpdateFailureFixture
     void publishDraftAccount_publishesButFailsToUpdateStatus_leavesDraftPublishableForRetry() throws Exception {
-        // Arrange: @Sql creates a submitted draft and installs a trigger that fails the final status update.
+        // Arrange
+        String etag = getDraftEtag();
 
-        // Act: approve the draft through the public PATCH endpoint, which starts the publish flow.
+        // Act: first publish attempt fails while saving the final published status.
         mockMvc.perform(patch(DRAFT_ACCOUNTS_URL_BASE + "/" + DRAFT_ACCOUNT_ID)
                 .with(userStateStub.getAuthenticaitonRequestPostProcessor())
                 .header("authorization", userStateStub.getBearerToken())
-                .header("If-Match", "0")
+                .header("If-Match", etag)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(updateRequestBody(0)))
+                .content(updateRequestBody(extractVersion(etag))))
             .andExpect(status().is5xxServerError());
 
-        // Assert: the stored proc created the defendant account, but the draft never saved the returned identifiers.
-        mockMvc.perform(get(DRAFT_ACCOUNTS_URL_BASE + "/" + DRAFT_ACCOUNT_ID)
+        // Assert: the draft was not published.
+        MvcResult afterFailure = mockMvc.perform(get(DRAFT_ACCOUNTS_URL_BASE + "/" + DRAFT_ACCOUNT_ID)
                 .with(userStateStub.getAuthenticaitonRequestPostProcessor())
                 .header("authorization", userStateStub.getBearerToken())
                 .header("Accept", MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(header().string("ETag", "\"2\""))
-            .andExpect(jsonPath("$.account_status").value("Publishing Failed"))
             .andExpect(jsonPath("$.account_number").doesNotExist())
-            .andExpect(jsonPath("$.account_id").doesNotExist());
+            .andExpect(jsonPath("$.account_id").doesNotExist())
+            .andReturn();
 
-        // Assert: atomic rollback means no defendant account was left behind after the failed publish.
+        String retryEtag = afterFailure.getResponse().getHeader("ETag");
         assertDefendantAccountSearchCount(0);
 
-        // Act: retry the same draft through PATCH. Because the draft has no account number, it is publishable again.
+        // Act: retry publish using the current ETag/version.
         mockMvc.perform(patch(DRAFT_ACCOUNTS_URL_BASE + "/" + DRAFT_ACCOUNT_ID)
                 .with(userStateStub.getAuthenticaitonRequestPostProcessor())
                 .header("authorization", userStateStub.getBearerToken())
-                .header("If-Match", "2")
+                .header("If-Match", retryEtag)
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(updateRequestBody(1)))
+                .content(updateRequestBody(extractVersion(retryEtag))))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(header().string("ETag", "\"4\""))
             .andExpect(jsonPath("$.account_status").value("Published"))
             .andExpect(jsonPath("$.account_number").isNotEmpty())
             .andExpect(jsonPath("$.account_id").isNumber());
 
-        // Assert: exactly one defendant account exists after the successful retry.
         assertDefendantAccountSearchCount(1);
     }
-
 
     @JiraStory("PO-7911")
     @JiraEpic("PO-973")
@@ -96,7 +94,7 @@ class DraftAccountPublishTransactionIntegrationTest extends AbstractIntegrationT
                 .header("If-Match", "0")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(updateRequestBody(0)))
-            .andExpect(status().is5xxServerError());
+            .andExpect(status().is2xxSuccessful());
 
         mockMvc.perform(get(DRAFT_ACCOUNTS_URL_BASE + "/" + DRAFT_ACCOUNT_ID)
                 .with(userStateStub.getAuthenticaitonRequestPostProcessor())
@@ -155,6 +153,20 @@ class DraftAccountPublishTransactionIntegrationTest extends AbstractIntegrationT
             .andExpect(jsonPath("$.count").value(expectedCount));
     }
 
+    private String getDraftEtag() throws Exception {
+        MvcResult result = mockMvc.perform(get(DRAFT_ACCOUNTS_URL_BASE + "/" + DRAFT_ACCOUNT_ID)
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .header("Accept", MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        return result.getResponse().getHeader("ETag");
+    }
+
+    private int extractVersion(String etag) {
+        return Integer.parseInt(etag.replace("\"", ""));
+    }
 
     @Target(ElementType.METHOD)
     @Retention(RetentionPolicy.RUNTIME)
@@ -163,7 +175,7 @@ class DraftAccountPublishTransactionIntegrationTest extends AbstractIntegrationT
         executionPhase = BEFORE_TEST_METHOD
     )
     @Sql(
-        scripts = "classpath:db/insertData/insert_into_draft_account_publish_retry.sql",
+        scripts = "classpath:db/insertData/insert_into_draft_account_publish_final_status_failure.sql",
         config = @SqlConfig(separator = "@@"),
         executionPhase = BEFORE_TEST_METHOD
     )
@@ -171,7 +183,7 @@ class DraftAccountPublishTransactionIntegrationTest extends AbstractIntegrationT
         scripts = "classpath:db/deleteData/delete_from_draft_account_publish_retry.sql",
         executionPhase = AFTER_TEST_METHOD
     )
-    private @interface DraftAccountPublishRetryFixture {
+    private @interface DraftAccountPublishDbUpdateFailureFixture {
 
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountPublishTransactionIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountPublishTransactionIntegrationTest.java
@@ -1,0 +1,201 @@
+package uk.gov.hmcts.opal.controllers;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlConfig;
+import uk.gov.hmcts.opal.AbstractIntegrationTest;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
+
+@ActiveProfiles({"integration"})
+@Slf4j(topic = "opal.DraftAccountPublishTransactionIntegrationTest")
+@DisplayName("DraftAccountPublishTransactionIntegrationTest")
+class DraftAccountPublishTransactionIntegrationTest extends AbstractIntegrationTest {
+
+    private static final long DRAFT_ACCOUNT_ID = 9_999_901L;
+    private static final String DRAFT_ACCOUNTS_URL_BASE = "/draft-accounts";
+    private static final String DEFENDANT_ACCOUNTS_SEARCH_URL = "/defendant-accounts/search";
+
+    @JiraStory("PO-7911")
+    @JiraEpic("PO-973")
+    @Test
+    @DraftAccountPublishRetryFixture
+    void publishDraftAccount_publishesButFailsToUpdateStatus_leavesDraftPublishableForRetry() throws Exception {
+        // Arrange: @Sql creates a submitted draft and installs a trigger that fails the final status update.
+
+        // Act: approve the draft through the public PATCH endpoint, which starts the publish flow.
+        mockMvc.perform(patch(DRAFT_ACCOUNTS_URL_BASE + "/" + DRAFT_ACCOUNT_ID)
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .header("If-Match", "0")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updateRequestBody(0)))
+            .andExpect(status().is5xxServerError());
+
+        // Assert: the stored proc created the defendant account, but the draft never saved the returned identifiers.
+        mockMvc.perform(get(DRAFT_ACCOUNTS_URL_BASE + "/" + DRAFT_ACCOUNT_ID)
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .header("Accept", MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(header().string("ETag", "\"2\""))
+            .andExpect(jsonPath("$.account_status").value("Publishing Failed"))
+            .andExpect(jsonPath("$.account_number").doesNotExist())
+            .andExpect(jsonPath("$.account_id").doesNotExist());
+
+        // Assert: atomic rollback means no defendant account was left behind after the failed publish.
+        assertDefendantAccountSearchCount(0);
+
+        // Act: retry the same draft through PATCH. Because the draft has no account number, it is publishable again.
+        mockMvc.perform(patch(DRAFT_ACCOUNTS_URL_BASE + "/" + DRAFT_ACCOUNT_ID)
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .header("If-Match", "2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updateRequestBody(1)))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(header().string("ETag", "\"4\""))
+            .andExpect(jsonPath("$.account_status").value("Published"))
+            .andExpect(jsonPath("$.account_number").isNotEmpty())
+            .andExpect(jsonPath("$.account_id").isNumber());
+
+        // Assert: exactly one defendant account exists after the successful retry.
+        assertDefendantAccountSearchCount(1);
+    }
+
+
+    @JiraStory("PO-7911")
+    @JiraEpic("PO-973")
+    @Test
+    @DraftAccountPublishSpFailureFixture
+    void publishDraftAccount_storedProcFailure_PersistsPublishingFailedStatusAndTimelineData() throws Exception {
+        mockMvc.perform(patch(DRAFT_ACCOUNTS_URL_BASE + "/" + DRAFT_ACCOUNT_ID)
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .header("If-Match", "0")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updateRequestBody(0)))
+            .andExpect(status().is5xxServerError());
+
+        mockMvc.perform(get(DRAFT_ACCOUNTS_URL_BASE + "/" + DRAFT_ACCOUNT_ID)
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .header("Accept", MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(header().string("ETag", "\"2\""))
+            .andExpect(jsonPath("$.account_status").value("Publishing Failed"))
+            .andExpect(jsonPath("$.account_number").doesNotExist())
+            .andExpect(jsonPath("$.account_id").doesNotExist())
+            .andExpect(jsonPath("$.status_message").value("Stored Procedure Failure."))
+            .andExpect(jsonPath("$.timeline_data[1].status").value("Publishing Pending"))
+            .andExpect(jsonPath("$.timeline_data[2].status").value("Publishing Failed"))
+            .andExpect(jsonPath("$.timeline_data[2].reason_text",
+                containsString("Stored Procedure Failure.")))
+            .andExpect(jsonPath("$.timeline_data[2].reason_text", containsString("Error code:"))
+            );
+
+        assertDefendantAccountSearchCount(0);
+    }
+
+    private String updateRequestBody(int version) {
+        return """
+            {
+              "account_status": "Publishing Pending",
+              "validated_by": "ignored-by-service",
+              "validated_by_name": "ignored-by-service",
+              "business_unit_id": 77,
+              "reason_text": "Approve for publish",
+              "version": %d
+            }
+            """.formatted(version);
+    }
+
+    private void assertDefendantAccountSearchCount(int expectedCount) throws Exception {
+        mockMvc.perform(post(DEFENDANT_ACCOUNTS_SEARCH_URL)
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "active_accounts_only": true,
+                      "business_unit_ids": [77],
+                      "reference_number": {
+                        "account_number": null,
+                        "prosecutor_case_reference": "PUBLISH-RETRY-IT",
+                        "organisation": false
+                      },
+                      "defendant": null,
+                      "consolidation_search": false
+                    }
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.count").value(expectedCount));
+    }
+
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Sql(
+        scripts = "classpath:db/deleteData/delete_from_draft_account_publish_retry.sql",
+        executionPhase = BEFORE_TEST_METHOD
+    )
+    @Sql(
+        scripts = "classpath:db/insertData/insert_into_draft_account_publish_retry.sql",
+        config = @SqlConfig(separator = "@@"),
+        executionPhase = BEFORE_TEST_METHOD
+    )
+    @Sql(
+        scripts = "classpath:db/deleteData/delete_from_draft_account_publish_retry.sql",
+        executionPhase = AFTER_TEST_METHOD
+    )
+    private @interface DraftAccountPublishRetryFixture {
+
+    }
+
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Sql(
+        scripts = "classpath:db/deleteData/delete_from_draft_account_publish_retry.sql",
+        executionPhase = BEFORE_TEST_METHOD
+    )
+    @Sql(
+        scripts = "classpath:db/insertData/insert_into_draft_account_publish_retry.sql",
+        config = @SqlConfig(separator = "@@"),
+        executionPhase = BEFORE_TEST_METHOD
+    )
+    @Sql(
+        scripts = "classpath:db/insertData/insert_into_draft_account_publish_sp_failure.sql",
+        config = @SqlConfig(separator = "@@"),
+        executionPhase = BEFORE_TEST_METHOD
+    )
+    @Sql(
+        scripts = "classpath:db/deleteData/delete_from_draft_account_publish_retry.sql",
+        executionPhase = AFTER_TEST_METHOD
+    )
+    public @interface DraftAccountPublishSpFailureFixture {
+
+    }
+}

--- a/src/integrationTest/resources/db/deleteData/delete_from_draft_account_publish_retry.sql
+++ b/src/integrationTest/resources/db/deleteData/delete_from_draft_account_publish_retry.sql
@@ -1,0 +1,146 @@
+DROP TRIGGER IF EXISTS fail_first_publish_retry_status_update ON draft_accounts;
+DROP FUNCTION IF EXISTS fail_first_publish_retry_status_update();
+DROP SEQUENCE IF EXISTS draft_account_publish_retry_failure_seq;
+
+DROP TRIGGER IF EXISTS fail_first_defendant_account_insert ON defendant_accounts;
+DROP FUNCTION IF EXISTS fail_first_defendant_account_insert();
+DROP SEQUENCE IF EXISTS defendant_account_publish_sp_failure_seq;
+
+DROP TABLE IF EXISTS publish_retry_account_ids;
+DROP TABLE IF EXISTS publish_retry_imposition_ids;
+DROP TABLE IF EXISTS publish_retry_party_ids;
+DROP TABLE IF EXISTS publish_retry_account_numbers;
+
+CREATE TEMP TABLE publish_retry_account_ids AS
+SELECT defendant_account_id
+FROM defendant_accounts
+WHERE prosecutor_case_reference = 'PUBLISH-RETRY-IT';
+
+CREATE TEMP TABLE publish_retry_imposition_ids AS
+SELECT imposition_id
+FROM impositions
+WHERE defendant_account_id IN (SELECT defendant_account_id FROM publish_retry_account_ids);
+
+CREATE TEMP TABLE publish_retry_party_ids AS
+SELECT party_id
+FROM defendant_account_parties
+WHERE defendant_account_id IN (SELECT defendant_account_id FROM publish_retry_account_ids);
+
+CREATE TEMP TABLE publish_retry_account_numbers AS
+SELECT account_number
+FROM defendant_accounts
+WHERE defendant_account_id IN (SELECT defendant_account_id FROM publish_retry_account_ids);
+
+DELETE FROM report_entries
+WHERE associated_record_type = 'defendant_accounts'
+  AND associated_record_id IN (
+      SELECT defendant_account_id::varchar
+      FROM publish_retry_account_ids
+  );
+
+DELETE FROM document_instances
+WHERE associated_record_type = 'defendant_accounts'
+  AND associated_record_id IN (
+      SELECT defendant_account_id::varchar
+      FROM publish_retry_account_ids
+  );
+
+DELETE FROM document_instances
+WHERE associated_record_type = 'impositions'
+  AND associated_record_id IN (
+      SELECT imposition_id::varchar
+      FROM publish_retry_imposition_ids
+  );
+
+DELETE FROM allocations
+WHERE imposition_id IN (
+    SELECT imposition_id
+    FROM publish_retry_imposition_ids
+);
+
+DELETE FROM impositions
+WHERE imposition_id IN (
+    SELECT imposition_id
+    FROM publish_retry_imposition_ids
+);
+
+DELETE FROM defendant_transactions
+WHERE defendant_account_id IN (
+    SELECT defendant_account_id
+    FROM publish_retry_account_ids
+);
+
+DELETE FROM payment_terms
+WHERE defendant_account_id IN (
+    SELECT defendant_account_id
+    FROM publish_retry_account_ids
+);
+
+DELETE FROM payment_card_requests
+WHERE defendant_account_id IN (
+    SELECT defendant_account_id
+    FROM publish_retry_account_ids
+);
+
+DELETE FROM enforcements
+WHERE defendant_account_id IN (
+    SELECT defendant_account_id
+    FROM publish_retry_account_ids
+);
+
+DELETE FROM fixed_penalty_offences
+WHERE defendant_account_id IN (
+    SELECT defendant_account_id
+    FROM publish_retry_account_ids
+);
+
+DELETE FROM notes
+WHERE associated_record_type = 'defendant_accounts'
+  AND associated_record_id IN (
+      SELECT defendant_account_id::text
+      FROM publish_retry_account_ids
+  );
+
+DELETE FROM aliases
+WHERE party_id IN (
+    SELECT party_id
+    FROM publish_retry_party_ids
+);
+
+DELETE FROM debtor_detail
+WHERE party_id IN (
+    SELECT party_id
+    FROM publish_retry_party_ids
+);
+
+DELETE FROM defendant_account_parties
+WHERE defendant_account_id IN (
+    SELECT defendant_account_id
+    FROM publish_retry_account_ids
+);
+
+DELETE FROM parties
+WHERE party_id IN (
+    SELECT party_id
+    FROM publish_retry_party_ids
+);
+
+DELETE FROM account_number_index
+WHERE account_number IN (
+    SELECT account_number
+    FROM publish_retry_account_numbers
+);
+
+DELETE FROM defendant_accounts
+WHERE defendant_account_id IN (
+    SELECT defendant_account_id
+    FROM publish_retry_account_ids
+);
+
+DELETE FROM draft_accounts
+WHERE draft_account_id = 9999901;
+
+DROP TABLE IF EXISTS publish_retry_account_numbers;
+DROP TABLE IF EXISTS publish_retry_party_ids;
+DROP TABLE IF EXISTS publish_retry_imposition_ids;
+DROP TABLE IF EXISTS publish_retry_account_ids;

--- a/src/integrationTest/resources/db/insertData/insert_into_draft_account_publish_final_status_failure.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_draft_account_publish_final_status_failure.sql
@@ -1,0 +1,143 @@
+DROP TRIGGER IF EXISTS fail_final_publish_status_update ON draft_accounts;
+@@
+
+DROP FUNCTION IF EXISTS fail_final_publish_status_update();
+@@
+
+DROP SEQUENCE IF EXISTS draft_account_publish_final_status_failure_seq;
+@@
+
+CREATE SEQUENCE draft_account_publish_final_status_failure_seq
+    START WITH 1
+    INCREMENT BY 1;
+@@
+
+CREATE OR REPLACE FUNCTION fail_final_publish_status_update()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.draft_account_id = 9999901
+   AND OLD.account_status = 'PUBLISHING_PENDING'::t_dra_account_status_enum
+   AND NEW.account_status = 'PUBLISHED'::t_dra_account_status_enum
+       AND nextval('draft_account_publish_final_status_failure_seq') <= 1 THEN
+        RAISE EXCEPTION 'Test-only failure during final Published status update';
+END IF;
+
+RETURN NEW;
+END;
+$$;
+@@
+
+CREATE TRIGGER fail_final_publish_status_update
+BEFORE UPDATE ON draft_accounts
+            FOR EACH ROW
+            EXECUTE FUNCTION fail_final_publish_status_update();
+@@
+
+INSERT INTO draft_accounts (
+    draft_account_id,
+    business_unit_id,
+    created_date,
+    submitted_by,
+    validated_date,
+    validated_by,
+    account,
+    account_type,
+    account_id,
+    account_snapshot,
+    account_status,
+    timeline_data,
+    account_number,
+    submitted_by_name,
+    account_status_date,
+    status_message,
+    validated_by_name,
+    version_number
+)
+VALUES (
+    9999901,
+    77,
+    CURRENT_TIMESTAMP,
+    'SUBMITTER',
+    NULL,
+    NULL,
+    $${
+      "account_type": "Fine",
+      "defendant_type": "adultOrYouthOnly",
+      "originator_id": 409,
+      "originator_name": "Burnley Crown Court",
+      "originator_type": "NEW",
+      "account_sentence_date": "2023-02-15",
+      "enforcement_court_id": 770000000021,
+      "collection_order_made": true,
+      "collection_order_date": "2023-02-22",
+      "payment_card_request": null,
+      "prosecutor_case_reference": "PUBLISH-RETRY-IT",
+      "defendant": {
+        "company_flag": false,
+        "surname": "TEST",
+        "forenames": "Publish",
+        "dob": "1990-01-01",
+        "address_line_1": "1 Test Street",
+        "post_code": "TE1 1ST",
+        "telephone_number_home": "02070000000",
+        "debtor_detail": {
+          "document_language": "EN",
+          "hearing_language": null,
+          "aliases": null
+        }
+      },
+      "offences": [
+        {
+          "offence_id": 33369,
+          "date_of_sentence": "2023-02-15",
+          "imposing_court_id": 770000000021,
+          "impositions": [
+            {
+              "result_id": "FO",
+              "amount_imposed": 100.00,
+              "amount_paid": 0.00,
+              "minor_creditor": null,
+              "major_creditor_id": null
+            }
+          ]
+        }
+      ],
+      "payment_terms": {
+        "payment_terms_type_code": "B",
+        "effective_date": "2023-03-22",
+        "instalment_period": null,
+        "instalment_amount": null,
+        "lump_sum_amount": null,
+        "default_days_in_jail": null,
+        "enforcements": null
+      },
+      "account_notes": null,
+      "fp_ticket_detail": null,
+      "suspended_committal_date": null
+    }$$::jsonb,
+    'Fine',
+    NULL,
+    $${
+      "account_type": "Fine",
+      "submitted_by": "SUBMITTER",
+      "submitted_by_name": "opal-publish-it"
+    }$$::jsonb,
+    'SUBMITTED',
+    $$[
+      {
+        "status": "Submitted",
+        "username": "SUBMITTER",
+        "reason_text": null,
+        "status_date": "2026-06-22"
+      }
+    ]$$::jsonb,
+    NULL,
+    'opal-publish-it',
+    CURRENT_TIMESTAMP,
+    NULL,
+    NULL,
+    0
+);
+@@

--- a/src/integrationTest/resources/db/insertData/insert_into_draft_account_publish_retry.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_draft_account_publish_retry.sql
@@ -1,0 +1,134 @@
+CREATE SEQUENCE draft_account_publish_retry_failure_seq
+    START WITH 1
+    INCREMENT BY 1;
+@@
+
+CREATE OR REPLACE FUNCTION fail_first_publish_retry_status_update()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.draft_account_id = 9999901
+        AND OLD.account_number IS NULL
+        AND NEW.account_number IS NOT NULL
+        AND nextval('draft_account_publish_retry_failure_seq') <= 1 THEN
+        RAISE EXCEPTION 'Test-only failure after defendant account creation and before final draft status update';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+@@
+
+CREATE TRIGGER fail_first_publish_retry_status_update
+BEFORE UPDATE ON draft_accounts
+FOR EACH ROW
+EXECUTE FUNCTION fail_first_publish_retry_status_update();
+@@
+
+INSERT INTO draft_accounts (
+    draft_account_id,
+    business_unit_id,
+    created_date,
+    submitted_by,
+    validated_date,
+    validated_by,
+    account,
+    account_type,
+    account_id,
+    account_snapshot,
+    account_status,
+    timeline_data,
+    account_number,
+    submitted_by_name,
+    account_status_date,
+    status_message,
+    validated_by_name,
+    version_number
+)
+VALUES (
+    9999901,
+    77,
+    CURRENT_TIMESTAMP,
+    'SUBMITTER',
+    NULL,
+    NULL,
+    $${
+      "account_type": "Fine",
+      "defendant_type": "adultOrYouthOnly",
+      "originator_id": 409,
+      "originator_name": "Burnley Crown Court",
+      "originator_type": "NEW",
+      "account_sentence_date": "2023-02-15",
+      "enforcement_court_id": 770000000021,
+      "collection_order_made": true,
+      "collection_order_date": "2023-02-22",
+      "payment_card_request": null,
+      "prosecutor_case_reference": "PUBLISH-RETRY-IT",
+      "defendant": {
+        "company_flag": false,
+        "surname": "TEST",
+        "forenames": "Publish",
+        "dob": "1990-01-01",
+        "address_line_1": "1 Test Street",
+        "post_code": "TE1 1ST",
+        "telephone_number_home": "02070000000",
+        "debtor_detail": {
+          "document_language": "EN",
+          "hearing_language": null,
+          "aliases": null
+        }
+      },
+      "offences": [
+        {
+          "offence_id": 33369,
+          "date_of_sentence": "2023-02-15",
+          "imposing_court_id": 770000000021,
+          "impositions": [
+            {
+              "result_id": "FO",
+              "amount_imposed": 100.00,
+              "amount_paid": 0.00,
+              "minor_creditor": null,
+              "major_creditor_id": null
+            }
+          ]
+        }
+      ],
+      "payment_terms": {
+        "payment_terms_type_code": "B",
+        "effective_date": "2023-03-22",
+        "instalment_period": null,
+        "instalment_amount": null,
+        "lump_sum_amount": null,
+        "default_days_in_jail": null,
+        "enforcements": null
+      },
+      "account_notes": null,
+      "fp_ticket_detail": null,
+      "suspended_committal_date": null
+    }$$::jsonb,
+    'Fine',
+    NULL,
+    $${
+      "account_type": "Fine",
+      "submitted_by": "SUBMITTER",
+      "submitted_by_name": "opal-publish-it"
+    }$$::jsonb,
+    'SUBMITTED',
+    $$[
+      {
+        "status": "Submitted",
+        "username": "SUBMITTER",
+        "reason_text": null,
+        "status_date": "2026-06-22"
+      }
+    ]$$::jsonb,
+    NULL,
+    'opal-publish-it',
+    CURRENT_TIMESTAMP,
+    NULL,
+    NULL,
+    0
+);
+@@

--- a/src/integrationTest/resources/db/insertData/insert_into_draft_account_publish_sp_failure.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_draft_account_publish_sp_failure.sql
@@ -1,0 +1,25 @@
+CREATE SEQUENCE defendant_account_publish_sp_failure_seq
+    START WITH 1
+    INCREMENT BY 1;
+@@
+
+CREATE OR REPLACE FUNCTION fail_first_defendant_account_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF NEW.prosecutor_case_reference = 'PUBLISH-RETRY-IT'
+       AND nextval('defendant_account_publish_sp_failure_seq') = 1 THEN
+        RAISE EXCEPTION 'Test-only failure during stored procedure defendant account insert';
+END IF;
+
+RETURN NEW;
+END;
+$$;
+@@
+
+CREATE TRIGGER fail_first_defendant_account_insert
+BEFORE INSERT ON defendant_accounts
+FOR EACH ROW
+EXECUTE FUNCTION fail_first_defendant_account_insert();
+@@

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/DraftAccountPublish.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/DraftAccountPublish.java
@@ -1,11 +1,7 @@
 package uk.gov.hmcts.opal.service.opal;
 
-import static uk.gov.hmcts.opal.entity.draft.StoredProcedureNames.DEF_ACC_ID;
-import static uk.gov.hmcts.opal.entity.draft.StoredProcedureNames.DEF_ACC_NO;
-
 import java.time.Clock;
 import java.time.LocalDate;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
@@ -33,18 +29,7 @@ public class DraftAccountPublish implements DraftAccountPublishInterface {
         log.debug(":publishDefendantAccount: About to call Out to Opal PostgreSQL Stored Procedure");
 
         try {
-            Map<String, Object> outputs = draftAccountTransactional.publishAccountStoredProc(publishEntity);
-
-            String accountNumber = outputs.getOrDefault(DEF_ACC_NO, "<null>").toString();
-            Long accountId = Long.parseLong(outputs.getOrDefault(DEF_ACC_ID, "0").toString());
-            log.debug(":publishDefendantAccount: \n\nPublished,  account number: {}, account id: {}\n\n",
-                     accountNumber, accountId);
-
-            publishEntity.setAccountId(accountId);
-            publishEntity.setAccountNumber(accountNumber);
-            return draftAccountTransactional.updateStatus(publishEntity, DraftAccountStatus.PUBLISHED,
-                                                          draftAccountTransactional
-            );
+            return draftAccountTransactional.publishDefendantAccount(publishEntity);
         } catch (JpaSystemException | InvalidDataAccessApiUsageException e) {
             log.error(":publishDefendantAccount: Error Class: {}", e.getClass().getName());
             log.error(":publishDefendantAccount: ", e);
@@ -57,11 +42,18 @@ public class DraftAccountPublish implements DraftAccountPublishInterface {
                 LocalDate.now(clock), reason
             );
 
-            publishEntity.setTimelineData(timelineData.toJson());
-            publishEntity.setStatusMessage(LogUtil.ERRMSG_STORED_PROC_FAILURE);
-            return draftAccountTransactional.updateStatus(publishEntity, DraftAccountStatus.PUBLISHING_FAILED,
-                                                          draftAccountTransactional
+            DraftAccountEntity failedUpdate = new DraftAccountEntity();
+            failedUpdate.setDraftAccountId(publishEntity.getDraftAccountId());
+            failedUpdate.setTimelineData(timelineData.toJson());
+            failedUpdate.setStatusMessage(LogUtil.ERRMSG_STORED_PROC_FAILURE);
+            failedUpdate.setVersionNumber(publishEntity.getVersionNumber());
+
+            draftAccountTransactional.updateStatus(
+                failedUpdate,
+                DraftAccountStatus.PUBLISHING_FAILED,
+                draftAccountTransactional
             );
+            throw e;
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/DraftAccountPublish.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/DraftAccountPublish.java
@@ -48,12 +48,11 @@ public class DraftAccountPublish implements DraftAccountPublishInterface {
             failedUpdate.setStatusMessage(LogUtil.ERRMSG_STORED_PROC_FAILURE);
             failedUpdate.setVersionNumber(publishEntity.getVersionNumber());
 
-            draftAccountTransactional.updateStatus(
+            return draftAccountTransactional.updateStatus(
                 failedUpdate,
                 DraftAccountStatus.PUBLISHING_FAILED,
                 draftAccountTransactional
             );
-            throw e;
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactional.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactional.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.opal.service.opal.jpa;
 
 
+import static uk.gov.hmcts.opal.entity.draft.DraftAccountStatus.PUBLISHED;
 import static uk.gov.hmcts.opal.entity.draft.StoredProcedureNames.DEF_ACC_ID;
 import static uk.gov.hmcts.opal.entity.draft.StoredProcedureNames.DEF_ACC_NO;
 import static uk.gov.hmcts.opal.service.DraftAccountService.EVENT_ACCOUNT_APPROVAL;
@@ -43,6 +44,7 @@ import uk.gov.hmcts.opal.entity.draft.DraftAccountEntity_;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountSnapshots;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountStatus;
 import uk.gov.hmcts.opal.entity.draft.TimelineData;
+import uk.gov.hmcts.opal.exception.EntityNotSavedException;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.opal.exception.SubmitterDeniedException;
 import uk.gov.hmcts.opal.repository.BusinessUnitRepository;
@@ -237,22 +239,36 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
         // These are specific to the results from the 'publish' activity, failure
         dbDraftAccount.setStatusMessage(entity.getStatusMessage());
         dbDraftAccount.setTimelineData(entity.getTimelineData());
-
         return draftAccountRepository.save(dbDraftAccount);
     }
 
     @Transactional
     public DraftAccountEntity publishDefendantAccount(DraftAccountEntity publishEntity) {
         Map<String, Object> outputs = publishAccountStoredProc(publishEntity);
-
         String accountNumber = outputs.getOrDefault(DEF_ACC_NO, "<null>").toString();
         Long accountId = Long.parseLong(outputs.getOrDefault(DEF_ACC_ID, "0").toString());
         log.debug(":publishDefendantAccount: \n\nPublished,  account number: {}, account id: {}\n\n",
             accountNumber, accountId);
 
-        publishEntity.setAccountId(accountId);
-        publishEntity.setAccountNumber(accountNumber);
-        return updateStatus(publishEntity, DraftAccountStatus.PUBLISHED, this);
+        Long draftAccountId = publishEntity.getDraftAccountId();
+        DraftAccountEntity dbDraftAccount = this.getDraftAccount(draftAccountId);
+        verifyVersions(dbDraftAccount, publishEntity, draftAccountId, "updateStatus");
+
+        dbDraftAccount.setAccountStatus(PUBLISHED);
+        dbDraftAccount.setVersionNumber(publishEntity.getVersion().longValueExact());
+        dbDraftAccount.setAccountStatusDate(LocalDateTime.now(clock));
+
+        // These are specific to the results from the 'publish' activity, success
+        dbDraftAccount.setAccountNumber(accountNumber);
+        dbDraftAccount.setAccountId(accountId);
+        // These are specific to the results from the 'publish' activity, failure
+        dbDraftAccount.setStatusMessage(publishEntity.getStatusMessage());
+        dbDraftAccount.setTimelineData(publishEntity.getTimelineData());
+        try {
+            return draftAccountRepository.saveAndFlush(dbDraftAccount);
+        } catch (Exception e) {
+            throw new EntityNotSavedException("Unable to save draft account", e);
+        }
     }
 
     @Transactional

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactional.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactional.java
@@ -271,8 +271,7 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
         }
     }
 
-    @Transactional
-    public Map<String, Object> publishAccountStoredProc(DraftAccountEntity publishEntity) {
+    private Map<String, Object> publishAccountStoredProc(DraftAccountEntity publishEntity) {
 
         return draftAccountRepository.createDefendantAccount(publishEntity.getDraftAccountId(),
                                                              publishEntity.getBusinessUnit().getBusinessUnitId(),

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactional.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactional.java
@@ -1,15 +1,14 @@
 package uk.gov.hmcts.opal.service.opal.jpa;
 
 
+import static uk.gov.hmcts.opal.entity.draft.StoredProcedureNames.DEF_ACC_ID;
+import static uk.gov.hmcts.opal.entity.draft.StoredProcedureNames.DEF_ACC_NO;
 import static uk.gov.hmcts.opal.service.DraftAccountService.EVENT_ACCOUNT_APPROVAL;
 import static uk.gov.hmcts.opal.util.DateTimeUtils.toUtcDateTime;
 import static uk.gov.hmcts.opal.util.JsonPathUtil.createDocContext;
 import static uk.gov.hmcts.opal.util.VersionUtils.verifyIfMatch;
 import static uk.gov.hmcts.opal.util.VersionUtils.verifyVersions;
 
-import tools.jackson.core.JacksonException;
-import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.node.ObjectNode;
 import jakarta.persistence.EntityNotFoundException;
 import java.math.BigInteger;
 import java.time.Clock;
@@ -29,6 +28,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 import uk.gov.hmcts.opal.common.logging.SecurityEventLoggingService;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddDraftAccountRequestDto;
@@ -237,6 +239,20 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
         dbDraftAccount.setTimelineData(entity.getTimelineData());
 
         return draftAccountRepository.save(dbDraftAccount);
+    }
+
+    @Transactional
+    public DraftAccountEntity publishDefendantAccount(DraftAccountEntity publishEntity) {
+        Map<String, Object> outputs = publishAccountStoredProc(publishEntity);
+
+        String accountNumber = outputs.getOrDefault(DEF_ACC_NO, "<null>").toString();
+        Long accountId = Long.parseLong(outputs.getOrDefault(DEF_ACC_ID, "0").toString());
+        log.debug(":publishDefendantAccount: \n\nPublished,  account number: {}, account id: {}\n\n",
+            accountNumber, accountId);
+
+        publishEntity.setAccountId(accountId);
+        publishEntity.setAccountNumber(accountNumber);
+        return updateStatus(publishEntity, DraftAccountStatus.PUBLISHED, this);
     }
 
     @Transactional

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/DraftAccountPublishTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/DraftAccountPublishTest.java
@@ -88,17 +88,14 @@ class DraftAccountPublishTest {
             logUtilMock.when(LogUtil::getOrCreateOpalOperationId).thenReturn(operationId);
 
             DraftAccountEntity result = draftAccountPublish.publishDefendantAccount(pending, unitUser);
-
             ArgumentCaptor<DraftAccountEntity> captor = ArgumentCaptor.forClass(DraftAccountEntity.class);
-
             verify(draftAccountTransactional).updateStatus(
                 captor.capture(),
                 eq(DraftAccountStatus.PUBLISHING_FAILED),
                 same(draftAccountTransactional)
             );
-
             DraftAccountEntity failedUpdate = captor.getValue();
-
+            assertEquals(failedUpdate, result);
             assertEquals(pending.getDraftAccountId(), failedUpdate.getDraftAccountId());
             assertEquals(pending.getVersionNumber(), failedUpdate.getVersionNumber());
             assertEquals(LogUtil.ERRMSG_STORED_PROC_FAILURE, failedUpdate.getStatusMessage());
@@ -110,9 +107,7 @@ class DraftAccountPublishTest {
                 LocalDate.now(clock),
                 LogUtil.ERRMSG_STORED_PROC_FAILURE + " Error code: [" + operationId + "]"
             );
-
             assertEquals(expectedTimeline.toJson(), failedUpdate.getTimelineData());
-            assertEquals(failedUpdate, result);
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/DraftAccountPublishTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/DraftAccountPublishTest.java
@@ -75,36 +75,44 @@ class DraftAccountPublishTest {
         when(unitUser.getBusinessUnitUserId()).thenReturn(expectedUserId);
         when(draftAccountTransactional.publishDefendantAccount(any(DraftAccountEntity.class)))
             .thenThrow(thrown);
+
         when(draftAccountTransactional.updateStatus(
             any(DraftAccountEntity.class),
             eq(DraftAccountStatus.PUBLISHING_FAILED),
             same(draftAccountTransactional)
         )).thenAnswer(invocation -> invocation.getArgument(0));
+
         DraftAccountEntity pending = createPendingDraft();
+
         try (MockedStatic<LogUtil> logUtilMock = Mockito.mockStatic(LogUtil.class)) {
             logUtilMock.when(LogUtil::getOrCreateOpalOperationId).thenReturn(operationId);
 
             DraftAccountEntity result = draftAccountPublish.publishDefendantAccount(pending, unitUser);
 
             ArgumentCaptor<DraftAccountEntity> captor = ArgumentCaptor.forClass(DraftAccountEntity.class);
+
             verify(draftAccountTransactional).updateStatus(
                 captor.capture(),
                 eq(DraftAccountStatus.PUBLISHING_FAILED),
                 same(draftAccountTransactional)
             );
+
             DraftAccountEntity failedUpdate = captor.getValue();
-            assertEquals(failedUpdate, result);
+
             assertEquals(pending.getDraftAccountId(), failedUpdate.getDraftAccountId());
             assertEquals(pending.getVersionNumber(), failedUpdate.getVersionNumber());
             assertEquals(LogUtil.ERRMSG_STORED_PROC_FAILURE, failedUpdate.getStatusMessage());
+
             TimelineData expectedTimeline = new TimelineData(pending.getTimelineData());
-            assertEquals(expectedTimeline.toJson(), failedUpdate.getTimelineData());
             expectedTimeline.insertEntry(
                 expectedUserId,
                 DraftAccountStatus.PUBLISHING_FAILED.getLabel(),
                 LocalDate.now(clock),
                 LogUtil.ERRMSG_STORED_PROC_FAILURE + " Error code: [" + operationId + "]"
             );
+
+            assertEquals(expectedTimeline.toJson(), failedUpdate.getTimelineData());
+            assertEquals(failedUpdate, result);
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/DraftAccountPublishTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/DraftAccountPublishTest.java
@@ -1,172 +1,165 @@
 package uk.gov.hmcts.opal.service.opal;
 
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyShort;
-import static org.mockito.Mockito.spy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.opal.entity.draft.StoredProcedureNames.DEF_ACC_ID;
-import static uk.gov.hmcts.opal.entity.draft.StoredProcedureNames.DEF_ACC_NO;
 
-import java.lang.reflect.Field;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
-import java.util.Map;
-import java.util.Optional;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mapstruct.factory.Mappers;
-import org.mockito.InjectMocks;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.orm.jpa.JpaSystemException;
 import uk.gov.hmcts.opal.common.logging.LogUtil;
-import uk.gov.hmcts.opal.common.logging.SecurityEventLoggingService;
 import uk.gov.hmcts.opal.common.user.authorisation.model.BusinessUnitUser;
-import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountEntity;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountStatus;
 import uk.gov.hmcts.opal.entity.draft.TimelineData;
-import uk.gov.hmcts.opal.mapper.DraftAccountMapper;
-import uk.gov.hmcts.opal.repository.BusinessUnitRepository;
-import uk.gov.hmcts.opal.repository.DraftAccountRepository;
 import uk.gov.hmcts.opal.service.opal.jpa.DraftAccountTransactional;
 
 @ExtendWith(MockitoExtension.class)
 class DraftAccountPublishTest {
 
-    DraftAccountMapper mapper = Mappers.getMapper(DraftAccountMapper.class);
-
     @Mock
-    DraftAccountRepository draftRepository;
-
-    @Mock
-    BusinessUnitRepository businessRepository;
-
-    @Mock
-    SecurityEventLoggingService securityEventLoggingService;
-
-    @Spy
-    private Clock clock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
-
     private DraftAccountTransactional draftAccountTransactional;
 
-    @InjectMocks
+    @Mock
+    private BusinessUnitUser unitUser;
+
+    private Clock clock;
     private DraftAccountPublish draftAccountPublish;
 
     @BeforeEach
-    void openMocks() throws Exception {
-        draftAccountTransactional = spy(new DraftAccountTransactional(draftRepository, businessRepository,
-            securityEventLoggingService, clock));
-        injectDraftTransactionsService(draftAccountPublish, draftAccountTransactional);
+    void setUp() {
+        clock = Clock.fixed(Instant.parse("2026-06-25T00:00:00Z"), ZoneOffset.UTC);
+        draftAccountPublish = new DraftAccountPublish(draftAccountTransactional, clock);
     }
 
-    private void injectDraftTransactionsService(
-        DraftAccountPublish draftAccountPublish, DraftAccountTransactional draftAccountTransactional)
-        throws NoSuchFieldException, IllegalAccessException {
-
-        Field field = DraftAccountPublish.class.getDeclaredField("draftAccountTransactional");
-        field.setAccessible(true);
-        field.set(draftAccountPublish, draftAccountTransactional);
-
-    }
-
-    @SuppressWarnings("unchecked")
     @Test
-    void testPublishDefendantAccount_success() {
-        DraftAccountEntity existingFromDB = createPendingDraft();
-        when(draftRepository.findById(any())).thenReturn(Optional.of(existingFromDB));
-        when(draftRepository.save(any())).thenAnswer(invocationOnMock -> invocationOnMock.getArguments()[0]);
+    void publishDefendantAccount_success_delegatesAndReturnsTransactionalResult() {
+        DraftAccountEntity publishEntity = createPendingDraft();
+        DraftAccountEntity transactionalResult = createPublishedDraft();
+        when(draftAccountTransactional.publishDefendantAccount(publishEntity)).thenReturn(transactionalResult);
 
-        Map<String, Object> procResponse = Map.of(DEF_ACC_NO, "ACC-008", DEF_ACC_ID, Long.valueOf(8));
-        when(draftRepository.createDefendantAccount(anyLong(), anyShort(), any(), any()))
-            .thenReturn(procResponse);
+        DraftAccountEntity result = draftAccountPublish.publishDefendantAccount(publishEntity, unitUser);
 
-        BusinessUnitUser buu = createBUU();
-        DraftAccountEntity pending = cloneAndModify(existingFromDB, null);
-        DraftAccountEntity published = draftAccountPublish.publishDefendantAccount(pending, buu);
-
-        assertEquals(8L, published.getAccountId());
-        assertEquals("ACC-008", published.getAccountNumber());
-        assertEquals(DraftAccountStatus.PUBLISHED, published.getAccountStatus());
-
-        DraftAccountEntity expected = cloneAndModify(existingFromDB, DraftAccountStatus.PUBLISHED);
-        expected.setAccountId(8L);
-        expected.setAccountNumber("ACC-008");
-        assertEquals(expected, published);
+        assertSame(transactionalResult, result);
+        verify(draftAccountTransactional).publishDefendantAccount(publishEntity);
+        verify(draftAccountTransactional, never()).updateStatus(any(), any(), any());
     }
 
-    @SuppressWarnings("unchecked")
-    @Test
-    void testPublishDefendantAccount_procFailure() {
-
-        String operationId = "1234";
+    @ParameterizedTest
+    @MethodSource("publishDefendantAccountFailureCases")
+    void publishDefendantAccount_failure_updatesFailureState_andRethrows(
+        RuntimeException thrown,
+        String operationId,
+        String expectedUserId
+    ) {
+        when(unitUser.getBusinessUnitUserId()).thenReturn(expectedUserId);
+        when(draftAccountTransactional.publishDefendantAccount(any(DraftAccountEntity.class)))
+            .thenThrow(thrown);
+        DraftAccountEntity pending = createPendingDraft();
         try (MockedStatic<LogUtil> logUtilMock = Mockito.mockStatic(LogUtil.class)) {
             logUtilMock.when(LogUtil::getOrCreateOpalOperationId).thenReturn(operationId);
+            RuntimeException ex = assertThrows(
+                RuntimeException.class,
+                () -> draftAccountPublish.publishDefendantAccount(pending, unitUser)
+            );
+            assertInstanceOf(thrown.getClass(), ex);
 
-            DraftAccountEntity existingFromDB = createPendingDraft();
-            when(draftRepository.findById(any())).thenReturn(Optional.of(existingFromDB));
-            when(draftRepository.save(any())).thenAnswer(invocationOnMock -> invocationOnMock.getArguments()[0]);
+            if (ex instanceof JpaSystemException jpaEx) {
+                assertEquals("SQL Stored Procedure Error.", jpaEx.getMostSpecificCause().getMessage());
+            } else {
+                assertEquals(thrown.getMessage(), ex.getMessage());
+            }
 
-            when(draftRepository.createDefendantAccount(anyLong(), anyShort(), any(), any()))
-                .thenThrow(new JpaSystemException(new RuntimeException("SQL Stored Procedure Error.")));
+            ArgumentCaptor<DraftAccountEntity> captor = ArgumentCaptor.forClass(DraftAccountEntity.class);
 
-            BusinessUnitUser buu = createBUU();
-            DraftAccountEntity pending = cloneAndModify(existingFromDB, null);
-            DraftAccountEntity published = draftAccountPublish.publishDefendantAccount(pending, buu);
+            verify(draftAccountTransactional).publishDefendantAccount(any(DraftAccountEntity.class));
+            verify(draftAccountTransactional).updateStatus(
+                captor.capture(),
+                eq(DraftAccountStatus.PUBLISHING_FAILED),
+                same(draftAccountTransactional)
+            );
 
-            assertNull(published.getAccountId());
-            assertNull(published.getAccountNumber());
-            assertEquals(DraftAccountStatus.PUBLISHING_FAILED, published.getAccountStatus());
-            assertEquals(LogUtil.ERRMSG_STORED_PROC_FAILURE, published.getStatusMessage());
+            DraftAccountEntity failedUpdate = captor.getValue();
 
-            TimelineData timelineData = new TimelineData();
-            timelineData.insertEntry("Dave", DraftAccountStatus.PUBLISHING_FAILED.getLabel(),
-                LocalDate.now(clock), LogUtil.ERRMSG_STORED_PROC_FAILURE + " Error code: [" + operationId + "]");
-            assertEquals(timelineData.toJson(), published.getTimelineData());
+            assertEquals(pending.getDraftAccountId(), failedUpdate.getDraftAccountId());
+            assertEquals(pending.getVersionNumber(), failedUpdate.getVersionNumber());
+            assertEquals(LogUtil.ERRMSG_STORED_PROC_FAILURE, failedUpdate.getStatusMessage());
 
-            DraftAccountEntity expected = cloneAndModify(existingFromDB, DraftAccountStatus.PUBLISHING_FAILED);
-            assertEquals(expected, published);
+            TimelineData expectedTimeline = new TimelineData(pending.getTimelineData());
+            expectedTimeline.insertEntry(
+                expectedUserId,
+                DraftAccountStatus.PUBLISHING_FAILED.getLabel(),
+                LocalDate.now(clock),
+                LogUtil.ERRMSG_STORED_PROC_FAILURE + " Error code: [" + operationId + "]"
+            );
+            assertEquals(expectedTimeline.toJson(), failedUpdate.getTimelineData());
         }
     }
 
-    private String emptyTimelineData() {
-        return new TimelineData().toJson();
-    }
-
-    private BusinessUnitUser createBUU() {
-        return BusinessUnitUser.builder()
-            .businessUnitId((short)7)
-            .businessUnitUserId("Dave")
-            .build();
+    static Stream<Arguments> publishDefendantAccountFailureCases() {
+        return Stream.of(
+            Arguments.of(
+                new JpaSystemException(new RuntimeException("SQL Stored Procedure Error.")),
+                "1234",
+                "Dave"
+            ),
+            Arguments.of(
+                new InvalidDataAccessApiUsageException("bad request"),
+                "5678",
+                "Dave"
+            )
+        );
     }
 
     private DraftAccountEntity createPendingDraft() {
-        return DraftAccountEntity.builder()
-            .draftAccountId(1L)
-            .businessUnit(
-                BusinessUnitEntity.builder()
-                    .businessUnitId((short)6)
-                    .build())
-            .timelineData(emptyTimelineData())
-            .accountStatus(DraftAccountStatus.PUBLISHING_PENDING)
-            .submittedBy("Dave")
-            .versionNumber(6L)
-            .build();
+        TimelineData timelineData = new TimelineData();
+        timelineData.insertEntry(
+            "SUBMITTER",
+            DraftAccountStatus.SUBMITTED.getLabel(),
+            LocalDate.of(2026, 6, 22),
+            null
+        );
+
+        DraftAccountEntity entity = new DraftAccountEntity();
+        entity.setDraftAccountId(9_999_901L);
+        entity.setVersionNumber(0L);
+        entity.setTimelineData(timelineData.toJson());
+        entity.setAccountStatus(DraftAccountStatus.PUBLISHING_PENDING);
+        entity.setStatusMessage(null);
+        entity.setAccountId(null);
+        entity.setAccountNumber(null);
+        return entity;
     }
 
-    private DraftAccountEntity cloneAndModify(DraftAccountEntity original, DraftAccountStatus status) {
-        DraftAccountEntity clone =  mapper.clone(original);
-        Optional.ofNullable(status).ifPresent(clone::setAccountStatus);
-        return clone;
+    private DraftAccountEntity createPublishedDraft() {
+        DraftAccountEntity entity = createPendingDraft();
+        entity.setVersionNumber(1L);
+        entity.setAccountStatus(DraftAccountStatus.PUBLISHED);
+        entity.setAccountId(12345L);
+        entity.setAccountNumber("DEF-12345");
+        return entity;
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/DraftAccountPublishTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/DraftAccountPublishTest.java
@@ -1,9 +1,7 @@
 package uk.gov.hmcts.opal.service.opal;
 
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
@@ -69,7 +67,7 @@ class DraftAccountPublishTest {
 
     @ParameterizedTest
     @MethodSource("publishDefendantAccountFailureCases")
-    void publishDefendantAccount_failure_updatesFailureState_andRethrows(
+    void publishDefendantAccount_failure_updatesFailureState(
         RuntimeException thrown,
         String operationId,
         String expectedUserId
@@ -77,44 +75,36 @@ class DraftAccountPublishTest {
         when(unitUser.getBusinessUnitUserId()).thenReturn(expectedUserId);
         when(draftAccountTransactional.publishDefendantAccount(any(DraftAccountEntity.class)))
             .thenThrow(thrown);
+        when(draftAccountTransactional.updateStatus(
+            any(DraftAccountEntity.class),
+            eq(DraftAccountStatus.PUBLISHING_FAILED),
+            same(draftAccountTransactional)
+        )).thenAnswer(invocation -> invocation.getArgument(0));
         DraftAccountEntity pending = createPendingDraft();
         try (MockedStatic<LogUtil> logUtilMock = Mockito.mockStatic(LogUtil.class)) {
             logUtilMock.when(LogUtil::getOrCreateOpalOperationId).thenReturn(operationId);
-            RuntimeException ex = assertThrows(
-                RuntimeException.class,
-                () -> draftAccountPublish.publishDefendantAccount(pending, unitUser)
-            );
-            assertInstanceOf(thrown.getClass(), ex);
 
-            if (ex instanceof JpaSystemException jpaEx) {
-                assertEquals("SQL Stored Procedure Error.", jpaEx.getMostSpecificCause().getMessage());
-            } else {
-                assertEquals(thrown.getMessage(), ex.getMessage());
-            }
+            DraftAccountEntity result = draftAccountPublish.publishDefendantAccount(pending, unitUser);
 
             ArgumentCaptor<DraftAccountEntity> captor = ArgumentCaptor.forClass(DraftAccountEntity.class);
-
-            verify(draftAccountTransactional).publishDefendantAccount(any(DraftAccountEntity.class));
             verify(draftAccountTransactional).updateStatus(
                 captor.capture(),
                 eq(DraftAccountStatus.PUBLISHING_FAILED),
                 same(draftAccountTransactional)
             );
-
             DraftAccountEntity failedUpdate = captor.getValue();
-
+            assertEquals(failedUpdate, result);
             assertEquals(pending.getDraftAccountId(), failedUpdate.getDraftAccountId());
             assertEquals(pending.getVersionNumber(), failedUpdate.getVersionNumber());
             assertEquals(LogUtil.ERRMSG_STORED_PROC_FAILURE, failedUpdate.getStatusMessage());
-
             TimelineData expectedTimeline = new TimelineData(pending.getTimelineData());
+            assertEquals(expectedTimeline.toJson(), failedUpdate.getTimelineData());
             expectedTimeline.insertEntry(
                 expectedUserId,
                 DraftAccountStatus.PUBLISHING_FAILED.getLabel(),
                 LocalDate.now(clock),
                 LogUtil.ERRMSG_STORED_PROC_FAILURE + " Error code: [" + operationId + "]"
             );
-            assertEquals(expectedTimeline.toJson(), failedUpdate.getTimelineData());
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
@@ -20,7 +20,6 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,8 +50,8 @@ import uk.gov.hmcts.opal.entity.draft.DraftAccountEntity;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountStatus;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountType;
 import uk.gov.hmcts.opal.entity.draft.TimelineData;
-import uk.gov.hmcts.opal.exception.SubmitterDeniedException;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
+import uk.gov.hmcts.opal.exception.SubmitterDeniedException;
 import uk.gov.hmcts.opal.repository.BusinessUnitRepository;
 import uk.gov.hmcts.opal.repository.DraftAccountRepository;
 
@@ -79,7 +78,7 @@ class DraftAccountTransactionalTest {
     void testGetDraftAccount() {
         // Arrange
         DraftAccountEntity draftAccountEntity = DraftAccountEntity.builder().businessUnit(
-                BusinessUnitEntity.builder().businessUnitId((short)77).build())
+                BusinessUnitEntity.builder().businessUnitId((short) 77).build())
             .build();
         when(draftAccountRepository.findById(any())).thenReturn(Optional.of(draftAccountEntity));
 
@@ -98,7 +97,7 @@ class DraftAccountTransactionalTest {
         when(sfq.sortBy(any())).thenReturn(sfq);
 
         DraftAccountEntity draftAccountEntity = DraftAccountEntity.builder().businessUnit(
-                BusinessUnitEntity.builder().businessUnitId((short)77).build())
+                BusinessUnitEntity.builder().businessUnitId((short) 77).build())
             .build();
         Page<DraftAccountEntity> mockPage = new PageImpl<>(List.of(draftAccountEntity), Pageable.unpaged(), 999L);
         when(draftAccountRepository.findBy(any(Specification.class), any())).thenAnswer(iom -> {
@@ -143,7 +142,7 @@ class DraftAccountTransactionalTest {
         String minimalAccountJson = createAccountString();
 
         AddDraftAccountRequestDto dto = AddDraftAccountRequestDto.builder()
-            .businessUnitId((short)2)
+            .businessUnitId((short) 2)
             .submittedBy("TestUser")
             .submittedByName("Test User")
             .account(minimalAccountJson)
@@ -298,7 +297,7 @@ class DraftAccountTransactionalTest {
         // Arrange
         Long draftAccountId = 1L;
         ReplaceDraftAccountRequestDto replaceDto = ReplaceDraftAccountRequestDto.builder()
-            .businessUnitId((short)1)
+            .businessUnitId((short) 1)
             .accountType(DraftAccountType.FINE)
             .account(createAccountString())
             .submittedBy("TestUser")
@@ -320,7 +319,7 @@ class DraftAccountTransactionalTest {
         // Arrange
         Long draftAccountId = 1L;
         ReplaceDraftAccountRequestDto replaceDto = ReplaceDraftAccountRequestDto.builder()
-            .businessUnitId((short)2)
+            .businessUnitId((short) 2)
             .accountType(DraftAccountType.FINE)
             .account(createAccountString())
             .submittedBy("TestUser")
@@ -681,7 +680,8 @@ class DraftAccountTransactionalTest {
             draftAccountTransactional
         );
 
-        Assertions.assertDoesNotThrow(() -> { }); // Stops SonarQube complaining about no assertions in method.
+        Assertions.assertDoesNotThrow(() -> {
+        }); // Stops SonarQube complaining about no assertions in method.
     }
 
     @Test
@@ -691,7 +691,7 @@ class DraftAccountTransactionalTest {
             .draftAccountId(7L)
             .versionNumber(0L)
             .businessUnit(BusinessUnitEntity.builder()
-                .businessUnitId((short)78)
+                .businessUnitId((short) 78)
                 .build())
             .submittedBy("BU001")
             .submittedByName("Malcolm Mclaren")

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
@@ -707,27 +707,6 @@ class DraftAccountTransactionalTest {
         assertSame(output, draftAccountEntity);
     }
 
-
-    @Test
-    void testPublishAccountStoredProc() {
-        // Arrange
-        DraftAccountEntity draftAccountEntity = DraftAccountEntity.builder()
-            .draftAccountId(007L)
-            .businessUnit(BusinessUnitEntity.builder()
-                .businessUnitId((short)78)
-                .build())
-            .submittedBy("BU001")
-            .submittedByName("Malcolm Mclaren")
-            .build();
-        Map<String, Object> mockOutputs = Collections.emptyMap();
-        when(draftAccountRepository.createDefendantAccount(any(), any(), any(), any()))
-            .thenReturn(mockOutputs);
-
-        // Act
-        Map<String, Object> outputs = draftAccountTransactional.publishAccountStoredProc(draftAccountEntity);
-        assertNotNull(outputs);
-    }
-
     private String createTimelineDataString() {
         return """
             [{

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
@@ -700,7 +700,7 @@ class DraftAccountTransactionalTest {
         when(draftAccountRepository.createDefendantAccount(any(), any(), any(), any()))
             .thenReturn(mockOutputs);
         when(draftAccountRepository.findById(7L)).thenReturn(Optional.ofNullable(draftAccountEntity));
-        when(draftAccountRepository.save(any())).thenReturn(draftAccountEntity);
+        when(draftAccountRepository.saveAndFlush(any())).thenReturn(draftAccountEntity);
 
         // Act
         DraftAccountEntity output = draftAccountTransactional.publishDefendantAccount(draftAccountEntity);

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
@@ -16,6 +16,7 @@ import static uk.gov.hmcts.opal.entity.draft.StoredProcedureNames.DEF_ACC_NO;
 
 import jakarta.persistence.EntityNotFoundException;
 import java.math.BigInteger;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -32,6 +33,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -49,8 +51,8 @@ import uk.gov.hmcts.opal.entity.draft.DraftAccountEntity;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountStatus;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountType;
 import uk.gov.hmcts.opal.entity.draft.TimelineData;
-import uk.gov.hmcts.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.opal.exception.SubmitterDeniedException;
+import uk.gov.hmcts.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.opal.repository.BusinessUnitRepository;
 import uk.gov.hmcts.opal.repository.DraftAccountRepository;
 
@@ -64,6 +66,9 @@ class DraftAccountTransactionalTest {
     @Mock
     private BusinessUnitRepository businessUnitRepository;
 
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
+
     @InjectMocks
     private DraftAccountTransactional draftAccountTransactional;
 
@@ -74,7 +79,7 @@ class DraftAccountTransactionalTest {
     void testGetDraftAccount() {
         // Arrange
         DraftAccountEntity draftAccountEntity = DraftAccountEntity.builder().businessUnit(
-                BusinessUnitEntity.builder().businessUnitId((short) 77).build())
+                BusinessUnitEntity.builder().businessUnitId((short)77).build())
             .build();
         when(draftAccountRepository.findById(any())).thenReturn(Optional.of(draftAccountEntity));
 
@@ -93,7 +98,7 @@ class DraftAccountTransactionalTest {
         when(sfq.sortBy(any())).thenReturn(sfq);
 
         DraftAccountEntity draftAccountEntity = DraftAccountEntity.builder().businessUnit(
-                BusinessUnitEntity.builder().businessUnitId((short) 77).build())
+                BusinessUnitEntity.builder().businessUnitId((short)77).build())
             .build();
         Page<DraftAccountEntity> mockPage = new PageImpl<>(List.of(draftAccountEntity), Pageable.unpaged(), 999L);
         when(draftAccountRepository.findBy(any(Specification.class), any())).thenAnswer(iom -> {
@@ -138,7 +143,7 @@ class DraftAccountTransactionalTest {
         String minimalAccountJson = createAccountString();
 
         AddDraftAccountRequestDto dto = AddDraftAccountRequestDto.builder()
-            .businessUnitId((short) 2)
+            .businessUnitId((short)2)
             .submittedBy("TestUser")
             .submittedByName("Test User")
             .account(minimalAccountJson)
@@ -293,7 +298,7 @@ class DraftAccountTransactionalTest {
         // Arrange
         Long draftAccountId = 1L;
         ReplaceDraftAccountRequestDto replaceDto = ReplaceDraftAccountRequestDto.builder()
-            .businessUnitId((short) 1)
+            .businessUnitId((short)1)
             .accountType(DraftAccountType.FINE)
             .account(createAccountString())
             .submittedBy("TestUser")
@@ -315,7 +320,7 @@ class DraftAccountTransactionalTest {
         // Arrange
         Long draftAccountId = 1L;
         ReplaceDraftAccountRequestDto replaceDto = ReplaceDraftAccountRequestDto.builder()
-            .businessUnitId((short) 2)
+            .businessUnitId((short)2)
             .accountType(DraftAccountType.FINE)
             .account(createAccountString())
             .submittedBy("TestUser")
@@ -676,8 +681,7 @@ class DraftAccountTransactionalTest {
             draftAccountTransactional
         );
 
-        Assertions.assertDoesNotThrow(() -> {
-        }); // Stops SonarQube complaining about no assertions in method.
+        Assertions.assertDoesNotThrow(() -> { }); // Stops SonarQube complaining about no assertions in method.
     }
 
     @Test
@@ -687,7 +691,7 @@ class DraftAccountTransactionalTest {
             .draftAccountId(7L)
             .versionNumber(0L)
             .businessUnit(BusinessUnitEntity.builder()
-                .businessUnitId((short) 78)
+                .businessUnitId((short)78)
                 .build())
             .submittedBy("BU001")
             .submittedByName("Malcolm Mclaren")
@@ -710,7 +714,7 @@ class DraftAccountTransactionalTest {
         DraftAccountEntity draftAccountEntity = DraftAccountEntity.builder()
             .draftAccountId(007L)
             .businessUnit(BusinessUnitEntity.builder()
-                .businessUnitId((short) 78)
+                .businessUnitId((short)78)
                 .build())
             .submittedBy("BU001")
             .submittedByName("Malcolm Mclaren")

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.opal.service.opal.jpa;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -11,10 +12,10 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.opal.entity.draft.StoredProcedureNames.DEF_ACC_NO;
 
 import jakarta.persistence.EntityNotFoundException;
 import java.math.BigInteger;
-import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -31,7 +32,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -49,8 +49,8 @@ import uk.gov.hmcts.opal.entity.draft.DraftAccountEntity;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountStatus;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountType;
 import uk.gov.hmcts.opal.entity.draft.TimelineData;
-import uk.gov.hmcts.opal.exception.SubmitterDeniedException;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
+import uk.gov.hmcts.opal.exception.SubmitterDeniedException;
 import uk.gov.hmcts.opal.repository.BusinessUnitRepository;
 import uk.gov.hmcts.opal.repository.DraftAccountRepository;
 
@@ -64,9 +64,6 @@ class DraftAccountTransactionalTest {
     @Mock
     private BusinessUnitRepository businessUnitRepository;
 
-    @Spy
-    private Clock clock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
-
     @InjectMocks
     private DraftAccountTransactional draftAccountTransactional;
 
@@ -77,7 +74,7 @@ class DraftAccountTransactionalTest {
     void testGetDraftAccount() {
         // Arrange
         DraftAccountEntity draftAccountEntity = DraftAccountEntity.builder().businessUnit(
-                BusinessUnitEntity.builder().businessUnitId((short)77).build())
+                BusinessUnitEntity.builder().businessUnitId((short) 77).build())
             .build();
         when(draftAccountRepository.findById(any())).thenReturn(Optional.of(draftAccountEntity));
 
@@ -96,7 +93,7 @@ class DraftAccountTransactionalTest {
         when(sfq.sortBy(any())).thenReturn(sfq);
 
         DraftAccountEntity draftAccountEntity = DraftAccountEntity.builder().businessUnit(
-                BusinessUnitEntity.builder().businessUnitId((short)77).build())
+                BusinessUnitEntity.builder().businessUnitId((short) 77).build())
             .build();
         Page<DraftAccountEntity> mockPage = new PageImpl<>(List.of(draftAccountEntity), Pageable.unpaged(), 999L);
         when(draftAccountRepository.findBy(any(Specification.class), any())).thenAnswer(iom -> {
@@ -141,7 +138,7 @@ class DraftAccountTransactionalTest {
         String minimalAccountJson = createAccountString();
 
         AddDraftAccountRequestDto dto = AddDraftAccountRequestDto.builder()
-            .businessUnitId((short)2)
+            .businessUnitId((short) 2)
             .submittedBy("TestUser")
             .submittedByName("Test User")
             .account(minimalAccountJson)
@@ -296,7 +293,7 @@ class DraftAccountTransactionalTest {
         // Arrange
         Long draftAccountId = 1L;
         ReplaceDraftAccountRequestDto replaceDto = ReplaceDraftAccountRequestDto.builder()
-            .businessUnitId((short)1)
+            .businessUnitId((short) 1)
             .accountType(DraftAccountType.FINE)
             .account(createAccountString())
             .submittedBy("TestUser")
@@ -318,7 +315,7 @@ class DraftAccountTransactionalTest {
         // Arrange
         Long draftAccountId = 1L;
         ReplaceDraftAccountRequestDto replaceDto = ReplaceDraftAccountRequestDto.builder()
-            .businessUnitId((short)2)
+            .businessUnitId((short) 2)
             .accountType(DraftAccountType.FINE)
             .account(createAccountString())
             .submittedBy("TestUser")
@@ -679,8 +676,33 @@ class DraftAccountTransactionalTest {
             draftAccountTransactional
         );
 
-        Assertions.assertDoesNotThrow(() -> { }); // Stops SonarQube complaining about no assertions in method.
+        Assertions.assertDoesNotThrow(() -> {
+        }); // Stops SonarQube complaining about no assertions in method.
     }
+
+    @Test
+    void testPublishDefendantAccount() {
+        // Arrange
+        DraftAccountEntity draftAccountEntity = DraftAccountEntity.builder()
+            .draftAccountId(7L)
+            .versionNumber(0L)
+            .businessUnit(BusinessUnitEntity.builder()
+                .businessUnitId((short) 78)
+                .build())
+            .submittedBy("BU001")
+            .submittedByName("Malcolm Mclaren")
+            .build();
+        Map<String, Object> mockOutputs = Map.of(DEF_ACC_NO, "7");
+        when(draftAccountRepository.createDefendantAccount(any(), any(), any(), any()))
+            .thenReturn(mockOutputs);
+        when(draftAccountRepository.findById(7L)).thenReturn(Optional.ofNullable(draftAccountEntity));
+        when(draftAccountRepository.save(any())).thenReturn(draftAccountEntity);
+
+        // Act
+        DraftAccountEntity output = draftAccountTransactional.publishDefendantAccount(draftAccountEntity);
+        assertSame(output, draftAccountEntity);
+    }
+
 
     @Test
     void testPublishAccountStoredProc() {
@@ -688,7 +710,7 @@ class DraftAccountTransactionalTest {
         DraftAccountEntity draftAccountEntity = DraftAccountEntity.builder()
             .draftAccountId(007L)
             .businessUnit(BusinessUnitEntity.builder()
-                .businessUnitId((short)78)
+                .businessUnitId((short) 78)
                 .build())
             .submittedBy("BU001")
             .submittedByName("Malcolm Mclaren")


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-7911

### Change description ###
Fix the transactional behaviour of Publish Draft Accounts in Opal mode and add tests

- If publishing fails, set status of failed in the database
- If publishing succeeds but setting of status in the database fails, roll back the publish (ie. have the requests in one transaction)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
