### PR TITLE
PO-5741 : Draft Account Reference Validation Service

### DIFF
--- a/src/functionalTest/resources/features/opalMode/manualAccountCreation/draftAccounts/accountJson/account.json
+++ b/src/functionalTest/resources/features/opalMode/manualAccountCreation/draftAccounts/accountJson/account.json
@@ -4,7 +4,7 @@
   "defendant_type": "DEFENDANT",
   "originator_name": "Humber Magistrates' Court",
   "originator_id": 1980,
-  "enforcement_court_id": 101,
+  "enforcement_court_id": 260000000048,
   "collection_order_made": true,
   "collection_order_made_today": false,
   "payment_card_request": true,
@@ -17,10 +17,10 @@
   "offences": [
     {
       "date_of_sentence": "2023-01-01",
-      "offence_id": 1234,
+      "offence_id": 35014,
       "impositions": [
         {
-          "result_id": "1234",
+          "result_id": "FO",
           "amount_imposed": 500.0,
           "amount_paid": 200.0
         }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CommonDraftAccountControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CommonDraftAccountControllerIntegrationTest.java
@@ -11,6 +11,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
@@ -18,7 +19,9 @@ import org.springframework.test.context.jdbc.Sql;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.SchemaPaths;
 import uk.gov.hmcts.opal.common.logging.SecurityEventLoggingService;
+import uk.gov.hmcts.opal.entity.draft.DraftAccountEntity;
 import uk.gov.hmcts.opal.logging.integration.service.LoggingService;
+import uk.gov.hmcts.opal.repository.DraftAccountRepository;
 import uk.gov.hmcts.opal.service.opal.JsonSchemaValidationService;
 
 @ActiveProfiles({"integration"})
@@ -55,6 +58,9 @@ class CommonDraftAccountControllerIntegrationTest extends AbstractIntegrationTes
 
     @MockitoBean
     Clock clock;
+
+    @Autowired
+    protected DraftAccountRepository draftAccountRepository;
 
     @BeforeEach
     void setupClock() {
@@ -107,6 +113,10 @@ class CommonDraftAccountControllerIntegrationTest extends AbstractIntegrationTes
             .andReturn()
             .getResponse()
             .getHeader("ETag");
+    }
+
+    protected DraftAccountEntity getDraftAccount(long draftAccountId) {
+        return draftAccountRepository.findById(draftAccountId).orElseThrow();
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerIntegrationTest.java
@@ -184,7 +184,7 @@ class DraftAccountControllerIntegrationTest extends CommonDraftAccountController
                 "originator_name": "Police Force",
                 "originator_id": 12345,
                 "originator_type": "NEW",
-                "enforcement_court_id": 101,
+                "enforcement_court_id": 260000000048,
                 "collection_order_made": true,
                 "collection_order_made_today": false,
                 "payment_card_request": true,
@@ -220,14 +220,14 @@ class DraftAccountControllerIntegrationTest extends CommonDraftAccountController
                 "offences": [
                   {
                     "date_of_sentence": "2023-11-15",
-                    "imposing_court_id": 202,
-                    "offence_id": 1234,
+                    "imposing_court_id": 260000000048,
+                    "offence_id": 35014,
                     "impositions": [
                       {
-                        "result_id": "1",
+                        "result_id": "FO",
                         "amount_imposed": 500.00,
                         "amount_paid": 200.00,
-                        "major_creditor_id": 999
+                        "major_creditor_id": null
                       }
                     ]
                   }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPostIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPostIntegrationTest.java
@@ -22,6 +22,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.dto.AddDraftAccountRequestDto;
 import uk.gov.hmcts.opal.dto.ToJsonString;
+import uk.gov.hmcts.opal.entity.draft.DraftAccountEntity;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountType;
 import uk.gov.hmcts.opal.logging.integration.dto.ParticipantIdentifier;
 import uk.gov.hmcts.opal.logging.integration.dto.PersonalDataProcessingCategory;
@@ -337,6 +338,42 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
     }
 
     @Test
+    @DisplayName("Create draft account - Should return 400 when reference validation fails and leave data unchanged")
+    @JiraStory("PO-973")
+    @JiraEpic("PO-2219")
+    void shouldReturn400WhenReferenceValidationFailsAndLeaveExistingDataUnchanged() throws Exception {
+        DraftAccountEntity before = getDraftAccount(5L);
+        long countBefore = draftAccountRepository.count();
+
+        mockMvc.perform(post(URL_BASE)
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidReferenceCreateRequestBody()))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.title").value("Bad Request"))
+            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/json-schema-validation"))
+            .andExpect(jsonPath("$.detail").value(expectedReferenceValidationErrorMessage()));
+
+        DraftAccountEntity after = getDraftAccount(5L);
+
+        assertEquals(countBefore, draftAccountRepository.count());
+        assertEquals(before.getAccount(), after.getAccount());
+        assertEquals(before.getAccountStatus(), after.getAccountStatus());
+        assertEquals(before.getVersionNumber(), after.getVersionNumber());
+        assertEquals(before.getAccountId(), after.getAccountId());
+        assertEquals(before.getAccountNumber(), after.getAccountNumber());
+        assertEquals(before.getStatusMessage(), after.getStatusMessage());
+        assertEquals(before.getSubmittedBy(), after.getSubmittedBy());
+        assertEquals(before.getSubmittedByName(), after.getSubmittedByName());
+        assertEquals(before.getValidatedBy(), after.getValidatedBy());
+        assertEquals(before.getValidatedByName(), after.getValidatedByName());
+        assertEquals(before.getAccountSnapshot(), after.getAccountSnapshot());
+        assertEquals(before.getTimelineData(), after.getTimelineData());
+    }
+
+    @Test
     @DisplayName("Create draft account - Should return 400 Bad Request [@PO-973, @PO-691]")
     @JiraStory("PO-973")
     @JiraStory("PO-691")
@@ -641,6 +678,26 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
               "account_status": "Submitted",
               "version": 0
             }""";
+    }
+
+    private static String invalidReferenceCreateRequestBody() {
+        return validCreateRequestBody()
+            .replace("\"enforcement_court_id\": 101", "\"enforcement_court_id\": 999999")
+            .replace("\"offence_id\": 1234", "\"offence_id\": 999998")
+            .replace("\"imposing_court_id\": 202", "\"imposing_court_id\": 999997")
+            .replace("\"result_id\": \"1\"", "\"result_id\": \"NOT-A-RESULT\"")
+            .replace("\"major_creditor_id\": 999", "\"major_creditor_id\": 999996");
+    }
+
+    private static String expectedReferenceValidationErrorMessage() {
+        return """
+            Draft account reference validation failed with 5 error(s):
+             - $.enforcement_court_id: court id 999999 does not exist
+             - $.offences[0].offence_id: offence id 999998 does not exist
+             - $.offences[0].imposing_court_id: court id 999997 does not exist
+             - $.offences[0].impositions[0].result_id: result id NOT-A-RESULT does not exist
+             - $.offences[0].impositions[0].major_creditor_id: major creditor id 999996 does not exist
+            """.stripIndent().stripTrailing();
     }
 
     private static String invalidCreateRequestBody() {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPostIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPostIntegrationTest.java
@@ -353,7 +353,7 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
             .andExpect(status().isBadRequest())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("$.title").value("Bad Request"))
-            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/json-schema-validation"))
+            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/invalid-reference-validation"))
             .andExpect(jsonPath("$.detail").value(expectedReferenceValidationErrorMessage()));
 
         DraftAccountEntity after = getDraftAccount(5L);

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPostIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPostIntegrationTest.java
@@ -76,7 +76,7 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
               "originator_name": "Police Force",
               "originator_id": 12345,
               "originator_type": "NEW",
-              "enforcement_court_id": 101,
+              "enforcement_court_id": 260000000048,
               "payment_card_request": true,
               "account_sentence_date": "2023-12-01",
               "defendant": {
@@ -109,7 +109,7 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
               "originator_name": "Police Force",
               "originator_id": 12345,
               "originator_type": "NEW",
-              "enforcement_court_id": 101,
+              "enforcement_court_id": 260000000048,
               "payment_card_request": true,
               "account_sentence_date": "2023-12-01",
               "defendant": {
@@ -610,7 +610,7 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
                 "originator_name": "Police Force",
                 "originator_id": 12345,
                 "originator_type": "NEW",
-                "enforcement_court_id": 101,
+                "enforcement_court_id": 260000000048,
                 "collection_order_made": true,
                 "collection_order_made_today": false,
                 "payment_card_request": true,
@@ -646,14 +646,14 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
                 "offences": [
                   {
                     "date_of_sentence": "2023-11-15",
-                    "imposing_court_id": 202,
-                    "offence_id": 1234,
+                    "imposing_court_id": 260000000048,
+                    "offence_id": 35014,
                     "impositions": [
                       {
-                        "result_id": "1",
+                        "result_id": "FO",
                         "amount_imposed": 500.00,
                         "amount_paid": 200.00,
-                        "major_creditor_id": 999
+                        "major_creditor_id": null
                       }
                     ]
                   }
@@ -682,11 +682,11 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
 
     private static String invalidReferenceCreateRequestBody() {
         return validCreateRequestBody()
-            .replace("\"enforcement_court_id\": 101", "\"enforcement_court_id\": 999999")
-            .replace("\"offence_id\": 1234", "\"offence_id\": 999998")
-            .replace("\"imposing_court_id\": 202", "\"imposing_court_id\": 999997")
-            .replace("\"result_id\": \"1\"", "\"result_id\": \"NOT-A-RESULT\"")
-            .replace("\"major_creditor_id\": 999", "\"major_creditor_id\": 999996");
+            .replace("\"enforcement_court_id\": 260000000048", "\"enforcement_court_id\": 999999")
+            .replace("\"offence_id\": 35014", "\"offence_id\": 999998")
+            .replace("\"imposing_court_id\": 260000000048", "\"imposing_court_id\": 999997")
+            .replace("\"result_id\": \"FO\"", "\"result_id\": \"NOT-A-RESULT\"")
+            .replace("\"major_creditor_id\": null", "\"major_creditor_id\": 999996");
     }
 
     private static String expectedReferenceValidationErrorMessage() {
@@ -735,7 +735,7 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
                 "originator_id": 123,
                 "originator_type": "NEW",
                 "prosecutor_case_reference": null,
-                "enforcement_court_id": 456,
+                "enforcement_court_id": 260000000048,
                 "collection_order_made": null,
                 "collection_order_made_today": null,
                 "collection_order_date": null,
@@ -779,11 +779,11 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
                 "offences": [
                   {
                     "date_of_sentence": "2025-10-01",
-                    "imposing_court_id": 789,
-                    "offence_id": 10,
+                    "imposing_court_id": 260000000048,
+                    "offence_id": 35014,
                     "impositions": [
                       {
-                        "result_id": "FINE",
+                        "result_id": "FO",
                         "amount_imposed": 100.00,
                         "amount_paid": 0.00,
                         "major_creditor_id": null,

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPutIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPutIntegrationTest.java
@@ -523,7 +523,7 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
                 "originator_name": "Police Force",
                 "originator_id": 12345,
                 "originator_type": "NEW",
-                "enforcement_court_id": 101,
+                "enforcement_court_id": 260000000048,
                 "collection_order_made": true,
                 "collection_order_made_today": false,
                 "payment_card_request": true,
@@ -559,14 +559,14 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
                 "offences": [
                   {
                     "date_of_sentence": "2023-11-15",
-                    "imposing_court_id": 202,
-                    "offence_id": 1234,
+                    "imposing_court_id": 260000000048,
+                    "offence_id": 35014,
                     "impositions": [
                       {
-                        "result_id": "1",
+                        "result_id": "FO",
                         "amount_imposed": 500.00,
                         "amount_paid": 200.00,
-                        "major_creditor_id": 999
+                        "major_creditor_id": null
                       }
                     ]
                   }
@@ -605,7 +605,7 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
                 "originator_name": "Police Force",
                 "originator_id": 12345,
                 "originator_type": "TFO",
-                "enforcement_court_id": 101,
+                "enforcement_court_id": 260000000048,
                 "collection_order_made": true,
                 "collection_order_made_today": false,
                 "payment_card_request": true,
@@ -641,14 +641,14 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
                 "offences": [
                   {
                     "date_of_sentence": "2023-11-15",
-                    "imposing_court_id": 202,
-                    "offence_id": 1234,
+                    "imposing_court_id": 260000000048,
+                    "offence_id": 35014,
                     "impositions": [
                       {
-                        "result_id": "1",
+                        "result_id": "FO",
                         "amount_imposed": 500.00,
                         "amount_paid": 200.00,
-                        "major_creditor_id": 999
+                        "major_creditor_id": null
                       }
                     ]
                   }
@@ -680,11 +680,11 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
 
     private static String invalidReferenceReplaceRequestBody(Long version) {
         return validReplaceRequestBody(version)
-            .replace("\"enforcement_court_id\": 101", "\"enforcement_court_id\": 999999")
-            .replace("\"offence_id\": 1234", "\"offence_id\": 999998")
-            .replace("\"imposing_court_id\": 202", "\"imposing_court_id\": 999997")
-            .replace("\"result_id\": \"1\"", "\"result_id\": \"NOT-A-RESULT\"")
-            .replace("\"major_creditor_id\": 999", "\"major_creditor_id\": 999996");
+            .replace("\"enforcement_court_id\": 260000000048", "\"enforcement_court_id\": 999999")
+            .replace("\"offence_id\": 35014", "\"offence_id\": 999998")
+            .replace("\"imposing_court_id\": 260000000048", "\"imposing_court_id\": 999997")
+            .replace("\"result_id\": \"FO\"", "\"result_id\": \"NOT-A-RESULT\"")
+            .replace("\"major_creditor_id\": null", "\"major_creditor_id\": 999996");
     }
 
     private static String expectedReferenceValidationErrorMessage() {
@@ -710,7 +710,7 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
                 "originator_name": "Police Force",
                 "originator_id": 12345,
                 "originator_type": "NEW",
-                "enforcement_court_id": 101,
+                "enforcement_court_id": 260000000048,
                 "collection_order_made": true,
                 "collection_order_made_today": false,
                 "payment_card_request": true,
@@ -734,11 +734,11 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
                 "offences": [
                   {
                     "date_of_sentence": "2023-11-15",
-                    "imposing_court_id": 202,
-                    "offence_id": 1234,
+                    "imposing_court_id": 260000000048,
+                    "offence_id": 35014,
                     "impositions": [
                       {
-                        "result_id": "1",
+                        "result_id": "FO",
                         "amount_imposed": 500.00,
                         "amount_paid": 200.00,
                         "major_creditor_id": null,
@@ -783,7 +783,7 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
                 "originator_name": "Police Force",
                 "originator_id": 12345,
                 "originator_type": "NEW",
-                "enforcement_court_id": 101,
+                "enforcement_court_id": 260000000048,
                 "collection_order_made": true,
                 "collection_order_made_today": false,
                 "payment_card_request": true,
@@ -799,14 +799,14 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
                 "offences": [
                   {
                     "date_of_sentence": "2023-11-15",
-                    "imposing_court_id": 202,
-                    "offence_id": 1234,
+                    "imposing_court_id": 260000000048,
+                    "offence_id": 35014,
                     "impositions": [
                       {
-                        "result_id": "1",
+                        "result_id": "FO",
                         "amount_imposed": 500.00,
                         "amount_paid": 200.00,
-                        "major_creditor_id": 999
+                        "major_creditor_id": null
                       }
                     ]
                   }
@@ -841,7 +841,7 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
                 "originator_name": "Police Force",
                 "originator_id": 12345,
                 "originator_type": "NEW",
-                "enforcement_court_id": 101,
+                "enforcement_court_id": 260000000048,
                 "collection_order_made": true,
                 "collection_order_made_today": false,
                 "payment_card_request": true,
@@ -865,14 +865,14 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
                 "offences": [
                   {
                     "date_of_sentence": "2023-11-15",
-                    "imposing_court_id": 202,
-                    "offence_id": 1234,
+                    "imposing_court_id": 260000000048,
+                    "offence_id": 35014,
                     "impositions": [
                       {
-                        "result_id": "1",
+                        "result_id": "FO",
                         "amount_imposed": 500.00,
                         "amount_paid": 200.00,
-                        "major_creditor_id": 999
+                        "major_creditor_id": null
                       }
                     ]
                   }
@@ -907,7 +907,7 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
                 "originator_name": "Police Force",
                 "originator_id": 12345,
                 "originator_type": "NEW",
-                "enforcement_court_id": 101,
+                "enforcement_court_id": 260000000048,
                 "collection_order_made": true,
                 "collection_order_made_today": false,
                 "payment_card_request": true,
@@ -923,11 +923,11 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
                 "offences": [
                   {
                     "date_of_sentence": "2023-11-15",
-                    "imposing_court_id": 202,
-                    "offence_id": 1234,
+                    "imposing_court_id": 260000000048,
+                    "offence_id": 35014,
                     "impositions": [
                       {
-                        "result_id": "1",
+                        "result_id": "FO",
                         "amount_imposed": 500.00,
                         "amount_paid": 200.00,
                         "major_creditor_id": null,

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPutIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPutIntegrationTest.java
@@ -472,7 +472,7 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
             .andExpect(status().isBadRequest())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("$.title").value("Bad Request"))
-            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/json-schema-validation"))
+            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/invalid-reference-validation"))
             .andExpect(jsonPath("$.detail").value(expectedReferenceValidationErrorMessage()));
 
         DraftAccountEntity after = getDraftAccount(5L);

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPutIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPutIntegrationTest.java
@@ -23,6 +23,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.dto.DraftAccountResponseDto;
 import uk.gov.hmcts.opal.dto.PdplIdentifierType;
 import uk.gov.hmcts.opal.dto.ToJsonString;
+import uk.gov.hmcts.opal.entity.draft.DraftAccountEntity;
 import uk.gov.hmcts.opal.logging.integration.dto.PersonalDataProcessingCategory;
 import uk.gov.hmcts.opal.logging.integration.dto.PersonalDataProcessingLogDetails;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
@@ -454,6 +455,44 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
     }
 
     @Test
+    @DisplayName("Replace draft account - Should return 400 when reference validation fails and leave data unchanged")
+    @JiraStory("PO-973")
+    @JiraEpic("PO-2220")
+    void testReplaceDraftAccount_referenceValidationFailure_returns400AndLeavesDataUnchanged() throws Exception {
+        DraftAccountEntity before = getDraftAccount(5L);
+        long countBefore = draftAccountRepository.count();
+        String ifMatch = getIfMatchForDraftAccount(5L);
+
+        mockMvc.perform(put(URL_BASE + "/5")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .header("If-Match", ifMatch)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(invalidReferenceReplaceRequestBody(0L)))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.title").value("Bad Request"))
+            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/json-schema-validation"))
+            .andExpect(jsonPath("$.detail").value(expectedReferenceValidationErrorMessage()));
+
+        DraftAccountEntity after = getDraftAccount(5L);
+
+        assertEquals(countBefore, draftAccountRepository.count());
+        assertEquals(before.getAccount(), after.getAccount());
+        assertEquals(before.getAccountStatus(), after.getAccountStatus());
+        assertEquals(before.getVersionNumber(), after.getVersionNumber());
+        assertEquals(before.getAccountId(), after.getAccountId());
+        assertEquals(before.getAccountNumber(), after.getAccountNumber());
+        assertEquals(before.getStatusMessage(), after.getStatusMessage());
+        assertEquals(before.getSubmittedBy(), after.getSubmittedBy());
+        assertEquals(before.getSubmittedByName(), after.getSubmittedByName());
+        assertEquals(before.getValidatedBy(), after.getValidatedBy());
+        assertEquals(before.getValidatedByName(), after.getValidatedByName());
+        assertEquals(before.getAccountSnapshot(), after.getAccountSnapshot());
+        assertEquals(before.getTimelineData(), after.getTimelineData());
+    }
+
+    @Test
     @DisplayName("Replace draft account - user with no permission [@PO-973, @PO-830]")
     @JiraStory("PO-973")
     @JiraStory("PO-830")
@@ -637,6 +676,26 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
             """
 
                 }""";
+    }
+
+    private static String invalidReferenceReplaceRequestBody(Long version) {
+        return validReplaceRequestBody(version)
+            .replace("\"enforcement_court_id\": 101", "\"enforcement_court_id\": 999999")
+            .replace("\"offence_id\": 1234", "\"offence_id\": 999998")
+            .replace("\"imposing_court_id\": 202", "\"imposing_court_id\": 999997")
+            .replace("\"result_id\": \"1\"", "\"result_id\": \"NOT-A-RESULT\"")
+            .replace("\"major_creditor_id\": 999", "\"major_creditor_id\": 999996");
+    }
+
+    private static String expectedReferenceValidationErrorMessage() {
+        return """
+            Draft account reference validation failed with 5 error(s):
+             - $.enforcement_court_id: court id 999999 does not exist
+             - $.offences[0].offence_id: offence id 999998 does not exist
+             - $.offences[0].imposing_court_id: court id 999997 does not exist
+             - $.offences[0].impositions[0].result_id: result id NOT-A-RESULT does not exist
+             - $.offences[0].impositions[0].major_creditor_id: major creditor id 999996 does not exist
+            """.stripIndent().stripTrailing();
     }
 
     private static String validReplaceRequestBodyForPdpl(Long version) {

--- a/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
@@ -518,7 +518,8 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(InvalidReferenceValidationException.class)
-    public ResponseEntity<ProblemDetail> handleInvalidReferenceValidationException(InvalidReferenceValidationException e) {
+    public ResponseEntity<ProblemDetail> handleInvalidReferenceValidationException(
+        InvalidReferenceValidationException e) {
         ProblemDetail problemDetail = createProblemDetail(
             HttpStatus.BAD_REQUEST,
             "Bad Request",

--- a/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
@@ -48,6 +48,7 @@ import uk.gov.hmcts.common.exceptions.standard.UnauthorizedException;
 import uk.gov.hmcts.opal.common.exception.OpalApiException;
 import uk.gov.hmcts.opal.common.logging.LogUtil;
 import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
+import uk.gov.hmcts.opal.exception.InvalidReferenceValidationException;
 import uk.gov.hmcts.opal.exception.JsonSchemaValidationException;
 import uk.gov.hmcts.opal.exception.MissingReportServiceException;
 import uk.gov.hmcts.opal.exception.MissingStoredReportContentException;
@@ -510,6 +511,19 @@ public class GlobalExceptionHandler {
             "Bad Request",
             "The request does not conform to the required JSON schema",
             "json-schema-validation",
+            false,
+            e
+        );
+        return responseWithProblemDetail(HttpStatus.BAD_REQUEST, problemDetail);
+    }
+
+    @ExceptionHandler(InvalidReferenceValidationException.class)
+    public ResponseEntity<ProblemDetail> handleInvalidReferenceValidationException(InvalidReferenceValidationException e) {
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.BAD_REQUEST,
+            "Bad Request",
+            e.getMessage(),
+            "invalid-reference-validation",
             false,
             e
         );

--- a/src/main/java/uk/gov/hmcts/opal/exception/InvalidReferenceValidationException.java
+++ b/src/main/java/uk/gov/hmcts/opal/exception/InvalidReferenceValidationException.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.opal.exception;
+
+public class InvalidReferenceValidationException extends RuntimeException {
+
+    public InvalidReferenceValidationException(String msg) {
+        super(msg);
+    }
+
+    public InvalidReferenceValidationException(Throwable t) {
+        super(t);
+    }
+
+    public InvalidReferenceValidationException(String message, Throwable t) {
+        super(message, t);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationService.java
@@ -1,0 +1,128 @@
+package uk.gov.hmcts.opal.service;
+
+import static uk.gov.hmcts.opal.util.JsonPathUtil.createDocContext;
+import static uk.gov.hmcts.opal.util.JsonPathUtil.safeReadList;
+import static uk.gov.hmcts.opal.util.JsonPathUtil.safeReadLong;
+import static uk.gov.hmcts.opal.util.JsonPathUtil.safeReadString;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.opal.exception.JsonSchemaValidationException;
+import uk.gov.hmcts.opal.repository.CourtLiteRepository;
+import uk.gov.hmcts.opal.repository.MajorCreditorRepository;
+import uk.gov.hmcts.opal.repository.OffenceRepository;
+import uk.gov.hmcts.opal.repository.ResultRepository;
+import uk.gov.hmcts.opal.util.JsonPathUtil;
+
+@Service
+@RequiredArgsConstructor
+public class DraftAccountReferenceValidationService {
+
+    private static final String ROOT_PATH = "$";
+
+    private final CourtLiteRepository courtLiteRepository;
+    private final OffenceRepository offenceRepository;
+    private final ResultRepository resultRepository;
+    private final MajorCreditorRepository majorCreditorRepository;
+
+    @Transactional(readOnly = true)
+    public void validateReferences(String accountJson) {
+        JsonPathUtil.DocContext docContext;
+        try {
+            docContext = createDocContext(accountJson, "DraftAccountReferenceValidationService");
+        } catch (IllegalArgumentException ex) {
+            throw new JsonSchemaValidationException("Unable to parse draft account JSON: " + ex.getMessage(), ex);
+        }
+
+        List<String> failures = new ArrayList<>();
+
+        validateEnforcementCourt(docContext, failures);
+        validateOffences(docContext, failures);
+        validatePaymentTermsEnforcements(docContext, failures);
+
+        if (!failures.isEmpty()) {
+            throw new JsonSchemaValidationException(buildFailureMessage(failures));
+        }
+    }
+
+    private void validateEnforcementCourt(JsonPathUtil.DocContext docContext, List<String> failures) {
+        Long enforcementCourtId = safeReadLong(docContext, ROOT_PATH + ".enforcement_court_id");
+        if (enforcementCourtId == null) {
+            return;
+        }
+
+        if (!courtLiteRepository.existsById(enforcementCourtId)) {
+            failures.add(ROOT_PATH + ".enforcement_court_id: court id " + enforcementCourtId + " does not exist");
+        }
+    }
+
+    private void validateOffences(JsonPathUtil.DocContext docContext, List<String> failures) {
+        List<?> offences = safeReadList(docContext, ROOT_PATH + ".offences");
+        if (offences == null) {
+            return;
+        }
+
+        for (int offenceIndex = 0; offenceIndex < offences.size(); offenceIndex++) {
+            String offencePath = ROOT_PATH + ".offences[" + offenceIndex + "]";
+
+            Long offenceId = safeReadLong(docContext, offencePath + ".offence_id");
+            if (offenceId != null && !offenceRepository.existsById(offenceId)) {
+                failures.add(offencePath + ".offence_id: offence id " + offenceId + " does not exist");
+            }
+
+            Long imposingCourtId = safeReadLong(docContext, offencePath + ".imposing_court_id");
+            if (imposingCourtId != null && !courtLiteRepository.existsById(imposingCourtId)) {
+                failures.add(offencePath + ".imposing_court_id: court id " + imposingCourtId + " does not exist");
+            }
+
+            List<?> impositions = safeReadList(docContext, offencePath + ".impositions");
+            if (impositions == null) {
+                continue;
+            }
+
+            for (int impositionIndex = 0; impositionIndex < impositions.size(); impositionIndex++) {
+                String impositionPath = offencePath + ".impositions[" + impositionIndex + "]";
+
+                String resultId = safeReadString(docContext, impositionPath + ".result_id", null);
+                if (resultId != null && !resultRepository.existsById(resultId)) {
+                    failures.add(impositionPath + ".result_id: result id " + resultId + " does not exist");
+                }
+
+                Long majorCreditorId = safeReadLong(docContext, impositionPath + ".major_creditor_id");
+                if (majorCreditorId != null && !majorCreditorRepository.existsById(majorCreditorId)) {
+                    failures.add(impositionPath + ".major_creditor_id: major creditor id " + majorCreditorId
+                        + " does not exist");
+                }
+            }
+        }
+    }
+
+    private void validatePaymentTermsEnforcements(JsonPathUtil.DocContext docContext, List<String> failures) {
+        List<?> enforcements = safeReadList(docContext, ROOT_PATH + ".payment_terms.enforcements");
+        if (enforcements == null) {
+            return;
+        }
+
+        for (int enforcementIndex = 0; enforcementIndex < enforcements.size(); enforcementIndex++) {
+            String enforcementPath = ROOT_PATH + ".payment_terms.enforcements[" + enforcementIndex + "]";
+
+            String resultId = safeReadString(docContext, enforcementPath + ".result_id", null);
+            if (resultId != null && !resultRepository.existsById(resultId)) {
+                failures.add(enforcementPath + ".result_id: result id " + resultId + " does not exist");
+            }
+        }
+    }
+
+    private String buildFailureMessage(List<String> failures) {
+        StringBuilder message = new StringBuilder("Draft account reference validation failed with ")
+            .append(failures.size())
+            .append(" error(s):");
+        for (String failure : failures) {
+            message.append("\n - ").append(failure);
+        }
+        return message.toString();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationService.java
@@ -10,6 +10,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.opal.exception.InvalidReferenceValidationException;
 import uk.gov.hmcts.opal.exception.JsonSchemaValidationException;
 import uk.gov.hmcts.opal.repository.CourtLiteRepository;
 import uk.gov.hmcts.opal.repository.MajorCreditorRepository;
@@ -44,7 +45,7 @@ public class DraftAccountReferenceValidationService {
         validatePaymentTermsEnforcements(docContext, failures);
 
         if (!failures.isEmpty()) {
-            throw new JsonSchemaValidationException(buildFailureMessage(failures));
+            throw new InvalidReferenceValidationException(buildFailureMessage(failures));
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/opal/service/DraftAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DraftAccountService.java
@@ -18,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.UnexpectedRollbackException;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.opal.SchemaPaths;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.common.logging.SecurityEventLoggingService;
@@ -165,6 +166,7 @@ public class DraftAccountService {
             .toList();
     }
 
+    @Transactional
     public DraftAccountResponseDto submitDraftAccount(AddDraftAccountRequestDto dto) {
 
         UserState userState = userStateService.getUserStateV1FromSecurityContext();
@@ -192,6 +194,7 @@ public class DraftAccountService {
 
     }
 
+    @Transactional
     public DraftAccountResponseDto replaceDraftAccount(Long draftAccountId, ReplaceDraftAccountRequestDto dto,
                                                        String ifMatch) {
 

--- a/src/main/java/uk/gov/hmcts/opal/service/DraftAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DraftAccountService.java
@@ -62,6 +62,8 @@ public class DraftAccountService {
 
     private final JsonSchemaValidationService jsonSchemaValidationService;
 
+    private final DraftAccountReferenceValidationService referenceValidationService;
+
     private final DraftAccountMapper draftAccountMapper;
 
     private final DraftAccountPublishProxy accountPublishProxy;
@@ -174,6 +176,7 @@ public class DraftAccountService {
             applySubmittedBy(dto, userState, unitUser);
 
             jsonSchemaValidationService.validateOrError(dto.toJson(), ADD_DRAFT_ACCOUNT_REQUEST_JSON);
+            referenceValidationService.validateReferences(dto.getAccount());
             DraftAccountEntity entity = draftAccountTransactional.submitDraftAccount(dto);
             log.debug(":submitDraftAccount: created in DB: {}", entity);
 
@@ -199,7 +202,7 @@ public class DraftAccountService {
             BusinessUnitUser unitUser = getBusinessUnitUserOrThrow(userState, dto.getBusinessUnitId());
             applySubmittedBy(dto, userState, unitUser);
             jsonSchemaValidationService.validateOrError(dto.toJson(), REPLACE_DRAFT_ACCOUNT_REQUEST_JSON);
-
+            referenceValidationService.validateReferences(dto.getAccount());
             DraftAccountEntity replacedEntity = draftAccountTransactional
                 .replaceDraftAccount(draftAccountId, dto, draftAccountTransactional, ifMatch);
             verifyUpdated(replacedEntity, dto, draftAccountId, "replaceDraftAccount");
@@ -227,9 +230,7 @@ public class DraftAccountService {
                 applyValidatedBy(dto, userState, unitUser.orElseThrow());
             }
             jsonSchemaValidationService.validateOrError(dto.toJson(), UPDATE_DRAFT_ACCOUNT_REQUEST_JSON);
-
             BigInteger updateVersion = extractBigInteger(ifMatch);
-
             DraftAccountEntity updatedEntity = draftAccountTransactional.updateDraftAccount(draftAccountId, dto,
                 draftAccountTransactional, updateVersion, userState);
             verifyUpdated(updatedEntity, updateVersion, draftAccountId, "updateDraftAccount");

--- a/src/main/java/uk/gov/hmcts/opal/util/JsonPathUtil.java
+++ b/src/main/java/uk/gov/hmcts/opal/util/JsonPathUtil.java
@@ -7,6 +7,7 @@ import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.PathNotFoundException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j(topic = "opal.JsonPathUtil")
@@ -108,6 +109,37 @@ public class JsonPathUtil {
                 return new BigDecimal(String.valueOf(value));
             }
             return new BigDecimal(String.valueOf(value));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static List<?> safeReadList(DocContext docContext, String path) {
+        try {
+            Object value = docContext.read(path);
+            if (value instanceof List<?> list) {
+                return list;
+            }
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static Long safeReadLong(DocContext docContext, String path) {
+        try {
+            Object value = docContext.read(path);
+            if (value == null) {
+                return null;
+            }
+            if (value instanceof Number number) {
+                return number.longValue();
+            }
+            String stringValue = String.valueOf(value).trim();
+            if (stringValue.isEmpty()) {
+                return null;
+            }
+            return Long.parseLong(stringValue);
         } catch (Exception e) {
             return null;
         }

--- a/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
@@ -61,6 +61,7 @@ import uk.gov.hmcts.opal.common.user.authentication.exception.AuthenticationErro
 import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
 import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountEntity;
+import uk.gov.hmcts.opal.exception.InvalidReferenceValidationException;
 import uk.gov.hmcts.opal.exception.JsonSchemaValidationException;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.opal.exception.SubmitterDeniedException;
@@ -372,6 +373,19 @@ class GlobalExceptionHandlerTest {
             .handleJsonSchemaValidationException(new JsonSchemaValidationException("bad schema"));
         assertEquals(HttpStatus.BAD_REQUEST, r.getStatusCode());
         assertEquals(false, r.getBody().getProperties().get("retriable"));
+    }
+
+    @Test
+    void handleInvalidReferenceValidation_false() {
+        InvalidReferenceValidationException ex = new InvalidReferenceValidationException("bad reference data");
+        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleInvalidReferenceValidationException(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, r.getStatusCode());
+        ProblemDetail pd = r.getBody();
+        assertEquals("Bad Request", pd.getTitle());
+        assertEquals("bad reference data", pd.getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/invalid-reference-validation"), pd.getType());
+        assertEquals(false, pd.getProperties().get("retriable"));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationServiceTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.hmcts.opal.exception.JsonSchemaValidationException;
+import uk.gov.hmcts.opal.exception.InvalidReferenceValidationException;
 import uk.gov.hmcts.opal.repository.CourtLiteRepository;
 import uk.gov.hmcts.opal.repository.MajorCreditorRepository;
 import uk.gov.hmcts.opal.repository.OffenceRepository;
@@ -54,7 +54,7 @@ class DraftAccountReferenceValidationServiceTest {
         when(resultRepository.existsById(anyString())).thenReturn(false);
         when(majorCreditorRepository.existsById(anyLong())).thenReturn(false);
 
-        JsonSchemaValidationException exception = assertThrows(JsonSchemaValidationException.class,
+        InvalidReferenceValidationException exception = assertThrows(InvalidReferenceValidationException.class,
             () -> service.validateReferences(validAccountJson()));
 
         String message = exception.getMessage();

--- a/src/test/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationServiceTest.java
@@ -1,0 +1,124 @@
+package uk.gov.hmcts.opal.service;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.opal.exception.JsonSchemaValidationException;
+import uk.gov.hmcts.opal.repository.CourtLiteRepository;
+import uk.gov.hmcts.opal.repository.MajorCreditorRepository;
+import uk.gov.hmcts.opal.repository.OffenceRepository;
+import uk.gov.hmcts.opal.repository.ResultRepository;
+
+@ExtendWith(MockitoExtension.class)
+class DraftAccountReferenceValidationServiceTest {
+
+    @Mock
+    private CourtLiteRepository courtLiteRepository;
+
+    @Mock
+    private OffenceRepository offenceRepository;
+
+    @Mock
+    private ResultRepository resultRepository;
+
+    @Mock
+    private MajorCreditorRepository majorCreditorRepository;
+
+    @InjectMocks
+    private DraftAccountReferenceValidationService service;
+
+    @Test
+    void validateReferences_whenAllReferencesExist_shouldPass() {
+        when(courtLiteRepository.existsById(anyLong())).thenReturn(true);
+        when(offenceRepository.existsById(anyLong())).thenReturn(true);
+        when(resultRepository.existsById(anyString())).thenReturn(true);
+        when(majorCreditorRepository.existsById(anyLong())).thenReturn(true);
+
+        assertDoesNotThrow(() -> service.validateReferences(validAccountJson()));
+    }
+
+    @Test
+    void validateReferences_whenSomeReferencesAreMissing_shouldReportAllFailures() {
+        when(courtLiteRepository.existsById(anyLong())).thenReturn(false);
+        when(offenceRepository.existsById(anyLong())).thenReturn(false);
+        when(resultRepository.existsById(anyString())).thenReturn(false);
+        when(majorCreditorRepository.existsById(anyLong())).thenReturn(false);
+
+        JsonSchemaValidationException exception = assertThrows(JsonSchemaValidationException.class,
+            () -> service.validateReferences(validAccountJson()));
+
+        String message = exception.getMessage();
+        assertContains(message, "$.enforcement_court_id");
+        assertContains(message, "$.offences[0].offence_id");
+        assertContains(message, "$.offences[0].imposing_court_id");
+        assertContains(message, "$.offences[0].impositions[0].result_id");
+        assertContains(message, "$.offences[0].impositions[0].major_creditor_id");
+        assertContains(message, "$.offences[1].offence_id");
+        assertContains(message, "$.offences[1].imposing_court_id");
+        assertContains(message, "$.offences[1].impositions[0].result_id");
+        assertContains(message, "$.offences[1].impositions[0].major_creditor_id");
+        assertContains(message, "$.payment_terms.enforcements[0].result_id");
+        assertContains(message, "$.payment_terms.enforcements[1].result_id");
+
+        verify(courtLiteRepository, times(3)).existsById(anyLong());
+        verify(offenceRepository, times(2)).existsById(anyLong());
+        verify(resultRepository, times(4)).existsById(anyString());
+        verify(majorCreditorRepository, times(2)).existsById(anyLong());
+    }
+
+    private static void assertContains(String message, String fragment) {
+        org.junit.jupiter.api.Assertions.assertTrue(message.contains(fragment),
+            () -> "Expected message to contain: " + fragment + "\nActual message:\n" + message);
+    }
+
+    private static String validAccountJson() {
+        return """
+            {
+              "enforcement_court_id": 11,
+              "offences": [
+                {
+                  "offence_id": 21,
+                  "imposing_court_id": 31,
+                  "impositions": [
+                    {
+                      "result_id": "PRIS",
+                      "major_creditor_id": 41
+                    }
+                  ]
+                },
+                {
+                  "offence_id": 22,
+                  "imposing_court_id": 32,
+                  "impositions": [
+                    {
+                      "result_id": "NOENF",
+                      "major_creditor_id": 42
+                    }
+                  ]
+                }
+              ],
+              "payment_terms": {
+                "payment_terms_type_code": "B",
+                "enforcements": [
+                  {
+                    "result_id": "COLLO"
+                  },
+                  {
+                    "result_id": "MISSING"
+                  }
+                ]
+              }
+            }
+            """;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
@@ -78,6 +78,9 @@ class DraftAccountServiceTest {
     private DraftAccountTransactional draftAccountTransactional;
 
     @Mock
+    private DraftAccountReferenceValidationService referenceValidationService;
+
+    @Mock
     private DraftAccountMapper draftAccountMapper;
 
     @Mock
@@ -186,6 +189,7 @@ class DraftAccountServiceTest {
 
         // Assert
         assertEquals(draftAccountEntity.getAccount(), result.getAccount());
+        verify(referenceValidationService).validateReferences(addDraftAccountDto.getAccount());
         ArgumentCaptor<AddDraftAccountRequestDto> captor = ArgumentCaptor.forClass(AddDraftAccountRequestDto.class);
         verify(draftAccountTransactional, times(1)).submitDraftAccount(captor.capture());
         assertEquals("USER01", captor.getValue().getSubmittedBy());
@@ -313,6 +317,7 @@ class DraftAccountServiceTest {
         assertEquals(DraftAccountType.FINE, result.getAccountType());
         assertEquals(DraftAccountStatus.RESUBMITTED, result.getAccountStatus());
         assertEquals(createTimelineDataString(), result.getTimelineData());
+        verify(referenceValidationService).validateReferences(replaceDto.getAccount());
 
         ArgumentCaptor<ReplaceDraftAccountRequestDto> captor =
             ArgumentCaptor.forClass(ReplaceDraftAccountRequestDto.class);

--- a/src/test/java/uk/gov/hmcts/opal/util/JsonPathUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/util/JsonPathUtilTest.java
@@ -38,6 +38,10 @@ class JsonPathUtilTest {
             Arguments.of(
                 (Supplier<Object>) () -> JsonPathUtil.safeReadBigDecimal(context, unknownPath),
                 null
+            ),
+            Arguments.of(
+                (Supplier<Object>) () -> JsonPathUtil.safeReadLong(context, unknownPath),
+                null
             )
         );
     }
@@ -98,6 +102,16 @@ class JsonPathUtilTest {
         BigDecimal actual = JsonPathUtil.safeReadBigDecimal(context, "$.bigDecimalField");
 
         assertEquals(BigDecimal.valueOf(10.5), actual);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{\"longField\": 10}", "{\"longField\": \"10\"}"})
+    void safeReadLong_returnsLong(String json) {
+        DocContext context = JsonPathUtil.createDocContext(json, "");
+
+        Long actual = JsonPathUtil.safeReadLong(context, "$.longField");
+
+        assertEquals(Long.valueOf(10), actual);
     }
 
     @Test


### PR DESCRIPTION
[PO-5741](https://tools.hmcts.net/jira/browse/PO-5741) BE - Draft Account Reference Validation Infrastructure

### Changes:

Added DraftAccountReferenceValidationService to validate draft-account JSON reference IDs against the database using JsonPath.

We are checking these reference IDs in the draft account JSON:

- $.enforcement_court_id
- $.offences[*].offence_id
- $.offences[*].imposing_court_id
- $.offences[*].impositions[*].result_id
- $.offences[*].impositions[*].major_creditor_id
- $.payment_terms.enforcements[*].result_id

