### PR TITLE
PO-7248: Add Integration Tests for Cached Endpoints

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/BusinessUnitControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/BusinessUnitControllerIntegrationTest.java
@@ -202,21 +202,20 @@ class BusinessUnitControllerIntegrationTest extends AbstractIntegrationTest {
     void testGetBusinessUnitsRefData_usesCacheOnRepeatedRequest() throws Exception {
         clearInvocations(businessUnitLiteRepository);
 
-        String firstBody = mockMvc.perform(get(URL_BASE)
-                .header("authorization", userStateStub.getBearerToken()))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-
-        String secondBody = mockMvc.perform(get(URL_BASE)
-                .header("authorization", userStateStub.getBearerToken()))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+        String firstBody = performRequest();
+        String secondBody = performRequest();
 
         assertEquals(firstBody, secondBody);
         assertEquals(1, countInvocationsByMethodName(businessUnitLiteRepository, "findBy"));
     }
+
+    private String performRequest() throws Exception {
+        return mockMvc.perform(get(URL_BASE)
+                .header("authorization", userStateStub.getBearerToken()))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    }
+
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/BusinessUnitControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/BusinessUnitControllerIntegrationTest.java
@@ -4,6 +4,8 @@ import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.clearInvocations;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_CLASS;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_CLASS;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -11,6 +13,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.support.SpyInvocationSupport.countInvocationsByMethodName;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -24,6 +27,7 @@ import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.SchemaPaths;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.dto.ToJsonString;
+import uk.gov.hmcts.opal.repository.BusinessUnitLiteRepository;
 import uk.gov.hmcts.opal.service.opal.JsonSchemaValidationService;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
@@ -42,6 +46,9 @@ class BusinessUnitControllerIntegrationTest extends AbstractIntegrationTest {
 
     @MockitoSpyBean
     private JsonSchemaValidationService jsonSchemaValidationService;
+
+    @MockitoSpyBean
+    private BusinessUnitLiteRepository businessUnitLiteRepository;
 
     @Test
     @DisplayName("Get Business Unit by ID - success")
@@ -186,5 +193,30 @@ class BusinessUnitControllerIntegrationTest extends AbstractIntegrationTest {
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.count").value(0));
+    }
+
+    @Test
+    @DisplayName("Get Business Unit Ref Data uses cache on repeated identical request")
+    @JiraStory("PO-7248")
+    @JiraEpic("PO-8248")
+    void testGetBusinessUnitsRefData_usesCacheOnRepeatedRequest() throws Exception {
+        clearInvocations(businessUnitLiteRepository);
+
+        String firstBody = mockMvc.perform(get(URL_BASE)
+                .header("authorization", userStateStub.getBearerToken()))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        String secondBody = mockMvc.perform(get(URL_BASE)
+                .header("authorization", userStateStub.getBearerToken()))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertEquals(firstBody, secondBody);
+        assertEquals(1, countInvocationsByMethodName(businessUnitLiteRepository, "findBy"));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CourtControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CourtControllerIntegrationTest.java
@@ -177,23 +177,20 @@ class CourtControllerIntegrationTest extends AbstractIntegrationTest {
     void testGetCourtRefData_usesCacheOnRepeatedRequest() throws Exception {
         clearInvocations(courtLiteRepository);
 
-        String firstBody = mockMvc.perform(get(URL_BASE)
-                .header("authorization", userStateStub.getBearerToken())
-                .param("business_unit", "99"))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-
-        String secondBody = mockMvc.perform(get(URL_BASE)
-                .header("authorization", userStateStub.getBearerToken())
-                .param("business_unit", "99"))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+        String firstBody = performRequest();
+        String secondBody = performRequest();
 
         assertEquals(firstBody, secondBody);
         assertEquals(1, countInvocationsByMethodName(courtLiteRepository, "findBy"));
+    }
+
+    private String performRequest() throws Exception {
+        return mockMvc.perform(get(URL_BASE)
+                .header("authorization", userStateStub.getBearerToken())
+                .param("business_unit", "99"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CourtControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CourtControllerIntegrationTest.java
@@ -1,11 +1,14 @@
 package uk.gov.hmcts.opal.controllers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.clearInvocations;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_CLASS;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.support.SpyInvocationSupport.countInvocationsByMethodName;
 
 import lombok.extern.slf4j.Slf4j;
 import org.hamcrest.core.IsNull;
@@ -19,6 +22,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.SchemaPaths;
 import uk.gov.hmcts.opal.dto.ToJsonString;
+import uk.gov.hmcts.opal.repository.CourtLiteRepository;
 import uk.gov.hmcts.opal.service.opal.JsonSchemaValidationService;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
@@ -39,6 +43,9 @@ class CourtControllerIntegrationTest extends AbstractIntegrationTest {
 
     @MockitoSpyBean
     private JsonSchemaValidationService jsonSchemaValidationService;
+
+    @MockitoSpyBean
+    private CourtLiteRepository courtLiteRepository;
 
     @Test
     @DisplayName("Get court by ID - When court does exist [@PO-272, @PO-424]")
@@ -161,5 +168,32 @@ class CourtControllerIntegrationTest extends AbstractIntegrationTest {
             .andExpect(jsonPath("$.refData[0].business_unit_id").value(99));
 
         jsonSchemaValidationService.validateOrError(body, GET_COURTS_REF_DATA_RESPONSE);
+    }
+
+    @Test
+    @DisplayName("Get court reference data uses cache on repeated identical request")
+    @JiraStory("PO-7248")
+    @JiraEpic("PO-8248")
+    void testGetCourtRefData_usesCacheOnRepeatedRequest() throws Exception {
+        clearInvocations(courtLiteRepository);
+
+        String firstBody = mockMvc.perform(get(URL_BASE)
+                .header("authorization", userStateStub.getBearerToken())
+                .param("business_unit", "99"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        String secondBody = mockMvc.perform(get(URL_BASE)
+                .header("authorization", userStateStub.getBearerToken())
+                .param("business_unit", "99"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertEquals(firstBody, secondBody);
+        assertEquals(1, countInvocationsByMethodName(courtLiteRepository, "findBy"));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/EnforcerControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/EnforcerControllerIntegrationTest.java
@@ -1,16 +1,22 @@
 package uk.gov.hmcts.opal.controllers;
 
 import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.clearInvocations;
+import static uk.gov.hmcts.opal.support.SpyInvocationSupport.countInvocationsByMethodName;
+
 import lombok.extern.slf4j.Slf4j;
 import org.hamcrest.core.IsNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.dto.ToJsonString;
+import uk.gov.hmcts.opal.repository.EnforcerRepository;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 
@@ -29,6 +35,9 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 class EnforcerControllerIntegrationTest extends AbstractIntegrationTest {
 
     private static final String URL_BASE = "/enforcers";
+
+    @MockitoSpyBean
+    private EnforcerRepository enforcerRepository;
 
     @Test
     @JiraStory("PO-304")
@@ -134,4 +143,30 @@ class EnforcerControllerIntegrationTest extends AbstractIntegrationTest {
             .andExpect(jsonPath("$.refData[?(@.enforcer_id == 1)].enforcer_code").value(hasItem(1)))
             .andExpect(jsonPath("$.refData[?(@.enforcer_id == 1)].name").value(hasItem("AAA Enforcers")));
     }
+
+    @Test
+    @DisplayName("Get Enforcer Ref Data uses cache on repeated identical request")
+    @JiraStory("PO-7248")
+    @JiraEpic("PO-8248")
+    void testGetEnforcerRefData_usesCacheOnRepeatedRequest() throws Exception {
+        clearInvocations(enforcerRepository);
+
+        String firstBody = mockMvc.perform(get(URL_BASE)
+                .header("authorization", userStateStub.getBearerToken()))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        String secondBody = mockMvc.perform(get(URL_BASE)
+                .header("authorization", userStateStub.getBearerToken()))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertEquals(firstBody, secondBody);
+        assertEquals(1, countInvocationsByMethodName(enforcerRepository, "findBy"));
+    }
+
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/EnforcerControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/EnforcerControllerIntegrationTest.java
@@ -151,22 +151,20 @@ class EnforcerControllerIntegrationTest extends AbstractIntegrationTest {
     void testGetEnforcerRefData_usesCacheOnRepeatedRequest() throws Exception {
         clearInvocations(enforcerRepository);
 
-        String firstBody = mockMvc.perform(get(URL_BASE)
-                .header("authorization", userStateStub.getBearerToken()))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-
-        String secondBody = mockMvc.perform(get(URL_BASE)
-                .header("authorization", userStateStub.getBearerToken()))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+        String firstBody = performRequest();
+        String secondBody = performRequest();
 
         assertEquals(firstBody, secondBody);
         assertEquals(1, countInvocationsByMethodName(enforcerRepository, "findBy"));
+    }
+
+    private String performRequest() throws Exception {
+        return mockMvc.perform(get(URL_BASE)
+                .header("authorization", userStateStub.getBearerToken()))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LocalJusticeAreaControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LocalJusticeAreaControllerIntegrationTest.java
@@ -294,20 +294,19 @@ class LocalJusticeAreaControllerIntegrationTest extends AbstractIntegrationTest 
     void testGetLocalJusticeAreasRefData_usesCacheOnRepeatedRequest() throws Exception {
         clearInvocations(localJusticeAreaRepository);
 
-        String body1 = mockMvc.perform(get(URL_BASE).param(LJA_TYPE_PARAM, "CRWCRT", "SJCRT"))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+        String firstBody = performRequest();
+        String secondBody = performRequest();
 
-        String body2 = mockMvc.perform(get(URL_BASE).param(LJA_TYPE_PARAM, "CRWCRT", "SJCRT"))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-
-        assertEquals(body1, body2);
+        assertEquals(firstBody, secondBody);
         assertEquals(1, countInvocationsByMethodName(localJusticeAreaRepository, "findBy"));
+    }
+
+    private String performRequest() throws Exception {
+        return mockMvc.perform(get(URL_BASE).param(LJA_TYPE_PARAM, "CRWCRT", "SJCRT"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
     }
 
     private @NonNull String getResponseBody(ResultActions actions, String methodName)

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LocalJusticeAreaControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/LocalJusticeAreaControllerIntegrationTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.SchemaPaths;
 import uk.gov.hmcts.opal.dto.ToJsonString;
+import uk.gov.hmcts.opal.repository.LocalJusticeAreaRepository;
 import uk.gov.hmcts.opal.service.opal.JsonSchemaValidationService;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
@@ -27,12 +28,14 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.clearInvocations;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_CLASS;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.support.SpyInvocationSupport.countInvocationsByMethodName;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration"})
@@ -48,6 +51,9 @@ class LocalJusticeAreaControllerIntegrationTest extends AbstractIntegrationTest 
 
     @MockitoSpyBean
     CacheManager cacheManager;
+
+    @MockitoSpyBean
+    private LocalJusticeAreaRepository localJusticeAreaRepository;
 
     @MockitoSpyBean
     private JsonSchemaValidationService jsonSchemaValidationService;
@@ -279,6 +285,29 @@ class LocalJusticeAreaControllerIntegrationTest extends AbstractIntegrationTest 
                 hasItem("0007")))
             .andExpect(jsonPath("$.refData[?(@.local_justice_area_id == 1)].lja_type",
                 hasItem("LJA")));
+    }
+
+    @Test
+    @DisplayName("LocalJusticeAreasRefData uses cache on repeated identical request")
+    @JiraStory("PO-7248")
+    @JiraEpic("PO-8248")
+    void testGetLocalJusticeAreasRefData_usesCacheOnRepeatedRequest() throws Exception {
+        clearInvocations(localJusticeAreaRepository);
+
+        String body1 = mockMvc.perform(get(URL_BASE).param(LJA_TYPE_PARAM, "CRWCRT", "SJCRT"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        String body2 = mockMvc.perform(get(URL_BASE).param(LJA_TYPE_PARAM, "CRWCRT", "SJCRT"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertEquals(body1, body2);
+        assertEquals(1, countInvocationsByMethodName(localJusticeAreaRepository, "findBy"));
     }
 
     private @NonNull String getResponseBody(ResultActions actions, String methodName)

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MajorCreditorControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MajorCreditorControllerIntegrationTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.clearInvocations;
 import static uk.gov.hmcts.opal.support.SpyInvocationSupport.countInvocationsByMethodName;
-
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,7 +26,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration"})
@@ -154,22 +152,20 @@ class MajorCreditorControllerIntegrationTest extends AbstractIntegrationTest {
     void testGetMajorCreditorsRefData_usesCacheOnRepeatedRequest() throws Exception {
         clearInvocations(majorCreditorRepository);
 
-        String firstBody = mockMvc.perform(get(URL_BASE)
-                .header("authorization", userStateStub.getBearerToken()))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-
-        String secondBody = mockMvc.perform(get(URL_BASE)
-                .header("authorization", userStateStub.getBearerToken()))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+        String firstBody = performRequest();
+        String secondBody = performRequest();
 
         assertEquals(firstBody, secondBody);
         assertEquals(1, countInvocationsByMethodName(majorCreditorRepository, "findBy"));
+    }
+
+    private String performRequest() throws Exception {
+        return mockMvc.perform(get(URL_BASE)
+                .header("authorization", userStateStub.getBearerToken()))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MajorCreditorControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MajorCreditorControllerIntegrationTest.java
@@ -1,6 +1,9 @@
 package uk.gov.hmcts.opal.controllers;
 
 import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.clearInvocations;
+import static uk.gov.hmcts.opal.support.SpyInvocationSupport.countInvocationsByMethodName;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -13,6 +16,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.SchemaPaths;
 import uk.gov.hmcts.opal.dto.ToJsonString;
+import uk.gov.hmcts.opal.repository.MajorCreditorRepository;
 import uk.gov.hmcts.opal.service.opal.JsonSchemaValidationService;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
@@ -39,6 +43,9 @@ class MajorCreditorControllerIntegrationTest extends AbstractIntegrationTest {
 
     @MockitoSpyBean
     private JsonSchemaValidationService jsonSchemaValidationService;
+
+    @MockitoSpyBean
+    private MajorCreditorRepository majorCreditorRepository;
 
     @Test
     @DisplayName("Get major creditor by ID [@PO-349, PO-304]")
@@ -138,6 +145,31 @@ class MajorCreditorControllerIntegrationTest extends AbstractIntegrationTest {
             .andReturn();
 
         jsonSchemaValidationService.validateOrError(body, GET_MAJOR_CREDS_REF_DATA_RESPONSE);
+    }
+
+    @Test
+    @DisplayName("Major creditor reference data uses cache on repeated identical request")
+    @JiraStory("PO-7248")
+    @JiraEpic("PO-8248")
+    void testGetMajorCreditorsRefData_usesCacheOnRepeatedRequest() throws Exception {
+        clearInvocations(majorCreditorRepository);
+
+        String firstBody = mockMvc.perform(get(URL_BASE)
+                .header("authorization", userStateStub.getBearerToken()))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        String secondBody = mockMvc.perform(get(URL_BASE)
+                .header("authorization", userStateStub.getBearerToken()))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertEquals(firstBody, secondBody);
+        assertEquals(1, countInvocationsByMethodName(majorCreditorRepository, "findBy"));
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OffenceControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OffenceControllerIntegrationTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.SchemaPaths;
 import uk.gov.hmcts.opal.dto.ToJsonString;
+import uk.gov.hmcts.opal.repository.OffenceRepository;
 import uk.gov.hmcts.opal.service.opal.JsonSchemaValidationService;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
@@ -21,12 +22,15 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.clearInvocations;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_CLASS;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.support.SpyInvocationSupport.countInvocationsByMethodName;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 
 @ActiveProfiles({"integration"})
@@ -43,6 +47,9 @@ class OffenceControllerIntegrationTest extends AbstractIntegrationTest {
 
     @MockitoSpyBean
     private JsonSchemaValidationService jsonSchemaValidationService;
+
+    @MockitoSpyBean
+    private OffenceRepository offenceRepository;
 
     @Test
     @DisplayName("Get offence by ID [@PO-420, PO-272]")
@@ -332,6 +339,56 @@ class OffenceControllerIntegrationTest extends AbstractIntegrationTest {
 
         jsonSchemaValidationService.validateOrError(body, POST_OFFENCES_SEARCH_RESPONSE);
 
+    }
+
+    @Test
+    @DisplayName("Get offence reference data uses cache on repeated identical request")
+    @JiraStory("PO-7248")
+    @JiraEpic("PO-8248")
+    void testGetOffenceReferenceData_usesCacheOnRepeatedRequest() throws Exception {
+        clearInvocations(offenceRepository);
+
+        String firstBody = mockMvc.perform(get(URL_BASE).param("cjs_code", "CW96023"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        String secondBody = mockMvc.perform(get(URL_BASE).param("cjs_code", "CW96023"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertEquals(firstBody, secondBody);
+        assertEquals(1, countInvocationsByMethodName(offenceRepository, "findBy"));
+    }
+
+    @Test
+    @DisplayName("Post offence search uses cache on repeated identical request")
+    @JiraStory("PO-7248")
+    @JiraEpic("PO-8248")
+    void testPostOffencesSearch_usesCacheOnRepeatedRequest() throws Exception {
+        clearInvocations(offenceRepository);
+
+        String firstBody = mockMvc.perform(post(URL_BASE + "/search")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"cjs_code\":\"IC01001\"}"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        String secondBody = mockMvc.perform(post(URL_BASE + "/search")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"cjs_code\":\"IC01001\"}"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertEquals(firstBody, secondBody);
+        assertEquals(1, countInvocationsByMethodName(offenceRepository, "findBy"));
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OffenceControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OffenceControllerIntegrationTest.java
@@ -348,17 +348,8 @@ class OffenceControllerIntegrationTest extends AbstractIntegrationTest {
     void testGetOffenceReferenceData_usesCacheOnRepeatedRequest() throws Exception {
         clearInvocations(offenceRepository);
 
-        String firstBody = mockMvc.perform(get(URL_BASE).param("cjs_code", "CW96023"))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-
-        String secondBody = mockMvc.perform(get(URL_BASE).param("cjs_code", "CW96023"))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+        String firstBody = performOffenceRefDataRequest();
+        String secondBody = performOffenceRefDataRequest();
 
         assertEquals(firstBody, secondBody);
         assertEquals(1, countInvocationsByMethodName(offenceRepository, "findBy"));
@@ -371,24 +362,29 @@ class OffenceControllerIntegrationTest extends AbstractIntegrationTest {
     void testPostOffencesSearch_usesCacheOnRepeatedRequest() throws Exception {
         clearInvocations(offenceRepository);
 
-        String firstBody = mockMvc.perform(post(URL_BASE + "/search")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"cjs_code\":\"IC01001\"}"))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-
-        String secondBody = mockMvc.perform(post(URL_BASE + "/search")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"cjs_code\":\"IC01001\"}"))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+        String firstBody = performOffenceSearchRequest();
+        String secondBody = performOffenceSearchRequest();
 
         assertEquals(firstBody, secondBody);
         assertEquals(1, countInvocationsByMethodName(offenceRepository, "findBy"));
+    }
+
+    private String performOffenceRefDataRequest() throws Exception {
+        return mockMvc.perform(get(URL_BASE).param("cjs_code", "CW96023"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+    }
+
+    private String performOffenceSearchRequest() throws Exception {
+        return mockMvc.perform(post(URL_BASE + "/search")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"cjs_code\":\"IC01001\"}"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ProsecutorControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ProsecutorControllerIntegrationTest.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.opal.controllers;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.clearInvocations;
+import static uk.gov.hmcts.opal.support.SpyInvocationSupport.countInvocationsByMethodName;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,6 +13,7 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.dto.ToJsonString;
+import uk.gov.hmcts.opal.repository.ProsecutorRepository;
 import uk.gov.hmcts.opal.service.opal.JsonSchemaValidationService;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
@@ -32,6 +36,9 @@ class ProsecutorControllerIntegrationTest extends AbstractIntegrationTest {
 
     @MockitoSpyBean
     private JsonSchemaValidationService jsonSchemaValidationService;
+
+    @MockitoSpyBean
+    private ProsecutorRepository prosecutorRepository;
 
     @Test
     @DisplayName("Get Prosecutor By ID [@PO-1787]")
@@ -101,6 +108,31 @@ class ProsecutorControllerIntegrationTest extends AbstractIntegrationTest {
             .andExpect(jsonPath("$.address_line_1").value(expected))
             .andExpect(jsonPath("$.address_line_2").value("Boundaryville"))
             .andExpect(jsonPath("$.address_line_3").value("Boundaryton"));
+    }
+
+    @Test
+    @DisplayName("Get Prosecutors as Reference Data uses cache on repeated identical request")
+    @JiraStory("PO-7248")
+    @JiraEpic("PO-8248")
+    void testGetProsecutorsRefData_usesCacheOnRepeatedRequest() throws Exception {
+        clearInvocations(prosecutorRepository);
+
+        String firstBody = mockMvc.perform(get(URL_BASE)
+                .header("authorization", userStateStub.getBearerToken()))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        String secondBody = mockMvc.perform(get(URL_BASE)
+                .header("authorization", userStateStub.getBearerToken()))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertEquals(firstBody, secondBody);
+        assertEquals(1, countInvocationsByMethodName(prosecutorRepository, "findBy"));
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ProsecutorControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ProsecutorControllerIntegrationTest.java
@@ -117,22 +117,20 @@ class ProsecutorControllerIntegrationTest extends AbstractIntegrationTest {
     void testGetProsecutorsRefData_usesCacheOnRepeatedRequest() throws Exception {
         clearInvocations(prosecutorRepository);
 
-        String firstBody = mockMvc.perform(get(URL_BASE)
-                .header("authorization", userStateStub.getBearerToken()))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-
-        String secondBody = mockMvc.perform(get(URL_BASE)
-                .header("authorization", userStateStub.getBearerToken()))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+        String firstBody = performRequest();
+        String secondBody = performRequest();
 
         assertEquals(firstBody, secondBody);
         assertEquals(1, countInvocationsByMethodName(prosecutorRepository, "findBy"));
+    }
+
+    private String performRequest() throws Exception {
+        return mockMvc.perform(get(URL_BASE)
+                .header("authorization", userStateStub.getBearerToken()))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
@@ -2,6 +2,10 @@ package uk.gov.hmcts.opal.controllers;
 
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_CLASS;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -20,6 +24,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import uk.gov.hmcts.opal.AbstractIntegrationTest;
 import uk.gov.hmcts.opal.SchemaPaths;
 import uk.gov.hmcts.opal.dto.ToJsonString;
+import uk.gov.hmcts.opal.repository.ResultRepository;
 import uk.gov.hmcts.opal.service.opal.JsonSchemaValidationService;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
@@ -42,6 +47,9 @@ class ResultControllerIntegrationTest extends AbstractIntegrationTest {
 
     @MockitoSpyBean
     private JsonSchemaValidationService jsonSchemaValidationService;
+
+    @MockitoSpyBean
+    private ResultRepository resultRepository;
 
     @Test
     @DisplayName("Get result by ID - validates all fields populated [@PO-703, PO-304, PO-2449]")
@@ -569,6 +577,29 @@ class ResultControllerIntegrationTest extends AbstractIntegrationTest {
             .andExpect(jsonPath("$.refData[*].result_id").value(org.hamcrest.Matchers.not(hasItems("NBWT"))));
 
         jsonSchemaValidationService.validateOrError(body, GET_RESULTS_REF_DATA_RESPONSE);
+    }
+
+    @Test
+    @DisplayName("Get result by ID uses cache on repeated identical request")
+    @JiraStory("PO-7248")
+    @JiraEpic("PO-8248")
+    void testGetResultById_usesCacheOnRepeatedRequest() throws Exception {
+        clearInvocations(resultRepository);
+
+        String firstBody = mockMvc.perform(get(URL_BASE + "/BBBBBB"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        String secondBody = mockMvc.perform(get(URL_BASE + "/BBBBBB"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertEquals(firstBody, secondBody);
+        verify(resultRepository, times(1)).findById("BBBBBB");
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ResultControllerIntegrationTest.java
@@ -586,20 +586,19 @@ class ResultControllerIntegrationTest extends AbstractIntegrationTest {
     void testGetResultById_usesCacheOnRepeatedRequest() throws Exception {
         clearInvocations(resultRepository);
 
-        String firstBody = mockMvc.perform(get(URL_BASE + "/BBBBBB"))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
-
-        String secondBody = mockMvc.perform(get(URL_BASE + "/BBBBBB"))
-            .andExpect(status().isOk())
-            .andReturn()
-            .getResponse()
-            .getContentAsString();
+        String firstBody = performRequest();
+        String secondBody = performRequest();
 
         assertEquals(firstBody, secondBody);
         verify(resultRepository, times(1)).findById("BBBBBB");
+    }
+
+    private String performRequest() throws Exception {
+        return mockMvc.perform(get(URL_BASE + "/BBBBBB"))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/support/SpyInvocationSupport.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/support/SpyInvocationSupport.java
@@ -1,0 +1,15 @@
+package uk.gov.hmcts.opal.support;
+
+import static org.mockito.Mockito.mockingDetails;
+
+public final class SpyInvocationSupport {
+
+    private SpyInvocationSupport() {
+    }
+
+    public static long countInvocationsByMethodName(Object spy, String methodName) {
+        return mockingDetails(spy).getInvocations().stream()
+            .filter(invocation -> invocation.getMethod().getName().equals(methodName))
+            .count();
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-7248

### Change description ###
- Added integration test coverage for cacheable endpoints.
- Each covered endpoint now has at least one test that calls the same endpoint twice with the same request, verifying the first call populates the cache and the second call returns the same result without re-invoking the service/repository logic.
- Added shared spy-invocation test support to keep cache verification consistent across the new integration tests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
