### PR TITLE
Fix the integration Zephyr task wiring

### DIFF
--- a/gradle/zephyr.gradle
+++ b/gradle/zephyr.gradle
@@ -210,6 +210,7 @@ tasks.register('createJiraTicketsFromJUnit5ReportIntegrationTest', JavaExec) {
     description = "Processes Junit5Report-IntegrationTest.json to create and link Jira tickets to each test"
     def junit5ReportJson = file("integration-output/zephyr/Junit5Report-IntegrationTest.json")
 
+    dependsOn('copyIntegrationJunit5Report')
     inputs.file(junit5ReportJson)
 
     classpath = configurations.zephyrCucumberReportProcessor
@@ -223,6 +224,7 @@ tasks.register('updateJiraTicketsFromJUnit5ReportIntegrationTest', JavaExec) {
     description = "Processes Junit5Report-IntegrationTest.json to update Jira tickets"
     def junit5ReportJson = file("integration-output/zephyr/Junit5Report-IntegrationTest.json")
 
+    dependsOn('copyIntegrationJunit5Report')
     inputs.file(junit5ReportJson)
 
     classpath = configurations.zephyrCucumberReportProcessor
@@ -236,6 +238,7 @@ tasks.register('createJiraExecutionFromJUnit5ReportIntegrationTest', JavaExec) {
     description = "Processes Junit5Report-IntegrationTest.json to create Zephyr executions"
     def junit5ReportJson = file("integration-output/zephyr/Junit5Report-IntegrationTest.json")
 
+    dependsOn('copyIntegrationJunit5Report')
     inputs.file(junit5ReportJson)
 
     classpath = configurations.zephyrCucumberReportProcessor


### PR DESCRIPTION
N/A


### JIRA link (if applicable) ###

N/A

### Change description ###

This change only fixes the integration Zephyr task wiring: if the JUnit5 integration JSON is missing, the integration reporting step will fail for the real missing-file reason, but the Jenkins pipeline will still continue on to the functional stage because the integration stage error is caught and the build is marked failed rather than aborted

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
