### PR TITLE
PO-3832 - alter permission check logic for opal addNote

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyNotesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LegacyNotesIntegrationTest.java
@@ -5,11 +5,14 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TE
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
+import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 
 @ActiveProfiles({"integration", "legacy"})
 @Sql(scripts = "classpath:db/insertData/insert_into_defendant_accounts.sql", executionPhase = BEFORE_TEST_CLASS)
@@ -31,6 +34,25 @@ public class LegacyNotesIntegrationTest extends NotesIntegrationTest {
     @JiraTestKey("PO-5957")
     void testSearchDefendantAccount_NoAccountsFound() throws Exception {
         super.legacyTestAddNote500Error(log);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("nonNotesPermissions")
+    @JiraStory("PO-1566")
+    @JiraEpic("PO-812")
+    @JiraTestKey("PO-5959")
+    void testLegacyNotes_Forbidden(FinesPermission permission) throws Exception {
+        super.postNotes_UserWithoutPermission(permission);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("businessUnitAuthorizationScenarios")
+    @JiraStory("PO-1566")
+    @JiraEpic("PO-812")
+    @JiraTestKey("PO-5960")
+    void testLegacyNotes_BusinessUnitAuthorization(BusinessUnitAuthorizationScenario scenario)
+        throws Exception {
+        super.postNotes_BusinessUnitAuthorization(scenario);
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/NotesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/NotesIntegrationTest.java
@@ -3,9 +3,11 @@ package uk.gov.hmcts.opal.controllers;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.authorisation.model.FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES;
 import static uk.gov.hmcts.opal.controllers.util.UserStateUtil.allFinesPermissionsToken;
 import static uk.gov.hmcts.opal.controllers.util.UserStateUtil.noFinesPermissionsToken;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.slf4j.Logger;
 import org.springframework.http.HttpHeaders;
@@ -23,11 +25,15 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
 
     private static final String URL_BASE = "/notes";
 
+    @BeforeEach
+    void setUp() {
+        userStateStub.addPermissions((short) 78, ADD_ACCOUNT_ACTIVITY_NOTES);
+    }
+
 
     @DisplayName("OPAL: POST /notes/add creates note for defendant account [PO-1566]")
     @JiraStory("PO-1566")
     void postNotesImpl(Logger log) throws Exception {
-
         // Arrange
         Note note = new Note();
         note.setNoteText("test");
@@ -52,6 +58,7 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
                     .content(payload)
                     .header("authorization", userStateStub.getBearerToken())
                     .header(HttpHeaders.IF_MATCH, "\"" + currentVersion + "\"")
+                    .header("Business_Unit_ID", "78")
                     .with(authentication(allFinesPermissionsToken()))
             );
 
@@ -67,7 +74,7 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
 
         Note note = new Note();
         note.setNoteText("test");
-        note.setRecordId("122");
+        note.setRecordId("7A");
         note.setRecordType(RecordType.DEFENDANT_ACCOUNTS);
         note.setNoteType("AA");
 
@@ -82,6 +89,7 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
                     .content(objectMapper.writeValueAsString(request))
                     .header("authorization", userStateStub.getBearerToken())
                     .header("If-Match", "1")
+                    .header("Business_Unit_ID", "78")
                     .with(authentication(allFinesPermissionsToken()))
             );
 
@@ -112,6 +120,7 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
                 .with(userStateStub.getAuthenticaitonRequestPostProcessor())
                 .header("authorization", userStateStub.getBearerToken())
                 .header("If-Match", "1")
+                .header("Business_Unit_ID", "78")
                 .with(authentication(noFinesPermissionsToken()))
         );
 
@@ -121,6 +130,8 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
     @DisplayName("post notes for a defendant account in legacy [PO-1975]")
     @JiraStory("PO-1975")
     void legacyTestAddNoteSuccess(Logger log) throws Exception {
+
+        userStateStub.addPermissions((short) 78, ADD_ACCOUNT_ACTIVITY_NOTES);
 
         Note note = new Note();
         note.setNoteText("test");
@@ -139,6 +150,7 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
                     .content(objectMapper.writeValueAsString(request))
                     .header("authorization", userStateStub.getBearerToken())
                     .header("If-Match", "1")
+                    .header("Business_Unit_ID", 78)
                     .with(authentication(allFinesPermissionsToken()))
             );
 
@@ -152,6 +164,8 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
     @DisplayName("post notes for a defendant account ID that does not exist in legacy [PO-1975]")
     @JiraStory("PO-1975")
     void legacyTestAddNote500Error(Logger log) throws Exception {
+
+        userStateStub.addPermissions((short) 78, ADD_ACCOUNT_ACTIVITY_NOTES);
 
         Note note = new Note();
         note.setNoteText("FAIL");
@@ -170,6 +184,7 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
                     .content(objectMapper.writeValueAsString(request))
                     .header("authorization", userStateStub.getBearerToken())
                     .header("If-Match", "5")
+                    .header("Business_Unit_ID", "78")
                     .with(authentication(allFinesPermissionsToken()))
             );
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/NotesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/NotesIntegrationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.controllers;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -47,9 +48,9 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
         final String payload = objectMapper.writeValueAsString(request);
         log.info(":testPostNotes payload: {}", payload);
 
-        // Read the current version immediately before use (avoids distance warning & stale reads)
-        final Integer currentVersion = DefendantAccountVersionUtil.getVersion(jdbcTemplate, 77L);
-
+        // Read the current version immediately before use
+        final Integer versionBefore = DefendantAccountVersionUtil.getVersion(jdbcTemplate, 77L);
+        assertThat(versionBefore).isNotNull();
         // Act
         ResultActions result =
             mockMvc.perform(
@@ -57,7 +58,7 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(payload)
                     .header("authorization", userStateStub.getBearerToken())
-                    .header(HttpHeaders.IF_MATCH, "\"" + currentVersion + "\"")
+                    .header(HttpHeaders.IF_MATCH, "\"" + versionBefore + "\"")
                     .header("Business_Unit_ID", "78")
                     .with(authentication(allFinesPermissionsToken()))
             );
@@ -66,6 +67,10 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
         String body = result.andReturn().getResponse().getContentAsString();
         log.info(":testPostNotes response:\n{}", ToJsonString.toPrettyJson(body));
         result.andExpect(status().isCreated());
+
+        // Assert defendantAccount version incremented
+        final Integer versionAfter = DefendantAccountVersionUtil.getVersion(jdbcTemplate, 77L);
+        assertThat(versionAfter).isEqualTo(versionBefore + 1);
     }
 
     @DisplayName("post notes for a defendant account ID that does not exist [PO-1566]")
@@ -74,7 +79,7 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
 
         Note note = new Note();
         note.setNoteText("test");
-        note.setRecordId("7A");
+        note.setRecordId("7");
         note.setRecordType(RecordType.DEFENDANT_ACCOUNTS);
         note.setNoteType("AA");
 
@@ -98,6 +103,34 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
         log.info(":testPostNotes: Response body:\n" + ToJsonString.toPrettyJson(body));
 
         resultActions.andExpect(status().isNotFound());
+    }
+
+    @DisplayName("post notes for an invalid defendant account ID [PO-1566]")
+    @JiraStory("PO-1566")
+    void postNotes_badRequest(Logger log) throws Exception {
+
+        Note note = new Note();
+        note.setRecordId("ABC1");
+        note.setRecordType(RecordType.CREDITOR_ACCOUNTS);
+
+        AddNoteRequest request = new AddNoteRequest();
+
+        request.setActivityNote(note);
+
+        ResultActions resultActions =
+            mockMvc.perform(
+                post(URL_BASE + "/add")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+                    .header("authorization", userStateStub.getBearerToken())
+                    .header("If-Match", "1")
+                    .header("Business_Unit_ID", "78")
+                    .with(authentication(allFinesPermissionsToken()))
+            );
+
+        String body = resultActions.andReturn().getResponse().getContentAsString();
+        log.info(":testPostNotes: Response body:\n" + ToJsonString.toPrettyJson(body));
+        resultActions.andExpect(status().isBadRequest());
     }
 
     @DisplayName("post notes - user without permission [PO-1566]")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/NotesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/NotesIntegrationTest.java
@@ -3,18 +3,23 @@ package uk.gov.hmcts.opal.controllers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.opal.authorisation.model.FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES;
 import static uk.gov.hmcts.opal.controllers.util.UserStateUtil.allFinesPermissionsToken;
-import static uk.gov.hmcts.opal.controllers.util.UserStateUtil.noFinesPermissionsToken;
+import static uk.gov.hmcts.opal.controllers.util.UserStateUtil.permissionsToken;
 
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.slf4j.Logger;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
+import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.controllers.util.DefendantAccountVersionUtil;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
 import uk.gov.hmcts.opal.dto.Note;
@@ -24,7 +29,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 
 abstract class NotesIntegrationTest extends AbstractIntegrationTest {
 
-    private static final String URL_BASE = "/notes";
+    protected static final String URL_BASE = "/notes";
 
     @BeforeEach
     void setUp() {
@@ -135,7 +140,7 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
 
     @DisplayName("post notes - user without permission [PO-1566]")
     @JiraStory("PO-1566")
-    void postNotes_UserWithoutPermission(Logger log) throws Exception {
+    void postNotes_UserWithoutPermission(FinesPermission permission) throws Exception {
 
         Note note = new Note();
         note.setNoteText("test note");
@@ -154,10 +159,114 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
                 .header("authorization", userStateStub.getBearerToken())
                 .header("If-Match", "1")
                 .header("Business_Unit_ID", "78")
-                .with(authentication(noFinesPermissionsToken()))
+                .with(authentication(permissionsToken((short) 78, permission)))
         );
+        resultActions.andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.detail")
+                .value("You do not have permission to access this resource"));
+    }
 
-        resultActions.andExpect(status().isForbidden());
+    protected static Stream<FinesPermission> nonNotesPermissions() {
+        return Stream.of(FinesPermission.values())
+            .filter(permission -> permission != ADD_ACCOUNT_ACTIVITY_NOTES);
+    }
+
+    void postNotes_BusinessUnitAuthorization(BusinessUnitAuthorizationScenario scenario) throws Exception {
+
+        userStateStub.setupWithNoPermissions();
+
+        if (scenario.authenticationBusinessUnitId() != null) {
+            userStateStub.addPermissions(scenario.authenticationBusinessUnitId(), scenario.permission());
+        }
+
+        Note note = new Note();
+        note.setNoteText("test note");
+        note.setRecordId("77");
+        note.setRecordType(RecordType.DEFENDANT_ACCOUNTS);
+        note.setNoteType("AA");
+
+        AddNoteRequest request = new AddNoteRequest();
+        request.setActivityNote(note);
+
+        var requestBuilder =
+            post(URL_BASE + "/add")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header(HttpHeaders.AUTHORIZATION, userStateStub.getBearerToken())
+                .header(HttpHeaders.IF_MATCH, "1")
+                .with(authentication(permissionsToken(
+                    scenario.authenticationBusinessUnitId(), scenario.permission())));
+
+        if (scenario.requestBusinessUnitId() != null) {
+            requestBuilder.header("Business_Unit_ID", scenario.requestBusinessUnitId());
+        }
+
+        ResultActions resultActions = mockMvc.perform(requestBuilder);
+
+        String body = resultActions.andReturn().getResponse().getContentAsString();
+        log.info(":testPostNotes_BusinessUnitAuthorization [{}] response body:\n{}",
+            scenario.displayName(), ToJsonString.toPrettyJson(body));
+
+        resultActions.andExpect(status().is(scenario.expectedStatus().value()))
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.type").value(scenario.expectedType()))
+            .andExpect(jsonPath("$.title").value(scenario.expectedTitle()))
+            .andExpect(jsonPath("$.detail").value(scenario.expectedDetail()))
+            .andExpect(jsonPath("$.status").value(scenario.expectedStatus().value()))
+            .andExpect(jsonPath("$.retriable").value(false));
+    }
+
+    protected static Stream<BusinessUnitAuthorizationScenario> businessUnitAuthorizationScenarios() {
+        return Stream.of(
+            new BusinessUnitAuthorizationScenario(
+                "missing Business_Unit_ID header",
+                null,
+                (short) 78,
+                ADD_ACCOUNT_ACTIVITY_NOTES,
+                HttpStatus.BAD_REQUEST,
+                "https://hmcts.gov.uk/problems/missing-header",
+                "Missing Required Header",
+                "Required request header \"Business_Unit_ID\" is missing"
+            ),
+            new BusinessUnitAuthorizationScenario(
+                "wrong business unit in header",
+                (short) 99,
+                (short) 78,
+                ADD_ACCOUNT_ACTIVITY_NOTES,
+                HttpStatus.FORBIDDEN,
+                "https://hmcts.gov.uk/problems/forbidden",
+                "Forbidden",
+                "You do not have permission to access this resource"
+            ),
+            new BusinessUnitAuthorizationScenario(
+                "permission present in another BU",
+                (short) 78,
+                (short) 99,
+                ADD_ACCOUNT_ACTIVITY_NOTES,
+                HttpStatus.FORBIDDEN,
+                "https://hmcts.gov.uk/problems/forbidden",
+                "Forbidden",
+                "You do not have permission to access this resource"
+            )
+        );
+    }
+
+    protected record BusinessUnitAuthorizationScenario(
+        String displayName,
+        Short requestBusinessUnitId,
+        Short authenticationBusinessUnitId,
+        FinesPermission permission,
+        HttpStatus expectedStatus,
+        String expectedType,
+        String expectedTitle,
+        String expectedDetail
+    ) {
+
+        @Override
+        public String toString() {
+            return displayName;
+        }
     }
 
     @DisplayName("post notes for a defendant account in legacy [PO-1975]")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalNotesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalNotesIntegrationTest.java
@@ -1,12 +1,15 @@
 package uk.gov.hmcts.opal.controllers;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_CLASS;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_CLASS;
 
 import lombok.extern.slf4j.Slf4j;
+import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
@@ -33,12 +36,13 @@ public class OpalNotesIntegrationTest extends NotesIntegrationTest {
         super.postNotes_IDNotFoundError(log);
     }
 
-    @Test
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("nonNotesPermissions")
     @JiraStory("PO-1566")
     @JiraEpic("PO-812")
     @JiraTestKey("PO-6225")
-    void testOpalNotes_Forbidden() throws Exception {
-        super.postNotes_UserWithoutPermission(log);
+    void testOpalNotes_Forbidden(FinesPermission permission) throws Exception {
+        super.postNotes_UserWithoutPermission(permission);
     }
 
     @Test
@@ -46,5 +50,14 @@ public class OpalNotesIntegrationTest extends NotesIntegrationTest {
     @JiraEpic("PO-812")
     void testOpalNotes_BadRequest() throws Exception {
         super.postNotes_badRequest(log);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("businessUnitAuthorizationScenarios")
+    @JiraStory("PO-1566")
+    @JiraEpic("PO-812")
+    @JiraTestKey("PO-6228")
+    void testOpalNotes_BusinessUnitAuthorization(BusinessUnitAuthorizationScenario scenario) throws Exception {
+        super.postNotes_BusinessUnitAuthorization(scenario);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalNotesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalNotesIntegrationTest.java
@@ -29,7 +29,7 @@ public class OpalNotesIntegrationTest extends NotesIntegrationTest {
     @JiraStory("PO-1566")
     @JiraEpic("PO-812")
     @JiraTestKey("PO-6227")
-    void testOpalNotes_500Error() throws Exception {
+    void testOpalNotes_NotFound() throws Exception {
         super.postNotes_IDNotFoundError(log);
     }
 
@@ -39,5 +39,12 @@ public class OpalNotesIntegrationTest extends NotesIntegrationTest {
     @JiraTestKey("PO-6225")
     void testOpalNotes_Forbidden() throws Exception {
         super.postNotes_UserWithoutPermission(log);
+    }
+
+    @Test
+    @JiraStory("PO-1566")
+    @JiraEpic("PO-812")
+    void testOpalNotes_BadRequest() throws Exception {
+        super.postNotes_badRequest(log);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/util/Release1bFeatureToggleRequestUtil.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/util/Release1bFeatureToggleRequestUtil.java
@@ -78,6 +78,7 @@ public final class Release1bFeatureToggleRequestUtil {
                     .contentType(MediaType.APPLICATION_JSON)
                     .header("Authorization", AUTHORIZATION)
                     .header("If-Match", IF_MATCH)
+                    .header("Business_Unit_ID", "78")
                     .content("""
                         {
                           "activity_note": {

--- a/src/main/java/uk/gov/hmcts/opal/authorisation/model/FinesPermission.java
+++ b/src/main/java/uk/gov/hmcts/opal/authorisation/model/FinesPermission.java
@@ -20,6 +20,7 @@ public enum FinesPermission implements PermissionDescriptor {
     CHECK_VALIDATE_DRAFT_ACCOUNTS(5L, "Check and Validate Draft Accounts"),
     SEARCH_AND_VIEW_ACCOUNTS(6L, "Search and View Accounts"),
     ACCOUNT_MAINTENANCE(7L, "Account Maintenance"),
+    ADD_ACCOUNT_ACTIVITY_NOTES(8L, "Add account activity notes"),
     VIEW_CREDITOR_BACS(11L, "View Creditor BACS"),
     AMEND_PAYMENT_TERMS(9L, "Amend Payment Terms"),
     ENTER_ENFORCEMENT(10L, "Enter Enforcement"),

--- a/src/main/java/uk/gov/hmcts/opal/controllers/NotesController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/NotesController.java
@@ -32,14 +32,12 @@ public class NotesController {
     @Operation(summary = "adds a note to an entity")
     @FeatureToggle(feature = RELEASE_1B, defaultValueProperty = RELEASE_1B_ENABLED_PROPERTY)
     public ResponseEntity<String> addNote(
-        @RequestBody
-        AddNoteRequest request,
-        @RequestHeader("If-Match") String ifMatch) {
+        @RequestBody AddNoteRequest request,
+        @RequestHeader("If-Match") String ifMatch,
+        @RequestHeader("Business_Unit_ID") Short businessUnitId) {
 
         log.debug(":POST:postDefendantAccountSearch: query: \n{}", request.toPrettyJson());
-
-        String response =
-            notesService.addNote(request, ifMatch);
+        String response = notesService.addNote(request, ifMatch, businessUnitId);
 
         return buildCreatedResponse(response);
     }

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/search/LegacyAddNoteRequest.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/search/LegacyAddNoteRequest.java
@@ -18,11 +18,11 @@ public class LegacyAddNoteRequest {
 
     @NotBlank
     @XmlElement(name = "business_unit_id", required = true)
-    private String businessUnitId;
+    private Short businessUnitId;
 
     @NotBlank
     @XmlElement(name = "business_unit_user_id", required = true)
-    private String businessUnitUserId;
+    private Long businessUnitUserId;
 
     @NotNull
     @XmlElement(name = "version", required = true)

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/search/LegacyAddNoteRequest.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/search/LegacyAddNoteRequest.java
@@ -7,6 +7,7 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
+import java.math.BigInteger;
 import lombok.Builder;
 import lombok.Data;
 
@@ -26,7 +27,7 @@ public class LegacyAddNoteRequest {
 
     @NotNull
     @XmlElement(name = "version", required = true)
-    private Long version;
+    private BigInteger version;
 
     @NotNull
     @Valid

--- a/src/main/java/uk/gov/hmcts/opal/service/NotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/NotesService.java
@@ -2,15 +2,11 @@ package uk.gov.hmcts.opal.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
-import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
+import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
-import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
-import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
 import uk.gov.hmcts.opal.service.proxy.NotesProxy;
 
 @Service
@@ -20,27 +16,15 @@ public class NotesService {
 
     private final NotesProxy notesProxy;
     private final UserStateService userStateService;
-    private final DefendantAccountRepository defendantAccountRepository;
 
-
-    public String addNote(AddNoteRequest request, String ifMatch) {
+    public String addNote(AddNoteRequest request, String ifMatch, Short businessUnitId) {
         log.debug(":addNote:");
 
         UserState userState = userStateService.getUserStateV1FromSecurityContext();
-
-        DefendantAccountEntity account =
-            defendantAccountRepository
-                .findById(Long.valueOf(request.getActivityNote().getRecordId()))
-                .orElseThrow(() -> new ResponseStatusException(
-                    HttpStatus.NOT_FOUND, "Account %s not found".formatted(request.getActivityNote().getRecordId())
-                ));
-
-        Short businessUnitId = account.getBusinessUnit().getBusinessUnitId();
         if (!userState.hasBusinessUnitUserWithPermission(
-            businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE)) {
+            businessUnitId, FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES)) {
             throw new PermissionNotAllowedException(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE);
         }
-
-        return notesProxy.addNote(request, ifMatch, userState, account);
+        return notesProxy.addNote(request, ifMatch, userState, businessUnitId);
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/iface/NotesServiceInterface.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/iface/NotesServiceInterface.java
@@ -2,10 +2,9 @@ package uk.gov.hmcts.opal.service.iface;
 
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
-import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 
 public interface NotesServiceInterface {
 
-    String addNote(AddNoteRequest request, String ifMatch, UserState user, DefendantAccountEntity account);
+    String addNote(AddNoteRequest request, String ifMatch, UserState user, Short businessUnitId);
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service.legacy;
 
+import java.math.BigInteger;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -55,6 +56,6 @@ public class LegacyNotesService implements NotesServiceInterface {
             .recordId(request.getActivityNote().getRecordId()).build();
 
         return LegacyAddNoteRequest.builder().businessUnitId(defendantBusinessUnitId)
-            .businessUnitUserId(user.getUserId()).version(Long.valueOf(version)).activityNote(note).build();
+            .businessUnitUserId(user.getUserId()).version(new BigInteger(version)).activityNote(note).build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
@@ -26,7 +26,7 @@ public class LegacyNotesService implements NotesServiceInterface {
         GatewayService.Response<LegacyAddNoteResponse> response = gatewayService.postToGateway(
             ADD_NOTE,
             LegacyAddNoteResponse.class,
-            createRequest(request, ifMatch, user, String.valueOf(businessUnitId)),
+            createRequest(request, ifMatch, user, businessUnitId),
             null
         );
 
@@ -48,13 +48,13 @@ public class LegacyNotesService implements NotesServiceInterface {
     }
 
     private LegacyAddNoteRequest createRequest(AddNoteRequest request, String version, UserState user,
-                                               String defendantBusinessUnitId) {
+                                               Short defendantBusinessUnitId) {
 
         LegacyNote note = LegacyNote.builder().noteText(request.getActivityNote().getNoteText())
             .noteType(request.getActivityNote().getNoteType()).recordType(request.getActivityNote().getRecordType())
             .recordId(request.getActivityNote().getRecordId()).build();
 
         return LegacyAddNoteRequest.builder().businessUnitId(defendantBusinessUnitId)
-            .businessUnitUserId(user.getUserId().toString()).version(Long.valueOf(version)).activityNote(note).build();
+            .businessUnitUserId(user.getUserId()).version(Long.valueOf(version)).activityNote(note).build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
@@ -9,7 +9,6 @@ import uk.gov.hmcts.opal.dto.AddNoteRequest;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyAddNoteRequest;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyAddNoteResponse;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyNote;
-import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.service.iface.NotesServiceInterface;
 
 @Service
@@ -21,13 +20,13 @@ public class LegacyNotesService implements NotesServiceInterface {
     private final GatewayService gatewayService;
 
     @Override
-    public String addNote(AddNoteRequest request, String ifMatch, UserState user, DefendantAccountEntity account) {
+    public String addNote(AddNoteRequest request, String ifMatch, UserState user, Short businessUnitId) {
         log.info(":LegacyAddNote");
 
         GatewayService.Response<LegacyAddNoteResponse> response = gatewayService.postToGateway(
             ADD_NOTE,
             LegacyAddNoteResponse.class,
-            createRequest(request, ifMatch, user, account.getBusinessUnit().getBusinessUnitId().toString()),
+            createRequest(request, ifMatch, user, String.valueOf(businessUnitId)),
             null
         );
 

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementService.java
@@ -220,7 +220,7 @@ public class OpalDefendantAccountEnforcementService
             buildRemoveEnforcementHoldNoteRequest(defendantAccountId, request),
             VersionUtils.createETag(savedEntity),
             userState,
-            savedEntity
+            businessUnitId
         );
 
         amendmentService.auditFinaliseStoredProc(

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalNotesService.java
@@ -3,8 +3,6 @@ package uk.gov.hmcts.opal.service.opal;
 import static uk.gov.hmcts.opal.dto.RecordType.DEFENDANT_ACCOUNTS;
 import static uk.gov.hmcts.opal.util.VersionUtils.verifyIfMatch;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.LockModeType;
 import jakarta.transaction.Transactional;
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -12,9 +10,7 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.math.NumberUtils;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
 import uk.gov.hmcts.opal.dto.Note;
@@ -24,6 +20,7 @@ import uk.gov.hmcts.opal.entity.NoteType;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.repository.NoteRepository;
 import uk.gov.hmcts.opal.service.iface.NotesServiceInterface;
+import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
 
 @Service
 @Slf4j(topic = "opal.OpalNotesService")
@@ -31,25 +28,19 @@ import uk.gov.hmcts.opal.service.iface.NotesServiceInterface;
 public class OpalNotesService implements NotesServiceInterface {
 
     private final NoteRepository repository;
-    private final EntityManager em;
+    private final DefendantAccountRepositoryService defendantAccountRepositoryService;
     private final Clock clock;
 
     @Override
     @Transactional
     public String addNote(AddNoteRequest req, String ifMatch, UserState user, Short businessUnitId) {
-        // TODO - waiting for PO-1564 to call DefendantAccountService to get the account
-
         log.info(":OpalAddNote");
 
         String accountId = req.getActivityNote().getRecordId();
-        if (!Objects.equals(req.getActivityNote().getRecordType(), DEFENDANT_ACCOUNTS) || !NumberUtils.isCreatable(
-            accountId)) {
-            throw accountNotFound(accountId);
-        }
-        DefendantAccountEntity managed = em.find(DefendantAccountEntity.class, Long.valueOf(accountId));
-        if (managed == null) {
-            throw accountNotFound(accountId);
-        }
+        validateAccountId(req, accountId);
+        DefendantAccountEntity managed =
+            defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(Long.parseLong(accountId));
+
         verifyIfMatch(managed, ifMatch, managed.getVersion(), "addNote");
 
         Note requestNote = req.getActivityNote();
@@ -61,20 +52,22 @@ public class OpalNotesService implements NotesServiceInterface {
         note.setBusinessUnitUserId(managed.getBusinessUnit().getBusinessUnitId().toString());
         note.setPostedDate(LocalDateTime.now(clock));
         note.setPostedByUsername(user.getDisplayName());
-
         NoteEntity entity = repository.save(note);
-
-        // IMPORTANT: lock the MANAGED instance, not the detached parameter
-        em.lock(managed, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
-
         return entity.getNoteId().toString();
     }
 
-    private ResponseStatusException accountNotFound(String accountId) {
-        return new ResponseStatusException(
-            HttpStatus.NOT_FOUND,
-            "Account %s not found".formatted(accountId)
-        );
+    private static void validateAccountId(AddNoteRequest req, String accountId) {
+        if (!Objects.equals(req.getActivityNote().getRecordType(), DEFENDANT_ACCOUNTS)) {
+            throw new IllegalArgumentException(
+                "recordType must be '%s'".formatted(DEFENDANT_ACCOUNTS)
+            );
+        }
+
+        if (!NumberUtils.isCreatable(accountId)) {
+            throw new IllegalArgumentException(
+                "recordId must be a numeric value"
+            );
+        }
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalNotesService.java
@@ -38,6 +38,8 @@ public class OpalNotesService implements NotesServiceInterface {
 
         String accountId = req.getActivityNote().getRecordId();
         validateAccountId(req, accountId);
+        //Use getDefendantAccountByIdForUpdate() as this ensures the account version is increased with
+        // OPTIMISTIC_FORCE_INCREMENT locking
         DefendantAccountEntity managed =
             defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(Long.parseLong(accountId));
 

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalNotesService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service.opal;
 
+import static uk.gov.hmcts.opal.dto.RecordType.DEFENDANT_ACCOUNTS;
 import static uk.gov.hmcts.opal.util.VersionUtils.verifyIfMatch;
 
 import jakarta.persistence.EntityManager;
@@ -7,19 +8,20 @@ import jakarta.persistence.LockModeType;
 import jakarta.transaction.Transactional;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
-
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
 import uk.gov.hmcts.opal.dto.Note;
 import uk.gov.hmcts.opal.entity.AssociatedRecordType;
-import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.entity.NoteEntity;
 import uk.gov.hmcts.opal.entity.NoteType;
+import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.repository.NoteRepository;
 import uk.gov.hmcts.opal.service.iface.NotesServiceInterface;
 
@@ -34,25 +36,23 @@ public class OpalNotesService implements NotesServiceInterface {
 
     @Override
     @Transactional
-    public String addNote(AddNoteRequest req, String ifMatch, UserState user, DefendantAccountEntity account) {
+    public String addNote(AddNoteRequest req, String ifMatch, UserState user, Short businessUnitId) {
         // TODO - waiting for PO-1564 to call DefendantAccountService to get the account
 
         log.info(":OpalAddNote");
 
-        Long accountId = account.getDefendantAccountId();
-        DefendantAccountEntity managed = em.find(DefendantAccountEntity.class, accountId);
-
-        if (managed == null) {
-            throw new ResponseStatusException(
-                HttpStatus.NOT_FOUND,
-                "Account %s not found".formatted(accountId)
-            );
+        String accountId = req.getActivityNote().getRecordId();
+        if (!Objects.equals(req.getActivityNote().getRecordType(), DEFENDANT_ACCOUNTS) || !NumberUtils.isCreatable(
+            accountId)) {
+            throw accountNotFound(accountId);
         }
-
+        DefendantAccountEntity managed = em.find(DefendantAccountEntity.class, Long.valueOf(accountId));
+        if (managed == null) {
+            throw accountNotFound(accountId);
+        }
         verifyIfMatch(managed, ifMatch, managed.getVersion(), "addNote");
 
         Note requestNote = req.getActivityNote();
-
         NoteEntity note = new NoteEntity();
         note.setNoteText(requestNote.getNoteText());
         note.setNoteType(NoteType.valueOf(requestNote.getNoteType()));
@@ -68,6 +68,13 @@ public class OpalNotesService implements NotesServiceInterface {
         em.lock(managed, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
 
         return entity.getNoteId().toString();
+    }
+
+    private ResponseStatusException accountNotFound(String accountId) {
+        return new ResponseStatusException(
+            HttpStatus.NOT_FOUND,
+            "Account %s not found".formatted(accountId)
+        );
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountRepositoryService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountRepositoryService.java
@@ -56,6 +56,9 @@ public class DefendantAccountRepositoryService {
         }
     }
 
+    /**
+     * Get entity by defendantAccountId with OPTIMISTIC_FORCE_INCREMENT locking.
+     */
     public DefendantAccountEntity getDefendantAccountByIdForUpdate(long defendantAccountId) {
         return defendantAccountRepository.findByDefendantAccountIdForUpdate(defendantAccountId)
             .orElseThrow(() -> new EntityNotFoundException(

--- a/src/main/java/uk/gov/hmcts/opal/service/proxy/NotesProxy.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/proxy/NotesProxy.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
-import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.service.iface.NotesServiceInterface;
 import uk.gov.hmcts.opal.service.legacy.LegacyNotesService;
 import uk.gov.hmcts.opal.service.opal.DynamicConfigService;
@@ -25,8 +24,8 @@ public class NotesProxy implements NotesServiceInterface, ProxyInterface {
     }
 
     @Override
-    public String addNote(AddNoteRequest request, String ifMatch, UserState user, DefendantAccountEntity account) {
-        return getCurrentModeService().addNote(request, ifMatch, user, account);
+    public String addNote(AddNoteRequest request, String ifMatch, UserState user, Short businessUnitId) {
+        return getCurrentModeService().addNote(request, ifMatch, user, businessUnitId);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/opal/controllers/NotesControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/NotesControllerTest.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.opal.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.hmcts.opal.dto.AddNoteRequest;
+import uk.gov.hmcts.opal.service.NotesService;
+
+
+@ExtendWith(MockitoExtension.class)
+class NotesControllerTest {
+
+    @Mock
+    private NotesService notesService;
+
+    @InjectMocks
+    private NotesController controller;
+
+    @Test
+    void addNote_returnsCreatedResponse() {
+        AddNoteRequest request = new AddNoteRequest();
+        String ifMatch = "etag-123";
+        short businessUnitId = 7;
+        when(notesService.addNote(request, ifMatch, businessUnitId))
+            .thenReturn("note-created");
+
+        ResponseEntity<String> response = controller.addNote(request, ifMatch, businessUnitId);
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertEquals("note-created", response.getBody());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/NotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/NotesServiceTest.java
@@ -1,172 +1,72 @@
 package uk.gov.hmcts.opal.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.LockModeType;
-import java.time.Clock;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.web.server.ResponseStatusException;
+import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
+import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
-import uk.gov.hmcts.opal.dto.Note;
-import uk.gov.hmcts.opal.dto.RecordType;
-import uk.gov.hmcts.opal.entity.AssociatedRecordType;
-import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
-import uk.gov.hmcts.opal.entity.NoteEntity;
-import uk.gov.hmcts.opal.entity.NoteType;
-import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
-import uk.gov.hmcts.opal.exception.ResourceConflictException;
-import uk.gov.hmcts.opal.repository.NoteRepository;
-import uk.gov.hmcts.opal.service.opal.OpalNotesService;
+import uk.gov.hmcts.opal.service.proxy.NotesProxy;
 
 @ExtendWith(MockitoExtension.class)
 class NotesServiceTest {
 
-    @Mock private NoteRepository repository;
-    @Mock private EntityManager em;
-    @Mock private UserState user;
+    public static final String IF_MATCH = "etag-123";
+    public static final Short BUSINESS_UNIT_ID = 10;
+    @Mock
+    private NotesProxy notesProxy;
 
-    @InjectMocks
-    private OpalNotesService service;
+    @Mock
+    private UserStateService userStateService;
 
-    @Spy
-    private Clock clock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
+    @Mock
+    private UserState userState;
 
-    // common test data objects (no stubbing here to keep STRICT_STUBS happy)
-    private AddNoteRequest request;
-    private DefendantAccountEntity detachedParam;
-    private DefendantAccountEntity managedInEm;
+    private NotesService notesService;
 
     @BeforeEach
     void setUp() {
-        // Build request payload
-        Note n = new Note();
-        n.setRecordId("77");
-        n.setRecordType(RecordType.DEFENDANT_ACCOUNTS);
-        n.setNoteText("hello world");
-        n.setNoteType("AA");
-
-        request = new AddNoteRequest();
-        request.setActivityNote(n);
-
-        // Detached param passed by caller
-        detachedParam = new DefendantAccountEntity();
-        detachedParam.setDefendantAccountId(77L);
-        detachedParam.setVersionNumber(2L); // irrelevant to service; it re-fetches
-
-        // Managed entity returned by em.find(...)
-        managedInEm = new DefendantAccountEntity();
-        managedInEm.setDefendantAccountId(77L);
-        managedInEm.setVersionNumber(2L);
-        managedInEm.setBusinessUnit(bu((short) 1));
+        notesService = new NotesService(notesProxy, userStateService);
     }
 
     @Test
-    void addNote_success_savesFields_returnsId_andLocksManagedEntity() {
-        when(em.find(DefendantAccountEntity.class, 77L)).thenReturn(managedInEm);
-        when(user.getDisplayName()).thenReturn("Normal User");
+    void addNote_shouldThrowPermissionNotAllowedException_whenUserLacksPermission() {
+        // given
+        AddNoteRequest request = new AddNoteRequest();
 
-        // repository.save returns an entity with generated id
-        NoteEntity persisted = new NoteEntity();
-        persisted.setNoteId(123456789L);
-        when(repository.save(any(NoteEntity.class))).thenReturn(persisted);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
+        when(userState.hasBusinessUnitUserWithPermission(
+            BUSINESS_UNIT_ID, FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES)).thenReturn(false);
 
-        // Use a quoted If-Match to exercise the strip-quotes logic
-        String returnedId = service.addNote(request, "\"2\"", user, detachedParam);
-
-        assertEquals("123456789", returnedId);
-
-        // Verify saved values
-        ArgumentCaptor<NoteEntity> captor = ArgumentCaptor.forClass(NoteEntity.class);
-        verify(repository).save(captor.capture());
-        NoteEntity toSave = captor.getValue();
-
-        assertEquals("hello world", toSave.getNoteText());
-        assertEquals(NoteType.AA, toSave.getNoteType());
-        assertEquals("77", toSave.getAssociatedRecordId());
-        assertEquals(AssociatedRecordType.DEFENDANT_ACCOUNTS, toSave.getAssociatedRecordType());
-        assertEquals("1", toSave.getBusinessUnitUserId()); // short -> "1"
-        assertEquals("Normal User", toSave.getPostedByUsername());
-        assertNotNull(toSave.getPostedDate(), "postedDate should be set");
-        assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), toSave.getPostedDate());
-
-        // Lock is called on the MANAGED instance
-        verify(em).lock(eq(managedInEm), eq(LockModeType.OPTIMISTIC_FORCE_INCREMENT));
-        verifyNoMoreInteractions(repository, em);
-    }
-
-    @Test
-    void addNote_accountNotFound_throws404_andDoesNotSaveOrLock() {
-        when(em.find(DefendantAccountEntity.class, 77L)).thenReturn(null);
-
-        ResponseStatusException ex = assertThrows(
-            ResponseStatusException.class,
-            () -> service.addNote(request, "2", user, detachedParam)
+        // when / then
+        assertThrows(
+            PermissionNotAllowedException.class,
+            () -> notesService.addNote(request, IF_MATCH, BUSINESS_UNIT_ID)
         );
-
-        assertEquals(HttpStatus.NOT_FOUND, ex.getStatusCode());
-        assertNotNull(ex.getReason());
-        assertTrue(ex.getReason().contains("Account 77 not found"));
-
-        verify(repository, never()).save(any());
-        verify(em, never()).lock(any(), any());
     }
 
     @Test
-    void addNote_versionMismatch_throwsObjectOptimisticLockingFailure_andDoesNotSaveOrLock() {
-        // DB version is 2; pass mismatching If-Match "1"
-        when(em.find(DefendantAccountEntity.class, 77L)).thenReturn(managedInEm);
+    void addNote_shouldDelegateToNotesProxy_whenUserHasPermission() {
+        // given
+        AddNoteRequest request = new AddNoteRequest();
+        String expectedResponse = "note-id-456";
 
-        ObjectOptimisticLockingFailureException ex = assertThrows(
-            ObjectOptimisticLockingFailureException.class,
-            () -> service.addNote(request, "1", user, detachedParam)
-        );
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
+        when(userState.hasBusinessUnitUserWithPermission(
+            BUSINESS_UNIT_ID, FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES)).thenReturn(true);
+        when(notesProxy.addNote(request, IF_MATCH, userState, BUSINESS_UNIT_ID)).thenReturn(expectedResponse);
 
-        assertTrue(ex.getMessage() == null || ex.getMessage().contains("Version")
-                       || ex.getMessage().contains("match"), "Expected version mismatch message");
+        // when
+        String actualResponse = notesService.addNote(request, IF_MATCH, BUSINESS_UNIT_ID);
 
-        verify(repository, never()).save(any());
-        verify(em, never()).lock(any(), any());
-    }
-
-    @Test
-    void addNote_ifMatchNull_throwsResourceConflict_andDoesNotSaveOrLock() {
-        when(em.find(DefendantAccountEntity.class, 77L)).thenReturn(managedInEm);
-
-        assertThrows(ResourceConflictException.class,
-                     () -> service.addNote(request, null, user, detachedParam));
-
-        verify(repository, never()).save(any());
-        verify(em, never()).lock(any(), any());
-    }
-
-    // ---------- helpers ----------
-
-    private static BusinessUnitEntity bu(short id) {
-        BusinessUnitEntity bu = new BusinessUnitEntity();
-        bu.setBusinessUnitId(id);
-        return bu;
+        // then
+        assertEquals(expectedResponse, actualResponse);
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/OpalNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/OpalNotesServiceTest.java
@@ -54,7 +54,6 @@ class OpalNotesServiceTest {
         // Arrange
         when(clock.instant()).thenReturn(Instant.parse("2026-07-03T10:15:30Z"));
         when(clock.getZone()).thenReturn(ZoneOffset.UTC);
-        AddNoteRequest req = buildRequest("77", RecordType.DEFENDANT_ACCOUNTS);
         DefendantAccountEntity managed = new DefendantAccountEntity();
         managed.setVersionNumber(12L);
         BusinessUnitEntity businessUnit = new BusinessUnitEntity();
@@ -66,6 +65,7 @@ class OpalNotesServiceTest {
             .thenReturn(managed);
         when(user.getDisplayName()).thenReturn("Test User");
         when(repository.save(any(NoteEntity.class))).thenReturn(saved);
+        AddNoteRequest req = buildRequest("77", RecordType.DEFENDANT_ACCOUNTS);
 
         // Act
         String result = service.addNote(req, "\"12\"", user, (short) 78);

--- a/src/test/java/uk/gov/hmcts/opal/service/OpalNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/OpalNotesServiceTest.java
@@ -1,0 +1,202 @@
+package uk.gov.hmcts.opal.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
+import uk.gov.hmcts.opal.dto.AddNoteRequest;
+import uk.gov.hmcts.opal.dto.Note;
+import uk.gov.hmcts.opal.dto.RecordType;
+import uk.gov.hmcts.opal.entity.AssociatedRecordType;
+import uk.gov.hmcts.opal.entity.NoteEntity;
+import uk.gov.hmcts.opal.entity.NoteType;
+import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
+import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
+import uk.gov.hmcts.opal.exception.ResourceConflictException;
+import uk.gov.hmcts.opal.repository.NoteRepository;
+import uk.gov.hmcts.opal.service.opal.OpalNotesService;
+
+@ExtendWith(MockitoExtension.class)
+class OpalNotesServiceTest {
+
+    @Mock
+    private NoteRepository repository;
+    @Mock
+    private EntityManager em;
+    @Mock
+    private UserState user;
+
+    @InjectMocks
+    private OpalNotesService service;
+
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
+
+    // common test data objects (no stubbing here to keep STRICT_STUBS happy)
+    private AddNoteRequest request;
+    private DefendantAccountEntity managedInEm;
+
+    @BeforeEach
+    void setUp() {
+        // Build request payload
+        Note n = new Note();
+        n.setRecordId("77");
+        n.setRecordType(RecordType.DEFENDANT_ACCOUNTS);
+        n.setNoteText("hello world");
+        n.setNoteType("AA");
+
+        request = new AddNoteRequest();
+        request.setActivityNote(n);
+
+        // Managed entity returned by em.find(...)
+        managedInEm = new DefendantAccountEntity();
+        managedInEm.setDefendantAccountId(77L);
+        managedInEm.setVersionNumber(2L);
+        managedInEm.setBusinessUnit(bu((short) 1));
+    }
+
+    @Test
+    void addNote_success_savesFields_returnsId_andLocksManagedEntity() {
+        when(em.find(DefendantAccountEntity.class, 77L)).thenReturn(managedInEm);
+        when(user.getDisplayName()).thenReturn("Normal User");
+
+        // repository.save returns an entity with generated id
+        NoteEntity persisted = new NoteEntity();
+        persisted.setNoteId(123456789L);
+        when(repository.save(any(NoteEntity.class))).thenReturn(persisted);
+
+        // Use a quoted If-Match to exercise the strip-quotes logic
+        String returnedId = service.addNote(request, "\"2\"", user, (short) 2);
+
+        assertEquals("123456789", returnedId);
+
+        // Verify saved values
+        ArgumentCaptor<NoteEntity> captor = ArgumentCaptor.forClass(NoteEntity.class);
+        verify(repository).save(captor.capture());
+        NoteEntity toSave = captor.getValue();
+
+        assertEquals("hello world", toSave.getNoteText());
+        assertEquals(NoteType.AA, toSave.getNoteType());
+        assertEquals("77", toSave.getAssociatedRecordId());
+        assertEquals(AssociatedRecordType.DEFENDANT_ACCOUNTS, toSave.getAssociatedRecordType());
+        assertEquals("1", toSave.getBusinessUnitUserId()); // short -> "1"
+        assertEquals("Normal User", toSave.getPostedByUsername());
+        assertNotNull(toSave.getPostedDate(), "postedDate should be set");
+        assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), toSave.getPostedDate());
+
+        // Lock is called on the MANAGED instance
+        verify(em).lock(eq(managedInEm), eq(LockModeType.OPTIMISTIC_FORCE_INCREMENT));
+        verifyNoMoreInteractions(repository, em);
+    }
+
+    @Test
+    void addNote_accountNotFound_throws404_andDoesNotSaveOrLock() {
+        when(em.find(DefendantAccountEntity.class, 77L)).thenReturn(null);
+
+        ResponseStatusException ex = assertThrows(
+            ResponseStatusException.class,
+            () -> service.addNote(request, "2", user, (short) 2)
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, ex.getStatusCode());
+        assertNotNull(ex.getReason());
+        assertTrue(ex.getReason().contains("Account 77 not found"));
+
+        verify(repository, never()).save(any());
+        verify(em, never()).lock(any(), any());
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidAccounts")
+    void addNote_accountIdIsNotANumber_throws404_andDoesNotSaveOrLock() {
+        Note note = new Note();
+        note.setRecordId("NaN");
+        note.setRecordType(RecordType.DEFENDANT_ACCOUNTS);
+        request = new AddNoteRequest();
+        request.setActivityNote(note);
+
+        ResponseStatusException ex = assertThrows(
+            ResponseStatusException.class,
+            () -> service.addNote(request, "2", user, (short) 2)
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, ex.getStatusCode());
+        assertNotNull(ex.getReason());
+        assertTrue(ex.getReason().contains("Account NaN not found"));
+
+        verify(repository, never()).save(any());
+        verify(em, never()).lock(any(), any());
+    }
+
+    @Test
+    void addNote_versionMismatch_throwsObjectOptimisticLockingFailure_andDoesNotSaveOrLock() {
+        // DB version is 2; pass mismatching If-Match "1"
+        when(em.find(DefendantAccountEntity.class, 77L)).thenReturn(managedInEm);
+
+        ObjectOptimisticLockingFailureException ex = assertThrows(
+            ObjectOptimisticLockingFailureException.class,
+            () -> service.addNote(request, "1", user, (short) 2)
+        );
+
+        assertTrue(ex.getMessage() == null || ex.getMessage().contains("Version")
+            || ex.getMessage().contains("match"), "Expected version mismatch message");
+
+        verify(repository, never()).save(any());
+        verify(em, never()).lock(any(), any());
+    }
+
+    @Test
+    void addNote_ifMatchNull_throwsResourceConflict_andDoesNotSaveOrLock() {
+        when(em.find(DefendantAccountEntity.class, 77L)).thenReturn(managedInEm);
+
+        assertThrows(ResourceConflictException.class,
+            () -> service.addNote(request, null, user, (short) 2));
+
+        verify(repository, never()).save(any());
+        verify(em, never()).lock(any(), any());
+    }
+
+    // ---------- helpers ----------
+
+    private static BusinessUnitEntity bu(short id) {
+        BusinessUnitEntity bu = new BusinessUnitEntity();
+        bu.setBusinessUnitId(id);
+        return bu;
+    }
+
+    private static Stream<Arguments> invalidAccounts() {
+        return Stream.of(Arguments.of(Note.builder().recordId("NaN").recordType(RecordType.CREDITOR_ACCOUNTS).build()),
+            Arguments.of(Note.builder().recordId("77").recordType(RecordType.REPORT_INSTANCES)),
+            Arguments.of(Note.builder().recordId("NaN").recordType(RecordType.DEFENDANT_ACCOUNTS))
+        );
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/OpalNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/OpalNotesServiceTest.java
@@ -1,37 +1,22 @@
 package uk.gov.hmcts.opal.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.LockModeType;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.web.server.ResponseStatusException;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
 import uk.gov.hmcts.opal.dto.Note;
@@ -41,162 +26,92 @@ import uk.gov.hmcts.opal.entity.NoteEntity;
 import uk.gov.hmcts.opal.entity.NoteType;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
-import uk.gov.hmcts.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.opal.repository.NoteRepository;
 import uk.gov.hmcts.opal.service.opal.OpalNotesService;
+import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
 
 @ExtendWith(MockitoExtension.class)
 class OpalNotesServiceTest {
 
     @Mock
     private NoteRepository repository;
+
     @Mock
-    private EntityManager em;
+    private DefendantAccountRepositoryService defendantAccountRepositoryService;
+
+    @Mock
+    private Clock clock;
+
     @Mock
     private UserState user;
 
     @InjectMocks
     private OpalNotesService service;
 
-    @Spy
-    private Clock clock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
-
-    // common test data objects (no stubbing here to keep STRICT_STUBS happy)
-    private AddNoteRequest request;
-    private DefendantAccountEntity managedInEm;
-
-    @BeforeEach
-    void setUp() {
-        // Build request payload
-        Note n = new Note();
-        n.setRecordId("77");
-        n.setRecordType(RecordType.DEFENDANT_ACCOUNTS);
-        n.setNoteText("hello world");
-        n.setNoteType("AA");
-
-        request = new AddNoteRequest();
-        request.setActivityNote(n);
-
-        // Managed entity returned by em.find(...)
-        managedInEm = new DefendantAccountEntity();
-        managedInEm.setDefendantAccountId(77L);
-        managedInEm.setVersionNumber(2L);
-        managedInEm.setBusinessUnit(bu((short) 1));
-    }
-
     @Test
-    void addNote_success_savesFields_returnsId_andLocksManagedEntity() {
-        when(em.find(DefendantAccountEntity.class, 77L)).thenReturn(managedInEm);
-        when(user.getDisplayName()).thenReturn("Normal User");
+    @DisplayName("addNote saves a note and returns the note id")
+    void addNote_shouldSaveNoteAndReturnId() {
+        // Arrange
+        when(clock.instant()).thenReturn(Instant.parse("2026-07-03T10:15:30Z"));
+        when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+        AddNoteRequest req = buildRequest("77", RecordType.DEFENDANT_ACCOUNTS);
+        DefendantAccountEntity managed = new DefendantAccountEntity();
+        managed.setVersionNumber(12L);
+        BusinessUnitEntity businessUnit = new BusinessUnitEntity();
+        businessUnit.setBusinessUnitId((short) 78);
+        managed.setBusinessUnit(businessUnit);
+        NoteEntity saved = new NoteEntity();
+        saved.setNoteId(999L);
+        when(defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(77L))
+            .thenReturn(managed);
+        when(user.getDisplayName()).thenReturn("Test User");
+        when(repository.save(any(NoteEntity.class))).thenReturn(saved);
 
-        // repository.save returns an entity with generated id
-        NoteEntity persisted = new NoteEntity();
-        persisted.setNoteId(123456789L);
-        when(repository.save(any(NoteEntity.class))).thenReturn(persisted);
+        // Act
+        String result = service.addNote(req, "\"12\"", user, (short) 78);
 
-        // Use a quoted If-Match to exercise the strip-quotes logic
-        String returnedId = service.addNote(request, "\"2\"", user, (short) 2);
-
-        assertEquals("123456789", returnedId);
-
-        // Verify saved values
+        // Assert
+        assertThat(result).isEqualTo("999");
         ArgumentCaptor<NoteEntity> captor = ArgumentCaptor.forClass(NoteEntity.class);
         verify(repository).save(captor.capture());
-        NoteEntity toSave = captor.getValue();
-
-        assertEquals("hello world", toSave.getNoteText());
-        assertEquals(NoteType.AA, toSave.getNoteType());
-        assertEquals("77", toSave.getAssociatedRecordId());
-        assertEquals(AssociatedRecordType.DEFENDANT_ACCOUNTS, toSave.getAssociatedRecordType());
-        assertEquals("1", toSave.getBusinessUnitUserId()); // short -> "1"
-        assertEquals("Normal User", toSave.getPostedByUsername());
-        assertNotNull(toSave.getPostedDate(), "postedDate should be set");
-        assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), toSave.getPostedDate());
-
-        // Lock is called on the MANAGED instance
-        verify(em).lock(eq(managedInEm), eq(LockModeType.OPTIMISTIC_FORCE_INCREMENT));
-        verifyNoMoreInteractions(repository, em);
+        NoteEntity entity = captor.getValue();
+        assertThat(entity.getNoteText()).isEqualTo("test");
+        assertThat(entity.getNoteType()).isEqualTo(NoteType.AA);
+        assertThat(entity.getAssociatedRecordId()).isEqualTo("77");
+        assertThat(entity.getAssociatedRecordType()).isEqualTo(AssociatedRecordType.DEFENDANT_ACCOUNTS);
+        assertThat(entity.getBusinessUnitUserId()).isEqualTo("78");
+        assertThat(entity.getPostedDate()).isEqualTo(
+            LocalDateTime.ofInstant(Instant.parse("2026-07-03T10:15:30Z"), ZoneOffset.UTC));
+        assertThat(entity.getPostedByUsername()).isEqualTo("Test User");
+        verify(defendantAccountRepositoryService).getDefendantAccountByIdForUpdate(77L);
     }
 
     @Test
-    void addNote_accountNotFound_throws404_andDoesNotSaveOrLock() {
-        when(em.find(DefendantAccountEntity.class, 77L)).thenReturn(null);
+    void addNote_shouldThrowWhenRecordTypeIsInvalid() {
+        AddNoteRequest req = buildRequest("77", RecordType.CREDITOR_ACCOUNTS);
 
-        ResponseStatusException ex = assertThrows(
-            ResponseStatusException.class,
-            () -> service.addNote(request, "2", user, (short) 2)
-        );
-
-        assertEquals(HttpStatus.NOT_FOUND, ex.getStatusCode());
-        assertNotNull(ex.getReason());
-        assertTrue(ex.getReason().contains("Account 77 not found"));
-
-        verify(repository, never()).save(any());
-        verify(em, never()).lock(any(), any());
+        assertThatThrownBy(() -> service.addNote(req, "\"12\"", user, (short) 78))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("recordType must be 'defendant_accounts'");
     }
 
-    @ParameterizedTest
-    @MethodSource("invalidAccounts")
-    void addNote_accountIdIsNotANumber_throws404_andDoesNotSaveOrLock() {
+    @Test
+    void addNote_shouldThrowWhenRecordIdIsNotNumeric() {
+        AddNoteRequest req = buildRequest("abc", RecordType.DEFENDANT_ACCOUNTS);
+
+        assertThatThrownBy(() -> service.addNote(req, "\"12\"", user, (short) 78))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("recordId must be a numeric value");
+    }
+
+    private static AddNoteRequest buildRequest(String recordId, RecordType recordType) {
         Note note = new Note();
-        note.setRecordId("NaN");
-        note.setRecordType(RecordType.DEFENDANT_ACCOUNTS);
-        request = new AddNoteRequest();
-        request.setActivityNote(note);
-
-        ResponseStatusException ex = assertThrows(
-            ResponseStatusException.class,
-            () -> service.addNote(request, "2", user, (short) 2)
-        );
-
-        assertEquals(HttpStatus.NOT_FOUND, ex.getStatusCode());
-        assertNotNull(ex.getReason());
-        assertTrue(ex.getReason().contains("Account NaN not found"));
-
-        verify(repository, never()).save(any());
-        verify(em, never()).lock(any(), any());
-    }
-
-    @Test
-    void addNote_versionMismatch_throwsObjectOptimisticLockingFailure_andDoesNotSaveOrLock() {
-        // DB version is 2; pass mismatching If-Match "1"
-        when(em.find(DefendantAccountEntity.class, 77L)).thenReturn(managedInEm);
-
-        ObjectOptimisticLockingFailureException ex = assertThrows(
-            ObjectOptimisticLockingFailureException.class,
-            () -> service.addNote(request, "1", user, (short) 2)
-        );
-
-        assertTrue(ex.getMessage() == null || ex.getMessage().contains("Version")
-            || ex.getMessage().contains("match"), "Expected version mismatch message");
-
-        verify(repository, never()).save(any());
-        verify(em, never()).lock(any(), any());
-    }
-
-    @Test
-    void addNote_ifMatchNull_throwsResourceConflict_andDoesNotSaveOrLock() {
-        when(em.find(DefendantAccountEntity.class, 77L)).thenReturn(managedInEm);
-
-        assertThrows(ResourceConflictException.class,
-            () -> service.addNote(request, null, user, (short) 2));
-
-        verify(repository, never()).save(any());
-        verify(em, never()).lock(any(), any());
-    }
-
-    // ---------- helpers ----------
-
-    private static BusinessUnitEntity bu(short id) {
-        BusinessUnitEntity bu = new BusinessUnitEntity();
-        bu.setBusinessUnitId(id);
-        return bu;
-    }
-
-    private static Stream<Arguments> invalidAccounts() {
-        return Stream.of(Arguments.of(Note.builder().recordId("NaN").recordType(RecordType.CREDITOR_ACCOUNTS).build()),
-            Arguments.of(Note.builder().recordId("77").recordType(RecordType.REPORT_INSTANCES)),
-            Arguments.of(Note.builder().recordId("NaN").recordType(RecordType.DEFENDANT_ACCOUNTS))
-        );
+        note.setRecordId(recordId);
+        note.setRecordType(recordType);
+        note.setNoteText("test");
+        note.setNoteType("AA");
+        AddNoteRequest req = new AddNoteRequest();
+        req.setActivityNote(note);
+        return req;
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
@@ -66,8 +66,8 @@ class LegacyNotesServiceTest {
         assertEquals("77", id);
 
         LegacyAddNoteRequest sent = reqCap.getValue();
-        assertEquals("1", sent.getBusinessUnitId());
-        assertEquals("999", sent.getBusinessUnitUserId());
+        assertEquals((short) 1, sent.getBusinessUnitId());
+        assertEquals(999, sent.getBusinessUnitUserId());
         assertEquals(1L, sent.getVersion());
 
         LegacyNote sentNote = sent.getActivityNote();

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
@@ -60,10 +60,9 @@ class LegacyNotesServiceTest {
         )).thenReturn(resp);
 
         AddNoteRequest req = addReq("77", "hello");
-        DefendantAccountEntity account = accountWithBu((short) 1);
         when(user.getUserId()).thenReturn(999L);
 
-        String id = service.addNote(req, "1", user, account);
+        String id = service.addNote(req, "1", user, (short) 1);
         assertEquals("77", id);
 
         LegacyAddNoteRequest sent = reqCap.getValue();
@@ -107,10 +106,9 @@ class LegacyNotesServiceTest {
         )).thenReturn(resp);
 
         AddNoteRequest req = addReq("77", "boom");
-        DefendantAccountEntity account = accountWithBu((short) 5);
         when(user.getUserId()).thenReturn(1L);
 
-        String id = service.addNote(req, "1", user, account);
+        String id = service.addNote(req, "1", user, (short) 5);
         assertEquals("77", id);
 
         verify(gatewayService).postToGateway(
@@ -143,10 +141,9 @@ class LegacyNotesServiceTest {
         )).thenReturn(resp);
 
         AddNoteRequest req = addReq("77", "world");
-        DefendantAccountEntity account = accountWithBu((short) 9);
         when(user.getUserId()).thenReturn(42L);
 
-        String id = service.addNote(req, "1", user, account);
+        String id = service.addNote(req, "1", user, (short) 9);
         assertEquals("77", id);
 
         verify(gatewayService).postToGateway(
@@ -179,10 +176,9 @@ class LegacyNotesServiceTest {
         )).thenReturn(resp);
 
         AddNoteRequest req = addReq("77", "meh");
-        DefendantAccountEntity account = accountWithBu((short) 3);
         when(user.getUserId()).thenReturn(5L);
 
-        String id = service.addNote(req, "7", user, account);
+        String id = service.addNote(req, "7", user, (short) 3);
         assertEquals("77", id);
 
         verify(gatewayService).postToGateway(

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.math.BigInteger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -68,7 +69,7 @@ class LegacyNotesServiceTest {
         LegacyAddNoteRequest sent = reqCap.getValue();
         assertEquals((short) 1, sent.getBusinessUnitId());
         assertEquals(999, sent.getBusinessUnitUserId());
-        assertEquals(1L, sent.getVersion());
+        assertEquals(BigInteger.valueOf(1L), sent.getVersion());
 
         LegacyNote sentNote = sent.getActivityNote();
         assertNotNull(sentNote);

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
@@ -720,7 +720,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
                 addNoteRequestCaptor.capture(),
                 eq(updatedIfMatch),
                 eq(userState),
-                eq(defendantEntity)
+                eq((short) 10)
             );
             verifyNoInteractions(reportEntryService);
             verify(amendmentService).auditFinaliseStoredProc(

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalNotesServiceTest.java
@@ -1,4 +1,4 @@
-package uk.gov.hmcts.opal.service;
+package uk.gov.hmcts.opal.service.opal;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -27,7 +27,6 @@ import uk.gov.hmcts.opal.entity.NoteType;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.repository.NoteRepository;
-import uk.gov.hmcts.opal.service.opal.OpalNotesService;
 import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountRepositoryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountRepositoryServiceTest.java
@@ -3,8 +3,11 @@ package uk.gov.hmcts.opal.service.persistence;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import jakarta.persistence.EntityNotFoundException;
@@ -168,5 +171,43 @@ class DefendantAccountRepositoryServiceTest {
             .hasMessage("Defendant Account not found in business unit 78");
 
         verifyNoInteractions(defendantAccountRepository);
+    }
+
+    @Test
+    void validateFindByDefendantAccountIdForUpdate_defendantAccountFound() {
+        // Arrange
+        long defendantAccountId = 77L;
+        DefendantAccountEntity entity = new DefendantAccountEntity();
+        entity.setDefendantAccountId(defendantAccountId);
+
+        when(defendantAccountRepository.findByDefendantAccountIdForUpdate(defendantAccountId))
+            .thenReturn(Optional.of(entity));
+
+        // Act
+        DefendantAccountEntity result =
+            service.getDefendantAccountByIdForUpdate(defendantAccountId);
+
+        // Assert
+        assertThat(result).isSameAs(entity);
+        verify(defendantAccountRepository)
+            .findByDefendantAccountIdForUpdate(defendantAccountId);
+        verifyNoMoreInteractions(defendantAccountRepository);
+    }
+
+    @Test
+    void shouldThrowEntityNotFoundExceptionWhenDefendantAccountNotFound() {
+        long defendantAccountId = 77L;
+        when(defendantAccountRepository.findByDefendantAccountIdForUpdate(defendantAccountId))
+            .thenReturn(Optional.empty());
+
+        EntityNotFoundException exception = assertThrows(
+            EntityNotFoundException.class,
+            () -> service.getDefendantAccountByIdForUpdate(defendantAccountId)
+        );
+
+        assertEquals(
+            "Defendant Account not found with id: 77",
+            exception.getMessage()
+        );
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-3832


### Change description ###
- Pass Business Unit Id in as a header parameter
- remove the account retrieval in NotesService
- get account from record_id in OpalNotesService
- Introduce dedicated `ADD_ACCOUNT_ACTIVITY_NOTES` fines permissions
- Update tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
