### PR TITLE
P0 2985-Get-Result-Add-Welsh-Language-Support

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/opal/steps/GetResultsStepDef.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/steps/GetResultsStepDef.java
@@ -3,14 +3,17 @@ package uk.gov.hmcts.opal.steps;
 import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import io.restassured.path.json.JsonPath;
 import io.restassured.specification.RequestSpecification;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static net.serenitybdd.rest.SerenityRest.then;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.hmcts.opal.config.Constants.RESULTS_URI;
 
 /**
@@ -83,6 +86,20 @@ public class GetResultsStepDef extends BaseStepDef {
     }
 
     /**
+     * Requests the single-result endpoint for the supplied result identifier with Welsh result
+     * parameters requested.
+     *
+     * @param resultId result identifier to request.
+     */
+    @When("I request result with identifier {string} including Welsh parameters")
+    public void getResultByIdIncludingWelshParameters(String resultId) {
+        authorisedJsonRequest()
+            .param("include_welsh", true)
+            .when()
+            .get(getTestUrl() + RESULTS_URI + "/" + resultId);
+    }
+
+    /**
      * Asserts that the results response contains the expected number of records.
      *
      * @param count expected number of matching records.
@@ -126,6 +143,25 @@ public class GetResultsStepDef extends BaseStepDef {
     }
 
     /**
+     * Asserts that result_parameters contains a contiguous sequence of parameter entries.
+     *
+     * @param data Cucumber table containing expected parameter field values.
+     */
+    @Then("the result parameters contain the following entries in order")
+    public void resultParametersContainEntriesInOrder(DataTable data) {
+        List<Map<String, String>> expectedParameters = data.asMaps(String.class, String.class);
+        then().assertThat().statusCode(200);
+
+        String resultParameters = then().extract().body().jsonPath().getString("result_parameters");
+        List<Map<String, Object>> actualParameters = JsonPath.from(resultParameters).getList("$");
+
+        assertTrue(
+            containsExpectedSequence(actualParameters, expectedParameters),
+            "Expected result parameter sequence was not found"
+        );
+    }
+
+    /**
      * Executes the shared GET /results request using the supplied identifiers and optional
      * query parameters.
      *
@@ -144,6 +180,41 @@ public class GetResultsStepDef extends BaseStepDef {
         request
             .when()
             .get(getTestUrl() + RESULTS_URI);
+    }
+
+    private boolean containsExpectedSequence(
+        List<Map<String, Object>> actualParameters,
+        List<Map<String, String>> expectedParameters) {
+
+        for (int startIndex = 0; startIndex <= actualParameters.size() - expectedParameters.size(); startIndex++) {
+            if (sequenceMatches(actualParameters, expectedParameters, startIndex)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean sequenceMatches(
+        List<Map<String, Object>> actualParameters,
+        List<Map<String, String>> expectedParameters,
+        int startIndex) {
+
+        for (int offset = 0; offset < expectedParameters.size(); offset++) {
+            if (!parameterMatches(actualParameters.get(startIndex + offset), expectedParameters.get(offset))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean parameterMatches(Map<String, Object> actualParameter, Map<String, String> expectedParameter) {
+        for (Map.Entry<String, String> entry : expectedParameter.entrySet()) {
+            if (dataExists(entry.getValue())
+                && !entry.getValue().equals(String.valueOf(actualParameter.get(entry.getKey())))) {
+                return false;
+            }
+        }
+        return true;
     }
 
 }

--- a/src/functionalTest/resources/features/opalMode/results/Results.feature
+++ b/src/functionalTest/resources/features/opalMode/results/Results.feature
@@ -67,6 +67,14 @@ Feature: Results Reference Data
       | result_id                | AEO  |
       | requires_employment_data | true |
 
+  @JIRA-STORY:PO-2985 @JIRA-EPIC:PO-2630
+  Scenario: Result by ID can include Welsh text result parameters
+    When I request result with identifier "SC" including Welsh parameters
+    Then the result parameters contain the following entries in order
+      | name            | type | language_dependent | hint                                          |
+      | paymentterms    | text | true               |                                               |
+      | cy_paymentterms | text | true               | Provide a welsh version for the defendant    |
+
   @JIRA-STORY:PO-3765 @Ignore @release-1b
   Scenario: Result filtering is available when release-1b is enabled
     When I request results for identifiers "NBWT,NAP" using filter "enforcement_override" with value "true"

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
@@ -96,6 +96,28 @@ class ResultControllerIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @DisplayName("PO-2985 Get result by ID duplicates Welsh result parameters when requested")
+    @JiraStory("PO-2985")
+    @JiraEpic("PO-2630")
+    void getResultById_whenIncludeWelshTrue_returnsWelshResultParameters() throws Exception {
+        ResultActions actions = mockMvc.perform(get(URL_BASE + "/DDDDDD?include_welsh=true"));
+
+        String body = actions.andReturn().getResponse().getContentAsString();
+        log.info(":getResultById_whenIncludeWelshTrue_returnsWelshResultParameters: Response body:\n{}",
+            ToJsonString.toPrettyJson(body));
+
+        actions.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.result_id").value("DDDDDD"))
+            .andExpect(jsonPath("$.result_parameters").value(
+                "[{\"name\":\"sample_name\",\"type\":\"text\",\"hint\":\"some hint\",\"language_dependent\":true},"
+                    + "{\"name\":\"cy_sample_name\",\"type\":\"text\","
+                    + "\"hint\":\"Provide a welsh version for the defendant\",\"language_dependent\":true},"
+                    + "{\"name\":\"sample_name_2\",\"type\":\"text\",\"hint\":\"some hint 2\","
+                    + "\"language_dependent\":false}]"));
+    }
+
+    @Test
     @DisplayName("No results returned when result does not exist [@PO-703, PO-304]")
     @JiraStory("PO-703")
     @JiraStory("PO-304")

--- a/src/integrationTest/resources/db/insertData/insert_into_results.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_results.sql
@@ -135,7 +135,7 @@ VALUES
         FALSE,
         FALSE,
         FALSE,
-        '{"warrantDate":"2023-08-15","issuedBy":"Court A"}',
+        '[{"name":"sample_name","type":"text","hint":"some hint","language_dependent":true},{"name":"sample_name_2","type":"text","hint":"some hint 2","language_dependent":false}]',
         NULL,    -- allow_payment_terms
         FALSE,
         NULL,    -- allow_additional_action

--- a/src/main/java/uk/gov/hmcts/opal/controllers/ResultController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/ResultController.java
@@ -51,11 +51,13 @@ public class ResultController {
         feature = FeatureFlags.RELEASE_1B,
         defaultValueProperty = FeatureFlags.RELEASE_1B_ENABLED_PROPERTY
     )
-    public ResponseEntity<ResultDto> getResultById(@PathVariable String resultId) {
+    public ResponseEntity<ResultDto> getResultById(
+        @PathVariable String resultId,
+        @RequestParam(name = "include_welsh", required = false, defaultValue = "false") boolean includeWelsh) {
 
-        log.debug(":GET:getResultById: resultId: {}", resultId);
+        log.debug(":GET:getResultById: resultId: {}, includeWelsh: {}", resultId, includeWelsh);
 
-        return buildResponse(resultService.getResult(resultId));
+        return buildResponse(resultService.getResult(resultId, includeWelsh));
     }
 
 

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/ResultService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/ResultService.java
@@ -48,11 +48,7 @@ public class ResultService {
         return resultMapper.toRefData(getResultById(resultId));
     }
 
-    @Cacheable(value = "resultsCache", key = "#root.method.name + '_' + #resultId")
-    public ResultDto getResult(String resultId) {
-        return getResult(resultId, false);
-    }
-
+    @Cacheable(value = "resultsCache", key = "#root.method.name + '_' + #resultId + '_' + #includeWelsh")
     public ResultDto getResult(String resultId, boolean includeWelsh) {
         ResultEntity entity = resultRepository.findById(resultId)
             .orElseThrow(() -> new EntityNotFoundException("'Result' not found with id: " + resultId));

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/ResultService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/ResultService.java
@@ -12,7 +12,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 import uk.gov.hmcts.opal.dto.ResultDto;
+import uk.gov.hmcts.opal.dto.ToJsonString;
 import uk.gov.hmcts.opal.dto.reference.ResultReferenceData;
 import uk.gov.hmcts.opal.dto.reference.ResultReferenceDataResponse;
 import uk.gov.hmcts.opal.dto.search.ResultSearchDto;
@@ -29,6 +34,8 @@ public class ResultService {
     private final ResultRepository resultRepository;
     private final ResultMapper resultMapper;
     private final ResultSpecs resultSpecs;
+    private static final String WELSH_PARAMETER_PREFIX = "cy_";
+    private static final String WELSH_PARAMETER_HINT = "Provide a welsh version for the defendant";
 
     @Transactional(readOnly = true)
     public ResultEntity getResultById(String resultId) {
@@ -43,10 +50,53 @@ public class ResultService {
 
     @Cacheable(value = "resultsCache", key = "#root.method.name + '_' + #resultId")
     public ResultDto getResult(String resultId) {
+        return getResult(resultId, false);
+    }
+
+    public ResultDto getResult(String resultId, boolean includeWelsh) {
         ResultEntity entity = resultRepository.findById(resultId)
             .orElseThrow(() -> new EntityNotFoundException("'Result' not found with id: " + resultId));
 
-        return resultMapper.toDto(entity);
+        ResultDto result = resultMapper.toDto(entity);
+        if (includeWelsh) {
+            result.setResultParameters(addWelshResultParameters(result.getResultParameters()));
+        }
+
+        return result;
+    }
+
+    private String addWelshResultParameters(String resultParameters) {
+        try {
+            JsonNode parameters = ToJsonString.toJsonNode(resultParameters);
+            if (!parameters.isArray()) {
+                return resultParameters;
+            }
+
+            ArrayNode updatedParameters = ToJsonString.getObjectMapper().createArrayNode();
+            for (JsonNode parameter : parameters) {
+                updatedParameters.add(parameter.deepCopy());
+                if (isWelshParameterRequired(parameter)) {
+                    updatedParameters.add(createWelshParameter(parameter));
+                }
+            }
+
+            return ToJsonString.getObjectMapper().writeValueAsString(updatedParameters);
+        } catch (JacksonException e) {
+            return resultParameters;
+        }
+    }
+
+    private boolean isWelshParameterRequired(JsonNode parameter) {
+        return parameter.isObject()
+            && "text".equals(parameter.path("type").asText())
+            && parameter.path("language_dependent").asBoolean(false);
+    }
+
+    private ObjectNode createWelshParameter(JsonNode parameter) {
+        ObjectNode welshParameter = (ObjectNode) parameter.deepCopy();
+        welshParameter.put("name", WELSH_PARAMETER_PREFIX + parameter.path("name").asText());
+        welshParameter.put("hint", WELSH_PARAMETER_HINT);
+        return welshParameter;
     }
 
     // @Cacheable(cacheNames = "resultReferenceDataByIds", key = "#resultIds.orElse('noIds'))")

--- a/src/test/java/uk/gov/hmcts/opal/controllers/ResultControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/ResultControllerTest.java
@@ -22,7 +22,6 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -48,15 +47,15 @@ class ResultControllerTest {
             .resultTitleCy("Result AAA-BBB CY")
             .build();
 
-        when(resultService.getResult(anyString())).thenReturn(dto);
+        when(resultService.getResult("ABC", false)).thenReturn(dto);
 
         // Act
-        ResponseEntity<ResultDto> response = resultController.getResultById("ABC");
+        ResponseEntity<ResultDto> response = resultController.getResultById("ABC", false);
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(dto, response.getBody());
-        verify(resultService).getResult("ABC");
+        verify(resultService).getResult("ABC", false);
     }
 
     @Test
@@ -75,10 +74,10 @@ class ResultControllerTest {
             .manualEnforcement(true)
             .build();
 
-        when(resultService.getResult("ABC")).thenReturn(dto);
+        when(resultService.getResult("ABC", false)).thenReturn(dto);
 
         // Act
-        ResponseEntity<ResultDto> response = resultController.getResultById("ABC");
+        ResponseEntity<ResultDto> response = resultController.getResultById("ABC", false);
 
         // Assert
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -92,6 +91,24 @@ class ResultControllerTest {
         assertEquals(true, response.getBody().isGeneratesWarrant());
         assertEquals(false, response.getBody().getRequiresLja());
         assertEquals(true, response.getBody().isManualEnforcement());
+    }
+
+    @Test
+    void getResultById_whenIncludeWelshTrue_passesFlagToService() {
+        // Arrange
+        ResultDto dto = ResultDto.builder()
+            .resultId("ABC")
+            .build();
+
+        when(resultService.getResult("ABC", true)).thenReturn(dto);
+
+        // Act
+        ResponseEntity<ResultDto> response = resultController.getResultById("ABC", true);
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(dto, response.getBody());
+        verify(resultService).getResult("ABC", true);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/disco/opal/ResultServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/disco/opal/ResultServiceTest.java
@@ -254,7 +254,7 @@ class ResultServiceTest {
         when(resultMapper.toDto(entity)).thenReturn(dto);
 
         // Act
-        uk.gov.hmcts.opal.dto.ResultDto result = resultService.getResult("ABC");
+        uk.gov.hmcts.opal.dto.ResultDto result = resultService.getResult("ABC", false);
 
         // Assert
         assertNotNull(result);
@@ -393,47 +393,6 @@ class ResultServiceTest {
     }
 
     @Test
-    void getResult_whenIncludeWelshOmitted_doesNotAddWelshTextParameter() throws Exception {
-        // Arrange
-        String resultParameters = """
-            [
-              {
-                "name": "sample_name",
-                "type": "text",
-                "hint": "some hint",
-                "language_dependent": true
-              },
-              {
-                "name": "sample_name_2",
-                "type": "text",
-                "hint": "some hint 2",
-                "language_dependent": false
-              }
-            ]
-            """;
-        ResultEntity entity = ResultEntity.builder()
-            .resultId("ABC")
-            .resultParameters(resultParameters)
-            .build();
-        uk.gov.hmcts.opal.dto.ResultDto dto = uk.gov.hmcts.opal.dto.ResultDto.builder()
-            .resultId("ABC")
-            .resultParameters(resultParameters)
-            .build();
-
-        when(resultRepository.findById("ABC")).thenReturn(Optional.of(entity));
-        when(resultMapper.toDto(entity)).thenReturn(dto);
-
-        // Act
-        uk.gov.hmcts.opal.dto.ResultDto result = resultService.getResult("ABC");
-
-        // Assert
-        JsonNode parameters = ToJsonString.toJsonNode(result.getResultParameters());
-        assertEquals(2, parameters.size());
-        assertEquals("sample_name", parameters.get(0).get("name").asText());
-        assertEquals("sample_name_2", parameters.get(1).get("name").asText());
-    }
-
-    @Test
     void testGetResult_ThrowsWhenNotFound() {
         // Arrange
         when(resultRepository.findById("MISSING")).thenReturn(Optional.empty());
@@ -441,7 +400,7 @@ class ResultServiceTest {
         // Act + Assert
         org.junit.jupiter.api.Assertions.assertThrows(
             jakarta.persistence.EntityNotFoundException.class,
-            () -> resultService.getResult("MISSING")
+            () -> resultService.getResult("MISSING", false)
         );
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/disco/opal/ResultServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/disco/opal/ResultServiceTest.java
@@ -311,6 +311,129 @@ class ResultServiceTest {
     }
 
     @Test
+    void getResult_whenIncludeWelshTrueAndNoLanguageDependentParameters_returnsOriginalParameters() throws Exception {
+        // Arrange
+        String resultParameters = """
+            [
+              {
+                "name": "sample_name",
+                "type": "text",
+                "hint": "some hint",
+                "language_dependent": false
+              },
+              {
+                "name": "sample_name_2",
+                "type": "text",
+                "hint": "some hint 2",
+                "language_dependent": false
+              }
+            ]
+            """;
+        ResultEntity entity = ResultEntity.builder()
+            .resultId("ABC")
+            .resultParameters(resultParameters)
+            .build();
+        uk.gov.hmcts.opal.dto.ResultDto dto = uk.gov.hmcts.opal.dto.ResultDto.builder()
+            .resultId("ABC")
+            .resultParameters(resultParameters)
+            .build();
+
+        when(resultRepository.findById("ABC")).thenReturn(Optional.of(entity));
+        when(resultMapper.toDto(entity)).thenReturn(dto);
+
+        // Act
+        uk.gov.hmcts.opal.dto.ResultDto result = resultService.getResult("ABC", true);
+
+        // Assert
+        JsonNode parameters = ToJsonString.toJsonNode(result.getResultParameters());
+        assertEquals(2, parameters.size());
+        assertEquals("sample_name", parameters.get(0).get("name").asText());
+        assertEquals("sample_name_2", parameters.get(1).get("name").asText());
+    }
+
+    @Test
+    void getResult_whenIncludeWelshFalse_doesNotAddWelshTextParameter() throws Exception {
+        // Arrange
+        String resultParameters = """
+            [
+              {
+                "name": "sample_name",
+                "type": "text",
+                "hint": "some hint",
+                "language_dependent": true
+              },
+              {
+                "name": "sample_name_2",
+                "type": "text",
+                "hint": "some hint 2",
+                "language_dependent": false
+              }
+            ]
+            """;
+        ResultEntity entity = ResultEntity.builder()
+            .resultId("ABC")
+            .resultParameters(resultParameters)
+            .build();
+        uk.gov.hmcts.opal.dto.ResultDto dto = uk.gov.hmcts.opal.dto.ResultDto.builder()
+            .resultId("ABC")
+            .resultParameters(resultParameters)
+            .build();
+
+        when(resultRepository.findById("ABC")).thenReturn(Optional.of(entity));
+        when(resultMapper.toDto(entity)).thenReturn(dto);
+
+        // Act
+        uk.gov.hmcts.opal.dto.ResultDto result = resultService.getResult("ABC", false);
+
+        // Assert
+        JsonNode parameters = ToJsonString.toJsonNode(result.getResultParameters());
+        assertEquals(2, parameters.size());
+        assertEquals("sample_name", parameters.get(0).get("name").asText());
+        assertEquals("sample_name_2", parameters.get(1).get("name").asText());
+    }
+
+    @Test
+    void getResult_whenIncludeWelshOmitted_doesNotAddWelshTextParameter() throws Exception {
+        // Arrange
+        String resultParameters = """
+            [
+              {
+                "name": "sample_name",
+                "type": "text",
+                "hint": "some hint",
+                "language_dependent": true
+              },
+              {
+                "name": "sample_name_2",
+                "type": "text",
+                "hint": "some hint 2",
+                "language_dependent": false
+              }
+            ]
+            """;
+        ResultEntity entity = ResultEntity.builder()
+            .resultId("ABC")
+            .resultParameters(resultParameters)
+            .build();
+        uk.gov.hmcts.opal.dto.ResultDto dto = uk.gov.hmcts.opal.dto.ResultDto.builder()
+            .resultId("ABC")
+            .resultParameters(resultParameters)
+            .build();
+
+        when(resultRepository.findById("ABC")).thenReturn(Optional.of(entity));
+        when(resultMapper.toDto(entity)).thenReturn(dto);
+
+        // Act
+        uk.gov.hmcts.opal.dto.ResultDto result = resultService.getResult("ABC");
+
+        // Assert
+        JsonNode parameters = ToJsonString.toJsonNode(result.getResultParameters());
+        assertEquals(2, parameters.size());
+        assertEquals("sample_name", parameters.get(0).get("name").asText());
+        assertEquals("sample_name_2", parameters.get(1).get("name").asText());
+    }
+
+    @Test
     void testGetResult_ThrowsWhenNotFound() {
         // Arrange
         when(resultRepository.findById("MISSING")).thenReturn(Optional.empty());

--- a/src/test/java/uk/gov/hmcts/opal/disco/opal/ResultServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/disco/opal/ResultServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import tools.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -21,6 +22,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor.SpecificationFluentQuery;
+import uk.gov.hmcts.opal.dto.ToJsonString;
 import uk.gov.hmcts.opal.dto.reference.ResultReferenceData;
 import uk.gov.hmcts.opal.dto.reference.ResultReferenceDataResponse;
 import uk.gov.hmcts.opal.dto.search.ResultSearchDto;
@@ -261,6 +263,51 @@ class ResultServiceTest {
         assertEquals(true, result.getRequiresEmploymentData());
         verify(resultRepository).findById("ABC");
         verify(resultMapper).toDto(entity);
+    }
+
+    @Test
+    void getResult_whenIncludeWelshTrue_addsWelshTextParameterAfterOriginal() throws Exception {
+        // Arrange
+        String resultParameters = """
+            [
+              {
+                "name": "sample_name",
+                "type": "text",
+                "hint": "some hint",
+                "language_dependent": true
+              },
+              {
+                "name": "sample_name_2",
+                "type": "text",
+                "hint": "some hint 2",
+                "language_dependent": false
+              }
+            ]
+            """;
+        ResultEntity entity = ResultEntity.builder()
+            .resultId("ABC")
+            .resultParameters(resultParameters)
+            .build();
+        uk.gov.hmcts.opal.dto.ResultDto dto = uk.gov.hmcts.opal.dto.ResultDto.builder()
+            .resultId("ABC")
+            .resultParameters(resultParameters)
+            .build();
+
+        when(resultRepository.findById("ABC")).thenReturn(Optional.of(entity));
+        when(resultMapper.toDto(entity)).thenReturn(dto);
+
+        // Act
+        uk.gov.hmcts.opal.dto.ResultDto result = resultService.getResult("ABC", true);
+
+        // Assert
+        JsonNode parameters = ToJsonString.toJsonNode(result.getResultParameters());
+        assertEquals(3, parameters.size());
+        assertEquals("sample_name", parameters.get(0).get("name").asText());
+        assertEquals("cy_sample_name", parameters.get(1).get("name").asText());
+        assertEquals("Provide a welsh version for the defendant", parameters.get(1).get("hint").asText());
+        assertEquals(true, parameters.get(1).get("language_dependent").asBoolean());
+        assertEquals("text", parameters.get(1).get("type").asText());
+        assertEquals("sample_name_2", parameters.get(2).get("name").asText());
     }
 
     @Test


### PR DESCRIPTION
### https://tools.hmcts.net/jira/browse/PO-2985 ###





### 
- Added `include_welsh` support to `GET /results/{id}`
- Duplicates language-dependent text result parameters with a `cy_` prefix
- Sets Welsh duplicate hint to `Provide a welsh version for the defendant`
- Preserves existing behaviour when `include_welsh` is false or omitted ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
