### PR TITLE
Gradleupdate

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -68,50 +68,55 @@ def determineDevEnvironmentDeployment() {
   echo "Deploying Opal logging service (${env.OPAL_LOGGING_SERVICE_API_URL} - ${env.DEV_OPAL_LOGGING_SERVICE_IMAGE_SUFFIX}) instance in PR environment"
 }
 
-def ensureFunctionalReportOutputExists() {
-  if (steps.fileExists('functional-output/report/index.html')
-    || steps.fileExists('functional-output/report/htmlReport/test-summary.html')) {
-    return
+def copyReportOutputIfPresent(String targetDirectory, String sourceDirectory) {
+  steps.sh """
+    mkdir -p ${targetDirectory}
+    rm -rf ${targetDirectory}/report
+    cp -R ${sourceDirectory} ${targetDirectory}/report
+  """
+}
+
+def ensureReportOutputExists(String reportLabel, String targetDirectory, List<String> candidateDirectories) {
+  steps.sh """
+    mkdir -p ${targetDirectory}
+    rm -rf ${targetDirectory}/report
+  """
+
+  for (String candidateDirectory : candidateDirectories) {
+    if (steps.fileExists("${candidateDirectory}/index.html")
+      || steps.fileExists("${candidateDirectory}/htmlReport/test-summary.html")) {
+      copyReportOutputIfPresent(targetDirectory, candidateDirectory)
+      return
+    }
   }
 
-  if (steps.fileExists('functional-test-report/index.html')
-    || steps.fileExists('functional-test-report/htmlReport/test-summary.html')) {
-    steps.sh '''
-      mkdir -p functional-output
-      rm -rf functional-output/report
-      cp -R functional-test-report functional-output/report
-    '''
-  }
+  throw new RuntimeException(
+    "${reportLabel} was not generated in any expected report location: ${candidateDirectories.join(', ')}"
+  )
+}
+
+def ensureFunctionalReportOutputExists() {
+  ensureReportOutputExists(
+    'Functional Tests Report',
+    'functional-output',
+    ['functional-test-report', 'build/reports/tests/functionalOpal']
+  )
 }
 
 def ensureIntegrationReportOutputExists() {
-  if (steps.fileExists('integration-output/report/index.html')) {
-    return
-  }
-
-  if (steps.fileExists('build/reports/tests/integration/index.html')) {
-    steps.sh '''
-      mkdir -p integration-output
-      rm -rf integration-output/report
-      cp -R build/reports/tests/integration integration-output/report
-    '''
-  }
+  ensureReportOutputExists(
+    'Integration Tests Report',
+    'integration-output',
+    ['build/reports/tests/integration']
+  )
 }
 
 def ensureSmokeReportOutputExists() {
-  if (steps.fileExists('smoke-output/report/index.html')
-    || steps.fileExists('smoke-output/report/htmlReport/test-summary.html')) {
-    return
-  }
-
-  if (steps.fileExists('smoke-test-report/index.html')
-    || steps.fileExists('smoke-test-report/htmlReport/test-summary.html')) {
-    steps.sh '''
-      mkdir -p smoke-output
-      rm -rf smoke-output/report
-      cp -R smoke-test-report smoke-output/report
-    '''
-  }
+  ensureReportOutputExists(
+    'Smoke Tests Report',
+    'smoke-output',
+    ['smoke-test-report', 'build/reports/tests/smokeOpal']
+  )
 }
 
 def failBuildOnUnstableResults() {

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -55,6 +55,8 @@ def secrets = [
     ],
 ]
 
+def stageFailures = []
+
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
   [$class     : 'AzureKeyVaultSecret',
    secretType : 'Secret',
@@ -84,12 +86,56 @@ def configureZephyrExecution = { testEnvironment ->
           "Description: ${env.EXECUTION_CYCLE_DESCRIPTION}"
 }
 
-def publishIntegrationResults = {
-  steps.junit '**/test-results/integration/*.xml'
-  if (currentBuild.result == 'UNSTABLE') {
-    currentBuild.result = 'FAILURE'
+def recordStageFailure = { stageName, reason ->
+  def message = "${stageName}: ${reason}"
+  stageFailures << message
+  steps.echo message
+}
+
+def deleteStageOutputs = { List<String> paths ->
+  if (paths == null || paths.isEmpty()) {
+    return
   }
+
+  def script = paths.collect { "rm -rf '${it}'" }.join('\n')
+  steps.sh script
+}
+
+def copyReportOutputIfPresent = { targetDirectory, sourceDirectory ->
+  steps.sh """
+    mkdir -p ${targetDirectory}
+    rm -rf ${targetDirectory}/report
+    cp -R ${sourceDirectory} ${targetDirectory}/report
+  """
+}
+
+def ensureReportOutputExists = { reportLabel, targetDirectory, candidateDirectories ->
+  if (steps.fileExists("${targetDirectory}/report/index.html")
+    || steps.fileExists("${targetDirectory}/report/htmlReport/test-summary.html")) {
+    return
+  }
+
+  for (String candidateDirectory : candidateDirectories) {
+    if (steps.fileExists("${candidateDirectory}/index.html")
+      || steps.fileExists("${candidateDirectory}/htmlReport/test-summary.html")) {
+      copyReportOutputIfPresent(targetDirectory, candidateDirectory)
+      return
+    }
+  }
+
+  throw new RuntimeException(
+    "${reportLabel} was not generated in any expected report location: ${candidateDirectories.join(', ')}"
+  )
+}
+
+def publishIntegrationResults = {
+  steps.junit allowEmptyResults: true, testResults: '**/test-results/integration/*.xml'
   ensureIntegrationReportOutputExists()
+
+  if (!steps.fileExists('integration-output/zephyr/Junit5Report-IntegrationTest.json')) {
+    throw new RuntimeException('Integration Zephyr report was not generated at integration-output/zephyr/Junit5Report-IntegrationTest.json')
+  }
+
   steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'integration-output/**/*'
   publishHTML target: [
     allowMissing         : true,
@@ -102,56 +148,34 @@ def publishIntegrationResults = {
 }
 
 def ensureIntegrationReportOutputExists() {
-  if (steps.fileExists('integration-output/report/index.html')) {
-    return
-  }
-
-  if (steps.fileExists('build/reports/tests/integration/index.html')) {
-    steps.sh '''
-      mkdir -p integration-output
-      rm -rf integration-output/report
-      cp -R build/reports/tests/integration integration-output/report
-    '''
-  }
+  ensureReportOutputExists(
+    'Integration Tests Report',
+    'integration-output',
+    ['build/reports/tests/integration']
+  )
 }
 
-def ensureFunctionalReportOutputExists = { reportDirectory, rawReportDirectory ->
-  if (steps.fileExists("${reportDirectory}/report/index.html")
-    || steps.fileExists("${reportDirectory}/report/htmlReport/test-summary.html")) {
-    return
-  }
+def packageFunctionalReportOutput = { reportLabel, reportDirectory, sourceOutputDirectory, candidateReportDirectories ->
+  ensureReportOutputExists(reportLabel, reportDirectory, candidateReportDirectories)
 
-  if (steps.fileExists("${rawReportDirectory}/index.html")
-    || steps.fileExists("${rawReportDirectory}/htmlReport/test-summary.html")) {
+  if (reportDirectory != sourceOutputDirectory) {
     steps.sh """
       mkdir -p ${reportDirectory}
-      rm -rf ${reportDirectory}/report
-      cp -R ${rawReportDirectory} ${reportDirectory}/report
+      rm -rf ${reportDirectory}/zephyr
+      if [ -d "${sourceOutputDirectory}/zephyr" ]; then
+        cp -R ${sourceOutputDirectory}/zephyr ${reportDirectory}/zephyr
+      fi
     """
   }
 }
 
-def packageFunctionalReportOutput = { reportDirectory, rawReportDirectory, sourceOutputDirectory ->
-  if (reportDirectory == sourceOutputDirectory) {
-    ensureFunctionalReportOutputExists(reportDirectory, rawReportDirectory)
-    return
+def publishFunctionalResults = { reportLabel, reportDirectory, sourceOutputDirectory, candidateReportDirectories, reportNameSuffix, junitPattern,
+  zephyrReportPath ->
+  packageFunctionalReportOutput(reportLabel, reportDirectory, sourceOutputDirectory, candidateReportDirectories)
+
+  if (!steps.fileExists(zephyrReportPath)) {
+    throw new RuntimeException("${reportLabel} Zephyr report was not generated at ${zephyrReportPath}")
   }
-
-  steps.sh """
-    mkdir -p ${reportDirectory}
-    rm -rf ${reportDirectory}/report
-    rm -rf ${reportDirectory}/zephyr
-    if [ -d "${rawReportDirectory}" ]; then
-      cp -R ${rawReportDirectory} ${reportDirectory}/report
-    fi
-    if [ -d "${sourceOutputDirectory}/zephyr" ]; then
-      cp -R ${sourceOutputDirectory}/zephyr ${reportDirectory}/zephyr
-    fi
-  """
-}
-
-def publishFunctionalResults = { reportDirectory, rawReportDirectory, sourceOutputDirectory, reportNameSuffix, junitPattern ->
-  packageFunctionalReportOutput(reportDirectory, rawReportDirectory, sourceOutputDirectory)
 
   steps.archiveArtifacts allowEmptyArchive: true, artifacts: "${reportDirectory}/**/*"
   publishHTML target: [
@@ -163,12 +187,19 @@ def publishFunctionalResults = { reportDirectory, rawReportDirectory, sourceOutp
     reportName           : "Serenity Functional Test Report${reportNameSuffix}"
   ]
   steps.junit allowEmptyResults: true, testResults: junitPattern
-  if (currentBuild.result == 'UNSTABLE') {
-    currentBuild.result = 'FAILURE'
-  }
 }
 
 def publishSmokeResults = { reportNameSuffix ->
+  ensureReportOutputExists(
+    "Serenity Smoke Test Report${reportNameSuffix}",
+    'smoke-output',
+    ['smoke-test-report', 'build/reports/tests/smokeOpal']
+  )
+
+  if (!steps.fileExists('smoke-output/zephyr/cucumber-smoke.json')) {
+    throw new RuntimeException('Smoke Zephyr report was not generated at smoke-output/zephyr/cucumber-smoke.json')
+  }
+
   steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-output/**/*'
   publishHTML target: [
     allowMissing         : true,
@@ -179,8 +210,21 @@ def publishSmokeResults = { reportNameSuffix ->
     reportName           : "Serenity Smoke Test Report${reportNameSuffix}"
   ]
   steps.junit allowEmptyResults: true, testResults: '**/test-results/smoke/*.xml'
-  if (currentBuild.result == 'UNSTABLE') {
-    currentBuild.result = 'FAILURE'
+}
+
+def runFunctionalZephyrExecution = { stageName, stageKey ->
+  try {
+    builder.gradle("-PzephyrFunctionalStage=${stageKey} createJiraExecutionFromFunctionalReport")
+  } catch (error) {
+    recordStageFailure(stageName, "Zephyr execution failed. Error: ${error.message}")
+  }
+}
+
+def runIntegrationZephyrExecution = { stageName ->
+  try {
+    builder.gradle('createJiraExecutionFromIntegrationReport')
+  } catch (error) {
+    recordStageFailure(stageName, "Zephyr execution failed. Error: ${error.message}")
   }
 }
 
@@ -209,19 +253,27 @@ def authenticateHmctsProdAcr = {
 def runIntegrationStage = { stageName, shouldRunWithZephyr ->
   if (params.Integration) {
     stage(stageName) {
+      deleteStageOutputs([
+        'integration-output',
+        'build/reports/tests/integration',
+        'build/test-results/integration',
+        'target/zephyr-reports/Junit5Report-IntegrationTest.json',
+      ])
+
       try {
         authenticateHmctsProdAcr()
-
-        if (shouldRunWithZephyr) {
-          builder.gradle('integrationTestWithZephyrExecution')
-        } else {
-          builder.gradle('Integration')
-        }
+        builder.gradle('integration')
       } catch (error) {
-        currentBuild.result = 'FAILURE'
-        steps.echo "${stageName} failed. Marking build as FAILURE. Error: " + error.message
+        recordStageFailure(stageName, "failed. Error: ${error.message}")
       } finally {
-        publishIntegrationResults()
+        try {
+          publishIntegrationResults()
+        } catch (publishError) {
+          recordStageFailure(stageName, "result publication failed. Error: ${publishError.message}")
+        }
+        if (shouldRunWithZephyr) {
+          runIntegrationZephyrExecution(stageName)
+        }
       }
     }
   }
@@ -230,28 +282,37 @@ def runIntegrationStage = { stageName, shouldRunWithZephyr ->
 def runFunctionalStage = { stageName, shouldRunWithZephyr, reportNameSuffix ->
   if (params.Functional) {
     stage(stageName) {
+      deleteStageOutputs([
+        'functional-output',
+        'functional-test-report',
+        'build/reports/tests/functionalOpal',
+        'build/test-results/functional',
+        'target/zephyr-reports/cucumber-opal.json',
+        'target/site/serenity',
+        'target/cucumber.json',
+      ])
+
       try {
-        if (shouldRunWithZephyr) {
-          builder.gradle('functionalWithZephyrExecution')
-        } else {
-          builder.gradle('functional')
-        }
+        builder.gradle('clearReports functionalOpal')
       } catch (error) {
-        currentBuild.result = 'FAILURE'
-        steps.echo "${stageName} failed. Marking build as FAILURE. Error: " + error.message
+        recordStageFailure(stageName, "failed. Error: ${error.message}")
       } finally {
         try {
           builder.gradle('syncFunctionalArtifactsFromExistingResults')
           publishFunctionalResults(
+            'Functional Tests Report',
             'functional-output',
-            'functional-test-report',
             'functional-output',
+            ['functional-test-report', 'build/reports/tests/functionalOpal'],
             reportNameSuffix,
-            'build/test-results/functional/*.xml'
+            'build/test-results/functional/opal/*.xml',
+            'functional-output/zephyr/cucumber-opal.json'
           )
         } catch (publishError) {
-          currentBuild.result = 'FAILURE'
-          steps.echo "${stageName} result publication failed. Marking build as FAILURE. Error: " + publishError.message
+          recordStageFailure(stageName, "result publication failed. Error: ${publishError.message}")
+        }
+        if (shouldRunWithZephyr) {
+          runFunctionalZephyrExecution(stageName, 'functional')
         }
       }
     }
@@ -261,21 +322,29 @@ def runFunctionalStage = { stageName, shouldRunWithZephyr, reportNameSuffix ->
 def runSmokeStage = { stageName, shouldRunWithZephyr, reportNameSuffix ->
   if (params.Smoke) {
     stage(stageName) {
+      deleteStageOutputs([
+        'smoke-output',
+        'smoke-test-report',
+        'build/reports/tests/smokeOpal',
+        'build/test-results/smoke',
+        'target/zephyr-reports/cucumber-smoke.json',
+        'target/site/serenity',
+        'target/cucumber.json',
+      ])
+
       try {
-        if (shouldRunWithZephyr) {
-          builder.gradle('smokeWithZephyrExecution')
-        } else {
-          builder.gradle('smoke')
-        }
+        builder.gradle('clearReports smokeOpal')
       } catch (error) {
-        currentBuild.result = 'FAILURE'
-        steps.echo "${stageName} failed. Marking build as FAILURE. Error: " + error.message
+        recordStageFailure(stageName, "failed. Error: ${error.message}")
       } finally {
         try {
+          builder.gradle('syncSmokeArtifactsFromExistingResults')
           publishSmokeResults(reportNameSuffix)
         } catch (publishError) {
-          currentBuild.result = 'FAILURE'
-          steps.echo "${stageName} result publication failed. Marking build as FAILURE. Error: " + publishError.message
+          recordStageFailure(stageName, "result publication failed. Error: ${publishError.message}")
+        }
+        if (shouldRunWithZephyr) {
+          runFunctionalZephyrExecution(stageName, 'smoke')
         }
       }
     }
@@ -285,30 +354,41 @@ def runSmokeStage = { stageName, shouldRunWithZephyr, reportNameSuffix ->
 def runTaggedFunctionalStage = { enabled, stageName, shouldRunWithZephyr, reportDirectory, reportNameSuffix, tagFilter ->
   if (enabled) {
     stage(stageName) {
+      deleteStageOutputs([
+        reportDirectory,
+        'functional-output-demo',
+        'functional-test-report-demo',
+        'build/reports/tests/functionalOpalTags',
+        'build/test-results/functional',
+        'target/zephyr-reports/cucumber-opal-tags.json',
+        'target/site/serenity',
+        'target/cucumber.json',
+      ])
+
       try {
         withEnv(["TAGS=${tagFilter}"]) {
-          if (shouldRunWithZephyr) {
-            builder.gradle('clearReports functionalOpalTagsWithZephyrExecution')
-          } else {
-            builder.gradle('clearReports functionalOpalTags aggregate copyDemoFunctionalReport copyOpalTagsCucumberJson packageTaggedDemoFunctionalOutput')
-          }
+          builder.gradle('clearReports functionalOpalTags')
         }
       } catch (error) {
-        currentBuild.result = 'FAILURE'
-        steps.echo "${stageName} failed. Marking build as FAILURE. Error: " + error.message
+        recordStageFailure(stageName, "failed. Error: ${error.message}")
       } finally {
         try {
           builder.gradle('syncTaggedFunctionalArtifactsFromExistingResults')
           publishFunctionalResults(
+            "${stageName} Report",
             reportDirectory,
-            'functional-test-report-demo',
             'functional-output-demo',
+            ['functional-test-report-demo', 'build/reports/tests/functionalOpalTags'],
             reportNameSuffix,
-            'build/test-results/functional/opal-tags/*.xml'
+            'build/test-results/functional/opal-tags/*.xml',
+            "${reportDirectory}/zephyr/cucumber-opal-tags.json"
           )
         } catch (publishError) {
-          currentBuild.result = 'FAILURE'
-          steps.echo "${stageName} result publication failed. Marking build as FAILURE. Error: " + publishError.message
+          recordStageFailure(stageName, "result publication failed. Error: ${publishError.message}")
+        }
+        if (shouldRunWithZephyr) {
+          def zephyrStageKey = reportDirectory == 'functional-output-r1a-only-demo' ? 'runR1AOnly' : 'runR1AOff'
+          runFunctionalZephyrExecution(stageName, zephyrStageKey)
         }
       }
     }
@@ -366,6 +446,11 @@ withNightlyPipeline(type, product, component) {
         ' (Demo R1AOff)',
         r1AOffTagFilter
       )
+    }
+
+    if (!stageFailures.isEmpty()) {
+      currentBuild.result = 'FAILURE'
+      error("One or more selected test stages failed:\n - ${stageFailures.join('\n - ')}")
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Zephyr tasks require `JIRA_AUTH_TOKEN` to be exported before the upload task run
 
 The create and update tasks process an existing test report; they do not run the tests.
 Run the matching functional or integration suite first if the report is not already present.
+For local tagged runs, make sure the local fines service is already configured with the intended feature-flag state before executing the test command (and LAUNCH_DARKLY_ENABLED=false)
 
 Examples:
 
@@ -340,8 +341,29 @@ Examples:
 ./gradlew createJiraTicketsFromIntegrationReport
 ./gradlew updateJiraTicketsFromIntegrationReport
 ./gradlew createJiraExecutionFromIntegrationReport
+
 ./gradlew functional
+./gradlew -PzephyrFunctionalStage=functional createJiraTicketsFromFunctionalReport
+./gradlew -PzephyrFunctionalStage=functional updateJiraTicketsFromFunctionalReport
 ./gradlew -PzephyrFunctionalStage=functional createJiraExecutionFromFunctionalReport
+
+./gradlew smoke
+./gradlew -PzephyrFunctionalStage=smoke createJiraTicketsFromFunctionalReport
+./gradlew -PzephyrFunctionalStage=smoke updateJiraTicketsFromFunctionalReport
+./gradlew -PzephyrFunctionalStage=smoke createJiraExecutionFromFunctionalReport
+
+optional:
+export TEST_URL=https://opal-fines-service.demo.platform.hmcts.net
+export OPAL_USER_SERVICE_API_URL=https://opal-user-service.demo.platform.hmcts.net
+export OPAL_LOGGING_SERVICE_API_URL=https://opal-logging-service.demo.platform.hmcts.net
+
+TAGS='(@JIRA-LABEL:manual-account-creation or (@Opal and @FeatureToggle and @R1BOff)) and not @Smoke and not @Ignore and not (@R1AOff or @R1B or @R1COff or @R1C or @R1CFinance or @R1CWriteOff or @R1CWriteOffOff or @R1CEnforcementOperationalReporting or @R1CEnforcementOperationalReportingOff or @R1CAdministration)' ./gradlew functionalOpalTags
+./gradlew -PzephyrFunctionalStage=runR1AOnly createJiraExecutionFromFunctionalReport
+
+TAGS='@R1AOff and not @Ignore' ./gradlew functionalOpalTags
+./gradlew -PzephyrFunctionalStage=runR1AOff createJiraTicketsFromFunctionalReport
+./gradlew -PzephyrFunctionalStage=runR1AOff updateJiraTicketsFromFunctionalReport
+./gradlew -PzephyrFunctionalStage=runR1AOff createJiraExecutionFromFunctionalReport
 ```
 
 | Task | Purpose |

--- a/README.md
+++ b/README.md
@@ -333,6 +333,17 @@ Zephyr tasks require `JIRA_AUTH_TOKEN` to be exported before the upload task run
 The create and update tasks process an existing test report; they do not run the tests.
 Run the matching functional or integration suite first if the report is not already present.
 
+Examples:
+
+```bash
+./gradlew integration
+./gradlew createJiraTicketsFromIntegrationReport
+./gradlew updateJiraTicketsFromIntegrationReport
+./gradlew createJiraExecutionFromIntegrationReport
+./gradlew functional
+./gradlew -PzephyrFunctionalStage=functional createJiraExecutionFromFunctionalReport
+```
+
 | Task | Purpose |
 | --- | --- |
 | `createJiraTicketsFromFunctionalReport` | Creates and links Jira test tickets from the selected functional-family Zephyr report. Requires `-PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AOff`. |

--- a/README.md
+++ b/README.md
@@ -279,11 +279,11 @@ Nightly stages:
 
 | Stage | Environment | Controlled by | Gradle task flow |
 |-------|-------------|---------------|------------------|
-| `Integration Tests` | `staging` | `Integration` | `Integration` or `integrationTestWithZephyrExecution` |
-| `Functional Tests` | `staging` | `Functional` | `functional` or `functionalWithZephyrExecution` |
-| `Smoke Tests` | `staging` | `Smoke` | `smoke` or `smokeWithZephyrExecution` |
-| `Demo R1A Functional Tests` | `demo` | `RunR1AOnly` | `functionalOpalTags` or `functionalOpalTagsWithZephyrExecution` with the R1A manual-account-creation tag filter |
-| `R1AOff Demo Functional Tests` | `demo` | `RunR1AOff` | `functionalOpalTags` or `functionalOpalTagsWithZephyrExecution` with `@R1AOff and not @Ignore` |
+| `Integration Tests` | `staging` | `Integration` | `integration`, then `createJiraExecutionFromIntegrationReport` if Zephyr is enabled |
+| `Functional Tests` | `staging` | `Functional` | `clearReports functionalOpal`, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=functional` if Zephyr is enabled |
+| `Smoke Tests` | `staging` | `Smoke` | `clearReports smokeOpal`, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=smoke` if Zephyr is enabled |
+| `Demo R1A Functional Tests` | `demo` | `RunR1AOnly` | `clearReports functionalOpalTags` with the R1A manual-account-creation tag filter, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=runR1AOnly` if Zephyr is enabled |
+| `R1AOff Demo Functional Tests` | `demo` | `RunR1AOff` | `clearReports functionalOpalTags` with `@R1AOff and not @Ignore`, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=runR1AOff` if Zephyr is enabled |
 
 The demo R1A stage is intentionally limited to manual-account-creation scenarios and
 excludes R1A-off, R1B, R1B-off, R1C, and R1C-off style release-tagged scenarios. It
@@ -298,7 +298,7 @@ Nightly reports and artifacts:
 - Demo R1AOff publishes `Serenity Functional Test Report (Demo R1AOff)`.
 - Archived output folders are `integration-output`, `functional-output`, `functional-output-r1a-only-demo`, `functional-output-r1a-off-demo`, and `smoke-output`.
 - Functional and smoke outputs are published from `*/report` with Zephyr payloads under `*/zephyr`. Integration publishes `integration-output/report` and archives `integration-output/zephyr` when the integration Zephyr JSON is generated.
-- When `ZephyrExecution=true` or the nightly run is on Friday, integration, functional, smoke, demo R1A, and demo R1AOff all use their Zephyr-enabled Gradle flows.
+- When `ZephyrExecution=true` or the nightly run is on Friday, the nightly pipeline runs the selected test stage first, publishes its artifacts, then invokes the matching generic Zephyr execution task.
 
 Failure handling:
 
@@ -335,34 +335,12 @@ Run the matching functional or integration suite first if the report is not alre
 
 | Task | Purpose |
 | --- | --- |
-| `functionalWithZephyrExecution` | Runs the default Opal functional suite, creates an Opal Cucumber report copy, and creates the Opal Zephyr execution. |
-| `functionalWithTagsWithZephyrExecution` | Runs the default Opal functional suite and the tagged Opal functional suite selected by `TAGS` or `-Ptags`, then creates Zephyr executions for both reports. |
-| `functionalOpalWithZephyrExecution` | Runs only `functionalOpal`, copies its Cucumber report to `functional-output/zephyr/cucumber-opal.json`, and creates the Opal Zephyr execution. |
-| `functionalOpalTagsWithZephyrExecution` | Runs only `functionalOpalTags`, copies its Cucumber report to `functional-output-demo/zephyr/cucumber-opal-tags.json`, and creates the tagged Opal Zephyr execution. |
-| `functionalLegacyWithZephyrExecution` | Runs only `functionalLegacy`, copies its Cucumber report to `functional-output/zephyr/cucumber-legacy.json`, and creates the Legacy Zephyr execution. |
-| `smokeWithZephyrExecution` | Runs `smokeOpal`, copies its Cucumber report to `smoke-output/zephyr/cucumber-smoke.json`, and creates the smoke Zephyr execution. |
-
-| `createJiraTicketsFromCucumberReport` | Creates and links Jira test tickets from `target/cucumber.json`. |
-| `updateJiraTicketsFromCucumberReport` | Updates Jira test tickets from `target/cucumber.json`. |
-| `createJiraTicketsFromOpalCucumberReport` | Creates and links Jira test tickets from `functional-output/zephyr/cucumber-opal.json`. |
-| `updateJiraTicketsFromOpalCucumberReport` | Updates Jira test tickets from `functional-output/zephyr/cucumber-opal.json`. |
-| `createJiraTicketsFromOpalTagsCucumberReport` | Creates and links Jira test tickets from `functional-output-demo/zephyr/cucumber-opal-tags.json`. |
-| `updateJiraTicketsFromOpalTagsCucumberReport` | Updates Jira test tickets from `functional-output-demo/zephyr/cucumber-opal-tags.json`. |
-| `createJiraTicketsFromLegacyCucumberReport` | Creates and links Jira test tickets from `functional-output/zephyr/cucumber-legacy.json`. |
-| `updateJiraTicketsFromLegacyCucumberReport` | Updates Jira test tickets from `functional-output/zephyr/cucumber-legacy.json`. |
-| `createJiraTicketsFromSmokeCucumberReport` | Creates and links Jira test tickets from `smoke-output/zephyr/cucumber-smoke.json`. |
-| `updateJiraTicketsFromSmokeCucumberReport` | Updates Jira test tickets from `smoke-output/zephyr/cucumber-smoke.json`. |
-
-| `createJiraExecutionFromCucumberReport` | Creates a Zephyr execution from `target/cucumber.json`. |
-| `createJiraExecutionFromOpalCucumberReport` | Creates a Zephyr execution from `functional-output/zephyr/cucumber-opal.json`. |
-| `createJiraExecutionFromOpalTagsCucumberReport` | Creates a Zephyr execution from `functional-output-demo/zephyr/cucumber-opal-tags.json`. |
-| `createJiraExecutionFromLegacyCucumberReport` | Creates a Zephyr execution from `functional-output/zephyr/cucumber-legacy.json`. |
-| `createJiraExecutionFromSmokeCucumberReport` | Creates a Zephyr execution from `smoke-output/zephyr/cucumber-smoke.json`. |
-
-| `integrationTestWithZephyrExecution` | Runs `integration`, then creates a Zephyr execution from the generated JUnit5 integration report. |
-| `createJiraTicketsFromJUnit5ReportIntegrationTest` | Creates and links Jira test tickets from `integration-output/zephyr/Junit5Report-IntegrationTest.json`. |
-| `updateJiraTicketsFromJUnit5ReportIntegrationTest` | Updates Jira test tickets from `integration-output/zephyr/Junit5Report-IntegrationTest.json`. |
-| `createJiraExecutionFromJUnit5ReportIntegrationTest` | Creates a Zephyr execution from `integration-output/zephyr/Junit5Report-IntegrationTest.json`. |
+| `createJiraTicketsFromFunctionalReport` | Creates and links Jira test tickets from the selected functional-family Zephyr report. Requires `-PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AOff`. |
+| `updateJiraTicketsFromFunctionalReport` | Updates Jira test tickets from the selected functional-family Zephyr report. Requires `-PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AOff`. |
+| `createJiraExecutionFromFunctionalReport` | Creates a Zephyr execution from the selected functional-family Zephyr report. Requires `-PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AOff`. |
+| `createJiraTicketsFromIntegrationReport` | Creates and links Jira test tickets from `integration-output/zephyr/Junit5Report-IntegrationTest.json`. |
+| `updateJiraTicketsFromIntegrationReport` | Updates Jira test tickets from `integration-output/zephyr/Junit5Report-IntegrationTest.json`. |
+| `createJiraExecutionFromIntegrationReport` | Creates a Zephyr execution from `integration-output/zephyr/Junit5Report-IntegrationTest.json`. |
 
 ## Manual api testing (Postman)
 

--- a/build.gradle
+++ b/build.gradle
@@ -140,23 +140,17 @@ def logPublishedHtmlReport = { String label, String reportDirectory ->
 }
 
 def syncFunctionalArtifacts = { String reportLabel, String rawReportDirectory, String outputDirectory, String cucumberJsonFileName ->
-  delete(rawReportDirectory)
   delete("${outputDirectory}/report")
+  delete("${outputDirectory}/zephyr")
 
-  if (file("${rootDir}/target/site/serenity").exists()) {
+  if (file(rawReportDirectory).exists()) {
     copy {
-      from("${rootDir}/target/site/serenity")
-      into(rawReportDirectory)
-    }
-    copy {
-      from("${rootDir}/target/site/serenity")
+      from(rawReportDirectory)
       into("${outputDirectory}/report")
     }
   }
 
   if (cucumberJsonFileName != null) {
-    delete("${outputDirectory}/zephyr/${cucumberJsonFileName}")
-
     def cucumberJsonFile = file("${rootDir}/target/zephyr-reports/${cucumberJsonFileName}")
     if (cucumberJsonFile.exists()) {
       copy {
@@ -338,9 +332,17 @@ tasks.register('functionalOpal', Test) {
   reports.junitXml.getOutputLocation().set(layout.buildDirectory.dir("test-results/functional/opal"))
   testLogging.showStandardStreams = true
   environment("IS_LEGACY_MODE", "false")
+  systemProperty 'serenity.outputDirectory', "${rootDir}/functional-test-report"
+  systemProperty 'cucumber.plugin', "json:${rootDir}/target/zephyr-reports/cucumber-opal.json"
   include '**/OpalTestRunner.class'
 
   finalizedBy 'copyOpalCucumberJson'
+}
+
+tasks.register('copyOpalCucumberJson', Copy) {
+  from("${rootDir}/target/zephyr-reports/cucumber-opal.json")
+  into("${rootDir}/functional-output/zephyr")
+  outputs.upToDateWhen { false }
 }
 
 tasks.register('functionalOpalTags', Test) {
@@ -352,6 +354,8 @@ tasks.register('functionalOpalTags', Test) {
   reports.junitXml.getOutputLocation().set(layout.buildDirectory.dir("test-results/functional/opal-tags"))
   testLogging.showStandardStreams = true
   environment("IS_LEGACY_MODE", "false")
+  systemProperty 'serenity.outputDirectory', "${rootDir}/functional-test-report-demo"
+  systemProperty 'cucumber.plugin', "json:${rootDir}/target/zephyr-reports/cucumber-opal-tags.json"
 
   include '**/OpalTaggedTestRunner.class'
 
@@ -372,6 +376,12 @@ tasks.register('functionalOpalTags', Test) {
   finalizedBy 'copyOpalTagsCucumberJson'
 }
 
+tasks.register('copyOpalTagsCucumberJson', Copy) {
+  from("${rootDir}/target/zephyr-reports/cucumber-opal-tags.json")
+  into("${rootDir}/functional-output-demo/zephyr")
+  outputs.upToDateWhen { false }
+}
+
 tasks.register('functionalLegacy', Test) {
   description = "Runs functional tests against Legacy mode"
   group = "Verification"
@@ -381,10 +391,19 @@ tasks.register('functionalLegacy', Test) {
   reports.junitXml.getOutputLocation().set(layout.buildDirectory.dir("test-results/functional/legacy"))
   testLogging.showStandardStreams = true
   environment("IS_LEGACY_MODE", "true")
+  systemProperty 'serenity.outputDirectory', "${rootDir}/functional-test-report-legacy"
+  systemProperty 'cucumber.plugin', "json:${rootDir}/target/zephyr-reports/cucumber-legacy.json"
 
   include '**/LegacyTestRunner.class'
   finalizedBy 'copyLegacyCucumberJson'
 }
+
+tasks.register('copyLegacyCucumberJson', Copy) {
+  from("${rootDir}/target/zephyr-reports/cucumber-legacy.json")
+  into("${rootDir}/functional-output-legacy/zephyr")
+  outputs.upToDateWhen { false }
+}
+
 tasks.register('copyFunctionalReport', Copy) {
   dependsOn 'aggregate'
   from("${rootDir}/target/site/serenity")
@@ -439,6 +458,16 @@ tasks.register('syncTaggedFunctionalArtifactsFromExistingResults') {
       "${rootDir}/functional-test-report-demo",
       "${rootDir}/functional-output-demo",
       'cucumber-opal-tags.json'
+    )
+  }
+}
+tasks.register('syncSmokeArtifactsFromExistingResults') {
+  doLast {
+    syncFunctionalArtifacts(
+      'Smoke Test Report',
+      "${rootDir}/smoke-test-report",
+      "${rootDir}/smoke-output",
+      'cucumber-smoke.json'
     )
   }
 }
@@ -505,6 +534,8 @@ tasks.register('smokeOpal', Test) {
   classpath = sourceSets.functionalTest.runtimeClasspath
   reports.junitXml.getOutputLocation().set(layout.buildDirectory.dir("test-results/smoke"))
   testLogging.showStandardStreams = true
+  systemProperty 'serenity.outputDirectory', "${rootDir}/smoke-test-report"
+  systemProperty 'cucumber.plugin', "json:${rootDir}/target/zephyr-reports/cucumber-smoke.json"
 
   include '**/SmokeTestRunner.class'
   finalizedBy 'copySmokeCucumberJson'
@@ -519,7 +550,7 @@ tasks.register('copySmokeReport', Copy) {
   }
 }
 tasks.register('copySmokeCucumberJson', Copy) {
-  from("target/cucumber.json")
+  from("${rootDir}/target/zephyr-reports/cucumber-smoke.json")
   into("${rootDir}/smoke-output/zephyr")
   rename { "cucumber-smoke.json" }
   outputs.upToDateWhen { false }

--- a/gradle/zephyr.gradle
+++ b/gradle/zephyr.gradle
@@ -1,5 +1,7 @@
-var zephyrBaseArgs = [
-        //Jira Config
+import groovy.transform.Field
+
+@Field
+List<String> zephyrBaseArgs = [
         "jira-base-url=https://tools.hmcts.net/jira/rest/api/latest",
         "jira-project-id=28500",
         "jira-default-user=OPAL.Zephyr.automation",
@@ -10,350 +12,144 @@ var zephyrBaseArgs = [
         "execution-build=${System.getenv('EXECUTION_BUILD') ?: ''}",
         "execution-test-cycle-description=${System.getenv('EXECUTION_CYCLE_DESCRIPTION') ?: ''}"
 ]
-// helper that returns a NEW list each time
-def zephyrArgs = { String processType, String actionType, String testFolder, String reportPath ->
-    zephyrBaseArgs + [
-            "process-type=${processType}",
-            "action-type=${actionType}",
-            "base-path=${file("src/${testFolder}").absolutePath}",
-            "report-path=${reportPath}",
-            "github-repo-base-src-dir=https://github.com/hmcts/opal-fines-service/tree/master/src/${testFolder}",
-    ]
+
+List<String> zephyrArgs(String processType, String actionType, String testFolder, String reportPath) {
+    List<String> args = new ArrayList<>(zephyrBaseArgs)
+    args.add("process-type=${processType}")
+    args.add("action-type=${actionType}")
+    args.add("base-path=${file("src/${testFolder}").absolutePath}")
+    args.add("report-path=${reportPath}")
+    args.add("github-repo-base-src-dir=https://github.com/hmcts/opal-fines-service/tree/master/src/${testFolder}")
+    args
 }
 
-tasks.register('functionalWithZephyrExecution') {
-    group = "Zephyr Reporting - Cucumber"
-    description = "Runs functional tests"
-    gradle.startParameter.continueOnFailure = true
+@Field
+Map<String, Map<String, Object>> functionalZephyrTargets = [
+        functional: [
+                reportPath: "functional-output/zephyr/cucumber-opal.json",
+                testFolder: "functionalTest/resources",
+                syncTask  : "syncFunctionalArtifactsFromExistingResults",
+        ],
+        smoke: [
+                reportPath: "smoke-output/zephyr/cucumber-smoke.json",
+                testFolder: "functionalTest/resources",
+                syncTask  : "syncSmokeArtifactsFromExistingResults",
+        ],
+        runR1AOnly: [
+                reportPath: "functional-output-demo/zephyr/cucumber-opal-tags.json",
+                testFolder: "functionalTest/resources",
+                syncTask  : "syncTaggedFunctionalArtifactsFromExistingResults",
+        ],
+        runR1AOff: [
+                reportPath: "functional-output-demo/zephyr/cucumber-opal-tags.json",
+                testFolder: "functionalTest/resources",
+                syncTask  : "syncTaggedFunctionalArtifactsFromExistingResults",
+        ],
+]
 
-    dependsOn('clearReports',
-            'functionalOpal', 'copyOpalCucumberJson', 'createJiraExecutionFromOpalCucumberReport',
-            'aggregate', 'copyFunctionalReport', 'mergeFunctionalResults')
+Map<String, Object> resolveFunctionalZephyrTarget() {
+    String stageKey = (project.findProperty("zephyrFunctionalStage")
+            ?: System.getenv("ZEPHYR_FUNCTIONAL_STAGE"))?.toString()
+    String choices = functionalZephyrTargets.keySet().join(', ')
+    String example = "./gradlew -PzephyrFunctionalStage=functional createJiraExecutionFromFunctionalReport"
 
-    tasks.functionalOpal.mustRunAfter clearReports
-    tasks.copyOpalCucumberJson.mustRunAfter functionalOpal
-    tasks.createJiraExecutionFromOpalCucumberReport.mustRunAfter copyOpalCucumberJson
+    if (stageKey == null || stageKey.trim().isEmpty()) {
+        throw new GradleException(
+                "Set -PzephyrFunctionalStage to one of: ${choices}. Example: ${example}"
+        )
+    }
 
-    tasks.mergeFunctionalResults.mustRunAfter createJiraExecutionFromOpalCucumberReport
-    tasks.aggregate.mustRunAfter createJiraExecutionFromOpalCucumberReport
-    tasks.copyFunctionalReport.mustRunAfter aggregate
-    finalizedBy 'packageFunctionalOutput'
+    Map<String, Object> target = functionalZephyrTargets[stageKey]
+    if (target == null) {
+        throw new GradleException(
+                "Unknown zephyrFunctionalStage '${stageKey}'. Expected one of: ${choices}. Example: ${example}"
+        )
+    }
+
+    [stageKey: stageKey] + target
 }
 
-tasks.register('functionalWithTagsWithZephyrExecution') {
-    group = "Zephyr Reporting - Cucumber"
-    description = "Runs the default Opal suite plus tagged Opal scenarios and creates Zephyr executions"
-    gradle.startParameter.continueOnFailure = true
+void configureFunctionalZephyrTask(JavaExec task, String actionType, String description) {
+    task.group = "Zephyr Reporting - Cucumber"
+    task.description = description
+    task.classpath = configurations.zephyrCucumberReportProcessor
+    task.mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
+    task.dependsOn {
+        String syncTask = resolveFunctionalZephyrTarget().syncTask as String
+        [tasks.named(syncTask).get()]
+    }
 
-    dependsOn('clearReports',
-            'functionalOpal', 'copyOpalCucumberJson', 'createJiraExecutionFromOpalCucumberReport',
-            'functionalOpalTags', 'copyOpalTagsCucumberJson', 'createJiraExecutionFromOpalTagsCucumberReport',
-            'aggregate', 'copyDemoFunctionalReport', 'mergeFunctionalWithTagsResults')
+    task.doFirst {
+        Map<String, Object> target = resolveFunctionalZephyrTarget()
+        File reportFile = file(target.reportPath as String)
+        String testFolder = target.testFolder as String
 
-    tasks.functionalOpal.mustRunAfter clearReports
-    tasks.copyOpalCucumberJson.mustRunAfter functionalOpal
-    tasks.createJiraExecutionFromOpalCucumberReport.mustRunAfter copyOpalCucumberJson
+        if (!reportFile.exists()) {
+            throw new GradleException(
+                    "Functional Zephyr report for stage '${target.stageKey}' was not found at ${reportFile}"
+            )
+        }
 
-    tasks.functionalOpalTags.mustRunAfter createJiraExecutionFromOpalCucumberReport
-    tasks.copyOpalTagsCucumberJson.mustRunAfter functionalOpalTags
-    tasks.createJiraExecutionFromOpalTagsCucumberReport.mustRunAfter copyOpalTagsCucumberJson
-    tasks.mergeFunctionalWithTagsResults.mustRunAfter createJiraExecutionFromOpalTagsCucumberReport
-    tasks.aggregate.mustRunAfter createJiraExecutionFromOpalTagsCucumberReport
-    tasks.copyDemoFunctionalReport.mustRunAfter aggregate
-    finalizedBy 'packageDemoFunctionalOutput'
+        task.setArgs(zephyrArgs(
+                "CUCUMBER_JSON_REPORT",
+                actionType,
+                testFolder,
+                reportFile.absolutePath
+        ) as List<String>)
+    }
 }
 
-tasks.register('copyOpalCucumberJson', Copy) {
-    from("target/cucumber.json")
-    into("${rootDir}/functional-output/zephyr")
-    rename { "cucumber-opal.json" }
-    outputs.upToDateWhen { false }
+void configureIntegrationZephyrTask(JavaExec task, String actionType, String description) {
+    task.group = "Zephyr Reporting - JUnit5"
+    task.description = description
+    task.classpath = configurations.zephyrCucumberReportProcessor
+    task.mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
+    task.dependsOn('copyIntegrationJunit5Report')
+
+    File integrationReport = file("integration-output/zephyr/Junit5Report-IntegrationTest.json")
+
+    task.doFirst {
+        if (!integrationReport.exists()) {
+            throw new GradleException(
+                    "Integration Zephyr report was not found at ${integrationReport}"
+            )
+        }
+
+        task.setArgs(zephyrArgs(
+                "JUNIT5_JSON_REPORT",
+                actionType,
+                "integrationTest/java",
+                integrationReport.absolutePath
+        ) as List<String>)
+    }
 }
 
-tasks.register('copyOpalTagsCucumberJson', Copy) {
-    from("target/cucumber.json")
-    into("${rootDir}/functional-output-demo/zephyr")
-    rename { "cucumber-opal-tags.json" }
-    outputs.upToDateWhen { false }
+tasks.register('createJiraTicketsFromFunctionalReport', JavaExec) { JavaExec task ->
+    configureFunctionalZephyrTask(task, "CREATE_TICKETS",
+            "Creates and links Jira tickets from the selected functional-family Zephyr report. Requires -PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AOff")
 }
 
-tasks.register('copyLegacyCucumberJson', Copy) {
-    from("target/cucumber.json")
-    into("${rootDir}/functional-output/zephyr")
-    rename { "cucumber-legacy.json" }
-    outputs.upToDateWhen { false }
-}
-tasks.register('createJiraTicketsFromCucumberReport', JavaExec) {
-    group = "Zephyr Reporting - Cucumber"
-    description = "Processes cucumber.json to create and link Jira tickets to each test"
-    def cucumberJson = file("target/cucumber.json")
-
-    inputs.file(cucumberJson)
-
-    classpath = configurations.zephyrCucumberReportProcessor
-    mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-    args = zephyrArgs("CUCUMBER_JSON_REPORT", "CREATE_TICKETS", "functionalTest/resources", cucumberJson.absolutePath)
+tasks.register('updateJiraTicketsFromFunctionalReport', JavaExec) { JavaExec task ->
+    configureFunctionalZephyrTask(task, "UPDATE_TICKETS",
+            "Updates Jira tickets from the selected functional-family Zephyr report. Requires -PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AOff")
 }
 
-tasks.register('updateJiraTicketsFromCucumberReport', JavaExec) {
-    group = "Zephyr Reporting - Cucumber"
-
-    description = "Processes cucumber.json to update Jira tickets"
-    def cucumberJson = file("target/cucumber.json")
-
-    inputs.file(cucumberJson)
-
-    classpath = configurations.zephyrCucumberReportProcessor
-    mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-    args = zephyrArgs("CUCUMBER_JSON_REPORT", "UPDATE_TICKETS", "functionalTest/resources", cucumberJson.absolutePath)
+tasks.register('createJiraExecutionFromFunctionalReport', JavaExec) { JavaExec task ->
+    configureFunctionalZephyrTask(task, "CREATE_EXECUTION",
+            "Creates a Zephyr execution from the selected functional-family Zephyr report. Requires -PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AOff")
 }
 
-tasks.register('createJiraTicketsFromOpalCucumberReport', JavaExec) {
-    group = "Zephyr Reporting - Cucumber"
-    description = "Processes cucumber-opal.json to create and link Jira tickets to each test"
-    def opalCucumberJson = file("functional-output/zephyr/cucumber-opal.json")
-
-    inputs.file(opalCucumberJson)
-
-    classpath = configurations.zephyrCucumberReportProcessor
-    mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-    args = zephyrArgs("CUCUMBER_JSON_REPORT", "CREATE_TICKETS", "functionalTest/resources", opalCucumberJson.absolutePath)
+tasks.register('createJiraTicketsFromIntegrationReport', JavaExec) { JavaExec task ->
+    configureIntegrationZephyrTask(task, "CREATE_TICKETS",
+            "Creates and links Jira tickets from the integration JUnit5 Zephyr report")
 }
 
-tasks.register('updateJiraTicketsFromOpalCucumberReport', JavaExec) {
-    group = "Zephyr Reporting - Cucumber"
-    description = "Processes cucumber-opal.json to update Jira tickets"
-    def opalCucumberJson = file("functional-output/zephyr/cucumber-opal.json")
-
-    inputs.file(opalCucumberJson)
-
-    classpath = configurations.zephyrCucumberReportProcessor
-    mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-    args = zephyrArgs("CUCUMBER_JSON_REPORT", "UPDATE_TICKETS", "functionalTest/resources", opalCucumberJson.absolutePath)
+tasks.register('updateJiraTicketsFromIntegrationReport', JavaExec) { JavaExec task ->
+    configureIntegrationZephyrTask(task, "UPDATE_TICKETS",
+            "Updates Jira tickets from the integration JUnit5 Zephyr report")
 }
 
-tasks.register('createJiraTicketsFromOpalTagsCucumberReport', JavaExec) {
-    group = "Zephyr Reporting - Cucumber"
-    description = "Processes cucumber-opal-tags.json to create and link Jira tickets to each test"
-    def opalTagsCucumberJson = file("functional-output-demo/zephyr/cucumber-opal-tags.json")
-
-    inputs.file(opalTagsCucumberJson)
-
-    classpath = configurations.zephyrCucumberReportProcessor
-    mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-    args = zephyrArgs("CUCUMBER_JSON_REPORT", "CREATE_TICKETS", "functionalTest/resources", opalTagsCucumberJson.absolutePath)
-}
-
-tasks.register('updateJiraTicketsFromOpalTagsCucumberReport', JavaExec) {
-    group = "Zephyr Reporting - Cucumber"
-    description = "Processes cucumber-opal-tags.json to update Jira tickets"
-    def opalTagsCucumberJson = file("functional-output-demo/zephyr/cucumber-opal-tags.json")
-
-    inputs.file(opalTagsCucumberJson)
-
-    classpath = configurations.zephyrCucumberReportProcessor
-    mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-    args = zephyrArgs("CUCUMBER_JSON_REPORT", "UPDATE_TICKETS", "functionalTest/resources", opalTagsCucumberJson.absolutePath)
-}
-
-tasks.register('createJiraTicketsFromLegacyCucumberReport', JavaExec) {
-    group = "Zephyr Reporting - Cucumber"
-    description = "Processes cucumber-legacy.json to create and link Jira tickets to each test"
-    def legacyCucumberJson = file("functional-output/zephyr/cucumber-legacy.json")
-
-    inputs.file(legacyCucumberJson)
-
-    classpath = configurations.zephyrCucumberReportProcessor
-    mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-    args = zephyrArgs("CUCUMBER_JSON_REPORT", "CREATE_TICKETS", "functionalTest/resources", legacyCucumberJson.absolutePath)
-}
-
-tasks.register('updateJiraTicketsFromLegacyCucumberReport', JavaExec) {
-    group = "Zephyr Reporting - Cucumber"
-    description = "Processes cucumber-legacy.json to update Jira tickets"
-    def legacyCucumberJson = file("functional-output/zephyr/cucumber-legacy.json")
-
-    inputs.file(legacyCucumberJson)
-
-    classpath = configurations.zephyrCucumberReportProcessor
-    mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-    args = zephyrArgs("CUCUMBER_JSON_REPORT", "UPDATE_TICKETS", "functionalTest/resources", legacyCucumberJson.absolutePath)
-}
-
-tasks.register('createJiraTicketsFromSmokeCucumberReport', JavaExec) {
-    group = "Zephyr Reporting - Cucumber"
-    description = "Processes cucumber-smoke.json to create and link Jira tickets to each test"
-    def smokeCucumberJson = file("smoke-output/zephyr/cucumber-smoke.json")
-
-    inputs.file(smokeCucumberJson)
-
-    classpath = configurations.zephyrCucumberReportProcessor
-    mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-    args = zephyrArgs("CUCUMBER_JSON_REPORT", "CREATE_TICKETS", "functionalTest/resources", smokeCucumberJson.absolutePath)
-}
-
-tasks.register('updateJiraTicketsFromSmokeCucumberReport', JavaExec) {
-    group = "Zephyr Reporting - Cucumber"
-    description = "Processes cucumber-smoke.json to update Jira tickets"
-    def smokeCucumberJson = file("smoke-output/zephyr/cucumber-smoke.json")
-
-    inputs.file(smokeCucumberJson)
-
-    classpath = configurations.zephyrCucumberReportProcessor
-    mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-    args = zephyrArgs("CUCUMBER_JSON_REPORT", "UPDATE_TICKETS", "functionalTest/resources", smokeCucumberJson.absolutePath)
-}
-
-
-tasks.register('createJiraTicketsFromJUnit5ReportIntegrationTest', JavaExec) {
-    group = "Zephyr Reporting - JUnit5"
-    description = "Processes Junit5Report-IntegrationTest.json to create and link Jira tickets to each test"
-    def junit5ReportJson = file("integration-output/zephyr/Junit5Report-IntegrationTest.json")
-
-    dependsOn('copyIntegrationJunit5Report')
-    inputs.file(junit5ReportJson)
-
-    classpath = configurations.zephyrCucumberReportProcessor
-    mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-    args = zephyrArgs("JUNIT5_JSON_REPORT", "CREATE_TICKETS", "integrationTest/java", junit5ReportJson.absolutePath)
-}
-
-tasks.register('updateJiraTicketsFromJUnit5ReportIntegrationTest', JavaExec) {
-    group = "Zephyr Reporting - JUnit5"
-
-    description = "Processes Junit5Report-IntegrationTest.json to update Jira tickets"
-    def junit5ReportJson = file("integration-output/zephyr/Junit5Report-IntegrationTest.json")
-
-    dependsOn('copyIntegrationJunit5Report')
-    inputs.file(junit5ReportJson)
-
-    classpath = configurations.zephyrCucumberReportProcessor
-    mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-    args = zephyrArgs("JUNIT5_JSON_REPORT", "UPDATE_TICKETS", "integrationTest/java", junit5ReportJson.absolutePath)
-}
-
-tasks.register('createJiraExecutionFromJUnit5ReportIntegrationTest', JavaExec) {
-    group = "Zephyr Reporting - JUnit5"
-
-    description = "Processes Junit5Report-IntegrationTest.json to create Zephyr executions"
-    def junit5ReportJson = file("integration-output/zephyr/Junit5Report-IntegrationTest.json")
-
-    dependsOn('copyIntegrationJunit5Report')
-    inputs.file(junit5ReportJson)
-
-    classpath = configurations.zephyrCucumberReportProcessor
-    mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-    args = zephyrArgs("JUNIT5_JSON_REPORT", "CREATE_EXECUTION", "integrationTest/java", junit5ReportJson.absolutePath)
-}
-
-
-tasks.register('createJiraExecutionFromCucumberReport', JavaExec) {
-    group = "Zephyr Reporting - Cucumber"
-
-    description = "Processes cucumber.json to create Zephyr executions"
-    def cucumberJson = file("target/cucumber.json")
-
-    inputs.file(cucumberJson)
-
-    classpath = configurations.zephyrCucumberReportProcessor
-    mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-    args = zephyrArgs("CUCUMBER_JSON_REPORT", "CREATE_EXECUTION", "functionalTest/resources", cucumberJson.absolutePath)
-}
-
-tasks.register('createJiraExecutionFromLegacyCucumberReport', JavaExec) {
-    group = "Zephyr Reporting - Cucumber"
-    classpath = configurations.zephyrCucumberReportProcessor
-    mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-    def legacyCucumberJson = file("functional-output/zephyr/cucumber-legacy.json")
-    inputs.file(legacyCucumberJson)
-
-    args = zephyrArgs("CUCUMBER_JSON_REPORT", "CREATE_EXECUTION", "functionalTest/resources", legacyCucumberJson.absolutePath)
-}
-
-tasks.register('createJiraExecutionFromOpalCucumberReport', JavaExec) {
-    group = "Zephyr Reporting - Cucumber"
-    classpath = configurations.zephyrCucumberReportProcessor
-    mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-    def opalCucumberJson = file("functional-output/zephyr/cucumber-opal.json")
-    inputs.file(opalCucumberJson)
-
-    args = zephyrArgs("CUCUMBER_JSON_REPORT", "CREATE_EXECUTION", "functionalTest/resources", opalCucumberJson.absolutePath)
-}
-
-tasks.register('createJiraExecutionFromOpalTagsCucumberReport', JavaExec) {
-    group = "Zephyr Reporting - Cucumber"
-    classpath = configurations.zephyrCucumberReportProcessor
-    mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-    def opalTagsCucumberJson = file("functional-output-demo/zephyr/cucumber-opal-tags.json")
-    inputs.file(opalTagsCucumberJson)
-
-    args = zephyrArgs("CUCUMBER_JSON_REPORT", "CREATE_EXECUTION", "functionalTest/resources", opalTagsCucumberJson.absolutePath)
-}
-
-tasks.register('createJiraExecutionFromSmokeCucumberReport', JavaExec) {
-    group = "Zephyr Reporting - Cucumber"
-    classpath = configurations.zephyrCucumberReportProcessor
-    mainClass = "uk.hmcts.zephyr.automation.ZephyrAutomation"
-    def smokeCucumberJson = file("smoke-output/zephyr/cucumber-smoke.json")
-    inputs.file(smokeCucumberJson)
-
-    args = zephyrArgs("CUCUMBER_JSON_REPORT", "CREATE_EXECUTION", "functionalTest/resources", smokeCucumberJson.absolutePath)
-}
-
-tasks.register('functionalOpalWithZephyrExecution') {
-    group = "Zephyr Reporting - Cucumber"
-    description = "Runs functionalOpal then creates the Zephyr execution from the cucumber report"
-
-    dependsOn('functionalOpal', 'copyOpalCucumberJson', 'createJiraExecutionFromOpalCucumberReport')
-
-    tasks.copyOpalCucumberJson.mustRunAfter functionalOpal
-    tasks.createJiraExecutionFromOpalCucumberReport.mustRunAfter copyOpalCucumberJson
-}
-
-tasks.register('functionalOpalTagsWithZephyrExecution') {
-    group = "Zephyr Reporting - Cucumber"
-    description = "Runs functionalOpalTags then creates the Zephyr execution from the cucumber report"
-
-    dependsOn('functionalOpalTags', 'copyOpalTagsCucumberJson', 'createJiraExecutionFromOpalTagsCucumberReport',
-            'aggregate', 'copyDemoFunctionalReport')
-
-    tasks.copyOpalTagsCucumberJson.mustRunAfter functionalOpalTags
-    tasks.createJiraExecutionFromOpalTagsCucumberReport.mustRunAfter copyOpalTagsCucumberJson
-    tasks.aggregate.mustRunAfter createJiraExecutionFromOpalTagsCucumberReport
-    tasks.copyDemoFunctionalReport.mustRunAfter aggregate
-    finalizedBy 'packageTaggedDemoFunctionalOutput'
-}
-
-tasks.register('functionalLegacyWithZephyrExecution') {
-    group = "Zephyr Reporting - Cucumber"
-    description = "Runs functionalLegacy then creates the Zephyr execution from the cucumber report"
-
-    dependsOn('functionalLegacy', 'copyLegacyCucumberJson', 'createJiraExecutionFromLegacyCucumberReport')
-
-    tasks.copyLegacyCucumberJson.mustRunAfter functionalLegacy
-    tasks.createJiraExecutionFromLegacyCucumberReport.mustRunAfter copyLegacyCucumberJson
-}
-
-tasks.register('smokeWithZephyrExecution') {
-    group = "Zephyr Reporting - Cucumber"
-    description = "Runs smoke then creates the Zephyr execution from the cucumber report"
-
-    dependsOn('smokeOpal', 'copySmokeCucumberJson', 'createJiraExecutionFromSmokeCucumberReport',
-            'aggregate', 'copySmokeReport')
-
-    tasks.copySmokeCucumberJson.mustRunAfter smokeOpal
-    tasks.createJiraExecutionFromSmokeCucumberReport.mustRunAfter copySmokeCucumberJson
-    tasks.aggregate.mustRunAfter createJiraExecutionFromSmokeCucumberReport
-    tasks.copySmokeReport.mustRunAfter aggregate
-    finalizedBy 'packageSmokeOutput'
-}
-
-tasks.register('integrationTestWithZephyrExecution') {
-    group = "Zephyr Reporting - JUnit5"
-    description = "Runs integrationTest then creates the Zephyr execution from the JUnit5 report"
-
-    dependsOn('integration', 'createJiraExecutionFromJUnit5ReportIntegrationTest')
-
-    tasks.createJiraExecutionFromJUnit5ReportIntegrationTest.mustRunAfter integration
-    finalizedBy 'packageIntegrationOutput'
+tasks.register('createJiraExecutionFromIntegrationReport', JavaExec) { JavaExec task ->
+    configureIntegrationZephyrTask(task, "CREATE_EXECUTION",
+            "Creates a Zephyr execution from the integration JUnit5 Zephyr report")
 }

--- a/src/functionalTest/java/uk/gov/hmcts/opal/assertions/draftaccount/DraftAccountAssertions.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/assertions/draftaccount/DraftAccountAssertions.java
@@ -4,7 +4,6 @@ import io.restassured.response.Response;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Map;
-import net.serenitybdd.core.Serenity;
 import net.serenitybdd.rest.SerenityRest;
 import uk.gov.hmcts.opal.assertions.CommonResponseAssertions;
 
@@ -59,9 +58,6 @@ public class DraftAccountAssertions {
         String actual = String.valueOf(apiCreatedAt.truncatedTo(java.time.temporal.ChronoUnit.MILLIS));
         String expected = String.valueOf(originalCreatedAt.truncatedTo(java.time.temporal.ChronoUnit.MILLIS));
 
-        Serenity.recordReportData().withTitle("Times").andContents(
-            "Created at time: " + expected + "\nResponse created at time: " + actual);
-
         assertEquals(expected, actual, "Created at time has changed");
     }
 
@@ -77,9 +73,6 @@ public class DraftAccountAssertions {
 
         String original = String.valueOf(originalAccountStatusDate.truncatedTo(java.time.temporal.ChronoUnit.MILLIS));
         String current = String.valueOf(apiAccountStatusDate.truncatedTo(java.time.temporal.ChronoUnit.MILLIS));
-
-        Serenity.recordReportData().withTitle("Times").andContents(
-            "Initial account status date: " + original + "\nResponse account status date: " + current);
 
         assertTrue(
             apiAccountStatusDate.isAfter(originalAccountStatusDate),

--- a/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1aFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1aFeatureToggles.feature
@@ -10,20 +10,63 @@ Feature: Fines Service Release 1a Feature Toggles
     Then the request is rejected with status 404
     And the response reports that the feature is disabled
 
+    @JIRA-TEST-KEY:PO-8840
     Examples:
       | endpoint              |
       | Get Courts            |
+    @JIRA-TEST-KEY:PO-8841
+    Examples:
+      | endpoint              |
       | Search Courts         |
+    @JIRA-TEST-KEY:PO-8842
+    Examples:
+      | endpoint              |
       | Get Business Units    |
+    @JIRA-TEST-KEY:PO-8843
+    Examples:
+      | endpoint              |
       | Get Business Unit     |
+    @JIRA-TEST-KEY:PO-8844
+    Examples:
+      | endpoint              |
       | Get Local Justice Areas |
+    @JIRA-TEST-KEY:PO-8845
+    Examples:
+      | endpoint              |
       | Get Offences          |
+    @JIRA-TEST-KEY:PO-8846
+    Examples:
+      | endpoint              |
       | Get Offence           |
+    @JIRA-TEST-KEY:PO-8847
+    Examples:
+      | endpoint              |
       | Search Offences       |
+    @JIRA-TEST-KEY:PO-8848
+    Examples:
+      | endpoint              |
       | Get Major Creditors   |
+    @JIRA-TEST-KEY:PO-8849
+    Examples:
+      | endpoint              |
       | Get Prosecutors       |
+    @JIRA-TEST-KEY:PO-8850
+    Examples:
+      | endpoint              |
       | Add Draft Account     |
+    @JIRA-TEST-KEY:PO-8851
+    Examples:
+      | endpoint              |
       | Get Draft Accounts    |
+    @JIRA-TEST-KEY:PO-8852
+    Examples:
+      | endpoint              |
       | Get Draft Account     |
+    @JIRA-TEST-KEY:PO-8853
+    Examples:
+      | endpoint              |
       | Replace Draft Account |
+    @JIRA-TEST-KEY:PO-8854
+    Examples:
+      | endpoint              |
       | Update Draft Account  |

--- a/src/functionalTest/resources/features/opalMode/results/ResultsFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/results/ResultsFeatureToggles.feature
@@ -4,7 +4,7 @@ Feature: Results Feature Toggles
   Background:
     Given I am testing as the "opal-test@dev.platform.hmcts.net" user
 
-  @R1AOff @JIRA-STORY:PO-3765 @JIRA-STORY:PO-3754 @JIRA-EPIC:PO-3685
+  @R1AOff @JIRA-STORY:PO-3765 @JIRA-STORY:PO-3754 @JIRA-EPIC:PO-3685 @JIRA-TEST-KEY:PO-8855
   Scenario: Results endpoint is unavailable when release 1a is disabled
     When I request results for identifiers "FO,ABDC"
     Then the request is rejected with status 404

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountSummaryViewIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountSummaryViewIntegrationTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @DisplayName("Defendant Account Summary View Integration Tests")
 class DefendantAccountSummaryViewIntegrationTest extends AbstractOpalDefendantsIntegrationTest {
@@ -19,6 +20,7 @@ class DefendantAccountSummaryViewIntegrationTest extends AbstractOpalDefendantsI
     @JiraEpic("PO-2332")
     @JiraStory("PO-2334")
     @DisplayName("PO-2334 INT.01 - Get header summary returns has consolidated accounts true")
+    @JiraTestKey("PO-8761")
     void int01_getHeaderSummary_returnsHasConsolidatedAccountsTrue() throws Exception {
 
         ResultActions resultActions = mockMvc.perform(
@@ -49,6 +51,7 @@ class DefendantAccountSummaryViewIntegrationTest extends AbstractOpalDefendantsI
     @JiraEpic("PO-2332")
     @JiraStory("PO-2334")
     @DisplayName("PO-2334 INT.02 - Get header summary returns has consolidated accounts false")
+    @JiraTestKey("PO-8763")
     void int02_getHeaderSummary_returnsHasConsolidatedAccountsFalse() throws Exception {
 
         ResultActions resultActions = mockMvc.perform(
@@ -81,6 +84,7 @@ class DefendantAccountSummaryViewIntegrationTest extends AbstractOpalDefendantsI
     @JiraEpic("PO-2332")
     @JiraStory("PO-2334")
     @DisplayName("PO-2629 INT.08 - Get defendant account header summary returns forbidden response")
+    @JiraTestKey("PO-8762")
     void int08_getDefendantAccountHeaderSummary_returnsForbiddenResponse() throws Exception {
 
         ResultActions resultActions = mockMvc.perform(

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountPublishTransactionIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountPublishTransactionIntegrationTest.java
@@ -26,6 +26,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration"})
 @Slf4j(topic = "opal.DraftAccountPublishTransactionIntegrationTest")
@@ -40,6 +41,7 @@ class DraftAccountPublishTransactionIntegrationTest extends AbstractIntegrationT
     @JiraEpic("PO-973")
     @Test
     @DraftAccountPublishDbUpdateFailureFixture
+    @JiraTestKey("PO-8764")
     void publishDraftAccount_publishesButFailsToUpdateStatus_leavesDraftPublishableForRetry() throws Exception {
         // Arrange
         String etag = getDraftEtag();
@@ -87,6 +89,7 @@ class DraftAccountPublishTransactionIntegrationTest extends AbstractIntegrationT
     @JiraEpic("PO-973")
     @Test
     @DraftAccountPublishSpFailureFixture
+    @JiraTestKey("PO-8765")
     void publishDraftAccount_storedProcFailure_PersistsPublishingFailedStatusAndTimelineData() throws Exception {
         mockMvc.perform(patch(DRAFT_ACCOUNTS_URL_BASE + "/" + DRAFT_ACCOUNT_ID)
                 .with(userStateStub.getAuthenticaitonRequestPostProcessor())

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsPutPartyIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsPutPartyIntegrationTest.java
@@ -553,6 +553,7 @@ class OpalDefendantsPutPartyIntegrationTest extends AbstractOpalDefendantsIntegr
         @DisplayName("OPAL: PUT Replace DAP – Single name change creates one amendment.")
         @JiraStory("PO-2471")
         @JiraEpic("PO-1970")
+        @JiraTestKey("PO-8770")
         void put_singleNameChangeCreatesOneAmendment() throws Exception {
             userStateStub.addPermissions((short) 78, FinesPermission.values());
 
@@ -620,6 +621,7 @@ class OpalDefendantsPutPartyIntegrationTest extends AbstractOpalDefendantsIntegr
         @DisplayName("OPAL: PUT Replace DAP – Company name change creates one amendment.")
         @JiraStory("PO-2471")
         @JiraEpic("PO-1970")
+        @JiraTestKey("PO-8773")
         void put_companyNameChangeCreatesOneAmendment() throws Exception {
             userStateStub.addPermissions((short) 78, FinesPermission.values());
 
@@ -680,6 +682,7 @@ class OpalDefendantsPutPartyIntegrationTest extends AbstractOpalDefendantsIntegr
         @DisplayName("OPAL: PUT Replace DAP – Company name and address changes creates multiple amendments.")
         @JiraStory("PO-2471")
         @JiraEpic("PO-1970")
+        @JiraTestKey("PO-8774")
         void put_companyNameAddressChangeCreatesManyAmendments() throws Exception {
             userStateStub.addPermissions((short) 78, FinesPermission.values());
 
@@ -744,6 +747,7 @@ class OpalDefendantsPutPartyIntegrationTest extends AbstractOpalDefendantsIntegr
         @DisplayName("OPAL: PUT Replace DAP – Multiple alias changes creates multiple amendments.")
         @JiraStory("PO-2471")
         @JiraEpic("PO-1970")
+        @JiraTestKey("PO-8775")
         void put_manyAliasChangesCreatesManyAmendments() throws Exception {
             userStateStub.addPermissions((short) 78, FinesPermission.values());
 
@@ -813,6 +817,7 @@ class OpalDefendantsPutPartyIntegrationTest extends AbstractOpalDefendantsIntegr
         @DisplayName("OPAL: PUT Replace DAP – multiple address changes creates multiple amendments.")
         @JiraStory("PO-2471")
         @JiraEpic("PO-1970")
+        @JiraTestKey("PO-8772")
         void put_manyAddressChangesCreatesManyAmendments() throws Exception {
             userStateStub.addPermissions((short) 78, FinesPermission.values());
 
@@ -883,6 +888,7 @@ class OpalDefendantsPutPartyIntegrationTest extends AbstractOpalDefendantsIntegr
         @DisplayName("OPAL: PUT Replace DAP – Postcode changes creates single amendment.")
         @JiraStory("PO-2471")
         @JiraEpic("PO-1970")
+        @JiraTestKey("PO-8776")
         void put_postcodeChangeCreatesSingleAmendment() throws Exception {
             userStateStub.addPermissions((short) 78, FinesPermission.values());
 
@@ -950,6 +956,7 @@ class OpalDefendantsPutPartyIntegrationTest extends AbstractOpalDefendantsIntegr
         @DisplayName("OPAL: PUT Replace DAP – Date of birth change creates single amendment.")
         @JiraStory("PO-2471")
         @JiraEpic("PO-1970")
+        @JiraTestKey("PO-8767")
         void put_dobChangeCreatesSingleAmendment() throws Exception {
             userStateStub.addPermissions((short) 78, FinesPermission.values());
 
@@ -1017,6 +1024,7 @@ class OpalDefendantsPutPartyIntegrationTest extends AbstractOpalDefendantsIntegr
         @DisplayName("OPAL: PUT Replace DAP – Name and date of birth change creates two amendments.")
         @JiraStory("PO-2471")
         @JiraEpic("PO-1970")
+        @JiraTestKey("PO-8771")
         void put_nameAndDOBChangeCreatesTwoAmendments() throws Exception {
             userStateStub.addPermissions((short) 78, FinesPermission.values());
 
@@ -1086,6 +1094,7 @@ class OpalDefendantsPutPartyIntegrationTest extends AbstractOpalDefendantsIntegr
         @DisplayName("OPAL: PUT Replace DAP – Name plus alias changes creates multiple amendments.")
         @JiraStory("PO-2471")
         @JiraEpic("PO-1970")
+        @JiraTestKey("PO-8769")
         void put_nameAndAliasChangeCreatesManyAmendments() throws Exception {
             userStateStub.addPermissions((short) 78, FinesPermission.values());
 
@@ -1157,6 +1166,7 @@ class OpalDefendantsPutPartyIntegrationTest extends AbstractOpalDefendantsIntegr
         @DisplayName("OPAL: PUT Replace DAP – Name and address changes creates multiple amendments.")
         @JiraStory("PO-2471")
         @JiraEpic("PO-1970")
+        @JiraTestKey("PO-8768")
         void put_nameAddressChangeCreatesManyAmendments() throws Exception {
             userStateStub.addPermissions((short) 78, FinesPermission.values());
 
@@ -1228,6 +1238,7 @@ class OpalDefendantsPutPartyIntegrationTest extends AbstractOpalDefendantsIntegr
         @DisplayName("OPAL: PUT Replace DAP – No field changes creates no amendments")
         @JiraStory("PO-2471")
         @JiraEpic("PO-1970")
+        @JiraTestKey("PO-8766")
         void put_noChangeCreatesNoAmendment() throws Exception {
             userStateStub.addPermissions((short) 78, FinesPermission.values());
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMajorCreditorAccountHeaderSummaryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMajorCreditorAccountHeaderSummaryIntegrationTest.java
@@ -70,6 +70,7 @@ class OpalMajorCreditorAccountHeaderSummaryIntegrationTest extends AbstractInteg
     @DisplayName("PO-2131 INT.05 - Opal repeated request returns consistent body and ETag")
     @JiraStory("PO-2131")
     @JiraEpic("PO-1286")
+    @JiraTestKey("PO-8779")
     void getHeaderSummary_repeatedRequestReturnsConsistentResponse() throws Exception {
         userStateStub.setupWithNoPermissions();
         userStateStub.addPermissions((short) 77, SEARCH_AND_VIEW_ACCOUNTS);
@@ -97,6 +98,7 @@ class OpalMajorCreditorAccountHeaderSummaryIntegrationTest extends AbstractInteg
     @DisplayName("PO-2131 INT.06 - Opal permission in matching business unit returns 200")
     @JiraStory("PO-2131")
     @JiraEpic("PO-1286")
+    @JiraTestKey("PO-8778")
     void getHeaderSummary_permissionInMatchingBusinessUnitReturns200() throws Exception {
         userStateStub.setupWithNoPermissions();
         userStateStub.addPermissions((short) 77, SEARCH_AND_VIEW_ACCOUNTS);
@@ -113,6 +115,7 @@ class OpalMajorCreditorAccountHeaderSummaryIntegrationTest extends AbstractInteg
     @DisplayName("PO-2131 INT.07 - Opal valid token without permission returns 403")
     @JiraStory("PO-2131")
     @JiraEpic("PO-1286")
+    @JiraTestKey("PO-8777")
     void getHeaderSummary_withoutPermissionReturns403() throws Exception {
         userStateStub.setupWithNoPermissions();
 
@@ -127,6 +130,7 @@ class OpalMajorCreditorAccountHeaderSummaryIntegrationTest extends AbstractInteg
     @DisplayName("PO-2131 INT.07 - Opal permission in non-matching business unit returns 403")
     @JiraStory("PO-2131")
     @JiraEpic("PO-1286")
+    @JiraTestKey("PO-8782")
     void getHeaderSummary_permissionInDifferentBusinessUnitReturns403() throws Exception {
         userStateStub.setupWithNoPermissions();
         userStateStub.addPermissions((short) 10, SEARCH_AND_VIEW_ACCOUNTS);
@@ -174,6 +178,7 @@ class OpalMajorCreditorAccountHeaderSummaryIntegrationTest extends AbstractInteg
     @DisplayName("PO-2131 INT.08 - Opal missing token returns 403")
     @JiraStory("PO-2131")
     @JiraEpic("PO-1286")
+    @JiraTestKey("PO-8780")
     void getHeaderSummary_missingTokenReturnsForbidden() throws Exception {
         userStateStub.setupWithNoPermissions();
 
@@ -190,6 +195,7 @@ class OpalMajorCreditorAccountHeaderSummaryIntegrationTest extends AbstractInteg
     @DisplayName("PO-2131 INT.08 - Opal invalid token returns 403")
     @JiraStory("PO-2131")
     @JiraEpic("PO-1286")
+    @JiraTestKey("PO-8781")
     void getHeaderSummary_invalidTokenReturnsForbidden() throws Exception {
         mockMvc.perform(get(URL, 10770000000041L)
                 .accept(MediaType.APPLICATION_JSON)

--- a/src/integrationTest/java/uk/gov/hmcts/opal/jpa/OperationReportSpecsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/jpa/OperationReportSpecsTest.java
@@ -51,10 +51,28 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7796")
     @ParameterizedTest
     @MethodSource("businessUnitFiltersNullOrEmpty")
-    @JiraTestKey(value = "PO-8800", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
-    @JiraTestKey(value = "PO-8801", name = "[2] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
-    @JiraTestKey(value = "PO-8802", name = "[3] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
-    @JiraTestKey(value = "PO-8803", name = "[4] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
+    @JiraTestKey(
+        value = "PO-8800",
+        name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, "
+            + "enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, "
+            + "lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)"
+    )
+    @JiraTestKey(
+        value = "PO-8801",
+        name = "[2] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, "
+            + "enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, "
+            + "lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)"
+    )
+    @JiraTestKey(
+        value = "PO-8802",
+        name = "[3] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, "
+            + "reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)"
+    )
+    @JiraTestKey(
+        value = "PO-8803",
+        name = "[4] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, "
+            + "reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)"
+    )
     void businessUnitSpec_businessUnitIdsNullOrEmpty_returnConjunction(OperationReportFiltersDto filters) {
         long total = defendantAccountRepository.count();
 
@@ -85,8 +103,17 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7791")
     @ParameterizedTest
     @MethodSource("businessUnitFiltersList")
-    @JiraTestKey(value = "PO-8792", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
-    @JiraTestKey(value = "PO-8793", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
+    @JiraTestKey(
+        value = "PO-8792",
+        name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, "
+            + "enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, "
+            + "lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)"
+    )
+    @JiraTestKey(
+        value = "PO-8793",
+        name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, "
+            + "reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)"
+    )
     void businessUnitSpec_businessUnitIdsList_returnAllFromBusinessUnitIds(OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
 
@@ -112,8 +139,17 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7789")
     @ParameterizedTest
     @MethodSource("adultFilters")
-    @JiraTestKey(value = "PO-8790", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
-    @JiraTestKey(value = "PO-8791", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
+    @JiraTestKey(
+        value = "PO-8790",
+        name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, "
+            + "enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, "
+            + "lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)"
+    )
+    @JiraTestKey(
+        value = "PO-8791",
+        name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, "
+            + "reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)"
+    )
     void accountTypesSpec_includeAdult_returnAllAdultAccounts(OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
 
@@ -142,8 +178,17 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7802")
     @ParameterizedTest
     @MethodSource("youthFilters")
-    @JiraTestKey(value = "PO-8814", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
-    @JiraTestKey(value = "PO-8815", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
+    @JiraTestKey(
+        value = "PO-8814",
+        name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, "
+            + "enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, "
+            + "lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)"
+    )
+    @JiraTestKey(
+        value = "PO-8815",
+        name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, "
+            + "reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)"
+    )
     void accountTypesSpec_includeYouth_returnAllYouthAccounts(OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
 
@@ -171,8 +216,17 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7798")
     @ParameterizedTest
     @MethodSource("companyFilters")
-    @JiraTestKey(value = "PO-8804", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
-    @JiraTestKey(value = "PO-8805", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
+    @JiraTestKey(
+        value = "PO-8804",
+        name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, "
+            + "enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, "
+            + "lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)"
+    )
+    @JiraTestKey(
+        value = "PO-8805",
+        name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, "
+            + "reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)"
+    )
     void accountTypesSpec_includeCompany_returnAllCompanyAccounts(OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
 
@@ -200,8 +254,17 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7801")
     @ParameterizedTest
     @MethodSource("parentGuardianFilters")
-    @JiraTestKey(value = "PO-8811", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
-    @JiraTestKey(value = "PO-8812", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
+    @JiraTestKey(
+        value = "PO-8811",
+        name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, "
+            + "enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, "
+            + "lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)"
+    )
+    @JiraTestKey(
+        value = "PO-8812",
+        name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, "
+            + "reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)"
+    )
     void parentGuardianSpec_returnAllAccountsWithParentGuardian(OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
 
@@ -227,8 +290,17 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7793")
     @ParameterizedTest
     @MethodSource("collectionOrderFiltersWithValue")
-    @JiraTestKey(value = "PO-8796", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
-    @JiraTestKey(value = "PO-8797", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
+    @JiraTestKey(
+        value = "PO-8796",
+        name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, "
+            + "enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, "
+            + "lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)"
+    )
+    @JiraTestKey(
+        value = "PO-8797",
+        name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, "
+            + "reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)"
+    )
     void collectionOrderSpec_withCollectionOrder_returnAllAccountsWithCollectionOrder(
         OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
@@ -255,8 +327,17 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7788")
     @ParameterizedTest
     @MethodSource("collectionOrderFiltersWithoutValue")
-    @JiraTestKey(value = "PO-8788", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
-    @JiraTestKey(value = "PO-8789", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
+    @JiraTestKey(
+        value = "PO-8788",
+        name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, "
+            + "enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, "
+            + "lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)"
+    )
+    @JiraTestKey(
+        value = "PO-8789",
+        name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, "
+            + "reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)"
+    )
     void collectionOrderSpec_withoutCollectionOrder_returnAllAccountsWithoutCollectionOrder(
         OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
@@ -283,8 +364,17 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7787")
     @ParameterizedTest
     @MethodSource("liveStatusFilters")
-    @JiraTestKey(value = "PO-8786", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
-    @JiraTestKey(value = "PO-8787", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
+    @JiraTestKey(
+        value = "PO-8786",
+        name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, "
+            + "enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, "
+            + "lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)"
+    )
+    @JiraTestKey(
+        value = "PO-8787",
+        name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, "
+            + "reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)"
+    )
     void accountStatusSpec_live_returnAllAccountsWithLiveStatus(OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
 
@@ -312,8 +402,17 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7792")
     @ParameterizedTest
     @MethodSource("closedStatusFilters")
-    @JiraTestKey(value = "PO-8794", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
-    @JiraTestKey(value = "PO-8795", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
+    @JiraTestKey(
+        value = "PO-8794",
+        name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, "
+            + "enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, "
+            + "lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)"
+    )
+    @JiraTestKey(
+        value = "PO-8795",
+        name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, "
+            + "reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)"
+    )
     void accountStatusSpec_closed_returnAllAccountsWithClosedStatus(OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
 
@@ -341,8 +440,17 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7799")
     @ParameterizedTest
     @MethodSource("balanceRangeFilters")
-    @JiraTestKey(value = "PO-8807", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
-    @JiraTestKey(value = "PO-8808", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
+    @JiraTestKey(
+        value = "PO-8807",
+        name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, "
+            + "enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, "
+            + "lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)"
+    )
+    @JiraTestKey(
+        value = "PO-8808",
+        name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, "
+            + "reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)"
+    )
     void balanceRangeSpec_minAndMaxGiven_returnAllAccountsWithinRange(OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
 
@@ -374,8 +482,17 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7785")
     @ParameterizedTest
     @MethodSource("nameRangeFilters")
-    @JiraTestKey(value = "PO-8783", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
-    @JiraTestKey(value = "PO-8784", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=SINCE_DATE, sinceLastEnforcementAction=null, sinceDate=2000-01-01)")
+    @JiraTestKey(
+        value = "PO-8783",
+        name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, "
+            + "enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, "
+            + "lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)"
+    )
+    @JiraTestKey(
+        value = "PO-8784",
+        name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, "
+            + "reportMode=SINCE_DATE, sinceLastEnforcementAction=null, sinceDate=2000-01-01)"
+    )
     void nameRangeSpec_lowerAndUpperGiven_returnAllAccountsWithinRange(OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
 
@@ -411,8 +528,17 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7800")
     @ParameterizedTest
     @MethodSource("next7DaysFilters")
-    @JiraTestKey(value = "PO-8809", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
-    @JiraTestKey(value = "PO-8810", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
+    @JiraTestKey(
+        value = "PO-8809",
+        name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, "
+            + "enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, "
+            + "lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)"
+    )
+    @JiraTestKey(
+        value = "PO-8810",
+        name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, "
+            + "reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)"
+    )
     void next7DaysSpec_true_returnsAccountsWhereRelevantDateIsInNext7Days(OperationReportFiltersDto filters) {
         PaymentTermsEntity paymentTermsForSeededData = paymentTermsRepository
             .findByDefendantAccount_DefendantAccountIdAndEffectiveDateIsNotNullOrderByEffectiveDateAsc(77L)
@@ -559,4 +685,3 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     }
 
 }
-

--- a/src/integrationTest/java/uk/gov/hmcts/opal/jpa/OperationReportSpecsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/jpa/OperationReportSpecsTest.java
@@ -51,6 +51,10 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7796")
     @ParameterizedTest
     @MethodSource("businessUnitFiltersNullOrEmpty")
+    @JiraTestKey(value = "PO-8800", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
+    @JiraTestKey(value = "PO-8801", name = "[2] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
+    @JiraTestKey(value = "PO-8802", name = "[3] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
+    @JiraTestKey(value = "PO-8803", name = "[4] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
     void businessUnitSpec_businessUnitIdsNullOrEmpty_returnConjunction(OperationReportFiltersDto filters) {
         long total = defendantAccountRepository.count();
 
@@ -81,6 +85,8 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7791")
     @ParameterizedTest
     @MethodSource("businessUnitFiltersList")
+    @JiraTestKey(value = "PO-8792", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
+    @JiraTestKey(value = "PO-8793", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
     void businessUnitSpec_businessUnitIdsList_returnAllFromBusinessUnitIds(OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
 
@@ -106,6 +112,8 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7789")
     @ParameterizedTest
     @MethodSource("adultFilters")
+    @JiraTestKey(value = "PO-8790", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
+    @JiraTestKey(value = "PO-8791", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
     void accountTypesSpec_includeAdult_returnAllAdultAccounts(OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
 
@@ -134,6 +142,8 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7802")
     @ParameterizedTest
     @MethodSource("youthFilters")
+    @JiraTestKey(value = "PO-8814", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
+    @JiraTestKey(value = "PO-8815", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
     void accountTypesSpec_includeYouth_returnAllYouthAccounts(OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
 
@@ -161,6 +171,8 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7798")
     @ParameterizedTest
     @MethodSource("companyFilters")
+    @JiraTestKey(value = "PO-8804", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
+    @JiraTestKey(value = "PO-8805", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
     void accountTypesSpec_includeCompany_returnAllCompanyAccounts(OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
 
@@ -188,6 +200,8 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7801")
     @ParameterizedTest
     @MethodSource("parentGuardianFilters")
+    @JiraTestKey(value = "PO-8811", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
+    @JiraTestKey(value = "PO-8812", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
     void parentGuardianSpec_returnAllAccountsWithParentGuardian(OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
 
@@ -213,6 +227,8 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7793")
     @ParameterizedTest
     @MethodSource("collectionOrderFiltersWithValue")
+    @JiraTestKey(value = "PO-8796", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
+    @JiraTestKey(value = "PO-8797", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
     void collectionOrderSpec_withCollectionOrder_returnAllAccountsWithCollectionOrder(
         OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
@@ -239,6 +255,8 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7788")
     @ParameterizedTest
     @MethodSource("collectionOrderFiltersWithoutValue")
+    @JiraTestKey(value = "PO-8788", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
+    @JiraTestKey(value = "PO-8789", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
     void collectionOrderSpec_withoutCollectionOrder_returnAllAccountsWithoutCollectionOrder(
         OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
@@ -265,6 +283,8 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7787")
     @ParameterizedTest
     @MethodSource("liveStatusFilters")
+    @JiraTestKey(value = "PO-8786", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
+    @JiraTestKey(value = "PO-8787", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
     void accountStatusSpec_live_returnAllAccountsWithLiveStatus(OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
 
@@ -292,6 +312,8 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7792")
     @ParameterizedTest
     @MethodSource("closedStatusFilters")
+    @JiraTestKey(value = "PO-8794", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
+    @JiraTestKey(value = "PO-8795", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
     void accountStatusSpec_closed_returnAllAccountsWithClosedStatus(OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
 
@@ -319,6 +341,8 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7799")
     @ParameterizedTest
     @MethodSource("balanceRangeFilters")
+    @JiraTestKey(value = "PO-8807", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
+    @JiraTestKey(value = "PO-8808", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
     void balanceRangeSpec_minAndMaxGiven_returnAllAccountsWithinRange(OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
 
@@ -350,6 +374,8 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7785")
     @ParameterizedTest
     @MethodSource("nameRangeFilters")
+    @JiraTestKey(value = "PO-8783", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
+    @JiraTestKey(value = "PO-8784", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=SINCE_DATE, sinceLastEnforcementAction=null, sinceDate=2000-01-01)")
     void nameRangeSpec_lowerAndUpperGiven_returnAllAccountsWithinRange(OperationReportFiltersDto filters) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(OperationReportSpecs.build(filters));
 
@@ -385,6 +411,8 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7800")
     @ParameterizedTest
     @MethodSource("next7DaysFilters")
+    @JiraTestKey(value = "PO-8809", name = "[1] filters = OperationReportByEnforcementFiltersDto(reportEnforcementMode=null, enforcementDateFrom=null, enforcementDateTo=null, lastActionDateFrom=null, lastActionDateTo=null, regfDateFrom=null, regfDateTo=null, enforcementAction=null)")
+    @JiraTestKey(value = "PO-8810", name = "[2] filters = OperationReportByPaymentFiltersDto(isPaymentMade=null, reportMode=WITH_REGF, sinceLastEnforcementAction=null, sinceDate=null)")
     void next7DaysSpec_true_returnsAccountsWhereRelevantDateIsInNext7Days(OperationReportFiltersDto filters) {
         PaymentTermsEntity paymentTermsForSeededData = paymentTermsRepository
             .findByDefendantAccount_DefendantAccountIdAndEffectiveDateIsNotNullOrderByEffectiveDateAsc(77L)
@@ -436,6 +464,7 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8785")
     void paymentSpec_isPaymentMade_true_withFutureSinceDate_returnsNoAccounts() {
         OperationReportByPaymentFiltersDto filters = OperationReportByPaymentFiltersDto.builder()
             .isPaymentMade(true)
@@ -452,6 +481,7 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8806")
     void paymentSpec_isPaymentMade_false_withFutureSinceDate_returnsAllAccounts() {
         long total = defendantAccountRepository.count();
 
@@ -470,6 +500,7 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8813")
     void paymentSpec_sinceLastEnforcementAction_returnsMatchingAccounts() {
         OperationReportByPaymentFiltersDto filters = OperationReportByPaymentFiltersDto.builder()
             .sinceLastEnforcementAction(ABDC)
@@ -504,6 +535,8 @@ public class OperationReportSpecsTest extends AbstractIntegrationTest {
     @JiraTestKey("PO-7794")
     @ParameterizedTest
     @MethodSource("emptyAccountIdLists")
+    @JiraTestKey(value = "PO-8798", name = "[1] accountIds = null")
+    @JiraTestKey(value = "PO-8799", name = "[2] accountIds = []")
     void defendantAccountIdsIn_emptyOrNullList_returnsNoResults(List<Long> accountIds) {
         List<DefendantAccountEntity> results = defendantAccountRepository.findAll(
             OperationReportSpecs.defendantAccountIdsIn(accountIds)

--- a/src/integrationTest/java/uk/gov/hmcts/opal/service/report/OperationReportByEnforcementServiceDetailedTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/service/report/OperationReportByEnforcementServiceDetailedTest.java
@@ -96,6 +96,8 @@ public class OperationReportByEnforcementServiceDetailedTest extends AbstractInt
     @JiraTestKey("PO-7815")
     @JiraTestKey(value = "PO-8655", name = "[1] json = \"{\\\"reportType\\\": \\\"DETAILED\\\"}\"")
     @JiraTestKey(value = "PO-8656", name = "[2] json = \"{}\"")
+    @JiraTestKey(value = "PO-8816", name = "[1] json = \"{\\\"reportType\\\": \\\"DETAILED\\\", \\\"businessUnitIds\\\": [77, 78]}\"")
+    @JiraTestKey(value = "PO-8817", name = "[2] json = \"{\\\"businessUnitIds\\\": [77, 78]}\"")
     void generateReportData_filterDetailedReportType_returnSortedResultsOfDetailedReportType(String json) {
         //Arrange
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);

--- a/src/integrationTest/java/uk/gov/hmcts/opal/service/report/OperationReportByEnforcementServiceDetailedTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/service/report/OperationReportByEnforcementServiceDetailedTest.java
@@ -96,9 +96,14 @@ public class OperationReportByEnforcementServiceDetailedTest extends AbstractInt
     @JiraTestKey("PO-7815")
     @JiraTestKey(value = "PO-8655", name = "[1] json = \"{\\\"reportType\\\": \\\"DETAILED\\\"}\"")
     @JiraTestKey(value = "PO-8656", name = "[2] json = \"{}\"")
-    @JiraTestKey(value = "PO-8816", name = "[1] json = \"{\\\"reportType\\\": \\\"DETAILED\\\", \\\"businessUnitIds\\\": [77, 78]}\"")
+    @JiraTestKey(
+        value = "PO-8816",
+        name = "[1] json = \"{\\\"reportType\\\": \\\"DETAILED\\\", \\\"businessUnitIds\\\": [77, 78]}\""
+    )
     @JiraTestKey(value = "PO-8817", name = "[2] json = \"{\\\"businessUnitIds\\\": [77, 78]}\"")
-    void generateReportData_filterDetailedReportType_returnSortedResultsOfDetailedReportType(String json) {
+    void generateReportData_filterDetailedReportType_returnSortedResultsOfDetailedReportType(
+        String json
+    ) {
         //Arrange
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
         given(reportInstance.getReportParameters()).willReturn(json);
@@ -715,5 +720,4 @@ public class OperationReportByEnforcementServiceDetailedTest extends AbstractInt
         verifyMetadata(result);
     }
 }
-
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/service/report/OperationReportByPaymentServiceDetailedTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/service/report/OperationReportByPaymentServiceDetailedTest.java
@@ -41,6 +41,7 @@ import uk.gov.hmcts.opal.service.report.operation.OperationReportByPaymentServic
 import uk.gov.hmcts.opal.util.AgeUtil;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @Sql(scripts = "classpath:db/insertData/insert_into_enforcements.sql", executionPhase = BEFORE_TEST_CLASS)
 @Sql(scripts = "classpath:db/deleteData/delete_from_enforcements.sql", executionPhase = AFTER_TEST_CLASS)
@@ -80,6 +81,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8822")
     void generateReportData_filterDetailedReportType_returnSortedResultsOfDetailedReportType() {
         //Arrange
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
@@ -174,6 +176,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8827")
     void generateReportData_filterByIncludeAdult_returnResultsOfAdults() {
         //Arrange
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
@@ -206,6 +209,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8832")
     void generateReportData_filterByIncludeYouth_returnResultsOfYouth() {
         //Arrange
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
@@ -238,6 +242,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8836")
     void generateReportData_filterByIncludeCompany_returnResultsOfCompanies() {
         //Arrange
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
@@ -269,6 +274,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8837")
     void generateReportData_filterByParentOrGuardian_returnResultsWithParentOrGuardian() {
         //Arrange
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
@@ -304,6 +310,8 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
         "WITH, true",
         "WITHOUT, false"
     })
+    @JiraTestKey(value = "PO-8820", name = "[1] collectionOrderChoice = \"WITH\", expectedValue = \"true\"")
+    @JiraTestKey(value = "PO-8821", name = "[2] collectionOrderChoice = \"WITHOUT\", expectedValue = \"false\"")
     void generateReportData_filterByCollectionOrderChoice_returnResults(
         String collectionOrderChoice,
         boolean expectedValue
@@ -343,6 +351,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8818")
     void generateReportData_filterByAccountStatusLive_returnResults() {
         // Arrange
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
@@ -381,6 +390,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8828")
     void generateReportData_filterByAccountStatusClosed_returnResults() {
         // Arrange
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
@@ -419,6 +429,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8833")
     void generateReportData_filterByMinAndMaxBalance_returnSortedWithinMinAndMaxBalance() {
         //Arrange
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
@@ -450,6 +461,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8825")
     void generateReportData_filterByFirstPaymentOrPayByInNext7Days_returnsForAccountWithPaymentInNext7Days() {
         //Arrange
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
@@ -504,6 +516,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8823")
     void generateReportData_filterByNameRange_returnSortedWithinNameRange() {
         //Arrange
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
@@ -533,6 +546,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8829")
     void generateReportData_filterPaymentMadeSinceDate_returnSortedWithPaymentsMadeSinceDate() {
         // Arrange
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
@@ -593,6 +607,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8835")
     void generateReportData_filterPaymentNotMadeSinceDate_returnAccountsWithoutPaymentsMadeSinceDate() {
         // Arrange
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
@@ -635,6 +650,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8824")
     void generateReportData_filterNoPaymentSinceLastEnforcement_returnsAccountWithOnlyPaymentsBeforeLastEnforcement() {
         // Arrange
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
@@ -661,6 +677,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8834")
     void generateReportData_filterPaymentWithRegf_returnsExpectedResults_whenPaymentMadeIsTrue() {
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
         given(reportInstance.getReportParameters()).willReturn("""
@@ -684,6 +701,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8831")
     void generateReportData_filterPaymentWithRegf_returnsExpectedResults_whenPaymentMadeIsFalse() {
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
         given(reportInstance.getReportParameters()).willReturn("""
@@ -707,6 +725,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8819")
     void generateReportData_combinesRegfFilterAndBaseFilters_returnsExpectedResults() {
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
         given(reportInstance.getReportParameters()).willReturn("""
@@ -732,6 +751,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8838")
     void generateReportData_filterPaymentSinceLastEnforcement_returnsExpectedResults_whenPaymentMadeIsTrue() {
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
         given(reportInstance.getReportParameters()).willReturn("""
@@ -758,6 +778,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8826")
     void generateReportData_combinesSinceLastEnforcementFilterAndBaseFilters_returnsExpectedResults() {
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
         given(reportInstance.getReportParameters()).willReturn("""
@@ -786,6 +807,7 @@ public class OperationReportByPaymentServiceDetailedTest extends AbstractIntegra
     @JiraStory("PO-2256")
     @JiraEpic("PO-2248")
     @Test
+    @JiraTestKey("PO-8830")
     void generateReportData_filterPaymentSinceLastEnforcement_returnsExpectedResults_whenPaymentMadeIsFalse() {
         ReportInstanceEntity reportInstance = mock(ReportInstanceEntity.class);
         given(reportInstance.getReportParameters()).willReturn("""


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Refactors nightly and Zephyr reporting so each selected integration, functional, smoke, and tagged demo stage publishes its own isolated HTML and Zephyr artifacts, fails cleanly when expected reports are missing, and uses generic parameter-driven functional Zephyr tasks instead of the previous stage-specific task sprawl

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
