### PR TITLE
PO-3951 Added read-only Feign retry policy for user service

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/config/FeignConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/opal/config/FeignConfiguration.java
@@ -6,10 +6,9 @@ import org.springframework.cloud.openfeign.support.FeignHttpMessageConverters;
 import org.springframework.cloud.openfeign.support.ResponseEntityDecoder;
 import org.springframework.cloud.openfeign.support.SpringDecoder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
 public class FeignConfiguration {
+
 
     @Bean
     public Decoder feignDecoder(ObjectProvider<FeignHttpMessageConverters> messageConverters) {

--- a/src/main/java/uk/gov/hmcts/opal/config/ReadOnlyFeignRetryer.java
+++ b/src/main/java/uk/gov/hmcts/opal/config/ReadOnlyFeignRetryer.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.opal.config;
+
+import feign.Request;
+import feign.RetryableException;
+import feign.Retryer;
+import java.util.Set;
+
+public class ReadOnlyFeignRetryer implements Retryer {
+
+    private static final Set<Request.HttpMethod> RETRIABLE_METHODS = Set.of(
+        Request.HttpMethod.GET,
+        Request.HttpMethod.HEAD
+    );
+
+    private final Retryer delegate;
+
+    public ReadOnlyFeignRetryer() {
+        this(new Retryer.Default(100, 1000, 2));
+    }
+
+    public ReadOnlyFeignRetryer(Retryer delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void continueOrPropagate(RetryableException e) {
+        if (!RETRIABLE_METHODS.contains(e.method())) {
+            throw e;
+        }
+
+        delegate.continueOrPropagate(e);
+    }
+
+    @Override
+    public Retryer clone() {
+        return new ReadOnlyFeignRetryer(delegate.clone());
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,6 +24,12 @@ spring:
     import: "optional:configtree:/mnt/secrets/opal/"
   application:
     name: Opal Fines Service
+    cloud:
+      openfeign:
+        client:
+          config:
+            userService:
+              retryer: uk.gov.hmcts.opal.config.ReadOnlyFeignRetryer
   security:
     oauth2:
       client:

--- a/src/test/java/uk/gov/hmcts/opal/config/ReadOnlyFeignRetryerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/config/ReadOnlyFeignRetryerTest.java
@@ -1,0 +1,88 @@
+package uk.gov.hmcts.opal.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import feign.Request;
+import feign.RequestTemplate;
+import feign.RetryableException;
+import feign.Retryer;
+import java.net.SocketTimeoutException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class ReadOnlyFeignRetryerTest {
+
+    @Test
+    void continueOrPropagate_delegatesForGetRequests() {
+        RecordingRetryer delegate = new RecordingRetryer();
+        ReadOnlyFeignRetryer retryer = new ReadOnlyFeignRetryer(delegate);
+
+        assertDoesNotThrow(() -> retryer.continueOrPropagate(retryableException(Request.HttpMethod.GET)));
+
+        assertThat(delegate.attempts).isEqualTo(1);
+    }
+
+    @Test
+    void continueOrPropagate_propagatesForPostRequests() {
+        RecordingRetryer delegate = new RecordingRetryer();
+        ReadOnlyFeignRetryer retryer = new ReadOnlyFeignRetryer(delegate);
+        RetryableException exception = retryableException(Request.HttpMethod.POST);
+
+        assertThatThrownBy(() -> retryer.continueOrPropagate(exception)).isSameAs(exception);
+
+        assertThat(delegate.attempts).isZero();
+    }
+
+    @Test
+    void clone_usesClonedDelegate() {
+        RecordingRetryer delegate = new RecordingRetryer();
+        RecordingRetryer clonedDelegate = new RecordingRetryer();
+        delegate.clone = clonedDelegate;
+
+        Retryer retryer = new ReadOnlyFeignRetryer(delegate).clone();
+
+        assertDoesNotThrow(() -> retryer.continueOrPropagate(retryableException(Request.HttpMethod.GET)));
+
+        assertThat(delegate.attempts).isZero();
+        assertThat(clonedDelegate.attempts).isEqualTo(1);
+    }
+
+    private static RetryableException retryableException(Request.HttpMethod method) {
+        return new RetryableException(
+            -1,
+            "Read timed out",
+            method,
+            new SocketTimeoutException("Read timed out"),
+            (Long) null,
+            request(method)
+        );
+    }
+
+    private static Request request(Request.HttpMethod method) {
+        return Request.create(
+            method,
+            "http://user-service/opal/v2/users/0/state",
+            Map.of(),
+            (byte[]) null,
+            null,
+            new RequestTemplate()
+        );
+    }
+
+    private static class RecordingRetryer implements Retryer {
+        private int attempts;
+        private Retryer clone = this;
+
+        @Override
+        public void continueOrPropagate(RetryableException e) {
+            attempts++;
+        }
+
+        @Override
+        public Retryer clone() {
+            return clone;
+        }
+    }
+}


### PR DESCRIPTION
### https://tools.hmcts.net/jira/browse/PO-3951 ###



### Implemented a read-only Feign retry policy for user service calls.
Added ReadOnlyFeignRetryer to retry GET/HEAD requests only
Scoped the retryer to the userService OpenFeign client via configuration
Avoided retrying POST/write requests to prevent duplicate side effects
Removed the global Retryer bean approach after it conflicted with pdpoSyncRetryer  ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
