### PR TITLE
Allow OA submitted-by IDs in functional response assertions

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/opal/assertions/CommonResponseAssertions.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/assertions/CommonResponseAssertions.java
@@ -17,8 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class CommonResponseAssertions {
     private static final Pattern STRONG_ETAG = Pattern.compile("^\"[^\"]+\"$");
     private static final Pattern LEGACY_USER_ID_PATTERN = Pattern.compile("^(L\\d{3})JG$");
-    private static final String DEFAULT_APP_MODE = System.getenv().getOrDefault("DEFAULT_APP_MODE", "opal");
-    private static final String LEGACY_GATEWAY_URL = System.getenv().getOrDefault("OPAL_LEGACY_GATEWAY_URL", "");
 
     /**
      * Asserts that a response body contains the supplied field values.
@@ -43,9 +41,8 @@ public class CommonResponseAssertions {
     }
 
     /**
-     * Normalises selected expected values for deployed legacy environments whose upstream source
-     * returns the operational-assistant user-code variant instead of the stubbed judicial-greffe
-     * variant used elsewhere.
+     * Normalises selected expected values when the environment returns the operational-assistant
+     * user-code variant instead of the judicial-greffe variant used in the feature data.
      *
      * @param fieldName asserted response field name.
      * @param expected expected field value from the feature data.
@@ -54,7 +51,7 @@ public class CommonResponseAssertions {
      *         original expected value.
      */
     private String resolveEnvironmentSpecificExpectedValue(String fieldName, String expected, String actual) {
-        if (!isLegacyAgainstPreprod() || expected == null || actual == null) {
+        if (expected == null || actual == null) {
             return expected;
         }
 
@@ -68,20 +65,10 @@ public class CommonResponseAssertions {
             return expected;
         }
 
+        // Accept the operational-assistant variant for the same business-unit user id, for
+        // example L073JG in the feature data matching L073OA in deployed environments.
         String expectedPreprodValue = matcher.group(1) + "OA";
         return expectedPreprodValue.equals(actual) ? expectedPreprodValue : expected;
-    }
-
-    /**
-     * Identifies legacy-mode runs that are not backed by the legacy stub gateway.
-     *
-     * @return {@code true} when the current functional-test run is in legacy mode against a
-     *         non-stub legacy gateway; otherwise {@code false}.
-     */
-    private boolean isLegacyAgainstPreprod() {
-        return "legacy".equalsIgnoreCase(DEFAULT_APP_MODE)
-            && !LEGACY_GATEWAY_URL.isBlank()
-            && !LEGACY_GATEWAY_URL.contains("legacy-db-stub");
     }
 
     /**

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagIntegrationTest.java
@@ -84,7 +84,7 @@ class MinorCreditorApiControllerFeatureFlagIntegrationTest extends AbstractInteg
     @Test
     @JiraStory("PO-2642")
     @JiraEpic("PO-3685")
-    @JiraTestKey("PO-2642")
+    @JiraTestKey("PO-8672")
     void getMinorCreditorHistory_whenRelease1bDisabled_returns404AndDoesNotCallService() throws Exception {
         ResultActions result = mockMvc.perform(get("/minor-creditor-accounts/" + MINOR_CREDITOR_ACCOUNT_ID + "/history")
                                                    .header("Authorization", "Bearer some_value"));


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

update functional response assertions to accept OA submitted-by user IDs alongside the existing JG variants
add a clarifying code comment explaining the JG to OA fallback for deployed environments
remove the old legacy/preprod gate so the assertion matches current environment behaviour

Why:
Demo functional tests were failing because responses returned account_snapshot.submitted_by values such as L073OA and L077OA, while the feature expectations still use L073JG and L077JG.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
