### PR TITLE
publish functional reports after failures and sync missing Zephyr jira keys

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -217,6 +217,7 @@ def runFunctionalStage = { stageName, shouldRunWithZephyr, reportNameSuffix ->
         steps.echo "${stageName} failed. Marking build as FAILURE. Error: " + error.message
       } finally {
         try {
+          builder.gradle('syncFunctionalArtifactsFromExistingResults')
           publishFunctionalResults(
             'functional-output',
             'functional-test-report',
@@ -273,6 +274,7 @@ def runTaggedFunctionalStage = { enabled, stageName, shouldRunWithZephyr, report
         steps.echo "${stageName} failed. Marking build as FAILURE. Error: " + error.message
       } finally {
         try {
+          builder.gradle('syncTaggedFunctionalArtifactsFromExistingResults')
           publishFunctionalResults(
             reportDirectory,
             'functional-test-report-demo',

--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,45 @@ def pullLatestLegacyStubImageIfLocal = {
   }
 }
 
+def logPublishedHtmlReport = { String label, String reportDirectory ->
+  def indexFile = file("${reportDirectory}/index.html")
+  if (indexFile.exists()) {
+    logger.lifecycle("${label} available at - file://${indexFile.absolutePath}")
+  } else {
+    logger.lifecycle("${label} was not generated at ${reportDirectory}")
+  }
+}
+
+def syncFunctionalArtifacts = { String reportLabel, String rawReportDirectory, String outputDirectory, String cucumberJsonFileName ->
+  delete(rawReportDirectory)
+  delete("${outputDirectory}/report")
+
+  if (file("${rootDir}/target/site/serenity").exists()) {
+    copy {
+      from("${rootDir}/target/site/serenity")
+      into(rawReportDirectory)
+    }
+    copy {
+      from("${rootDir}/target/site/serenity")
+      into("${outputDirectory}/report")
+    }
+  }
+
+  if (cucumberJsonFileName != null) {
+    delete("${outputDirectory}/zephyr/${cucumberJsonFileName}")
+
+    def cucumberJsonFile = file("${rootDir}/target/zephyr-reports/${cucumberJsonFileName}")
+    if (cucumberJsonFile.exists()) {
+      copy {
+        from(cucumberJsonFile)
+        into("${outputDirectory}/zephyr")
+      }
+    }
+  }
+
+  logPublishedHtmlReport(reportLabel, "${outputDirectory}/report")
+}
+
 group = 'uk.gov.hmcts'
 version = '0.0.1'
 
@@ -350,13 +389,17 @@ tasks.register('copyFunctionalReport', Copy) {
   dependsOn 'aggregate'
   from("${rootDir}/target/site/serenity")
   into("${rootDir}/functional-test-report")
-  logger.quiet("Functional Test Report available at - file://${rootDir}/functional-test-report/index.html")
+  doLast {
+    logPublishedHtmlReport("Functional Test Report", "${rootDir}/functional-test-report")
+  }
 }
 tasks.register('copyDemoFunctionalReport', Copy) {
   dependsOn 'aggregate'
   from("${rootDir}/target/site/serenity")
   into("${rootDir}/functional-test-report-demo")
-  logger.quiet("Demo Functional Test Report available at - file://${rootDir}/functional-test-report-demo/index.html")
+  doLast {
+    logPublishedHtmlReport("Demo Functional Test Report", "${rootDir}/functional-test-report-demo")
+  }
 }
 tasks.register('packageFunctionalOutput', Copy) {
   dependsOn 'copyFunctionalReport', 'copyOpalCucumberJson'
@@ -377,6 +420,26 @@ tasks.register('packageTaggedDemoFunctionalOutput', Copy) {
   into("${rootDir}/functional-output-demo")
   from("${rootDir}/functional-test-report-demo") {
     into("report")
+  }
+}
+tasks.register('syncFunctionalArtifactsFromExistingResults') {
+  doLast {
+    syncFunctionalArtifacts(
+      'Functional Test Report',
+      "${rootDir}/functional-test-report",
+      "${rootDir}/functional-output",
+      'cucumber-opal.json'
+    )
+  }
+}
+tasks.register('syncTaggedFunctionalArtifactsFromExistingResults') {
+  doLast {
+    syncFunctionalArtifacts(
+      'Demo Functional Test Report',
+      "${rootDir}/functional-test-report-demo",
+      "${rootDir}/functional-output-demo",
+      'cucumber-opal-tags.json'
+    )
   }
 }
 tasks.register('copyIntegrationJunit5Report', Copy) {
@@ -451,7 +514,9 @@ tasks.register('copySmokeReport', Copy) {
   dependsOn 'aggregate'
   from("${rootDir}/target/site/serenity")
   into("${rootDir}/smoke-test-report")
-  logger.quiet("Smoke Test Report available at - file://${rootDir}/smoke-test-report/index.html")
+  doLast {
+    logPublishedHtmlReport("Smoke Test Report", "${rootDir}/smoke-test-report")
+  }
 }
 tasks.register('copySmokeCucumberJson', Copy) {
   from("target/cucumber.json")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/AmendmentControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/AmendmentControllerIntegrationTest.java
@@ -111,6 +111,7 @@ class AmendmentControllerIntegrationTest extends AbstractIntegrationTest {
     @Test
     @JiraStory("PO-3851")
     @JiraEpic("PO-3372")
+    @JiraTestKey("PO-8617")
     void testPostAmendmentsSearch_byAssociatedRecordType() throws Exception {
         ResultActions actions = mockMvc.perform(post(URL_BASE + "/search")
             .contentType(MediaType.APPLICATION_JSON)

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantAccountHistoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyDefendantAccountHistoryIntegrationTest.java
@@ -29,6 +29,7 @@ import uk.gov.hmcts.opal.dto.legacy.GetDefendantAccountHistoryLegacyRequest;
 import uk.gov.hmcts.opal.dto.legacy.GetDefendantAccountHistoryLegacyResponse;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "legacy"})
 @TestPropertySource(properties = {
@@ -49,6 +50,7 @@ class LegacyDefendantAccountHistoryIntegrationTest extends AbstractLegacyDefenda
     @DisplayName("PO-2647 legacy history returns mixed items and maps them")
     @JiraStory("PO-2647")
     @JiraEpic("PO-2621")
+    @JiraTestKey("PO-8619")
     void getDefendantAccountHistory_successReturnsMappedResponse() throws Exception {
         userStateStub.setupWithNoPermissions();
         userStateStub.addPermissions((short) 77, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
@@ -96,6 +98,7 @@ class LegacyDefendantAccountHistoryIntegrationTest extends AbstractLegacyDefenda
     @DisplayName("PO-2647 legacy history passes filters to gateway")
     @JiraStory("PO-2647")
     @JiraEpic("PO-2621")
+    @JiraTestKey("PO-8618")
     void getDefendantAccountHistory_filtersAreForwardedToLegacyRequest() throws Exception {
         userStateStub.setupWithNoPermissions();
         userStateStub.addPermissions((short) 77, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
@@ -128,6 +131,7 @@ class LegacyDefendantAccountHistoryIntegrationTest extends AbstractLegacyDefenda
     @DisplayName("PO-2647 legacy history not found returns 404")
     @JiraStory("PO-2647")
     @JiraEpic("PO-2621")
+    @JiraTestKey("PO-8620")
     void getDefendantAccountHistory_notFoundReturns404() throws Exception {
         userStateStub.setupWithNoPermissions();
         userStateStub.addPermissions((short) 77, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
@@ -144,6 +148,7 @@ class LegacyDefendantAccountHistoryIntegrationTest extends AbstractLegacyDefenda
     @DisplayName("PO-2647 legacy history without permission returns 403")
     @JiraStory("PO-2647")
     @JiraEpic("PO-2621")
+    @JiraTestKey("PO-8621")
     void getDefendantAccountHistory_withoutPermissionReturns403() throws Exception {
         userStateStub.setupWithNoPermissions();
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMinorCreditorHistoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMinorCreditorHistoryIntegrationTest.java
@@ -34,6 +34,7 @@ import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.service.UserStateService;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration", "opal"})
 @TestPropertySource(properties = {
@@ -74,6 +75,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @JiraStory("PO-2642")
     @JiraEpic("PO-2653")
     @DisplayName("PO-2642 INT.01/INT.05 returns all amendment history only when filtered")
+    @JiraTestKey("PO-8627")
     void getMinorCreditorHistory_whenFilteredToAmendments_returnsAllAmendments() throws Exception {
         ResultActions result = getHistory("itemTypes", "amendment");
 
@@ -87,6 +89,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @JiraStory("PO-2642")
     @JiraEpic("PO-2653")
     @DisplayName("PO-2642 INT.02/INT.06 returns all note history only when filtered")
+    @JiraTestKey("PO-8636")
     void getMinorCreditorHistory_whenFilteredToNotes_returnsAllNotes() throws Exception {
         ResultActions result = getHistory("itemTypes", "note");
 
@@ -99,6 +102,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @JiraStory("PO-2642")
     @JiraEpic("PO-2653")
     @DisplayName("PO-2642 INT.03/INT.07 returns all financial history only when filtered")
+    @JiraTestKey("PO-8638")
     void getMinorCreditorHistory_whenFilteredToFinancial_returnsAllFinancialItems() throws Exception {
         ResultActions result = getHistory("itemTypes", "financial");
 
@@ -112,6 +116,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @JiraStory("PO-2642")
     @JiraEpic("PO-2653")
     @DisplayName("PO-2642 INT.04 returns merged history latest-to-oldest")
+    @JiraTestKey("PO-8624")
     void getMinorCreditorHistory_whenNoFilters_returnsMergedLatestToOldestHistory() throws Exception {
         ResultActions result = getHistory();
 
@@ -130,6 +135,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @JiraStory("PO-2642")
     @JiraEpic("PO-2653")
     @DisplayName("PO-2642 INT.08 applies dateFrom as an inclusive lower bound")
+    @JiraTestKey("PO-8632")
     void getMinorCreditorHistory_whenDateFromProvided_appliesInclusiveLowerBound() throws Exception {
         ResultActions result = getHistory("dateFrom", "2026-01-15");
 
@@ -142,6 +148,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @JiraStory("PO-2642")
     @JiraEpic("PO-2653")
     @DisplayName("PO-2642 INT.09 applies dateTo as an inclusive upper bound")
+    @JiraTestKey("PO-8634")
     void getMinorCreditorHistory_whenDateToProvided_appliesInclusiveUpperBound() throws Exception {
         ResultActions result = getHistory("dateTo", "2026-01-10");
 
@@ -154,6 +161,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @JiraStory("PO-2642")
     @JiraEpic("PO-2653")
     @DisplayName("PO-2642 INT.10 applies an inclusive date range")
+    @JiraTestKey("PO-8635")
     void getMinorCreditorHistory_whenDateRangeProvided_returnsItemsWithinRange() throws Exception {
         ResultActions result = getHistory("dateFrom", "2026-01-10", "dateTo", "2026-01-25");
 
@@ -167,6 +175,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @JiraStory("PO-2642")
     @JiraEpic("PO-2653")
     @DisplayName("PO-2642 INT.11 combines date and item type filters")
+    @JiraTestKey("PO-8625")
     void getMinorCreditorHistory_whenDateAndTypeFiltersProvided_appliesBothFilters() throws Exception {
         ResultActions result = getHistory(
             "itemTypes", "financial",
@@ -183,6 +192,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @JiraStory("PO-2642")
     @JiraEpic("PO-2653")
     @DisplayName("PO-2642 INT.12 orders equal timestamps deterministically")
+    @JiraTestKey("PO-8630")
     void getMinorCreditorHistory_whenTimestampsMatch_ordersByTypeThenSourceId() throws Exception {
         ResultActions result = getHistory("dateFrom", "2026-01-31", "dateTo", "2026-01-31");
 
@@ -197,6 +207,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @JiraStory("PO-2642")
     @JiraEpic("PO-2653")
     @DisplayName("PO-2642 schema assertions verify documented history item shapes")
+    @JiraTestKey("PO-8637")
     void getMinorCreditorHistory_whenHistoryExists_returnsDocumentedPolymorphicShapes() throws Exception {
         ResultActions result = getHistory("dateFrom", "2026-01-31", "dateTo", "2026-01-31");
 
@@ -237,6 +248,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @JiraStory("PO-2642")
     @JiraEpic("PO-2653")
     @DisplayName("PO-2642 common response returns 401 when the user is unauthorised")
+    @JiraTestKey("PO-8629")
     void getMinorCreditorHistory_whenUnauthorised_returns401() throws Exception {
         doThrow(new ResponseStatusException(UNAUTHORIZED, "Unauthorized"))
             .when(userStateService).getUserStateV1FromSecurityContext();
@@ -251,6 +263,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @JiraStory("PO-2642")
     @JiraEpic("PO-2653")
     @DisplayName("PO-2642 common response returns 403 when the user lacks permission")
+    @JiraTestKey("PO-8628")
     void getMinorCreditorHistory_whenUserLacksPermission_returns403() throws Exception {
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(noPermissionsUser());
 
@@ -263,6 +276,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @JiraStory("PO-2642")
     @JiraEpic("PO-2653")
     @DisplayName("PO-2642 common response returns 404 when the account is missing")
+    @JiraTestKey("PO-8626")
     void getMinorCreditorHistory_whenAccountMissing_returns404() throws Exception {
         getHistory(MISSING_CREDITOR_ACCOUNT_ID)
             .andExpect(status().isNotFound())
@@ -273,6 +287,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @JiraStory("PO-2642")
     @JiraEpic("PO-2653")
     @DisplayName("PO-2642 common response returns 404 when the account is not a minor creditor")
+    @JiraTestKey("PO-8622")
     void getMinorCreditorHistory_whenAccountIsNotMinorCreditor_returns404() throws Exception {
         getHistory(NON_MINOR_CREDITOR_ACCOUNT_ID)
             .andExpect(status().isNotFound())
@@ -283,6 +298,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @JiraStory("PO-2642")
     @JiraEpic("PO-2653")
     @DisplayName("PO-2642 common response returns 408 for a timeout")
+    @JiraTestKey("PO-8631")
     void getMinorCreditorHistory_whenTimeoutOccurs_returns408() throws Exception {
         doThrow(new QueryTimeoutException("timeout"))
             .when(userStateService).getUserStateV1FromSecurityContext();
@@ -297,6 +313,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @JiraStory("PO-2642")
     @JiraEpic("PO-2653")
     @DisplayName("PO-2642 common response returns 503 for a database connectivity failure")
+    @JiraTestKey("PO-8623")
     void getMinorCreditorHistory_whenDatabaseUnavailable_returns503() throws Exception {
         doThrow(new DataAccessResourceFailureException("db unavailable"))
             .when(userStateService).getUserStateV1FromSecurityContext();
@@ -311,6 +328,7 @@ class OpalMinorCreditorHistoryIntegrationTest extends AbstractIntegrationTest {
     @JiraStory("PO-2642")
     @JiraEpic("PO-2653")
     @DisplayName("PO-2642 common response returns 500 for an unexpected failure")
+    @JiraTestKey("PO-8633")
     void getMinorCreditorHistory_whenUnexpectedFailureOccurs_returns500() throws Exception {
         doThrow(new ResponseStatusException(INTERNAL_SERVER_ERROR, "Boom"))
             .when(userStateService).getUserStateV1FromSecurityContext();

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/Release1bFeatureToggleLaunchDarklyEnabledFlagTrueIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/Release1bFeatureToggleLaunchDarklyEnabledFlagTrueIntegrationTest.java
@@ -54,6 +54,16 @@ class Release1bFeatureToggleLaunchDarklyEnabledFlagTrueIntegrationTest extends A
     @JiraTestKey(value = "PO-8586", name = "\"Get Defendant Account Payment Terms\"")
     @JiraTestKey(value = "PO-8587", name = "\"Add Defendant Account Payment Terms\"")
     @JiraTestKey(value = "PO-8588", name = "\"Add Defendant Account Payment Card Request\"")
+    @JiraTestKey(value = "PO-8639", name = "\"Get Defendant Account Fixed Penalty\"")
+    @JiraTestKey(value = "PO-8640", name = "\"Get Central Fund\"")
+    @JiraTestKey(value = "PO-8641", name = "\"Get Major Creditor Account Header Summary\"")
+    @JiraTestKey(value = "PO-8642", name = "\"Search Minor Creditor Accounts\"")
+    @JiraTestKey(value = "PO-8643", name = "\"Get Minor Creditor Account Header Summary\"")
+    @JiraTestKey(value = "PO-8644", name = "\"Get Minor Creditor Account At A Glance\"")
+    @JiraTestKey(value = "PO-8645", name = "\"Get Minor Creditor Account\"")
+    @JiraTestKey(value = "PO-8646", name = "\"Get Minor Creditor History\"")
+    @JiraTestKey(value = "PO-8647", name = "\"Patch Minor Creditor Account\"")
+    @JiraTestKey(value = "PO-8648", name = "\"Get Result By Id\"")
     void shouldNotReturnFeatureDisabledProblemWhenLaunchDarklyFlagIsTrue(String endpointName, RequestBuilder request)
         throws Exception {
         when(ldClient.boolVariation(eq(RELEASE_1B), any(LDContext.class), anyBoolean())).thenReturn(true);

--- a/src/integrationTest/java/uk/gov/hmcts/opal/jpa/ReportSpecsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/jpa/ReportSpecsTest.java
@@ -48,6 +48,8 @@ public class ReportSpecsTest extends AbstractIntegrationTest {
     @ParameterizedTest
     @NullAndEmptySource
     @JiraTestKey("PO-7796")
+    @JiraTestKey(value = "PO-8651", name = "[1] buIds = null")
+    @JiraTestKey(value = "PO-8652", name = "[2] buIds = []")
     void businessUnitSpec_businessUnitIdsNullOrEmpty_returnConjunction(List<Long> buIds) {
         //Arrange
         long total = defendantAccountRepository.count();
@@ -369,6 +371,8 @@ public class ReportSpecsTest extends AbstractIntegrationTest {
     @ParameterizedTest
     @MethodSource("emptyAccountIdLists")
     @JiraTestKey("PO-7794")
+    @JiraTestKey(value = "PO-8649", name = "[1] accountIds = null")
+    @JiraTestKey(value = "PO-8650", name = "[2] accountIds = []")
     void defendantAccountIdsIn_emptyOrNullList_returnsNoResults(List<Long> accountIds) {
         // Arrange
         Specification<DefendantAccountEntity> spec =

--- a/src/integrationTest/java/uk/gov/hmcts/opal/service/report/OperationReportByEnforcementServiceDetailedTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/service/report/OperationReportByEnforcementServiceDetailedTest.java
@@ -94,6 +94,8 @@ public class OperationReportByEnforcementServiceDetailedTest extends AbstractInt
         "{}"
     })
     @JiraTestKey("PO-7815")
+    @JiraTestKey(value = "PO-8655", name = "[1] json = \"{\\\"reportType\\\": \\\"DETAILED\\\"}\"")
+    @JiraTestKey(value = "PO-8656", name = "[2] json = \"{}\"")
     void generateReportData_filterDetailedReportType_returnSortedResultsOfDetailedReportType(String json) {
         //Arrange
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
@@ -515,6 +517,8 @@ public class OperationReportByEnforcementServiceDetailedTest extends AbstractInt
         "WITHOUT, false"
     })
     @JiraTestKey("PO-7813")
+    @JiraTestKey(value = "PO-8653", name = "[1] collectionOrderChoice = \"WITH\", expectedValue = \"true\"")
+    @JiraTestKey(value = "PO-8654", name = "[2] collectionOrderChoice = \"WITHOUT\", expectedValue = \"false\"")
     void generateReportData_filterByCollectionOrderChoice_returnResults(
         String collectionOrderChoice,
         boolean expectedValue

--- a/src/integrationTest/java/uk/gov/hmcts/opal/service/report/OperationReportByEnforcementServiceSummaryTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/service/report/OperationReportByEnforcementServiceSummaryTest.java
@@ -639,6 +639,8 @@ public class OperationReportByEnforcementServiceSummaryTest extends AbstractInte
         "WITHOUT, false"
     })
     @JiraTestKey("PO-7833")
+    @JiraTestKey(value = "PO-8657", name = "[1] collectionOrderChoice = \"WITH\", expectedValue = \"true\"")
+    @JiraTestKey(value = "PO-8658", name = "[2] collectionOrderChoice = \"WITHOUT\", expectedValue = \"false\"")
     void generateReportData_filterByCollectionOrderChoice_returnResults(
         String collectionOrderChoice,
         boolean expectedValue


### PR DESCRIPTION
### Change description ###

Ensures nightly functional reports are still packaged and published when the functional Gradle task fails, so Jenkins shows the functional and Demo R1A Serenity reports consistently.
Also updates the integration Zephyr JUnit report JSON to include missing Jira test keys added in this branch

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
