### PR TITLE
PO-8693 : Refactor OpalDefendantAccountService - Step 1

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
@@ -84,7 +84,6 @@ import uk.gov.hmcts.opal.entity.defendantaccount.AssociationType;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountHeaderViewEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountPartiesEntity;
-import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountSummaryViewEntity;
 import uk.gov.hmcts.opal.entity.enforcement.EnforcementEntity;
 import uk.gov.hmcts.opal.entity.paymentterms.PaymentTermsEntity;
 import uk.gov.hmcts.opal.entity.result.ResultEntity;
@@ -104,7 +103,6 @@ import uk.gov.hmcts.opal.repository.DebtorDetailRepository;
 import uk.gov.hmcts.opal.repository.DefendantAccountHeaderViewRepository;
 import uk.gov.hmcts.opal.repository.DefendantAccountPaymentTermsRepository;
 import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
-import uk.gov.hmcts.opal.repository.DefendantAccountSummaryViewRepository;
 import uk.gov.hmcts.opal.repository.EnforcementRepository;
 import uk.gov.hmcts.opal.repository.EnforcerRepository;
 import uk.gov.hmcts.opal.repository.FixedPenaltyOffenceRepository;
@@ -119,7 +117,9 @@ import uk.gov.hmcts.opal.repository.jpa.SearchConsolidatedEntitySpecs;
 import uk.gov.hmcts.opal.service.iface.DefendantAccountServiceInterface;
 import uk.gov.hmcts.opal.service.opal.history.defendant.DefendantAccountHistoryService;
 import uk.gov.hmcts.opal.service.iface.ReportEntryServiceInterface;
+import uk.gov.hmcts.opal.service.persistence.DefendantAccountHeaderViewRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
+import uk.gov.hmcts.opal.service.persistence.DefendantAccountSummaryViewRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.PartyRepositoryService;
 import uk.gov.hmcts.opal.service.UserStateService;
 import uk.gov.hmcts.opal.util.VersionUtils;
@@ -143,7 +143,8 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
 
     private final DefendantAccountPaymentTermsRepository defendantAccountPaymentTermsRepository;
 
-    private final DefendantAccountSummaryViewRepository defendantAccountSummaryViewRepository;
+    private final DefendantAccountSummaryViewRepositoryService defendantAccountSummaryViewRepositoryService;
+    private final DefendantAccountHeaderViewRepositoryService defendantAccountHeaderViewRepositoryService;
 
     private final CourtLiteRepository courtLiteRepository;
     private final AmendmentService amendmentService;
@@ -192,15 +193,13 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
 
     private final Clock clock;
 
-    //TODO - Remove once repository service is in use
     @Override
     @Transactional(readOnly = true)
     public DefendantAccountHeaderSummary getHeaderSummary(Long defendantAccountId) {
         log.debug(":getHeaderSummary: Opal mode - ID: {}", defendantAccountId);
 
-        DefendantAccountHeaderViewEntity entity = repository.findById(defendantAccountId)
-            .orElseThrow(() -> new EntityNotFoundException("Defendant Account not found with id: "
-                + defendantAccountId));
+        DefendantAccountHeaderViewEntity entity = defendantAccountHeaderViewRepositoryService
+            .getHeaderViewById(defendantAccountId);
 
         return defendantAccountHeaderSummaryMapper.toDto(entity);
     }
@@ -390,18 +389,12 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
             .build();
     }
 
-    //TODO - Remove this once repository service is in use
-    public DefendantAccountSummaryViewEntity getDefendantAccountSummaryViewById(long defendantAccountId) {
-        return defendantAccountSummaryViewRepository.findById(defendantAccountId)
-            .orElseThrow(() -> new EntityNotFoundException(
-                "Defendant Account Summary View not found with id: " + defendantAccountId));
-    }
-
     @Transactional(readOnly = true)
     public DefendantAccountAtAGlanceResponse getAtAGlance(Long defendantAccountId) {
         log.debug(":getAtAGlance (Opal): id: {}.", defendantAccountId);
         return OpalDefendantAccountBuilders
-            .buildAtAGlanceResponse(getDefendantAccountSummaryViewById(defendantAccountId));
+            .buildAtAGlanceResponse(
+                defendantAccountSummaryViewRepositoryService.getSummaryViewById(defendantAccountId));
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
@@ -100,7 +100,6 @@ import uk.gov.hmcts.opal.mapper.request.PaymentTermsMapper;
 import uk.gov.hmcts.opal.repository.AliasRepository;
 import uk.gov.hmcts.opal.repository.CourtLiteRepository;
 import uk.gov.hmcts.opal.repository.DebtorDetailRepository;
-import uk.gov.hmcts.opal.repository.DefendantAccountHeaderViewRepository;
 import uk.gov.hmcts.opal.repository.DefendantAccountPaymentTermsRepository;
 import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
 import uk.gov.hmcts.opal.repository.EnforcementRepository;
@@ -130,8 +129,6 @@ import uk.gov.hmcts.opal.util.VersionUtils;
 public class OpalDefendantAccountService implements DefendantAccountServiceInterface {
 
     private static final int TOO_MANY_SEARCH_RESULTS = 100;
-
-    private final DefendantAccountHeaderViewRepository repository;
 
     private final DefendantAccountRepository defendantAccountRepository;
 

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountService.java
@@ -119,6 +119,7 @@ import uk.gov.hmcts.opal.repository.jpa.SearchConsolidatedEntitySpecs;
 import uk.gov.hmcts.opal.service.iface.DefendantAccountServiceInterface;
 import uk.gov.hmcts.opal.service.opal.history.defendant.DefendantAccountHistoryService;
 import uk.gov.hmcts.opal.service.iface.ReportEntryServiceInterface;
+import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.PartyRepositoryService;
 import uk.gov.hmcts.opal.service.UserStateService;
 import uk.gov.hmcts.opal.util.VersionUtils;
@@ -182,26 +183,14 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
 
     private final DefendantAccountHistoryService defendantAccountHistoryService;
 
+    private final DefendantAccountRepositoryService defendantAccountRepositoryService;
+
     // Mappers
     private final DefendantAccountHeaderSummaryMapper defendantAccountHeaderSummaryMapper;
     private final EnforcerDefendantAccountMapper enforcerDefendantAccountMapper;
     private final PaymentTermsMapper paymentTermsMapper;
 
     private final Clock clock;
-
-    //TODO - Remove once repository service is in use
-    public DefendantAccountEntity getDefendantAccountById(long defendantAccountId) {
-        return defendantAccountRepository.findById(defendantAccountId)
-            .orElseThrow(() -> new EntityNotFoundException(
-                "Defendant Account not found with id: " + defendantAccountId));
-    }
-
-    //TODO - Remove once repository service is in use
-    public DefendantAccountEntity getDefendantAccountByIdForUpdate(long defendantAccountId) {
-        return defendantAccountRepository.findByDefendantAccountIdForUpdate(defendantAccountId)
-            .orElseThrow(() -> new EntityNotFoundException(
-                "Defendant Account not found with id: " + defendantAccountId));
-    }
 
     //TODO - Remove once repository service is in use
     @Override
@@ -338,7 +327,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
     public GetDefendantAccountFixedPenaltyResponse getDefendantAccountFixedPenalty(Long defendantAccountId) {
         log.debug(":getDefendantAccountFixedPenalty (Opal): id={}", defendantAccountId);
 
-        DefendantAccountEntity account = getDefendantAccountById(defendantAccountId);
+        DefendantAccountEntity account = defendantAccountRepositoryService.findById(defendantAccountId);
 
         FixedPenaltyOffenceEntity offence = fixedPenaltyOffenceRepository.findByDefendantAccountId(defendantAccountId)
             .orElseThrow(() -> new EntityNotFoundException(
@@ -357,7 +346,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
             defendantAccountPartyId);
 
         // Find the DefendantAccountEntity by ID
-        DefendantAccountEntity account = getDefendantAccountById(defendantAccountId);
+        DefendantAccountEntity account = defendantAccountRepositoryService.findById(defendantAccountId);
 
         // Find the DefendantAccountPartiesEntity by Party ID
         DefendantAccountPartiesEntity party = account.getParties().stream()
@@ -426,7 +415,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
     ) {
         log.debug(":updateDefendantAccount (Opal): accountId={}, bu={}", defendantAccountId, businessUnitId);
 
-        DefendantAccountEntity entity = getDefendantAccountById(defendantAccountId);
+        DefendantAccountEntity entity = defendantAccountRepositoryService.findById(defendantAccountId);
 
         if (entity.getBusinessUnit() == null
             || entity.getBusinessUnit().getBusinessUnitId() == null
@@ -522,7 +511,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
     //TODO - Remove once OpalDefendantAccountPartyService is in use
     // TODO - Created PO-2452 to fix bumping the version with a more atomically correct method
     private DefendantAccountEntity bumpVersion(Long accountId) {
-        DefendantAccountEntity entity = getDefendantAccountById(accountId);
+        DefendantAccountEntity entity = defendantAccountRepositoryService.findById(accountId);
         entity.setVersionNumber(entity.getVersion().add(BigInteger.ONE).longValueExact());
         return defendantAccountRepository.saveAndFlush(entity);
     }
@@ -545,7 +534,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
 
         log.debug(":replaceDefendantAccountParty: accountId: {}, partyId: {}", accountId, dapId);
 
-        DefendantAccountEntity account = getDefendantAccountById(accountId);
+        DefendantAccountEntity account = defendantAccountRepositoryService.findById(accountId);
 
         if (account.getBusinessUnit() == null
             || account.getBusinessUnit().getBusinessUnitId() == null
@@ -679,7 +668,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
 
         log.debug(":getEnforcementStatus: def acc: {}",  defendantAccountId);
 
-        DefendantAccountEntity defendantEntity = getDefendantAccountById(defendantAccountId);
+        DefendantAccountEntity defendantEntity = defendantAccountRepositoryService.findById(defendantAccountId);
         DefendantAccountPartiesEntity defendantParty = filterDefendantParty(defendantEntity);
         EnforcementEntity recentEnforcement = fetchEnforcementMostRecent(defendantEntity);
 
@@ -967,7 +956,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
 
         log.debug(":addPaymentCardRequest (Opal): accountId={}, bu={}", defendantAccountId, businessUnitId);
 
-        DefendantAccountEntity account = getDefendantAccountById(defendantAccountId);
+        DefendantAccountEntity account = defendantAccountRepositoryService.findById(defendantAccountId);
 
         amendmentService.auditInitialiseStoredProc(defendantAccountId, RecordType.DEFENDANT_ACCOUNTS);
 
@@ -988,7 +977,7 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
     //Deprecated - use DefendantAccountPaymentTermsService
     //TODO: Remove this method once OpalDefendantAccountPaymentTermsService is in use
     private DefendantAccountEntity loadAndValidateAccount(Long accountId, String buId) {
-        DefendantAccountEntity account = getDefendantAccountById(accountId);
+        DefendantAccountEntity account = defendantAccountRepositoryService.findById(accountId);
         validateBusinessUnitPresent(account, buId);
         return account;
     }
@@ -1065,7 +1054,8 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
         log.debug(":addPaymentTerms (Opal): accountId={}, bu={}", defendantAccountId, businessUnitId);
 
         // Look up the defendant account
-        DefendantAccountEntity defAccount = getDefendantAccountByIdForUpdate(defendantAccountId);
+        DefendantAccountEntity defAccount = defendantAccountRepositoryService
+            .getDefendantAccountByIdForUpdate(defendantAccountId);
 
         // Validate BU
         if (defAccount.getBusinessUnit() == null
@@ -1151,7 +1141,8 @@ public class OpalDefendantAccountService implements DefendantAccountServiceInter
         log.debug(":addPaymentTermsPreservingLastEnforcement (Opal): accountId={}, bu={}",
             defendantAccountId, businessUnitId);
 
-        DefendantAccountEntity defAccount = getDefendantAccountByIdForUpdate(defendantAccountId);
+        DefendantAccountEntity defAccount = defendantAccountRepositoryService
+            .getDefendantAccountByIdForUpdate(defendantAccountId);
 
         if (defAccount.getBusinessUnit() == null
             || defAccount.getBusinessUnit().getBusinessUnitId() == null

--- a/src/main/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountHeaderViewRepositoryService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountHeaderViewRepositoryService.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.opal.service.persistence;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountHeaderViewEntity;
+import uk.gov.hmcts.opal.repository.DefendantAccountHeaderViewRepository;
+
+@Service
+@Slf4j(topic = "opal.DefendantAccountHeaderViewService")
+@RequiredArgsConstructor
+public class DefendantAccountHeaderViewRepositoryService {
+
+    private final DefendantAccountHeaderViewRepository repository;
+
+    public DefendantAccountHeaderViewEntity getHeaderViewById(Long defendantAccountId) {
+        return repository.findById(defendantAccountId)
+            .orElseThrow(() -> new EntityNotFoundException("Defendant Account not found with id: "
+                + defendantAccountId));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountRepositoryService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountRepositoryService.java
@@ -55,4 +55,10 @@ public class DefendantAccountRepositoryService {
             throw new EntityNotFoundException("Defendant Account not found in business unit " + buId);
         }
     }
+
+    public DefendantAccountEntity getDefendantAccountByIdForUpdate(long defendantAccountId) {
+        return defendantAccountRepository.findByDefendantAccountIdForUpdate(defendantAccountId)
+            .orElseThrow(() -> new EntityNotFoundException(
+                "Defendant Account not found with id: " + defendantAccountId));
+    }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountSummaryViewRepositoryService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountSummaryViewRepositoryService.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.opal.service.persistence;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountSummaryViewEntity;
+import uk.gov.hmcts.opal.repository.DefendantAccountSummaryViewRepository;
+
+@Service
+@Slf4j(topic = "opal.DefendantAccountSummaryViewService")
+@RequiredArgsConstructor
+public class DefendantAccountSummaryViewRepositoryService {
+
+    private final DefendantAccountSummaryViewRepository repository;
+
+    public DefendantAccountSummaryViewEntity getSummaryViewById(Long defendantAccountId) {
+        return repository.findById(defendantAccountId)
+            .orElseThrow(() -> new EntityNotFoundException("Defendant Account not found with id: "
+                + defendantAccountId));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/report/CashListPaymentLinkService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/CashListPaymentLinkService.java
@@ -10,19 +10,19 @@ import uk.gov.hmcts.opal.entity.PaymentInEntity;
 import uk.gov.hmcts.opal.entity.SuspenseItemEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.repository.SuspenseItemRepository;
-import uk.gov.hmcts.opal.service.opal.OpalDefendantAccountService;
+import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
 
 @Component
 @RequiredArgsConstructor
 public class CashListPaymentLinkService {
 
-    private final OpalDefendantAccountService defendantAccountService;
+    private final DefendantAccountRepositoryService defendantAccountRepositoryService;
     private final SuspenseItemRepository suspenseItemRepository;
 
     public DefendantAccountEntity getDefendantAccount(PaymentInEntity payment) {
         Long defendantAccountId = parseAssociatedRecordId(payment, DEFENDANT_ACCOUNTS.getLabel());
         try {
-            return defendantAccountService.getDefendantAccountById(defendantAccountId);
+            return defendantAccountRepositoryService.findById(defendantAccountId);
         } catch (EntityNotFoundException e) {
             throw new EntityNotFoundException(
                 "Defendant account not found for associated_record_id: " + defendantAccountId, e);

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceAddPaymentTermsTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceAddPaymentTermsTest.java
@@ -8,7 +8,6 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.Optional;
@@ -19,8 +18,6 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.hmcts.opal.common.user.authorisation.model.BusinessUnitUser;
-import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.PaymentTerms;
 import uk.gov.hmcts.opal.dto.request.AddDefendantAccountPaymentTermsRequest;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
@@ -29,31 +26,19 @@ import uk.gov.hmcts.opal.entity.enforcement.EnforcementEntity;
 import uk.gov.hmcts.opal.entity.paymentterms.PaymentTermsEntity;
 import uk.gov.hmcts.opal.entity.result.ResultEntity;
 import uk.gov.hmcts.opal.mapper.request.PaymentTermsMapper;
-import uk.gov.hmcts.opal.repository.DefendantAccountPaymentTermsRepository;
 import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
 import uk.gov.hmcts.opal.repository.EnforcementRepository;
-import uk.gov.hmcts.opal.repository.ReportEntryRepository;
-import uk.gov.hmcts.opal.repository.ResultRepository;
-import uk.gov.hmcts.opal.service.UserStateService;
+import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
 
 @ExtendWith(MockitoExtension.class)
 public class OpalDefendantAccountServiceAddPaymentTermsTest {
     private static final LocalDateTime TEST_POSTED_DATE = LocalDateTime.of(2026, Month.JUNE, 11, 10, 0);
 
     @Mock
-    private DefendantAccountPaymentTermsRepository paymentTermsRepository;
-
-    @Mock
     private DefendantAccountRepository defendantAccountRepository;
 
     @Mock
     private EnforcementRepository enforcementRepository;
-
-    @Mock
-    private ResultRepository resultRepository;
-
-    @Mock
-    private ReportEntryRepository reportEntryRepository;
 
     // other dependencies the service needs (audit, userState, mappers etc.)
     @Mock
@@ -64,11 +49,6 @@ public class OpalDefendantAccountServiceAddPaymentTermsTest {
     private ResultService resultService;
     @Mock
     private ReportEntryService reportEntryService;
-    @Mock
-    private UserStateService userStateService;
-
-    @Mock
-    private EntityManager entityManager;
 
     @InjectMocks
     private OpalDefendantAccountService defendantAccountService;
@@ -77,10 +57,7 @@ public class OpalDefendantAccountServiceAddPaymentTermsTest {
     private ArgumentCaptor<DefendantAccountEntity> accountCaptor;
 
     @Mock
-    private BusinessUnitUser buUser;
-
-    @Mock
-    private UserState userState;
+    private DefendantAccountRepositoryService defendantAccountRepositoryService;
 
     @Mock
     private PaymentTermsMapper paymentTermsMapper;
@@ -109,8 +86,8 @@ public class OpalDefendantAccountServiceAddPaymentTermsTest {
         request.setPaymentTerms(paymentTermsDto);
 
         // Mock account lookup
-        when(defendantAccountRepository.findByDefendantAccountIdForUpdate(defendantAccountId))
-            .thenReturn(Optional.of(account));
+        when(defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(defendantAccountId))
+            .thenReturn(account);
 
         PaymentTermsEntity paymentTermsReturned = PaymentTermsEntity.builder()
             .paymentTermsId(200L)
@@ -182,8 +159,8 @@ public class OpalDefendantAccountServiceAddPaymentTermsTest {
             .versionNumber(1L)
             .build();
 
-        when(defendantAccountRepository.findByDefendantAccountIdForUpdate(defendantAccountId))
-            .thenReturn(Optional.of(account));
+        when(defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(defendantAccountId))
+            .thenReturn(account);
 
         PaymentTerms paymentTermsDto = new PaymentTerms();
         AddDefendantAccountPaymentTermsRequest request = new AddDefendantAccountPaymentTermsRequest();
@@ -239,8 +216,8 @@ public class OpalDefendantAccountServiceAddPaymentTermsTest {
         AddDefendantAccountPaymentTermsRequest request = new AddDefendantAccountPaymentTermsRequest();
         request.setPaymentTerms(paymentTermsDto);
 
-        when(defendantAccountRepository.findByDefendantAccountIdForUpdate(defendantAccountId))
-            .thenReturn(Optional.of(account));
+        when(defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(defendantAccountId))
+            .thenReturn(account);
 
         PaymentTermsEntity paymentTerms = PaymentTermsEntity.builder()
             .active(Boolean.TRUE)

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceCoreTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceCoreTest.java
@@ -25,15 +25,15 @@ import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.AssociationType;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountPartiesEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountStatus;
-import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountSummaryViewEntity;
 import uk.gov.hmcts.opal.entity.FixedPenaltyOffenceEntity;
 import uk.gov.hmcts.opal.entity.PartyEntity;
 import uk.gov.hmcts.opal.entity.enforcement.EnforcementEntity;
 import uk.gov.hmcts.opal.generated.model.GetEnforcementStatusResponse.DefendantAccountTypeEnum;
-import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
 import uk.gov.hmcts.opal.repository.DefendantAccountSummaryViewRepository;
 import uk.gov.hmcts.opal.service.persistence.DebtorDetailRepositoryService;
+import uk.gov.hmcts.opal.service.persistence.DefendantAccountHeaderViewRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
+import uk.gov.hmcts.opal.service.persistence.DefendantAccountSummaryViewRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.EnforcementRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.EnforcerRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.FixedPenaltyOffenceRepositoryService;
@@ -45,7 +45,8 @@ class OpalDefendantAccountServiceCoreTest {
     private DefendantAccountRepositoryService defendantAccountRepositoryService;
 
     @Mock
-    private DefendantAccountRepository defendantAccountRepository;
+    private DefendantAccountSummaryViewRepositoryService defendantAccountSummaryViewRepositoryService;
+    private DefendantAccountHeaderViewRepositoryService defendantAccountHeaderViewRepositoryService;
 
     @Mock
     private DefendantAccountSummaryViewRepository dasvRepository;
@@ -69,17 +70,6 @@ class OpalDefendantAccountServiceCoreTest {
     private OpalDefendantAccountFixedPenaltyService fpService;
     @InjectMocks
     private OpalDefendantAccountEnforcementService enforcementService;
-
-    @Test
-    void testGetDefendantAccountSummaryViewById() {
-        long testId = 1L;
-
-        DefendantAccountSummaryViewEntity viewEntity = DefendantAccountSummaryViewEntity.builder().build();
-        when(dasvRepository.findById(testId)).thenReturn(java.util.Optional.of(viewEntity));
-
-        DefendantAccountSummaryViewEntity result = service.getDefendantAccountSummaryViewById(testId);
-        assertNotNull(result);
-    }
 
     @Test
     void vehicleFixedPenaltyFlag_shouldBeFalse_whenVehicleRegistrationIsNullAndFlagFalse() {

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceCoreTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceCoreTest.java
@@ -71,17 +71,6 @@ class OpalDefendantAccountServiceCoreTest {
     private OpalDefendantAccountEnforcementService enforcementService;
 
     @Test
-    void testDefendantAccountById() {
-        long testId = 1L;
-
-        DefendantAccountEntity entity = DefendantAccountEntity.builder().build();
-        when(defendantAccountRepository.findById(testId)).thenReturn(Optional.ofNullable(entity));
-
-        DefendantAccountEntity result = service.getDefendantAccountById(testId);
-        assertNotNull(result);
-    }
-
-    @Test
     void testGetDefendantAccountSummaryViewById() {
         long testId = 1L;
 

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountUpdateTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountUpdateTest.java
@@ -54,6 +54,7 @@ import uk.gov.hmcts.opal.repository.EnforcerRepository;
 import uk.gov.hmcts.opal.repository.LocalJusticeAreaRepository;
 import uk.gov.hmcts.opal.repository.NoteRepository;
 import uk.gov.hmcts.opal.repository.ResultRepository;
+import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
 
 @ExtendWith(MockitoExtension.class)
 class OpalDefendantAccountUpdateTest {
@@ -85,6 +86,9 @@ class OpalDefendantAccountUpdateTest {
     @Mock
     private EnforcerDefendantAccountMapper enforcerDefendantAccountMapper;
 
+    @Mock
+    private DefendantAccountRepositoryService defendantAccountRepositoryService;
+
     @Spy
     private Clock clock = Clock.fixed(Instant.parse("2026-05-07T10:15:00Z"), ZoneOffset.UTC);
 
@@ -110,7 +114,7 @@ class OpalDefendantAccountUpdateTest {
         entity.setVersionNumber(1L);
 
         // Stubs
-        when(defendantAccountRepository.findById(id)).thenReturn(Optional.of(entity));
+        when(defendantAccountRepositoryService.findById(id)).thenReturn(entity);
         // Echo the saved entity (so assertions see updated values)
         when(defendantAccountRepository.save(any(DefendantAccountEntity.class))).thenAnswer(inv -> inv.getArgument(0));
 
@@ -229,7 +233,7 @@ class OpalDefendantAccountUpdateTest {
             .versionNumber(1L)
             .build();
 
-        when(defendantAccountRepository.findById(id)).thenReturn(Optional.of(entity));
+        when(defendantAccountRepositoryService.findById(id)).thenReturn(entity);
 
         UpdateDefendantAccountRequest req = UpdateDefendantAccountRequest.builder()
             .payload(UpdateDefendantAccountRequestPayload.builder()
@@ -240,25 +244,6 @@ class OpalDefendantAccountUpdateTest {
 
         assertThrows(EntityNotFoundException.class, () ->
             service.updateDefendantAccount(id, buHeader, req, "tester")
-        );
-        verify(defendantAccountRepository, never()).save(any());
-    }
-
-    @Test
-    void updateDefendantAccount_throwsWhenEntityNotFound() {
-        when(defendantAccountRepository.findById(99L)).thenReturn(Optional.empty());
-
-        UpdateDefendantAccountRequest req = UpdateDefendantAccountRequest.builder()
-            .payload(UpdateDefendantAccountRequestPayload.builder()
-                .commentAndNotes(CommentsAndNotesCommon.builder()
-                    .accountComment("x")
-                    .build())
-                .build())
-            .version(BigInteger.valueOf(1))
-            .build();
-
-        assertThrows(EntityNotFoundException.class, () ->
-            service.updateDefendantAccount(99L, "10", req, "tester")
         );
         verify(defendantAccountRepository, never()).save(any());
     }
@@ -275,7 +260,7 @@ class OpalDefendantAccountUpdateTest {
             .versionNumber(5L)
             .build();
 
-        when(defendantAccountRepository.findById(77L)).thenReturn(Optional.of(entity));
+        when(defendantAccountRepositoryService.findById(77L)).thenReturn(entity);
 
         var req = UpdateDefendantAccountRequest.builder()
             .payload(UpdateDefendantAccountRequestPayload.builder()
@@ -303,7 +288,7 @@ class OpalDefendantAccountUpdateTest {
             .versionNumber(0L)
             .build();
 
-        when(defendantAccountRepository.findById(77L)).thenReturn(Optional.of(entity));
+        when(defendantAccountRepositoryService.findById(77L)).thenReturn(entity);
         when(noteRepository.save(any())).thenReturn(null);
         doNothing().when(entityManager).lock(any(), any());
 
@@ -336,7 +321,7 @@ class OpalDefendantAccountUpdateTest {
             .versionNumber(0L)
             .build();
 
-        when(defendantAccountRepository.findById(77L)).thenReturn(Optional.of(entity));
+        when(defendantAccountRepositoryService.findById(77L)).thenReturn(entity);
         doNothing().when(entityManager).lock(any(), any());
 
         var req = UpdateDefendantAccountRequest.builder()
@@ -371,7 +356,7 @@ class OpalDefendantAccountUpdateTest {
             .versionNumber(0L)
             .build();
 
-        when(defendantAccountRepository.findById(77L)).thenReturn(Optional.of(entity));
+        when(defendantAccountRepositoryService.findById(77L)).thenReturn(entity);
         when(defendantAccountRepository.save(any(DefendantAccountEntity.class))).thenAnswer(inv -> inv.getArgument(0));
         doNothing().when(entityManager).lock(any(), any());
 
@@ -406,7 +391,7 @@ class OpalDefendantAccountUpdateTest {
         entity.setEnforcementOverrideEnforcerId(21L);
         entity.setEnforcementOverrideTfoLjaId((short) 240);
 
-        when(defendantAccountRepository.findById(77L)).thenReturn(Optional.of(entity));
+        when(defendantAccountRepositoryService.findById(77L)).thenReturn(entity);
         doNothing().when(entityManager).lock(any(), any());
 
         var req = UpdateDefendantAccountRequest.builder()
@@ -439,7 +424,7 @@ class OpalDefendantAccountUpdateTest {
             .versionNumber(0L)
             .build();
 
-        when(defendantAccountRepository.findById(77L)).thenReturn(Optional.of(entity));
+        when(defendantAccountRepositoryService.findById(77L)).thenReturn(entity);
         when(defendantAccountRepository.save(any(DefendantAccountEntity.class))).thenAnswer(inv -> inv.getArgument(0));
         doNothing().when(entityManager).lock(any(), any());
 
@@ -472,7 +457,7 @@ class OpalDefendantAccountUpdateTest {
             .versionNumber(0L)
             .build();
 
-        when(defendantAccountRepository.findById(77L)).thenReturn(Optional.of(entity));
+        when(defendantAccountRepositoryService.findById(77L)).thenReturn(entity);
         when(defendantAccountRepository.save(any(DefendantAccountEntity.class))).thenAnswer(inv -> inv.getArgument(0));
         doNothing().when(entityManager).lock(any(), any());
 

--- a/src/test/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountHeaderViewRepositoryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountHeaderViewRepositoryServiceTest.java
@@ -1,0 +1,58 @@
+package uk.gov.hmcts.opal.service.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.EntityNotFoundException;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountHeaderViewEntity;
+import uk.gov.hmcts.opal.repository.DefendantAccountHeaderViewRepository;
+
+@ExtendWith(MockitoExtension.class)
+class DefendantAccountHeaderViewRepositoryServiceTest {
+
+    @Mock
+    private DefendantAccountHeaderViewRepository repository;
+
+    @InjectMocks
+    private DefendantAccountHeaderViewRepositoryService service;
+
+    @Test
+    void getHeaderViewById_whenViewExists_returnsView() {
+        // arrange
+        Long defendantAccountId = 21L;
+        DefendantAccountHeaderViewEntity view = DefendantAccountHeaderViewEntity.builder()
+            .defendantAccountId(defendantAccountId)
+            .build();
+
+        when(repository.findById(defendantAccountId)).thenReturn(Optional.of(view));
+
+        // act
+        DefendantAccountHeaderViewEntity result = service.getHeaderViewById(defendantAccountId);
+
+        // assert
+        assertThat(result).isEqualTo(view);
+        verify(repository).findById(defendantAccountId);
+    }
+
+    @Test
+    void getHeaderViewById_whenViewMissing_throwsEntityNotFoundException() {
+        // arrange
+        Long defendantAccountId = 22L;
+        when(repository.findById(defendantAccountId)).thenReturn(Optional.empty());
+
+        // act / assert
+        assertThatThrownBy(() -> service.getHeaderViewById(defendantAccountId))
+            .isInstanceOf(EntityNotFoundException.class)
+            .hasMessage("Defendant Account not found with id: " + defendantAccountId);
+
+        verify(repository).findById(defendantAccountId);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountSummaryViewRepositoryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountSummaryViewRepositoryServiceTest.java
@@ -1,0 +1,58 @@
+package uk.gov.hmcts.opal.service.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.EntityNotFoundException;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountSummaryViewEntity;
+import uk.gov.hmcts.opal.repository.DefendantAccountSummaryViewRepository;
+
+@ExtendWith(MockitoExtension.class)
+class DefendantAccountSummaryViewRepositoryServiceTest {
+
+    @Mock
+    private DefendantAccountSummaryViewRepository repository;
+
+    @InjectMocks
+    private DefendantAccountSummaryViewRepositoryService service;
+
+    @Test
+    void getSummaryViewById_whenViewExists_returnsView() {
+        // arrange
+        Long defendantAccountId = 12L;
+        DefendantAccountSummaryViewEntity view = DefendantAccountSummaryViewEntity.builder()
+            .defendantAccountId(defendantAccountId)
+            .build();
+
+        when(repository.findById(defendantAccountId)).thenReturn(Optional.of(view));
+
+        // act
+        DefendantAccountSummaryViewEntity result = service.getSummaryViewById(defendantAccountId);
+
+        // assert
+        assertThat(result).isEqualTo(view);
+        verify(repository).findById(defendantAccountId);
+    }
+
+    @Test
+    void getSummaryViewById_whenViewMissing_throwsEntityNotFoundException() {
+        // arrange
+        Long defendantAccountId = 13L;
+        when(repository.findById(defendantAccountId)).thenReturn(Optional.empty());
+
+        // act / assert
+        assertThatThrownBy(() -> service.getSummaryViewById(defendantAccountId))
+            .isInstanceOf(EntityNotFoundException.class)
+            .hasMessage("Defendant Account not found with id: " + defendantAccountId);
+
+        verify(repository).findById(defendantAccountId);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/report/CashListPaymentLinkServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/CashListPaymentLinkServiceTest.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.opal.entity.SuspenseItemEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.repository.SuspenseItemRepository;
 import uk.gov.hmcts.opal.service.opal.OpalDefendantAccountService;
+import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
 
 @ExtendWith(MockitoExtension.class)
 class CashListPaymentLinkServiceTest {
@@ -32,13 +33,16 @@ class CashListPaymentLinkServiceTest {
     private OpalDefendantAccountService defendantAccountService;
 
     @Mock
+    private DefendantAccountRepositoryService defendantAccountRepositoryService;
+
+    @Mock
     private SuspenseItemRepository suspenseItemRepository;
 
     private CashListPaymentLinkService service;
 
     @BeforeEach
     void setUp() {
-        service = new CashListPaymentLinkService(defendantAccountService, suspenseItemRepository);
+        service = new CashListPaymentLinkService(defendantAccountRepositoryService, suspenseItemRepository);
     }
 
     @Test
@@ -47,7 +51,7 @@ class CashListPaymentLinkServiceTest {
         DefendantAccountEntity defendantAccount = DefendantAccountEntity.builder()
             .defendantAccountId(DEFENDANT_ACCOUNT_ID)
             .build();
-        when(defendantAccountService.getDefendantAccountById(DEFENDANT_ACCOUNT_ID))
+        when(defendantAccountRepositoryService.findById(DEFENDANT_ACCOUNT_ID))
             .thenReturn(defendantAccount);
 
         DefendantAccountEntity result = service.getDefendantAccount(payment);
@@ -93,7 +97,7 @@ class CashListPaymentLinkServiceTest {
     @Test
     void getDefendantAccount_throwsWhenDefendantAccountDoesNotExist() {
         PaymentInEntity payment = payment(1L, String.valueOf(DEFENDANT_ACCOUNT_ID));
-        when(defendantAccountService.getDefendantAccountById(DEFENDANT_ACCOUNT_ID))
+        when(defendantAccountRepositoryService.findById(DEFENDANT_ACCOUNT_ID))
             .thenThrow(new EntityNotFoundException("Defendant Account not found with id: " + DEFENDANT_ACCOUNT_ID));
 
         assertThatThrownBy(() -> service.getDefendantAccount(payment))


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/PO-8693
="Refactor OpalDefendantAccountService"

This is step one in the refactoring of OpalDefendantAccountService.

OpalDefendantAccountService now uses RepositoryServices to look up defendant accounts, the header views and the summary views.
Two new Repository Services have been added following the existing pattern.
