### PR TITLE
Run and publish integration tests explicitly in CNP

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -137,6 +137,23 @@ def publishFunctionalResults(String reportNameSuffix = '') {
   ]
 }
 
+def publishIntegrationResults() {
+  ensureIntegrationReportOutputExists()
+
+  steps.junit allowEmptyResults: true, testResults: '**/test-results/integration/*.xml'
+  failBuildOnUnstableResults()
+  steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'integration-output/**/*'
+
+  publishHTML target: [
+      allowMissing         : true,
+      alwaysLinkToLastBuild: true,
+      keepAll              : true,
+      reportDir            : "integration-output/report",
+      reportFiles          : "index.html",
+      reportName           : "Integration Tests Report"
+  ]
+}
+
 def publishSmokeResults(String reportNameSuffix = '') {
   ensureSmokeReportOutputExists()
 
@@ -168,6 +185,12 @@ withPipeline(type, product, component) {
     onPR {
       determineDevEnvironmentDeployment()
     }
+
+    try {
+      steps.sh './gradlew checkTestJiraAnnotations integration'
+    } finally {
+      publishIntegrationResults()
+    }
   }
 
   before('test') {
@@ -175,10 +198,7 @@ withPipeline(type, product, component) {
   }
 
   afterAlways('test') {
-    steps.junit '**/test-results/integration/*.xml'
-    failBuildOnUnstableResults()
-    ensureIntegrationReportOutputExists()
-    steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'integration-output/**/*'
+    publishIntegrationResults()
 
     publishHTML target: [
         allowMissing         : true,

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -185,14 +185,6 @@ withPipeline(type, product, component) {
     onPR {
       determineDevEnvironmentDeployment()
     }
-
-    steps.catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-      try {
-        steps.sh './gradlew checkTestJiraAnnotations integration'
-      } finally {
-        publishIntegrationResults()
-      }
-    }
   }
 
   before('test') {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -172,7 +172,7 @@ def publishSmokeResults(String reportNameSuffix = '') {
 }
 
 withPipeline(type, product, component) {
-  env.FAIL_FAST = true
+  env.FAIL_FAST = false
   env.STAGING_DB_SCHEMA = 'public'
   env.OPAL_LEGACY_GATEWAY_URL = 'https://opal-legacy-db-stub-staging.platform.hmcts.net/opal'
   env.OPAL_LEGACY_STUB_IMAGE = 'hmctsprod.azurecr.io/opal/legacy-db-stub:latest'
@@ -186,10 +186,12 @@ withPipeline(type, product, component) {
       determineDevEnvironmentDeployment()
     }
 
-    try {
-      steps.sh './gradlew checkTestJiraAnnotations integration'
-    } finally {
-      publishIntegrationResults()
+    steps.catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+      try {
+        steps.sh './gradlew checkTestJiraAnnotations integration'
+      } finally {
+        publishIntegrationResults()
+      }
     }
   }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Makes CNP run integration tests explicitly and publish the integration HTML/artifacts without depending on the shared pipeline’s implicit test stage.
Also keeps the functional report packaging fix so Serenity reports are still published reliably after failed functional runs.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
