### PR TITLE
PO-3863-db-enum-alignment-ResultEntity

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
@@ -590,7 +590,7 @@ class ResultControllerIntegrationTest extends AbstractIntegrationTest {
         String secondBody = performRequest();
 
         assertEquals(firstBody, secondBody);
-        verify(resultRepository, times(1)).findById("BBBBBB");
+        verify(resultRepository, times(1)).findWithFullGraphByResultId("BBBBBB");
     }
 
     private String performRequest() throws Exception {

--- a/src/main/java/uk/gov/hmcts/opal/entity/converter/ImpositionCreditorConverter.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/converter/ImpositionCreditorConverter.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.opal.entity.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.apache.logging.log4j.util.Strings;
+import uk.gov.hmcts.opal.entity.result.ImpositionCreditor;
+
+@Converter(autoApply = true)
+public class ImpositionCreditorConverter implements AttributeConverter<ImpositionCreditor, String> {
+
+    @Override
+    public String convertToDatabaseColumn(ImpositionCreditor attribute) {
+        return attribute == null ? null : attribute.getLabel();
+    }
+
+    @Override
+    public ImpositionCreditor convertToEntityAttribute(String dbData) {
+        return Strings.isBlank(dbData) ? null : ImpositionCreditor.getByLabel(dbData);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/entity/converter/ResultTypeConverter.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/converter/ResultTypeConverter.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.opal.entity.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.apache.logging.log4j.util.Strings;
+import uk.gov.hmcts.opal.entity.result.ResultType;
+
+@Converter(autoApply = true)
+public class ResultTypeConverter implements AttributeConverter<ResultType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(ResultType attribute) {
+        return attribute == null ? null : attribute.getLabel();
+    }
+
+    @Override
+    public ResultType convertToEntityAttribute(String dbData) {
+        return Strings.isBlank(dbData) ? null : ResultType.getByLabel(dbData);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/entity/result/ImpositionCreditor.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/result/ImpositionCreditor.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.opal.entity.result;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+
+public enum ImpositionCreditor {
+    ANY("Any"),
+    CF("CF"),
+    NOT_CPS("!CPS"),
+    CPS("CPS");
+
+    private final String label;
+
+    ImpositionCreditor(String label) {
+        this.label = label;
+    }
+
+    @JsonValue
+    public String getLabel() {
+        return label;
+    }
+
+    public static ImpositionCreditor getByLabel(String label) {
+        return Arrays.stream(values())
+            .filter(impositionCreditor -> impositionCreditor.label.equals(label))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Unknown ImpositionCreditor: " + label));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/entity/result/ResultEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/result/ResultEntity.java
@@ -6,6 +6,8 @@ import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.NamedAttributeNode;
 import jakarta.persistence.NamedEntityGraph;
 import jakarta.persistence.OneToMany;
@@ -19,6 +21,7 @@ import org.hibernate.annotations.ColumnTransformer;
 import uk.gov.hmcts.opal.entity.enforcement.EnforcementEntity;
 import uk.gov.hmcts.opal.entity.converter.ImpositionCreditorConverter;
 import uk.gov.hmcts.opal.entity.converter.ResultTypeConverter;
+import uk.gov.hmcts.opal.entity.ImpositionCategoriesEntity;
 
 import java.util.List;
 
@@ -34,7 +37,8 @@ import java.util.List;
 @NamedEntityGraph(
     name = ResultEntity.ENTITY_GRAPH_FULL,
     attributeNodes = {
-        @NamedAttributeNode("enforcements")
+        @NamedAttributeNode("enforcements"),
+        @NamedAttributeNode("impositionCategory")
     }
 )
 public class ResultEntity {
@@ -72,8 +76,9 @@ public class ResultEntity {
     @Column(name = "imposition", nullable = false)
     private boolean imposition;
 
-    @Column(name = "imposition_category", length = 30)
-    private String impositionCategory;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "imposition_category", referencedColumnName = "imposition_category")
+    private ImpositionCategoriesEntity impositionCategory;
 
     @Column(name = "imposition_accruing")
     private Boolean impositionAccruing;

--- a/src/main/java/uk/gov/hmcts/opal/entity/result/ResultEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/result/ResultEntity.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.opal.entity.result;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
@@ -14,7 +15,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.ColumnTransformer;
 import uk.gov.hmcts.opal.entity.enforcement.EnforcementEntity;
+import uk.gov.hmcts.opal.entity.converter.ImpositionCreditorConverter;
+import uk.gov.hmcts.opal.entity.converter.ResultTypeConverter;
 
 import java.util.List;
 
@@ -48,8 +52,10 @@ public class ResultEntity {
     @Column(name = "result_title_cy", length = 50, nullable = false)
     private String resultTitleCy;
 
-    @Column(name = "result_type", length = 10, nullable = false)
-    private String resultType;
+    @Convert(converter = ResultTypeConverter.class)
+    @ColumnTransformer(read = "result_type::text", write = "?::t_result_type_enum")
+    @Column(name = "result_type", length = 10, nullable = false, columnDefinition = "t_result_type_enum")
+    private ResultType resultType;
 
     @Column(name = "active", nullable = false)
     private boolean active;
@@ -58,8 +64,10 @@ public class ResultEntity {
     @Column(name = "imposition_allocation_priority")
     private Short impositionAllocationPriority;
 
-    @Column(name = "imposition_creditor", length = 10)
-    private String impositionCreditor;
+    @Convert(converter = ImpositionCreditorConverter.class)
+    @ColumnTransformer(read = "imposition_creditor::text", write = "?::t_imposition_creditor_enum")
+    @Column(name = "imposition_creditor", length = 10, columnDefinition = "t_imposition_creditor_enum")
+    private ImpositionCreditor impositionCreditor;
 
     @Column(name = "imposition", nullable = false)
     private boolean imposition;

--- a/src/main/java/uk/gov/hmcts/opal/entity/result/ResultType.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/result/ResultType.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.opal.entity.result;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
+
+public enum ResultType {
+    ACTION("Action"),
+    RESULT("Result");
+
+    private final String label;
+
+    ResultType(String label) {
+        this.label = label;
+    }
+
+    @JsonValue
+    public String getLabel() {
+        return label;
+    }
+
+    public static ResultType getByLabel(String label) {
+        return Arrays.stream(values())
+            .filter(resultType -> resultType.label.equals(label))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Unknown ResultType: " + label));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/mapper/ResultMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/mapper/ResultMapper.java
@@ -4,7 +4,9 @@ import org.mapstruct.Mapper;
 import uk.gov.hmcts.opal.dto.ResultDto;
 import uk.gov.hmcts.opal.dto.reference.ResultReferenceData;
 import uk.gov.hmcts.opal.dto.reference.ResultReferenceDataResponse;
+import uk.gov.hmcts.opal.entity.result.ImpositionCreditor;
 import uk.gov.hmcts.opal.entity.result.ResultEntity;
+import uk.gov.hmcts.opal.entity.result.ResultType;
 
 import java.util.List;
 
@@ -24,4 +26,12 @@ public interface ResultMapper {
     }
 
     ResultDto toDto(ResultEntity entity);
+
+    default String map(ResultType resultType) {
+        return resultType == null ? null : resultType.getLabel();
+    }
+
+    default String map(ImpositionCreditor impositionCreditor) {
+        return impositionCreditor == null ? null : impositionCreditor.getLabel();
+    }
 }

--- a/src/main/java/uk/gov/hmcts/opal/mapper/ResultMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/mapper/ResultMapper.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.opal.mapper;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import uk.gov.hmcts.opal.dto.ResultDto;
 import uk.gov.hmcts.opal.dto.reference.ResultReferenceData;
 import uk.gov.hmcts.opal.dto.reference.ResultReferenceDataResponse;
@@ -25,6 +26,7 @@ public interface ResultMapper {
             .build();
     }
 
+    @Mapping(target = "impositionCategory", source = "impositionCategory.impositionCategory")
     ResultDto toDto(ResultEntity entity);
 
     default String map(ResultType resultType) {

--- a/src/main/java/uk/gov/hmcts/opal/repository/ResultRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/ResultRepository.java
@@ -19,6 +19,9 @@ public interface ResultRepository extends JpaRepository<ResultEntity, String>,
     @EntityGraph(value = ResultEntity.ENTITY_GRAPH_LITE, type = EntityGraph.EntityGraphType.FETCH)
     Optional<ResultEntity> findById(String resultId);
 
+    @EntityGraph(value = ResultEntity.ENTITY_GRAPH_FULL, type = EntityGraph.EntityGraphType.FETCH)
+    Optional<ResultEntity> findWithFullGraphByResultId(String resultId);
+
     @Override
     @EntityGraph(value = ResultEntity.ENTITY_GRAPH_LITE, type = EntityGraph.EntityGraphType.FETCH)
     <S extends ResultEntity, R> R findBy(

--- a/src/main/java/uk/gov/hmcts/opal/repository/jpa/ResultSpecs.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/jpa/ResultSpecs.java
@@ -1,10 +1,11 @@
 package uk.gov.hmcts.opal.repository.jpa;
 
+import org.hibernate.query.criteria.JpaExpression;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.opal.dto.search.ResultSearchDto;
 import uk.gov.hmcts.opal.entity.result.ResultEntity;
 import uk.gov.hmcts.opal.entity.result.ResultEntity_;
+import uk.gov.hmcts.opal.dto.search.ResultSearchDto;
 
 import java.util.List;
 import java.util.Optional;
@@ -71,8 +72,8 @@ public class ResultSpecs extends EntitySpecs<ResultEntity> {
     }
 
     public static Specification<ResultEntity> likeResultType(String resultType) {
-        return (root, query, builder) ->
-            likeWildcardPredicate(root.get(ResultEntity_.resultType), builder, resultType);
+        return (root, query, builder) -> likeWildcardPredicate(
+            ((JpaExpression<?>) root.get(ResultEntity_.resultType)).cast(String.class), builder, resultType);
     }
 
     public static Specification<ResultEntity>
@@ -82,8 +83,9 @@ public class ResultSpecs extends EntitySpecs<ResultEntity> {
     }
 
     public static Specification<ResultEntity> likeImpositionCreditor(String impositionCreditor) {
-        return (root, query, builder) -> likeWildcardPredicate(root.get(ResultEntity_.impositionCreditor), builder,
-                                                               impositionCreditor);
+        return (root, query, builder) -> likeWildcardPredicate(
+            ((JpaExpression<?>) root.get(ResultEntity_.impositionCreditor)).cast(String.class), builder,
+            impositionCreditor);
     }
 
     public Specification<ResultEntity> likeAnyResult(String filter) {

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/ResultService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/ResultService.java
@@ -49,8 +49,9 @@ public class ResultService {
     }
 
     @Cacheable(value = "resultsCache", key = "#root.method.name + '_' + #resultId + '_' + #includeWelsh")
+    @Transactional(readOnly = true)
     public ResultDto getResult(String resultId, boolean includeWelsh) {
-        ResultEntity entity = resultRepository.findById(resultId)
+        ResultEntity entity = resultRepository.findWithFullGraphByResultId(resultId)
             .orElseThrow(() -> new EntityNotFoundException("'Result' not found with id: " + resultId));
 
         ResultDto result = resultMapper.toDto(entity);

--- a/src/main/resources/db/migration/ddl/V1_230__alter_results_enum_columns_and_imposition_category_fk.sql
+++ b/src/main/resources/db/migration/ddl/V1_230__alter_results_enum_columns_and_imposition_category_fk.sql
@@ -1,0 +1,34 @@
+/**
+* OPAL Program
+*
+* MODULE      : alter_results_enum_columns_and_imposition_category_fk.sql
+*
+* DESCRIPTION : Alter results enum-backed columns and imposition category foreign key
+*
+* VERSION HISTORY:
+*
+* Date          Author         Version     Nature of Change
+* ----------    -----------    --------    --------------------------------------------------------------------------------------------------
+* 03/06/2026    TMc            1.0         PO-3846 - Update columns on RESULTS table to use PostgreSQL ENUM and add FK to imposition_category
+*
+**/
+
+ALTER TABLE results
+    DROP CONSTRAINT IF EXISTS results_result_type_cc,
+    DROP CONSTRAINT IF EXISTS results_imposition_creditor_cc,
+    DROP CONSTRAINT IF EXISTS results_imposition_category_cc;
+
+ALTER TABLE results
+    ALTER COLUMN result_type TYPE t_result_type_enum
+        USING result_type::text::t_result_type_enum,
+    ALTER COLUMN imposition_creditor TYPE t_imposition_creditor_enum
+        USING imposition_creditor::text::t_imposition_creditor_enum;
+
+COMMENT ON COLUMN results.result_type IS 'Indicates if this is an actual result or just an action. Hard-coded in legacy GoB. Specific values can be found in the DB LLD on Confluence.';
+COMMENT ON COLUMN results.imposition_creditor IS 'Indicates the creditor to be used for the imposition. Hard-coded in legacy GoB. Specific values can be found in the DB LLD on Confluence.';
+
+ALTER TABLE results
+    ADD CONSTRAINT results_imposition_category_fk FOREIGN KEY (imposition_category)
+    REFERENCES imposition_categories (imposition_category);
+
+CREATE INDEX results_imposition_category_idx ON results (imposition_category);

--- a/src/test/java/uk/gov/hmcts/opal/controllers/ResultControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/ResultControllerTest.java
@@ -65,7 +65,7 @@ class ResultControllerTest {
             .resultId("ABC")
             .resultTitle("Some Title")
             .resultTitleCy("Welsh Title")
-            .resultType("TYPE1")
+            .resultType("Action")
             .active(true)
             .allowAdditionalAction(true)
             .allowPaymentTerms(false)
@@ -84,7 +84,7 @@ class ResultControllerTest {
         assertEquals("ABC", response.getBody().getResultId());
         assertEquals("Some Title", response.getBody().getResultTitle());
         assertEquals("Welsh Title", response.getBody().getResultTitleCy());
-        assertEquals("TYPE1", response.getBody().getResultType());
+        assertEquals("Action", response.getBody().getResultType());
         assertEquals(true, response.getBody().isActive());
         assertEquals(true, response.getBody().getAllowAdditionalAction());
         assertEquals(false, response.getBody().getAllowPaymentTerms());

--- a/src/test/java/uk/gov/hmcts/opal/disco/opal/ResultServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/disco/opal/ResultServiceTest.java
@@ -251,7 +251,7 @@ class ResultServiceTest {
             .requiresEmploymentData(true)
             .build();
 
-        when(resultRepository.findById("ABC")).thenReturn(Optional.of(entity));
+        when(resultRepository.findWithFullGraphByResultId("ABC")).thenReturn(Optional.of(entity));
         when(resultMapper.toDto(entity)).thenReturn(dto);
 
         // Act
@@ -262,7 +262,7 @@ class ResultServiceTest {
         assertEquals("ABC", result.getResultId());
         assertEquals("Result Title", result.getResultTitle());
         assertEquals(true, result.getRequiresEmploymentData());
-        verify(resultRepository).findById("ABC");
+        verify(resultRepository).findWithFullGraphByResultId("ABC");
         verify(resultMapper).toDto(entity);
     }
 
@@ -294,7 +294,7 @@ class ResultServiceTest {
             .resultParameters(resultParameters)
             .build();
 
-        when(resultRepository.findById("ABC")).thenReturn(Optional.of(entity));
+        when(resultRepository.findWithFullGraphByResultId("ABC")).thenReturn(Optional.of(entity));
         when(resultMapper.toDto(entity)).thenReturn(dto);
 
         // Act
@@ -339,7 +339,7 @@ class ResultServiceTest {
             .resultParameters(resultParameters)
             .build();
 
-        when(resultRepository.findById("ABC")).thenReturn(Optional.of(entity));
+        when(resultRepository.findWithFullGraphByResultId("ABC")).thenReturn(Optional.of(entity));
         when(resultMapper.toDto(entity)).thenReturn(dto);
 
         // Act
@@ -380,7 +380,7 @@ class ResultServiceTest {
             .resultParameters(resultParameters)
             .build();
 
-        when(resultRepository.findById("ABC")).thenReturn(Optional.of(entity));
+        when(resultRepository.findWithFullGraphByResultId("ABC")).thenReturn(Optional.of(entity));
         when(resultMapper.toDto(entity)).thenReturn(dto);
 
         // Act
@@ -396,7 +396,7 @@ class ResultServiceTest {
     @Test
     void testGetResult_ThrowsWhenNotFound() {
         // Arrange
-        when(resultRepository.findById("MISSING")).thenReturn(Optional.empty());
+        when(resultRepository.findWithFullGraphByResultId("MISSING")).thenReturn(Optional.empty());
 
         // Act + Assert
         org.junit.jupiter.api.Assertions.assertThrows(

--- a/src/test/java/uk/gov/hmcts/opal/disco/opal/ResultServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/disco/opal/ResultServiceTest.java
@@ -27,6 +27,7 @@ import uk.gov.hmcts.opal.dto.reference.ResultReferenceData;
 import uk.gov.hmcts.opal.dto.reference.ResultReferenceDataResponse;
 import uk.gov.hmcts.opal.dto.search.ResultSearchDto;
 import uk.gov.hmcts.opal.entity.result.ResultEntity;
+import uk.gov.hmcts.opal.entity.result.ResultType;
 import uk.gov.hmcts.opal.mapper.ResultMapper;
 import uk.gov.hmcts.opal.repository.ResultRepository;
 import uk.gov.hmcts.opal.repository.jpa.ResultSpecs;
@@ -220,8 +221,8 @@ class ResultServiceTest {
             entity.getResultTitle(),
             entity.getResultTitleCy(),
             entity.isActive(),
-            entity.getResultType(),
-            entity.getImpositionCreditor(),
+            entity.getResultType() == null ? null : entity.getResultType().getLabel(),
+            entity.getImpositionCreditor() == null ? null : entity.getImpositionCreditor().getLabel(),
             entity.getImpositionAllocationPriority()
         );
 
@@ -236,7 +237,7 @@ class ResultServiceTest {
             .resultId("ABC")
             .resultTitle("Result Title")
             .resultTitleCy("Welsh Title")
-            .resultType("TYPE1")
+            .resultType(ResultType.ACTION)
             .active(true)
             .requiresEmploymentData(true)
             .build();
@@ -245,7 +246,7 @@ class ResultServiceTest {
             .resultId("ABC")
             .resultTitle("Result Title")
             .resultTitleCy("Welsh Title")
-            .resultType("TYPE1")
+            .resultType("Action")
             .active(true)
             .requiresEmploymentData(true)
             .build();

--- a/src/test/java/uk/gov/hmcts/opal/entity/converter/ImpositionCreditorConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/entity/converter/ImpositionCreditorConverterTest.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.opal.entity.converter;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.opal.entity.result.ImpositionCreditor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ImpositionCreditorConverterTest {
+
+    private final ImpositionCreditorConverter converter = new ImpositionCreditorConverter();
+
+    @Test
+    void given_impositionCreditor_when_convertToDatabaseColumn_then_returnsLabel() {
+        assertEquals("Any", converter.convertToDatabaseColumn(ImpositionCreditor.ANY));
+        assertEquals("CF", converter.convertToDatabaseColumn(ImpositionCreditor.CF));
+        assertEquals("!CPS", converter.convertToDatabaseColumn(ImpositionCreditor.NOT_CPS));
+        assertEquals("CPS", converter.convertToDatabaseColumn(ImpositionCreditor.CPS));
+    }
+
+    @Test
+    void given_nullImpositionCreditor_when_convertToDatabaseColumn_then_returnsNull() {
+        assertNull(converter.convertToDatabaseColumn(null));
+    }
+
+    @Test
+    void given_validLabel_when_convertToEntityAttribute_then_returnsImpositionCreditor() {
+        assertEquals(ImpositionCreditor.ANY, converter.convertToEntityAttribute("Any"));
+        assertEquals(ImpositionCreditor.CF, converter.convertToEntityAttribute("CF"));
+        assertEquals(ImpositionCreditor.NOT_CPS, converter.convertToEntityAttribute("!CPS"));
+        assertEquals(ImpositionCreditor.CPS, converter.convertToEntityAttribute("CPS"));
+    }
+
+    @Test
+    void given_blankOrNullLabel_when_convertToEntityAttribute_then_returnsNull() {
+        assertNull(converter.convertToEntityAttribute(null));
+        assertNull(converter.convertToEntityAttribute(""));
+        assertNull(converter.convertToEntityAttribute(" "));
+    }
+
+    @Test
+    void given_unknownLabel_when_convertToEntityAttribute_then_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> converter.convertToEntityAttribute("Unknown"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/entity/converter/ResultTypeConverterTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/entity/converter/ResultTypeConverterTest.java
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.opal.entity.converter;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.opal.entity.result.ResultType;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ResultTypeConverterTest {
+
+    private final ResultTypeConverter converter = new ResultTypeConverter();
+
+    @Test
+    void given_resultType_when_convertToDatabaseColumn_then_returnsLabel() {
+        assertEquals("Action", converter.convertToDatabaseColumn(ResultType.ACTION));
+        assertEquals("Result", converter.convertToDatabaseColumn(ResultType.RESULT));
+    }
+
+    @Test
+    void given_nullResultType_when_convertToDatabaseColumn_then_returnsNull() {
+        assertNull(converter.convertToDatabaseColumn(null));
+    }
+
+    @Test
+    void given_validLabel_when_convertToEntityAttribute_then_returnsResultType() {
+        assertEquals(ResultType.ACTION, converter.convertToEntityAttribute("Action"));
+        assertEquals(ResultType.RESULT, converter.convertToEntityAttribute("Result"));
+    }
+
+    @Test
+    void given_blankOrNullLabel_when_convertToEntityAttribute_then_returnsNull() {
+        assertNull(converter.convertToEntityAttribute(null));
+        assertNull(converter.convertToEntityAttribute(""));
+        assertNull(converter.convertToEntityAttribute(" "));
+    }
+
+    @Test
+    void given_unknownLabel_when_convertToEntityAttribute_then_throwsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> converter.convertToEntityAttribute("Unknown"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/mapper/ResultMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/mapper/ResultMapperTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 import uk.gov.hmcts.opal.dto.reference.ResultReferenceData;
 import uk.gov.hmcts.opal.dto.reference.ResultReferenceDataResponse;
+import uk.gov.hmcts.opal.entity.ImpositionCategoriesEntity;
 import uk.gov.hmcts.opal.entity.result.ImpositionCreditor;
 import uk.gov.hmcts.opal.entity.result.ResultEntity;
 import uk.gov.hmcts.opal.entity.result.ResultType;
@@ -47,6 +48,10 @@ class ResultMapperTest {
     @Test
     void toRefDataFromFull_shouldMapFullEntityToDto() {
         // Arrange
+        ImpositionCategoriesEntity finesCategory = ImpositionCategoriesEntity.builder()
+            .impositionCategory("Fines")
+            .build();
+
         ResultEntity entity = ResultEntity.builder()
             .resultId("R456")
             .resultTitle("Full Result")
@@ -57,7 +62,7 @@ class ResultMapperTest {
             .impositionCreditor(ImpositionCreditor.ANY)
             // Include additional fields present only in Full entity
             .imposition(true)
-            .impositionCategory("Fines")
+            .impositionCategory(finesCategory)
             .impositionAccruing(false)
             .build();
 
@@ -111,7 +116,11 @@ class ResultMapperTest {
 
     @Test
     void toDto_shouldMapLiteEntityToFullResultDto() {
-        // Arrange — build full entity
+        // Arrange
+        ImpositionCategoriesEntity compensationCategory = ImpositionCategoriesEntity.builder()
+            .impositionCategory("Compensation")
+            .build();
+
         ResultEntity entity = ResultEntity.builder()
             .resultId("R999")
             .resultTitle("Full Title")
@@ -121,7 +130,7 @@ class ResultMapperTest {
             .impositionAllocationPriority((short) 3)
             .impositionCreditor(ImpositionCreditor.CF)
             .imposition(true)
-            .impositionCategory("Compensation")
+            .impositionCategory(compensationCategory)
             .impositionAccruing(false)
             .enforcement(true)
             .enforcementOverride(false)
@@ -158,7 +167,7 @@ class ResultMapperTest {
         assertEquals(entity.getImpositionAllocationPriority(), dto.getImpositionAllocationPriority());
         assertEquals(entity.getImpositionCreditor().getLabel(), dto.getImpositionCreditor());
         assertEquals(entity.isImposition(), dto.isImposition());
-        assertEquals(entity.getImpositionCategory(), dto.getImpositionCategory());
+        assertEquals("Compensation", dto.getImpositionCategory());
         assertEquals(entity.getImpositionAccruing(), dto.getImpositionAccruing());
         assertEquals(entity.isEnforcement(), dto.isEnforcement());
         assertEquals(entity.isEnforcementOverride(), dto.isEnforcementOverride());

--- a/src/test/java/uk/gov/hmcts/opal/mapper/ResultMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/mapper/ResultMapperTest.java
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 import uk.gov.hmcts.opal.dto.reference.ResultReferenceData;
 import uk.gov.hmcts.opal.dto.reference.ResultReferenceDataResponse;
+import uk.gov.hmcts.opal.entity.result.ImpositionCreditor;
 import uk.gov.hmcts.opal.entity.result.ResultEntity;
+import uk.gov.hmcts.opal.entity.result.ResultType;
 
 import java.util.List;
 
@@ -22,10 +24,10 @@ class ResultMapperTest {
             .resultId("R123")
             .resultTitle("Test Result")
             .resultTitleCy("Test Result Welsh")
-            .resultType("FPD")
+            .resultType(ResultType.ACTION)
             .active(true)
             .impositionAllocationPriority((short) 1)
-            .impositionCreditor("HMCTS")
+            .impositionCreditor(ImpositionCreditor.CF)
             .build();
 
         // Act
@@ -36,10 +38,10 @@ class ResultMapperTest {
         assertEquals("R123", result.getResultId());
         assertEquals("Test Result", result.getResultTitle());
         assertEquals("Test Result Welsh", result.getResultTitleCy());
-        assertEquals("FPD", result.getResultType());
+        assertEquals("Action", result.getResultType());
         assertEquals(true, result.isActive());
         assertEquals((short) 1, result.getImpositionAllocationPriority());
-        assertEquals("HMCTS", result.getImpositionCreditor());
+        assertEquals("CF", result.getImpositionCreditor());
     }
 
     @Test
@@ -49,13 +51,13 @@ class ResultMapperTest {
             .resultId("R456")
             .resultTitle("Full Result")
             .resultTitleCy("Full Result Welsh")
-            .resultType("FPR")
+            .resultType(ResultType.RESULT)
             .active(true)
             .impositionAllocationPriority((short) 2)
-            .impositionCreditor("COURT")
+            .impositionCreditor(ImpositionCreditor.ANY)
             // Include additional fields present only in Full entity
             .imposition(true)
-            .impositionCategory("FINE")
+            .impositionCategory("Fines")
             .impositionAccruing(false)
             .build();
 
@@ -67,10 +69,10 @@ class ResultMapperTest {
         assertEquals("R456", result.getResultId());
         assertEquals("Full Result", result.getResultTitle());
         assertEquals("Full Result Welsh", result.getResultTitleCy());
-        assertEquals("FPR", result.getResultType());
+        assertEquals("Result", result.getResultType());
         assertEquals(true, result.isActive());
         assertEquals((short) 2, result.getImpositionAllocationPriority());
-        assertEquals("COURT", result.getImpositionCreditor());
+        assertEquals("Any", result.getImpositionCreditor());
     }
 
     @Test
@@ -80,7 +82,7 @@ class ResultMapperTest {
             .resultId("R1")
             .resultTitle("Result 1")
             .resultTitleCy("Result 1 Welsh")
-            .resultType("TYPE1")
+            .resultType(ResultType.ACTION)
             .active(true)
             .build();
 
@@ -88,7 +90,7 @@ class ResultMapperTest {
             .resultId("R2")
             .resultTitle("Result 2")
             .resultTitleCy("Result 2 Welsh")
-            .resultType("TYPE2")
+            .resultType(ResultType.RESULT)
             .active(false)
             .build();
 
@@ -114,12 +116,12 @@ class ResultMapperTest {
             .resultId("R999")
             .resultTitle("Full Title")
             .resultTitleCy("Teitl Llawn")
-            .resultType("FULL")
+            .resultType(ResultType.RESULT)
             .active(true)
             .impositionAllocationPriority((short) 3)
-            .impositionCreditor("HMCTS")
+            .impositionCreditor(ImpositionCreditor.CF)
             .imposition(true)
-            .impositionCategory("CAT")
+            .impositionCategory("Compensation")
             .impositionAccruing(false)
             .enforcement(true)
             .enforcementOverride(false)
@@ -151,10 +153,10 @@ class ResultMapperTest {
         assertEquals(entity.getResultId(), dto.getResultId());
         assertEquals(entity.getResultTitle(), dto.getResultTitle());
         assertEquals(entity.getResultTitleCy(), dto.getResultTitleCy());
-        assertEquals(entity.getResultType(), dto.getResultType());
+        assertEquals(entity.getResultType().getLabel(), dto.getResultType());
         assertEquals(entity.isActive(), dto.isActive());
         assertEquals(entity.getImpositionAllocationPriority(), dto.getImpositionAllocationPriority());
-        assertEquals(entity.getImpositionCreditor(), dto.getImpositionCreditor());
+        assertEquals(entity.getImpositionCreditor().getLabel(), dto.getImpositionCreditor());
         assertEquals(entity.isImposition(), dto.isImposition());
         assertEquals(entity.getImpositionCategory(), dto.getImpositionCategory());
         assertEquals(entity.getImpositionAccruing(), dto.getImpositionAccruing());


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-3863
https://tools.hmcts.net/jira/browse/PO-3846 (DB)


### Change description ###
- Updated ResultEntity to use Java enums for result_type and imposition_creditor, aligning with the new Postgres enum columns.

- Added enum converters and column transformers so the Java enum values are persisted/read correctly against the database enum types.

- Updated result mapping/service/repository consumers to work with the new enum fields while preserving existing API response values.

- Modelled results.imposition_category as a JPA foreign-key relationship to ImpositionCategoriesEntity, referencing the unique imposition_category column.

- Added/updated unit and integration test coverage for the enum mappings, result DTO mapping, service lookups and repository behaviour.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
