### PR TITLE
PO-8671 Remove Global Exception Handler class duplication in Fines Service and Common Lib

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CentralFundControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CentralFundControllerIntegrationTest.java
@@ -215,14 +215,14 @@ class CentralFundControllerIntegrationTest extends AbstractIntegrationTest {
                                                String title,
                                                String detail,
                                                String type) {
-        assertEquals(Set.of("type", "title", "status", "detail", "instance", "operation_id", "retriable", "reason"),
+        assertEquals(Set.of("type", "title", "status", "detail", "instance", "operation_id", "retriable"),
             fieldNames(problem));
         assertEquals(statusCode, problem.get("status").asInt());
         assertEquals(title, problem.get("title").asText());
         assertEquals(detail, problem.get("detail").asText());
         assertEquals(type, problem.get("type").asText());
         assertFalse(problem.get("retriable").asBoolean());
-        assertTrue(problem.get("reason").asText().matches(".+"));
+        assertFalse(problem.has("reason"));
         assertTrue(problem.get("operation_id").asText().matches(".+"));
         assertTrue(problem.get("instance").asText().matches("https://hmcts.gov.uk/problems/instance/.+"));
     }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountHistoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountHistoryIntegrationTest.java
@@ -425,7 +425,9 @@ class DefendantAccountHistoryIntegrationTest extends AbstractOpalDefendantsInteg
         result.andExpect(status().isNotFound())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/entity-not-found"))
-            .andExpect(jsonPath("$.status").value(404));
+            .andExpect(jsonPath("$.status").value(404))
+            .andExpect(jsonPath("$.detail").value("The requested entity could not be found"))
+            .andExpect(jsonPath("$.reason").doesNotExist());
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MajorCreditorAtGlanceIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MajorCreditorAtGlanceIntegrationTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.opal.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
@@ -384,14 +385,14 @@ class MajorCreditorAtGlanceIntegrationTest extends AbstractIntegrationTest {
                                                String detail,
                                                String type,
                                                boolean retriable) {
-        assertEquals(Set.of("type", "title", "status", "detail", "instance", "operation_id", "retriable", "reason"),
+        assertEquals(Set.of("type", "title", "status", "detail", "instance", "operation_id", "retriable"),
             fieldNames(problem));
         assertEquals(statusCode, problem.get("status").asInt());
         assertEquals(title, problem.get("title").asText());
         assertEquals(detail, problem.get("detail").asText());
         assertEquals(type, problem.get("type").asText());
         assertEquals(retriable, problem.get("retriable").asBoolean());
-        assertTrue(problem.get("reason").asText().matches(".+"));
+        assertFalse(problem.has("reason"));
         assertTrue(problem.get("operation_id").asText().matches(".+"));
         assertTrue(problem.get("instance").asText().matches("https://hmcts.gov.uk/problems/instance/.+"));
     }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMajorCreditorAccountHeaderSummaryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMajorCreditorAccountHeaderSummaryIntegrationTest.java
@@ -249,14 +249,14 @@ class OpalMajorCreditorAccountHeaderSummaryIntegrationTest extends AbstractInteg
                                                String title,
                                                String detail,
                                                String type) {
-        assertEquals(Set.of("type", "title", "status", "detail", "instance", "operation_id", "retriable", "reason"),
+        assertEquals(Set.of("type", "title", "status", "detail", "instance", "operation_id", "retriable"),
             fieldNames(problem));
         assertEquals(statusCode, problem.get("status").asInt());
         assertEquals(title, problem.get("title").asText());
         assertEquals(detail, problem.get("detail").asText());
         assertEquals(type, problem.get("type").asText());
         assertFalse(problem.get("retriable").asBoolean());
-        assertTrue(problem.get("reason").asText().matches(".+"));
+        assertFalse(problem.has("reason"));
         assertTrue(problem.get("operation_id").asText().matches(".+"));
         assertTrue(problem.get("instance").asText().matches("https://hmcts.gov.uk/problems/instance/.+"));
     }

--- a/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import static uk.gov.hmcts.opal.util.VersionUtils.createETag;
 import feign.FeignException;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.Optional;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -287,6 +288,7 @@ public class GlobalExceptionHandler {
         return builder.body(problemDetail);
     }
 
+    @Getter
     public static class PaymentCardRequestAlreadyExistsException extends RuntimeException {
 
         private final String resourceType;
@@ -302,18 +304,6 @@ public class GlobalExceptionHandler {
 
         public PaymentCardRequestAlreadyExistsException(String resourceType, String resourceId) {
             this(resourceType, resourceId, null);
-        }
-
-        public String getResourceType() {
-            return resourceType;
-        }
-
-        public String getResourceId() {
-            return resourceId;
-        }
-
-        public Versioned getVersioned() {
-            return versioned;
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
@@ -3,8 +3,11 @@ package uk.gov.hmcts.opal.controllers.advice;
 import static uk.gov.hmcts.opal.util.VersionUtils.createETag;
 
 import feign.FeignException;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
@@ -30,6 +33,7 @@ import uk.gov.hmcts.opal.util.Versioned;
 
 @Slf4j(topic = "opal.GlobalExceptionHandler")
 @ControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(RequiredPermissionException.class)
@@ -88,6 +92,20 @@ public class GlobalExceptionHandler {
         );
 
         return responseWithProblemDetail(HttpStatus.UNPROCESSABLE_CONTENT, problemDetail);
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ProblemDetail> handleEntityNotFoundException(EntityNotFoundException ex) {
+        ProblemDetail problemDetail = createProblemDetail(
+            HttpStatus.NOT_FOUND,
+            "Entity Not Found",
+            "The requested entity could not be found",
+            "entity-not-found",
+            false,
+            ex
+        );
+
+        return responseWithProblemDetail(HttpStatus.NOT_FOUND, problemDetail);
     }
 
     @ExceptionHandler(DefendantAccountNotFoundException.class)

--- a/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
@@ -1,53 +1,20 @@
 package uk.gov.hmcts.opal.controllers.advice;
 
-import static uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService.AUTH_HEADER;
-import static uk.gov.hmcts.opal.util.HttpUtil.extractPreferredUsername;
 import static uk.gov.hmcts.opal.util.VersionUtils.createETag;
 
 import feign.FeignException;
-import jakarta.persistence.EntityNotFoundException;
-import jakarta.persistence.PersistenceException;
-import jakarta.persistence.QueryTimeoutException;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import java.net.ConnectException;
-import java.net.URI;
-import java.net.UnknownHostException;
-import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.Set;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.LazyInitializationException;
-import org.hibernate.PropertyValueException;
-import org.postgresql.util.PSQLException;
-import org.springframework.core.NestedExceptionUtils;
-import org.springframework.dao.DataAccessResourceFailureException;
-import org.springframework.dao.InvalidDataAccessApiUsageException;
-import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.ResponseEntity.BodyBuilder;
-import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.orm.jpa.JpaSystemException;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.transaction.TransactionSystemException;
-import org.springframework.web.HttpMediaTypeNotAcceptableException;
-import org.springframework.web.HttpMediaTypeNotSupportedException;
-import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpServerErrorException;
-import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
-import org.springframework.web.servlet.resource.NoResourceFoundException;
 import uk.gov.hmcts.common.exceptions.standard.UnauthorizedException;
-import uk.gov.hmcts.opal.common.exception.OpalApiException;
-import uk.gov.hmcts.opal.common.logging.LogUtil;
-import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
+import uk.gov.hmcts.opal.common.controllers.advice.OpalProblemDetailFactory;
 import uk.gov.hmcts.opal.exception.DefendantAccountNotFoundException;
 import uk.gov.hmcts.opal.exception.InvalidReferenceValidationException;
 import uk.gov.hmcts.opal.exception.JsonSchemaValidationException;
@@ -63,48 +30,7 @@ import uk.gov.hmcts.opal.util.Versioned;
 
 @Slf4j(topic = "opal.GlobalExceptionHandler")
 @ControllerAdvice
-@RequiredArgsConstructor
 public class GlobalExceptionHandler {
-
-    public static final String DB_UNAVAILABLE_MESSAGE = "Opal Fines Database is currently unavailable";
-    public static final String UNKNOWN = "'Unknown'";
-
-    private static final Set<Integer> RETRIABLE_HTTP = Set.of(429, 502, 503, 504);
-
-    private final AccessTokenService tokenService;
-
-    @ExceptionHandler(MissingRequestHeaderException.class)
-    public ResponseEntity<ProblemDetail> handleMissingRequestHeaderException(MissingRequestHeaderException ex) {
-        ProblemDetail problemDetail = createProblemDetail(
-            HttpStatus.BAD_REQUEST,
-            "Missing Required Header",
-            String.format("Required request header \"%s\" is missing", ex.getHeaderName()),
-            "missing-header",
-            false,
-            ex
-        );
-        return responseWithProblemDetail(HttpStatus.BAD_REQUEST, problemDetail);
-    }
-
-    @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<ProblemDetail> handleAccessDeniedException(AccessDeniedException ex,
-                                                                             HttpServletRequest request) {
-        String authorization = request.getHeader(AUTH_HEADER);
-        String preferredName = extractUsername(authorization);
-        String internalMessage = String.format("For user %s, %s", preferredName, ex.getMessage());
-        log.error("Permission denied: {}", internalMessage);
-
-        ProblemDetail problemDetail = createProblemDetail(
-            HttpStatus.FORBIDDEN,
-            "Forbidden",
-            "You do not have permission to access this resource",
-            "forbidden",
-            false,
-            ex
-        );
-
-        return responseWithProblemDetail(HttpStatus.FORBIDDEN, problemDetail);
-    }
 
     @ExceptionHandler(RequiredPermissionException.class)
     public ResponseEntity<ProblemDetail> handleRequiredPermissionException(RequiredPermissionException ex) {
@@ -120,87 +46,6 @@ public class GlobalExceptionHandler {
         return responseWithProblemDetail(HttpStatus.FORBIDDEN, problemDetail);
     }
 
-    @ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
-    public ResponseEntity<ProblemDetail> handleHttpMediaTypeNotAcceptableException(
-        HttpMediaTypeNotAcceptableException ex) {
-
-        ProblemDetail problemDetail = createProblemDetail(
-            HttpStatus.NOT_ACCEPTABLE,
-            "Not Acceptable",
-            "The requested media type cannot be produced by the server",
-            "not-acceptable",
-            false,
-            ex
-        );
-
-        return responseWithProblemDetail(HttpStatus.NOT_ACCEPTABLE, problemDetail);
-    }
-
-    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<ProblemDetail> handleMethodArgumentTypeMismatchException(
-        MethodArgumentTypeMismatchException ex) {
-
-        ProblemDetail problemDetail = createProblemDetail(
-            HttpStatus.NOT_ACCEPTABLE,
-            "Not Acceptable",
-            "Invalid parameter value format",
-            "type-mismatch",
-            false,
-            ex
-        );
-
-        return responseWithProblemDetail(HttpStatus.NOT_ACCEPTABLE, problemDetail);
-    }
-
-    @ExceptionHandler(PropertyValueException.class)
-    public ResponseEntity<ProblemDetail> handlePropertyValueException(PropertyValueException pve) {
-        ProblemDetail problemDetail = createProblemDetail(
-            HttpStatus.INTERNAL_SERVER_ERROR,
-            "Property Value Error",
-            "Invalid or missing value for a required property",
-            "property-value-error",
-            false,
-            pve
-        );
-
-        problemDetail.setProperty("entity", pve.getEntityName());
-        problemDetail.setProperty("property", pve.getPropertyName());
-
-        return responseWithProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, problemDetail);
-    }
-
-    @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
-    public ResponseEntity<ProblemDetail> handleHttpMediaTypeNotSupportedException(
-        HttpMediaTypeNotSupportedException ex) {
-
-        ProblemDetail problemDetail = createProblemDetail(
-            HttpStatus.UNSUPPORTED_MEDIA_TYPE,
-            "Unsupported Media Type",
-            "The Content-Type is not supported. Please use application/json",
-            "unsupported-media-type",
-            false,
-            ex
-        );
-
-        return responseWithProblemDetail(HttpStatus.UNSUPPORTED_MEDIA_TYPE, problemDetail);
-    }
-
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ProblemDetail> handleHttpMessageNotReadableException(
-        HttpMessageNotReadableException ex) {
-
-        ProblemDetail problemDetail = createProblemDetail(
-            HttpStatus.BAD_REQUEST,
-            "Bad Request",
-            "The request body could not be read. It may be missing or invalid JSON.",
-            "message-not-readable",
-            false,
-            ex
-        );
-
-        return responseWithProblemDetail(HttpStatus.BAD_REQUEST, problemDetail);
-    }
-
     @ExceptionHandler(UnauthorizedException.class)
     public ResponseEntity<ProblemDetail> handleUnauthorizedException(UnauthorizedException ex) {
         ProblemDetail problemDetail = createProblemDetail(
@@ -213,38 +58,6 @@ public class GlobalExceptionHandler {
         );
 
         return responseWithProblemDetail(HttpStatus.UNAUTHORIZED, problemDetail);
-    }
-
-    @ExceptionHandler(InvalidDataAccessApiUsageException.class)
-    public ResponseEntity<ProblemDetail> handleInvalidDataAccessApiUsageException(
-        InvalidDataAccessApiUsageException idaaue) {
-
-        ProblemDetail problemDetail = createProblemDetail(
-            HttpStatus.INTERNAL_SERVER_ERROR,
-            "Internal Server Error",
-            "A problem occurred while accessing data",
-            "invalid-data-access",
-            false,
-            idaaue
-        );
-
-        return responseWithProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, problemDetail);
-    }
-
-    @ExceptionHandler(InvalidDataAccessResourceUsageException.class)
-    public ResponseEntity<ProblemDetail> handleInvalidDataAccessResourceUsageException(
-        InvalidDataAccessResourceUsageException idarue) {
-
-        ProblemDetail problemDetail = createProblemDetail(
-            HttpStatus.INTERNAL_SERVER_ERROR,
-            "Internal Server Error",
-            "A problem occurred with the requested data resource",
-            "invalid-resource-usage",
-            false,
-            idarue
-        );
-
-        return responseWithProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, problemDetail);
     }
 
     @ExceptionHandler(UnprocessableException.class)
@@ -264,9 +77,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(UnsupportedContentTypeException.class)
-    public ResponseEntity<ProblemDetail> handleUnsupportedContentTypeException(
-        UnsupportedContentTypeException ex) {
-
+    public ResponseEntity<ProblemDetail> handleUnsupportedContentTypeException(UnsupportedContentTypeException ex) {
         ProblemDetail problemDetail = createProblemDetail(
             HttpStatus.UNPROCESSABLE_CONTENT,
             "Report Content Type Not Supported",
@@ -277,22 +88,6 @@ public class GlobalExceptionHandler {
         );
 
         return responseWithProblemDetail(HttpStatus.UNPROCESSABLE_CONTENT, problemDetail);
-    }
-
-    @ExceptionHandler(EntityNotFoundException.class)
-    public ResponseEntity<ProblemDetail> handleEntityNotFoundException(
-        EntityNotFoundException entityNotFoundException) {
-
-        ProblemDetail problemDetail = createProblemDetail(
-            HttpStatus.NOT_FOUND,
-            "Entity Not Found",
-            "The requested entity could not be found",
-            "entity-not-found",
-            false,
-            entityNotFoundException
-        );
-
-        return responseWithProblemDetail(HttpStatus.NOT_FOUND, problemDetail);
     }
 
     @ExceptionHandler(DefendantAccountNotFoundException.class)
@@ -341,362 +136,126 @@ public class GlobalExceptionHandler {
         return responseWithProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, problemDetail);
     }
 
-    @ExceptionHandler(NoSuchElementException.class)
-    public ResponseEntity<ProblemDetail> handleNoSuchElementException(
-        NoSuchElementException noSuchElementException) {
-
-        ProblemDetail problemDetail = createProblemDetail(
-            HttpStatus.NOT_FOUND,
-            "No Value Present",
-            "The requested element does not exist",
-            "no-such-element",
-            false,
-            noSuchElementException
-        );
-
-        return responseWithProblemDetail(HttpStatus.NOT_FOUND, problemDetail);
-    }
-
-    @ExceptionHandler(OpalApiException.class)
-    public ResponseEntity<ProblemDetail> handleOpalApiException(
-        OpalApiException opalApiException) {
-
-        HttpStatus status = opalApiException.getError().getHttpStatus();
-
-        ProblemDetail problemDetail = createProblemDetail(
-            status,
-            status.getReasonPhrase(),
-            "An error occurred while processing your request",
-            "opal-api-error",
-            false, // unless your internal error model marks it retriable
-            opalApiException
-        );
-
-        return responseWithProblemDetail(status, problemDetail);
-    }
-
-    @ExceptionHandler({ServletException.class, TransactionSystemException.class, PersistenceException.class})
-    public ResponseEntity<ProblemDetail> handleServletExceptions(Exception ex) {
-
-        if (ex instanceof QueryTimeoutException) {
-            ProblemDetail problemDetail = createProblemDetail(
-                HttpStatus.REQUEST_TIMEOUT,
-                "Request Timeout",
-                "The request did not receive a response from the database within the timeout period",
-                "query-timeout",
-                true, // retriable
-                ex
-            );
-            return responseWithProblemDetail(HttpStatus.REQUEST_TIMEOUT, problemDetail);
-        }
-
-        if (ex instanceof NoResourceFoundException nrfe) {
-            ProblemDetail problemDetail = createProblemDetail(
-                HttpStatus.NOT_FOUND,
-                "Not Found",
-                "The requested resource could not be found",
-                "resource-not-found",
-                false,
-                nrfe
-            );
-            return responseWithProblemDetail(HttpStatus.NOT_FOUND, problemDetail);
-        }
-
-        if (ex instanceof TransactionSystemException tse) {
-            Throwable root = NestedExceptionUtils.getMostSpecificCause(tse);
-            boolean retriable = isTransientSqlState(psqlState(root));
-            ProblemDetail problemDetail = createProblemDetail(
-                HttpStatus.INTERNAL_SERVER_ERROR,
-                "Transaction Error",
-                "A transaction error occurred while processing your request",
-                "transaction-error",
-                retriable,
-                tse
-            );
-            return responseWithProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, problemDetail);
-        }
-
-        // ServletException / PersistenceException default
-        ProblemDetail problemDetail = createProblemDetail(
-            HttpStatus.INTERNAL_SERVER_ERROR,
-            "Internal Server Error",
-            "An unexpected error occurred while processing your request",
-            "servlet-error",
-            false,
-            ex
-        );
-        return responseWithProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, problemDetail);
-    }
-
-    @ExceptionHandler(PSQLException.class)
-    public ResponseEntity<ProblemDetail> handlePsqlException(PSQLException psqlException) {
-        if (psqlException.getCause() instanceof ConnectException
-            || psqlException.getCause() instanceof UnknownHostException) {
-
-            ProblemDetail problemDetail = createProblemDetail(
-                HttpStatus.SERVICE_UNAVAILABLE,
-                "Service Unavailable",
-                DB_UNAVAILABLE_MESSAGE,
-                "database-unavailable",
-                true, // retriable on connectivity/DNS errors
-                psqlException
-            );
-            return responseWithProblemDetail(HttpStatus.SERVICE_UNAVAILABLE, problemDetail);
-        }
-
-        ProblemDetail problemDetail = createProblemDetail(
-            HttpStatus.INTERNAL_SERVER_ERROR,
-            "Internal Server Error",
-            "A database error occurred while processing your request",
-            "database-error",
-            false, // all other PSQLException -> not retriable (per list)
-            psqlException
-        );
-        return responseWithProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, problemDetail);
-    }
-
-    @ExceptionHandler(DataAccessResourceFailureException.class)
-    public ResponseEntity<ProblemDetail> handleDataAccessResourceFailureException(
-        DataAccessResourceFailureException e) {
-
-        ProblemDetail problemDetail = createProblemDetail(
-            HttpStatus.SERVICE_UNAVAILABLE,
-            "Service Unavailable",
-            DB_UNAVAILABLE_MESSAGE,
-            "database-unavailable",
-            true, // retriable
-            e
-        );
-        return responseWithProblemDetail(HttpStatus.SERVICE_UNAVAILABLE, problemDetail);
-    }
-
-    @ExceptionHandler(LazyInitializationException.class)
-    public ResponseEntity<ProblemDetail> handleLazyInitializationException(
-        LazyInitializationException e) {
-
-        ProblemDetail problemDetail = createProblemDetail(
-            HttpStatus.INTERNAL_SERVER_ERROR,
-            "Internal Server Error",
-            "A data access error occurred.",
-            "lazy-initialization",
-            false,
-            e
-        );
-        return responseWithProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, problemDetail);
-    }
-
-    @ExceptionHandler(JpaSystemException.class)
-    public ResponseEntity<ProblemDetail> handleJpaSystemException(JpaSystemException e) {
-        Throwable root = NestedExceptionUtils.getMostSpecificCause(e);
-        boolean retriable = isTransientSqlState(psqlState(root));
-
-        ProblemDetail problemDetail = createProblemDetail(
-            HttpStatus.INTERNAL_SERVER_ERROR,
-            "Internal Server Error",
-            "A persistence error occurred while processing your request",
-            "jpa-system-error",
-            retriable,
-            e
-        );
-        return responseWithProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, problemDetail);
-    }
-
-    @ExceptionHandler(HttpServerErrorException.class)
-    public ResponseEntity<ProblemDetail> handleHttpServerErrorException(HttpServerErrorException e) {
-        int upstream = e.getStatusCode().value();
-        HttpStatus responseStatus = upstream == HttpStatus.SERVICE_UNAVAILABLE.value()
-            ? HttpStatus.SERVICE_UNAVAILABLE
-            : HttpStatus.INTERNAL_SERVER_ERROR;
-        boolean retriable = RETRIABLE_HTTP.contains(upstream);
-
-        ProblemDetail problemDetail = createProblemDetail(
-            responseStatus,
-            responseStatus == HttpStatus.SERVICE_UNAVAILABLE ? "Service Unavailable" : "Downstream Server Error",
-            Optional.ofNullable(e.getStatusText()).filter(text -> !text.isBlank()).orElse(e.getMessage()),
-            "http-server-error",
-            retriable,
-            e
-        );
-
-        return responseWithProblemDetail(responseStatus, problemDetail);
-    }
-
     @ExceptionHandler(HttpClientErrorException.class)
-    public ResponseEntity<ProblemDetail> handleHttpClientErrorException(HttpClientErrorException e) {
-        HttpStatus status = HttpStatus.valueOf(e.getStatusCode().value());
+    public ResponseEntity<ProblemDetail> handleHttpClientErrorException(HttpClientErrorException ex) {
+        HttpStatus status = HttpStatus.valueOf(ex.getStatusCode().value());
 
         ProblemDetail problemDetail = createProblemDetail(
             status,
             status.getReasonPhrase(),
-            Optional.ofNullable(e.getStatusText()).filter(text -> !text.isBlank()).orElse(e.getMessage()),
+            Optional.ofNullable(ex.getStatusText()).filter(text -> !text.isBlank()).orElse(ex.getMessage()),
             "http-client-error",
             false,
-            e
+            ex
         );
 
         return responseWithProblemDetail(status, problemDetail);
     }
 
     @ExceptionHandler(JsonSchemaValidationException.class)
-    public ResponseEntity<ProblemDetail> handleJsonSchemaValidationException(JsonSchemaValidationException e) {
+    public ResponseEntity<ProblemDetail> handleJsonSchemaValidationException(JsonSchemaValidationException ex) {
         ProblemDetail problemDetail = createProblemDetail(
             HttpStatus.BAD_REQUEST,
             "Bad Request",
             "The request does not conform to the required JSON schema",
             "json-schema-validation",
             false,
-            e
+            ex
         );
         return responseWithProblemDetail(HttpStatus.BAD_REQUEST, problemDetail);
     }
 
     @ExceptionHandler(SchemaConfigurationException.class)
-    public ResponseEntity<ProblemDetail> handleSchemaConfigurationException(SchemaConfigurationException e) {
+    public ResponseEntity<ProblemDetail> handleSchemaConfigurationException(SchemaConfigurationException ex) {
         ProblemDetail problemDetail = createProblemDetail(
             HttpStatus.INTERNAL_SERVER_ERROR,
             "Internal Server Error",
-            e.getMessage(),
+            ex.getMessage(),
             "internal-server-error",
             false,
-            e
+            ex
         );
         return responseWithProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, problemDetail);
     }
 
     @ExceptionHandler(InvalidReferenceValidationException.class)
     public ResponseEntity<ProblemDetail> handleInvalidReferenceValidationException(
-        InvalidReferenceValidationException e) {
+        InvalidReferenceValidationException ex) {
         ProblemDetail problemDetail = createProblemDetail(
             HttpStatus.BAD_REQUEST,
             "Bad Request",
-            e.getMessage(),
+            ex.getMessage(),
             "invalid-reference-validation",
             false,
-            e
+            ex
         );
         return responseWithProblemDetail(HttpStatus.BAD_REQUEST, problemDetail);
-    }
-
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ProblemDetail> handleIllegalArgumentException(IllegalArgumentException e) {
-        ProblemDetail problemDetail = createProblemDetail(
-            HttpStatus.BAD_REQUEST,
-            "Bad Request",
-            "Invalid arguments were provided in the request",
-            "illegal-argument",
-            false,
-            e
-        );
-        return responseWithProblemDetail(HttpStatus.BAD_REQUEST, problemDetail);
-    }
-
-    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
-    public ResponseEntity<ProblemDetail> handleObjectOptimisticLockingFailureException(
-        ObjectOptimisticLockingFailureException e) {
-
-        ProblemDetail problemDetail = createProblemDetail(
-            HttpStatus.CONFLICT,
-            "Conflict",
-            Optional.ofNullable(e.getMessage()).orElse("Conflict updating record. Please try again."),
-            "optimistic-locking",
-            false,
-            e
-        );
-        problemDetail.setProperty("resourceType", e.getPersistentClassName());
-        problemDetail.setProperty("resourceId",
-                                  Optional.ofNullable(e.getIdentifier()).map(Object::toString).orElse(""));
-        return responseWithProblemDetail(HttpStatus.CONFLICT, problemDetail);
     }
 
     @ExceptionHandler(ResourceConflictException.class)
-    public ResponseEntity<ProblemDetail> handleResourceConflictException(ResourceConflictException e) {
+    public ResponseEntity<ProblemDetail> handleResourceConflictException(ResourceConflictException ex) {
         ProblemDetail problemDetail = createProblemDetail(
             HttpStatus.CONFLICT,
             "Conflict",
             "A conflict occurred with the requested resource",
             "resource-conflict",
             false,
-            e
+            ex
         );
-        problemDetail.setProperty("resourceType", e.getResourceType());
-        problemDetail.setProperty("resourceId", e.getResourceId());
-        problemDetail.setProperty("conflictReason", e.getConflictReason());
-        return responseWithProblemDetail(HttpStatus.CONFLICT, problemDetail, e.getVersioned());
+        problemDetail.setProperty("resourceType", ex.getResourceType());
+        problemDetail.setProperty("resourceId", ex.getResourceId());
+        problemDetail.setProperty("conflictReason", ex.getConflictReason());
+        return responseWithProblemDetail(HttpStatus.CONFLICT, problemDetail, ex.getVersioned());
     }
 
     @ExceptionHandler(SubmitterDeniedException.class)
-    public ResponseEntity<ProblemDetail> handleActionDeniedForSubmitterException(SubmitterDeniedException e) {
+    public ResponseEntity<ProblemDetail> handleActionDeniedForSubmitterException(SubmitterDeniedException ex) {
         ProblemDetail problemDetail = createProblemDetail(
             HttpStatus.FORBIDDEN,
-            "Submitter cannot " + e.getUpdateType(),
-            "A single user cannot submit and " + e.getUpdateType() + " the same Draft Account",
-            "submitter-cannot-" + e.getUpdateType(),
+            "Submitter cannot " + ex.getUpdateType(),
+            "A single user cannot submit and " + ex.getUpdateType() + " the same Draft Account",
+            "submitter-cannot-" + ex.getUpdateType(),
             false,
-            e
+            ex
         );
         return responseWithProblemDetail(HttpStatus.FORBIDDEN, problemDetail);
     }
 
-    @ExceptionHandler(GlobalExceptionHandler.PaymentCardRequestAlreadyExistsException.class)
+    @ExceptionHandler(PaymentCardRequestAlreadyExistsException.class)
     public ResponseEntity<ProblemDetail> handlePaymentCardRequestAlreadyExists(
-        PaymentCardRequestAlreadyExistsException e) {
+        PaymentCardRequestAlreadyExistsException ex) {
 
         ProblemDetail problemDetail = createProblemDetail(
             HttpStatus.CONFLICT,
             "Conflict",
-            e.getMessage(),
+            ex.getMessage(),
             "resource-conflict",
             true,
-            e
+            ex
         );
 
-        problemDetail.setProperty("resourceType", e.getResourceType());
-        problemDetail.setProperty("resourceId", e.getResourceId());
+        problemDetail.setProperty("resourceType", ex.getResourceType());
+        problemDetail.setProperty("resourceId", ex.getResourceId());
 
-        return responseWithProblemDetail(HttpStatus.CONFLICT, problemDetail, e.getVersioned());
+        return responseWithProblemDetail(HttpStatus.CONFLICT, problemDetail, ex.getVersioned());
     }
 
     @ExceptionHandler(FeignException.Unauthorized.class)
-    public ResponseEntity<ProblemDetail> handleFeignExceptionUnauthorized(FeignException.Unauthorized e) {
+    public ResponseEntity<ProblemDetail> handleFeignExceptionUnauthorized(FeignException.Unauthorized ex) {
         ProblemDetail problemDetail = createProblemDetail(
             HttpStatus.UNAUTHORIZED,
             "Not Authorised for Connection",
-            e.getMessage(),
+            ex.getMessage(),
             "unauthorized",
             false,
-            e
+            ex
         );
-        return responseWithProblemDetail(HttpStatus.valueOf(e.status()),problemDetail);
-    }
-
-    @ExceptionHandler(FeignException.class)
-    public ResponseEntity<ProblemDetail> handleFeignException(FeignException e) {
-        HttpStatus status = HttpStatus.valueOf(e.status());
-        boolean retriable = RETRIABLE_HTTP.contains(status.value());
-
-        ProblemDetail problemDetail = createProblemDetail(
-            status,
-            "Downstream Service Error",
-            "Problem with connecting to a dependant service: " + e.getMessage(),
-            "internal-server-error",
-            retriable,
-            e
-        );
-        return responseWithProblemDetail(status, problemDetail);
+        return responseWithProblemDetail(HttpStatus.UNAUTHORIZED, problemDetail);
     }
 
     private ProblemDetail createProblemDetail(HttpStatus status, String title, String detail,
                                               String typeUri, boolean retry, Throwable exception) {
-        String opalOperationId = LogUtil.getOrCreateOpalOperationId();
-        log.error("Error ID {}:", opalOperationId, exception);
-
-        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(status, detail);
-        problemDetail.setTitle(title);
-        problemDetail.setType(URI.create("https://hmcts.gov.uk/problems/" + typeUri));
-        problemDetail.setInstance(URI.create("https://hmcts.gov.uk/problems/instance/" + opalOperationId));
-        problemDetail.setProperty("operation_id", opalOperationId);
-        problemDetail.setProperty("retriable", retry);
-        return problemDetail;
+        return OpalProblemDetailFactory.createProblemDetail(status, title, detail, typeUri, retry, exception, log);
     }
 
     private ResponseEntity<ProblemDetail> responseWithProblemDetail(HttpStatus status, ProblemDetail problemDetail) {
@@ -704,58 +263,17 @@ public class GlobalExceptionHandler {
     }
 
     private ResponseEntity<ProblemDetail> responseWithProblemDetail(HttpStatus status, ProblemDetail problemDetail,
-        Versioned versioned) {
+                                                                    Versioned versioned) {
         BodyBuilder builder = ResponseEntity.status(status).contentType(MediaType.APPLICATION_PROBLEM_JSON);
-        Optional.ofNullable(versioned).ifPresent(v -> builder.eTag(createETag(v)));
+        Optional.ofNullable(versioned).ifPresent(value -> builder.eTag(createETag(value)));
         return builder.body(problemDetail);
     }
-
-    private String extractUsername(String authorization) {
-        try {
-            return extractPreferredUsername(authorization, tokenService);
-        } catch (Exception e) {
-            return UNKNOWN;
-        }
-    }
-
-    // ----- helpers -----
-
-    private static String psqlState(Throwable t) {
-        if (t instanceof PSQLException p) {
-            return p.getSQLState();
-        }
-
-        Throwable cause = t == null ? null : t.getCause();
-
-        if (cause instanceof PSQLException p) {
-            return p.getSQLState();
-        }
-
-        return null;
-    }
-
-    private static boolean isTransientSqlState(String state) {
-        if (state == null) {
-            return false;
-        }
-
-        return state.equals("40001")   // serialization_failure
-            || state.equals("40P01")   // deadlock_detected
-            || state.equals("55P03");  // lock_not_available
-    }
-
-    /**
-     * Exception type used for the specific PCR-already-exists conflict so we can return a tailored 409 Problem JSON
-     * (detail contains message, retriable=true).
-     *
-     * <p>Kept as a nested class to avoid creating a new top-level file.
-     */
 
     public static class PaymentCardRequestAlreadyExistsException extends RuntimeException {
 
         private final String resourceType;
         private final String resourceId;
-        private final Versioned versioned; // may be null
+        private final Versioned versioned;
 
         public PaymentCardRequestAlreadyExistsException(String resourceType, String resourceId, Versioned versioned) {
             super("A payment card request already exists for this account.");
@@ -780,5 +298,4 @@ public class GlobalExceptionHandler {
             return versioned;
         }
     }
-
 }

--- a/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
@@ -1,545 +1,269 @@
 package uk.gov.hmcts.opal.controllers.advice;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import feign.FeignException;
 import feign.Request;
 import feign.RequestTemplate;
 import feign.Response;
-import jakarta.persistence.EntityNotFoundException;
-import jakarta.persistence.PersistenceException;
-import jakarta.persistence.QueryTimeoutException;
-import jakarta.servlet.http.HttpServletRequest;
-import java.lang.reflect.Method;
 import java.math.BigInteger;
-import java.net.ConnectException;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
-import java.util.NoSuchElementException;
-import org.hibernate.LazyInitializationException;
-import org.hibernate.PropertyValueException;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Isolated;
-import org.mockito.Mockito;
-import org.postgresql.util.PSQLException;
-import org.postgresql.util.PSQLState;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.core.MethodParameter;
-import org.springframework.dao.DataAccessResourceFailureException;
-import org.springframework.dao.InvalidDataAccessApiUsageException;
-import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpInputMessage;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
-import org.springframework.orm.jpa.JpaSystemException;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.transaction.TransactionSystemException;
-import org.springframework.web.HttpMediaTypeNotAcceptableException;
-import org.springframework.web.HttpMediaTypeNotSupportedException;
-import org.springframework.web.bind.MissingRequestHeaderException;
-import org.springframework.web.client.HttpServerErrorException;
-import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
-import org.springframework.web.servlet.resource.NoResourceFoundException;
+import org.springframework.web.client.HttpClientErrorException;
+import uk.gov.hmcts.common.exceptions.standard.UnauthorizedException;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
-import uk.gov.hmcts.opal.common.exception.OpalApiException;
-import uk.gov.hmcts.opal.common.user.authentication.exception.AuthenticationError;
-import uk.gov.hmcts.opal.common.user.authentication.service.AccessTokenService;
-import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountEntity;
 import uk.gov.hmcts.opal.exception.DefendantAccountNotFoundException;
 import uk.gov.hmcts.opal.exception.InvalidReferenceValidationException;
 import uk.gov.hmcts.opal.exception.JsonSchemaValidationException;
-import uk.gov.hmcts.opal.exception.RequiredPermissionException;
+import uk.gov.hmcts.opal.exception.MissingReportServiceException;
+import uk.gov.hmcts.opal.exception.MissingStoredReportContentException;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
+import uk.gov.hmcts.opal.exception.RequiredPermissionException;
 import uk.gov.hmcts.opal.exception.SchemaConfigurationException;
 import uk.gov.hmcts.opal.exception.SubmitterDeniedException;
 import uk.gov.hmcts.opal.exception.UnprocessableException;
+import uk.gov.hmcts.opal.exception.UnsupportedContentTypeException;
 
-@SpringBootTest
-@ContextConfiguration(classes = GlobalExceptionHandler.class)
-@Isolated
 class GlobalExceptionHandlerTest {
 
-    @MockitoBean MissingRequestHeaderException missingRequestHeaderException;
-    @MockitoBean PermissionNotAllowedException permissionNotAllowedException;
-    @MockitoBean AccessTokenService tokenService;
-
-    @Autowired GlobalExceptionHandler globalExceptionHandler;
-
-    // ---------- Simple false (non-retriable) buckets ----------
+    private final GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
 
     @Test
-    void handleMissingHeader_false() throws NoSuchMethodException {
-        Method method = TestMissingHeaderClass.class.getMethod("testMethod", String.class);
-        MethodParameter param = new MethodParameter(method, 0);
-        MissingRequestHeaderException ex = new MissingRequestHeaderException("TYPE", param);
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleMissingRequestHeaderException(ex);
-
-        assertEquals(HttpStatus.BAD_REQUEST, r.getStatusCode());
-        ProblemDetail pd = r.getBody();
-        assertEquals(HttpStatus.BAD_REQUEST.value(), pd.getStatus());
-        assertEquals("Missing Required Header", pd.getTitle());
-        assertEquals(URI.create("https://hmcts.gov.uk/problems/missing-header"), pd.getType());
-        assertEquals(false, pd.getProperties().get("retriable"));
-    }
-
-    static class TestMissingHeaderClass {
-        public void testMethod(String type) {
-        }
-    }
-
-    @Test
-    void handleForbidden_false() {
-        AccessDeniedException ex = new AccessDeniedException("acces denied");
-        HttpServletRequest req = new MockHttpServletRequest();
-
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleAccessDeniedException(ex, req);
-        assertEquals(HttpStatus.FORBIDDEN, r.getStatusCode());
-        ProblemDetail pd = r.getBody();
-        assertEquals(HttpStatus.FORBIDDEN.value(), pd.getStatus());
-        assertEquals("Forbidden", pd.getTitle());
-        assertEquals(false, pd.getProperties().get("retriable"));
-        assertEquals(MediaType.APPLICATION_PROBLEM_JSON, r.getHeaders().getContentType());
-    }
-
-    @Test
-    void handleRequiredPermission_false() {
+    void handleRequiredPermission_returnsForbiddenProblem() {
         RequiredPermissionException ex = new RequiredPermissionException(FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
 
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleRequiredPermissionException(ex);
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleRequiredPermissionException(ex);
 
-        assertEquals(HttpStatus.FORBIDDEN, r.getStatusCode());
-        ProblemDetail pd = r.getBody();
-        assertEquals(HttpStatus.FORBIDDEN.value(), pd.getStatus());
-        assertEquals("Forbidden", pd.getTitle());
-        assertEquals("User requires permission: Search and View Accounts", pd.getDetail());
-        assertEquals(false, pd.getProperties().get("retriable"));
-        assertEquals(MediaType.APPLICATION_PROBLEM_JSON, r.getHeaders().getContentType());
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+        assertEquals(MediaType.APPLICATION_PROBLEM_JSON, response.getHeaders().getContentType());
+        assertEquals("Forbidden", response.getBody().getTitle());
+        assertEquals("User requires permission: Search and View Accounts", response.getBody().getDetail());
+        assertEquals(false, response.getBody().getProperties().get("retriable"));
     }
 
     @Test
-    void handleNotAcceptable_false() {
-        ResponseEntity<ProblemDetail> r =
-            globalExceptionHandler.handleHttpMediaTypeNotAcceptableException(
-                new HttpMediaTypeNotAcceptableException("nope"));
+    void handleUnauthorized_returnsUnauthorizedProblem() {
+        UnauthorizedException ex = new UnauthorizedException("Unauthorised", "Bad token");
 
-        assertEquals(HttpStatus.NOT_ACCEPTABLE, r.getStatusCode());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleUnauthorizedException(ex);
+
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        assertEquals(MediaType.APPLICATION_PROBLEM_JSON, response.getHeaders().getContentType());
+        assertEquals("Unauthorized", response.getBody().getTitle());
+        assertEquals("Missing or invalid access token", response.getBody().getDetail());
+        assertEquals(false, response.getBody().getProperties().get("retriable"));
     }
 
     @Test
-    void handleTypeMismatch_false() throws Exception {
-        Object invalidValue = "x";
-        Class<?> requiredType = Integer.class;
-        String name = "n";
-        Method m = GlobalExceptionHandlerTest.class.getMethod("sampleMethod", Integer.class);
-        MethodParameter mp = new MethodParameter(m, 0);
+    void handleUnprocessable_returnsReasonAndRetryFlag() {
+        UnprocessableException ex = new UnprocessableException("Too many results", true);
 
-        MethodArgumentTypeMismatchException ex = new MethodArgumentTypeMismatchException(
-            invalidValue, requiredType, name, mp, new NumberFormatException("bad"));
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleUnprocessableException(ex);
 
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleMethodArgumentTypeMismatchException(ex);
-        assertEquals(HttpStatus.NOT_ACCEPTABLE, r.getStatusCode());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
+        assertEquals(HttpStatus.UNPROCESSABLE_CONTENT, response.getStatusCode());
+        assertEquals("Unprocessable Content", response.getBody().getTitle());
+        assertEquals(true, response.getBody().getProperties().get("retriable"));
+        assertEquals("Too many results", response.getBody().getProperties().get("unprocessableReason"));
     }
 
     @Test
-    void handlePropertyValue_false() {
-        PropertyValueException ex = new PropertyValueException("msg", "entity", "prop");
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handlePropertyValueException(ex);
-        ProblemDetail pd = r.getBody();
+    void handleUnsupportedContentType_returnsUnprocessableProblem() {
+        UnsupportedContentTypeException ex = new UnsupportedContentTypeException(
+            "report",
+            "text/plain",
+            Collections.singletonList("application/pdf")
+        );
 
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, r.getStatusCode());
-        assertEquals("entity", pd.getProperties().get("entity"));
-        assertEquals("prop", pd.getProperties().get("property"));
-        assertEquals(false, pd.getProperties().get("retriable"));
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleUnsupportedContentTypeException(ex);
+
+        assertEquals(HttpStatus.UNPROCESSABLE_CONTENT, response.getStatusCode());
+        assertEquals("Report Content Type Not Supported", response.getBody().getTitle());
+        assertEquals(false, response.getBody().getProperties().get("retriable"));
     }
 
     @Test
-    void handleUnsupportedMediaType_false() {
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler
-            .handleHttpMediaTypeNotSupportedException(new HttpMediaTypeNotSupportedException("bad"));
-        assertEquals(HttpStatus.UNSUPPORTED_MEDIA_TYPE, r.getStatusCode());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
+    void handleDefendantAccountNotFound_returnsNotFoundProblem() {
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleDefendantAccountNotFoundException(
+            new DefendantAccountNotFoundException(999999999L)
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals("Defendant Account Not Found", response.getBody().getTitle());
+        assertEquals("Defendant account not found with id: 999999999", response.getBody().getDetail());
+        assertEquals(false, response.getBody().getProperties().get("retriable"));
     }
 
     @Test
-    void handleMessageNotReadable_false() {
-        HttpInputMessage msg = Mockito.mock(HttpInputMessage.class);
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler
-            .handleHttpMessageNotReadableException(new HttpMessageNotReadableException("x", msg));
-        assertEquals(HttpStatus.BAD_REQUEST, r.getStatusCode());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
+    void handleMissingStoredReportContent_returnsInternalServerErrorProblem() {
+        MissingStoredReportContentException ex = new MissingStoredReportContentException(12L, "blob/path");
+
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleMissingStoredReportContentException(ex);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals("Missing Data In Storage Account", response.getBody().getTitle());
+        assertEquals(
+            "Stored report content file 'blob/path' was not found for report instance id: 12",
+            response.getBody().getDetail()
+        );
+        assertEquals(false, response.getBody().getProperties().get("retriable"));
     }
 
     @Test
-    void handleInvalidDataAccessApiUsage_false() {
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler
-            .handleInvalidDataAccessApiUsageException(
-                new InvalidDataAccessApiUsageException("bad", new Throwable("root")));
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, r.getStatusCode());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
+    void handleMissingReportService_returnsInternalServerErrorProblem() {
+        MissingReportServiceException ex = new MissingReportServiceException("REPORT_1");
+
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleMissingReportServiceException(ex);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals("Missing Report Service", response.getBody().getTitle());
+        assertEquals(
+            "No report service implementation found for reportId: REPORT_1",
+            response.getBody().getDetail()
+        );
     }
 
     @Test
-    void handleInvalidDataAccessResourceUsage_false() {
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler
-            .handleInvalidDataAccessResourceUsageException(
-                new InvalidDataAccessResourceUsageException("bad"));
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, r.getStatusCode());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
+    void handleHttpClientError_returnsUpstreamStatus() {
+        HttpClientErrorException ex = HttpClientErrorException.create(
+            HttpStatusCode.valueOf(404),
+            "Not Found!",
+            HttpHeaders.EMPTY,
+            null,
+            null
+        );
+
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleHttpClientErrorException(ex);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals("Not Found", response.getBody().getTitle());
+        assertEquals("Not Found!", response.getBody().getDetail());
+        assertEquals(URI.create("https://hmcts.gov.uk/problems/http-client-error"), response.getBody().getType());
     }
 
     @Test
-    void handleEntityNotFound_false() {
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler
-            .handleEntityNotFoundException(new EntityNotFoundException("nf"));
-        assertEquals(HttpStatus.NOT_FOUND, r.getStatusCode());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
+    void handleJsonSchemaValidation_returnsBadRequestProblem() {
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleJsonSchemaValidationException(
+            new JsonSchemaValidationException("bad schema")
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Bad Request", response.getBody().getTitle());
+        assertEquals("The request does not conform to the required JSON schema", response.getBody().getDetail());
     }
 
     @Test
-    void handleDefendantAccountNotFound_false() {
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler
-            .handleDefendantAccountNotFoundException(new DefendantAccountNotFoundException(999999999L));
+    void handleSchemaConfiguration_returnsInternalServerErrorProblem() {
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleSchemaConfigurationException(
+            new SchemaConfigurationException("missing config")
+        );
 
-        assertEquals(HttpStatus.NOT_FOUND, r.getStatusCode());
-        ProblemDetail pd = r.getBody();
-        assertEquals(HttpStatus.NOT_FOUND.value(), pd.getStatus());
-        assertEquals("Defendant Account Not Found", pd.getTitle());
-        assertEquals("Defendant account not found with id: 999999999", pd.getDetail());
-        assertEquals(false, pd.getProperties().get("retriable"));
-        assertEquals(MediaType.APPLICATION_PROBLEM_JSON, r.getHeaders().getContentType());
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals("Internal Server Error", response.getBody().getTitle());
+        assertEquals("missing config", response.getBody().getDetail());
     }
 
     @Test
-    void handleNoSuchElement_false() {
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler
-            .handleNoSuchElementException(new NoSuchElementException("none"));
-        assertEquals(HttpStatus.NOT_FOUND, r.getStatusCode());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
+    void handleInvalidReferenceValidation_returnsBadRequestProblem() {
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleInvalidReferenceValidationException(
+            new InvalidReferenceValidationException("bad reference data")
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Bad Request", response.getBody().getTitle());
+        assertEquals("bad reference data", response.getBody().getDetail());
+        assertEquals(
+            URI.create("https://hmcts.gov.uk/problems/invalid-reference-validation"),
+            response.getBody().getType()
+        );
     }
 
     @Test
-    void handleOpalApi_false() {
-        OpalApiException ex = new OpalApiException(AuthenticationError.FAILED_TO_OBTAIN_AUTHENTICATION_CONFIG);
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleOpalApiException(ex);
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, r.getStatusCode());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
-    }
-
-    // ---------- Servlet/Transaction/Persistence buckets ----------
-
-    @Test
-    void handleServlet_queryTimeout_true() {
-        QueryTimeoutException ex = new QueryTimeoutException("q", null, null);
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleServletExceptions(ex);
-
-        assertEquals(HttpStatus.REQUEST_TIMEOUT, r.getStatusCode());
-        assertEquals(true, r.getBody().getProperties().get("retriable"));
-    }
-
-    @Test
-    void handleServlet_noResource_false() {
-        NoResourceFoundException ex = new NoResourceFoundException(HttpMethod.GET, "/x", "missing");
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleServletExceptions(ex);
-        assertEquals(HttpStatus.NOT_FOUND, r.getStatusCode());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
-    }
-
-    @Test
-    void handleServlet_txTransient_true() {
-        // underlying cause -> transient PSQLState (deadlock 40P01)
-        TransactionSystemException ex = new TransactionSystemException(
-            "tx", new PSQLException("deadlock", PSQLState.DEADLOCK_DETECTED));
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleServletExceptions(ex);
-
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, r.getStatusCode());
-        assertEquals(true, r.getBody().getProperties().get("retriable"));
-    }
-
-    @Test
-    void handleServlet_txNonTransient_false() {
-        // underlying cause -> non-transient PSQLState (syntax error)
-        TransactionSystemException ex = new TransactionSystemException(
-            "tx", new PSQLException("syntax", PSQLState.SYNTAX_ERROR));
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleServletExceptions(ex);
-
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, r.getStatusCode());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
-    }
-
-    @Test
-    void handleServlet_otherPersistence_false() {
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler
-            .handleServletExceptions(new PersistenceException("oops"));
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, r.getStatusCode());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
-    }
-
-    // ---------- PostgreSQL buckets ----------
-
-    @Test
-    void handlePsql_connectivity_true() throws Exception {
-        PSQLException ex = new PSQLException("db down", PSQLState.CONNECTION_FAILURE,
-                                             new ConnectException("refused"));
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handlePsqlException(ex);
-
-        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, r.getStatusCode());
-        assertEquals(true, r.getBody().getProperties().get("retriable"));
-        assertEquals(URI.create("https://hmcts.gov.uk/problems/database-unavailable"), r.getBody().getType());
-    }
-
-    @Test
-    void handlePsql_other_false() {
-        PSQLException ex = new PSQLException("db err", PSQLState.UNEXPECTED_ERROR, new Throwable("t"));
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handlePsqlException(ex);
-
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, r.getStatusCode());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
-        assertEquals(URI.create("https://hmcts.gov.uk/problems/database-error"), r.getBody().getType());
-    }
-
-    // ---------- DataAccess ----------
-
-    @Test
-    void handleDataAccessResourceFailure_true() {
-        DataAccessResourceFailureException ex = new DataAccessResourceFailureException("down");
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleDataAccessResourceFailureException(ex);
-
-        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, r.getStatusCode());
-        assertEquals(true, r.getBody().getProperties().get("retriable"));
-    }
-
-    // ---------- Lazy & JPA ----------
-
-    @Test
-    void handleLazy_false() {
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler
-            .handleLazyInitializationException(new LazyInitializationException("lazy"));
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, r.getStatusCode());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
-    }
-
-    @Test
-    void handleJpa_transient_true() {
-        // most specific cause -> SERIALIZATION_FAILURE (40001) -> true
-        PSQLException psql = new PSQLException("serial", PSQLState.SERIALIZATION_FAILURE);
-        JpaSystemException ex = new JpaSystemException(new RuntimeException("wrap", psql));
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleJpaSystemException(ex);
-
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, r.getStatusCode());
-        assertEquals(true, r.getBody().getProperties().get("retriable"));
-    }
-
-    @Test
-    void handleJpa_nonTransient_false() {
-        JpaSystemException ex = new JpaSystemException(new RuntimeException("plain"));
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleJpaSystemException(ex);
-
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, r.getStatusCode());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
-    }
-
-    // ---------- HttpServerErrorException ----------
-
-    @Test
-    void handleHttpServerError_forced500_retriableFalse() {
-        HttpServerErrorException ex = HttpServerErrorException.create(
-            HttpStatusCode.valueOf(404), "Not Found!", HttpHeaders.EMPTY, null, null);
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleHttpServerErrorException(ex);
-
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, r.getStatusCode());
-        ProblemDetail pd = r.getBody();
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), pd.getStatus());
-        assertEquals("Downstream Server Error", pd.getTitle());
-        assertEquals("Not Found!", pd.getDetail());
-        assertEquals(URI.create("https://hmcts.gov.uk/problems/http-server-error"), pd.getType());
-        assertEquals(false, pd.getProperties().get("retriable"));
-        assertNotNull(pd.getInstance());
-        assertTrue(r.getHeaders().getContentType().toString().contains(MediaType.APPLICATION_PROBLEM_JSON_VALUE));
-    }
-
-    @Test
-    void handleHttpServerError_forced500_retriableTrueOn503() {
-        HttpServerErrorException ex = HttpServerErrorException.create(
-            HttpStatusCode.valueOf(503), "Service Unavailable", HttpHeaders.EMPTY, null, null);
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleHttpServerErrorException(ex);
-
-        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, r.getStatusCode());
-        assertEquals(true, r.getBody().getProperties().get("retriable")); // 503 -> true
-    }
-
-    @Test
-    void handleHttpServerError_blankStatusText_fallsBackToMessage() {
-        HttpServerErrorException ex = HttpServerErrorException.create(
-            HttpStatusCode.valueOf(500), " ", HttpHeaders.EMPTY, null, null);
-
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleHttpServerErrorException(ex);
-
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, r.getStatusCode());
-        assertEquals(ex.getMessage(), r.getBody().getDetail());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
-    }
-
-    // ---------- JSON schema & IllegalArgument ----------
-
-    @Test
-    void handleJsonSchema_false() {
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler
-            .handleJsonSchemaValidationException(new JsonSchemaValidationException("bad schema"));
-        assertEquals(HttpStatus.BAD_REQUEST, r.getStatusCode());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
-    }
-
-    @Test
-    void handleSchemaConfiguration_false() {
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler
-            .handleSchemaConfigurationException(new SchemaConfigurationException("missing config"));
-
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, r.getStatusCode());
-        ProblemDetail pd = r.getBody();
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), pd.getStatus());
-        assertEquals("Internal Server Error", pd.getTitle());
-        assertEquals("missing config", pd.getDetail());
-        assertEquals(URI.create("https://hmcts.gov.uk/problems/internal-server-error"), pd.getType());
-        assertEquals(false, pd.getProperties().get("retriable"));
-    }
-
-    @Test
-    void handleInvalidReferenceValidation_false() {
-        InvalidReferenceValidationException ex = new InvalidReferenceValidationException("bad reference data");
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleInvalidReferenceValidationException(ex);
-
-        assertEquals(HttpStatus.BAD_REQUEST, r.getStatusCode());
-        ProblemDetail pd = r.getBody();
-        assertEquals("Bad Request", pd.getTitle());
-        assertEquals("bad reference data", pd.getDetail());
-        assertEquals(URI.create("https://hmcts.gov.uk/problems/invalid-reference-validation"), pd.getType());
-        assertEquals(false, pd.getProperties().get("retriable"));
-    }
-
-    @Test
-    void handleIllegalArgument_false() {
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler
-            .handleIllegalArgumentException(new IllegalArgumentException("bad arg"));
-        assertEquals(HttpStatus.BAD_REQUEST, r.getStatusCode());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
-    }
-
-    // ---------- Conflicts ----------
-
-    @Test
-    void handleOptimisticLock_false() {
-        ObjectOptimisticLockingFailureException ex =
-            new ObjectOptimisticLockingFailureException(DraftAccountEntity.class, "123");
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleObjectOptimisticLockingFailureException(ex);
-
-        assertEquals(HttpStatus.CONFLICT, r.getStatusCode());
-        ProblemDetail pd = r.getBody();
-        assertEquals(false, pd.getProperties().get("retriable"));
-        assertEquals(DraftAccountEntity.class.getName(), pd.getProperties().get("resourceType"));
-        assertEquals("123", pd.getProperties().get("resourceId"));
-    }
-
-    @Test
-    void handleResourceConflict_false() {
-        ResourceConflictException ex = new ResourceConflictException("DraftAccount", "123", "BU mismatch", null);
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleResourceConflictException(ex);
-
-        assertEquals(HttpStatus.CONFLICT, r.getStatusCode());
-        ProblemDetail pd = r.getBody();
-        assertEquals(false, pd.getProperties().get("retriable"));
-        assertEquals("DraftAccount", pd.getProperties().get("resourceType"));
-        assertEquals("123", pd.getProperties().get("resourceId"));
-        assertEquals("BU mismatch", pd.getProperties().get("conflictReason"));
-        assertNull(r.getHeaders().getETag());
-    }
-
-    @Test
-    void handleResourceConflict_withVersioned() {
+    void handleResourceConflict_returnsPropertiesAndEtag() {
         ResourceConflictException ex = new ResourceConflictException(
-            "DraftAccount", "123", "BU mismatch", () -> BigInteger.valueOf(666));
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleResourceConflictException(ex);
+            DraftAccountEntity.class.getSimpleName(),
+            123,
+            "BU mismatch",
+            () -> BigInteger.valueOf(666)
+        );
 
-        assertEquals(HttpStatus.CONFLICT, r.getStatusCode());
-        ProblemDetail pd = r.getBody();
-        assertEquals(false, pd.getProperties().get("retriable"));
-        assertEquals("DraftAccount", pd.getProperties().get("resourceType"));
-        assertEquals("123", pd.getProperties().get("resourceId"));
-        assertEquals("BU mismatch", pd.getProperties().get("conflictReason"));
-        assertEquals("\"666\"", r.getHeaders().getETag());
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleResourceConflictException(ex);
+
+        assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+        assertEquals(false, response.getBody().getProperties().get("retriable"));
+        assertEquals("DraftAccountEntity", response.getBody().getProperties().get("resourceType"));
+        assertEquals("123", response.getBody().getProperties().get("resourceId"));
+        assertEquals("BU mismatch", response.getBody().getProperties().get("conflictReason"));
+        assertEquals("\"666\"", response.getHeaders().getETag());
     }
 
     @Test
-    void handleUnprocessableException() {
-        UnprocessableException ex = new UnprocessableException("Too many results");
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleUnprocessableException(ex);
-
-        assertEquals(HttpStatus.UNPROCESSABLE_CONTENT, r.getStatusCode());
-        ProblemDetail pd = r.getBody();
-        assertEquals("Unprocessable Content", pd.getTitle());
-        assertEquals("Too many results", pd.getDetail());
-        assertEquals(false, pd.getProperties().get("retriable"));
-        assertEquals("Too many results", pd.getProperties().get("unprocessableReason"));
-        assertNull(r.getHeaders().getETag());
-    }
-
-    @Test
-    void handleSubmitterCannotValidate_forbidden() {
+    void handleSubmitterDenied_returnsForbiddenProblem() {
         SubmitterDeniedException ex = new SubmitterDeniedException("Pable", "validate");
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleActionDeniedForSubmitterException(ex);
 
-        assertEquals(HttpStatus.FORBIDDEN, r.getStatusCode());
-        ProblemDetail pd = r.getBody();
-        assertEquals(HttpStatus.FORBIDDEN.value(), pd.getStatus());
-        assertEquals("Submitter cannot validate", pd.getTitle());
-        assertEquals("A single user cannot submit and validate the same Draft Account", pd.getDetail());
-        assertEquals(URI.create("https://hmcts.gov.uk/problems/submitter-cannot-validate"), pd.getType());
-        assertEquals(false, pd.getProperties().get("retriable"));
-    }
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleActionDeniedForSubmitterException(ex);
 
-    // ---------- FeignException (generic handler) ----------
-
-    @Test
-    void handleFeign_generic_503_retriableTrue() {
-        FeignException ex = buildFeignException(503, "Service Unavailable");
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleFeignException(ex);
-
-        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, r.getStatusCode());
-        assertEquals(true, r.getBody().getProperties().get("retriable"));
-        assertEquals("Downstream Service Error", r.getBody().getTitle());
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+        assertEquals("Submitter cannot validate", response.getBody().getTitle());
+        assertEquals(
+            "A single user cannot submit and validate the same Draft Account",
+            response.getBody().getDetail()
+        );
+        assertEquals(
+            URI.create("https://hmcts.gov.uk/problems/submitter-cannot-validate"),
+            response.getBody().getType()
+        );
     }
 
     @Test
-    void handleFeign_generic_500_retriableFalse() {
-        FeignException ex = buildFeignException(500, "Boom");
-        ResponseEntity<ProblemDetail> r = globalExceptionHandler.handleFeignException(ex);
+    void handlePaymentCardRequestAlreadyExists_returnsConflictProblemAndEtag() {
+        GlobalExceptionHandler.PaymentCardRequestAlreadyExistsException ex =
+            new GlobalExceptionHandler.PaymentCardRequestAlreadyExistsException(
+                "DraftAccount",
+                "123",
+                () -> BigInteger.valueOf(99)
+            );
 
-        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, r.getStatusCode());
-        assertEquals(false, r.getBody().getProperties().get("retriable"));
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handlePaymentCardRequestAlreadyExists(ex);
+
+        assertEquals(HttpStatus.CONFLICT, response.getStatusCode());
+        assertEquals("Conflict", response.getBody().getTitle());
+        assertEquals("A payment card request already exists for this account.", response.getBody().getDetail());
+        assertEquals(true, response.getBody().getProperties().get("retriable"));
+        assertEquals("DraftAccount", response.getBody().getProperties().get("resourceType"));
+        assertEquals("123", response.getBody().getProperties().get("resourceId"));
+        assertEquals("\"99\"", response.getHeaders().getETag());
     }
 
-    // ---------- util ----------
+    @Test
+    void handlePaymentCardRequestAlreadyExists_withoutVersionedOmitsEtag() {
+        GlobalExceptionHandler.PaymentCardRequestAlreadyExistsException ex =
+            new GlobalExceptionHandler.PaymentCardRequestAlreadyExistsException("DraftAccount", "123");
 
-    public static void sampleMethod(Integer testParam) {
-        // no-op
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handlePaymentCardRequestAlreadyExists(ex);
+
+        assertNull(response.getHeaders().getETag());
+    }
+
+    @Test
+    void handleFeignUnauthorized_returnsUnauthorizedProblem() {
+        FeignException.Unauthorized ex = (FeignException.Unauthorized) buildFeignException(401, "Unauthorized");
+
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleFeignExceptionUnauthorized(ex);
+
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
+        assertEquals("Not Authorised for Connection", response.getBody().getTitle());
+        assertEquals(false, response.getBody().getProperties().get("retriable"));
     }
 
     private static FeignException buildFeignException(int status, String reason) {

--- a/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
@@ -7,6 +7,7 @@ import feign.FeignException;
 import feign.Request;
 import feign.RequestTemplate;
 import feign.Response;
+import jakarta.persistence.EntityNotFoundException;
 import java.math.BigInteger;
 import java.net.URI;
 import java.util.Collection;
@@ -102,6 +103,19 @@ class GlobalExceptionHandlerTest {
         assertEquals("Defendant Account Not Found", response.getBody().getTitle());
         assertEquals("Defendant account not found with id: 999999999", response.getBody().getDetail());
         assertEquals(false, response.getBody().getProperties().get("retriable"));
+    }
+
+    @Test
+    void handleEntityNotFound_returnsSanitizedNotFoundProblem() {
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleEntityNotFoundException(
+            new EntityNotFoundException("Defendant Account not found with id: 999999999")
+        );
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertEquals("Entity Not Found", response.getBody().getTitle());
+        assertEquals("The requested entity could not be found", response.getBody().getDetail());
+        assertEquals(false, response.getBody().getProperties().get("retriable"));
+        assertNull(response.getBody().getProperties().get("reason"));
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-8671


### Change description ###
Removes duplicated shared exception handling from Fines Service and brings its error contract back in line with the common library.

- refactored `GlobalExceptionHandler` in Fines Service to rely on `opal-common-lib` for shared exception mappings
- removed duplicated local handlers and kept only the Fines-specific exception handling that still belongs in this service
- kept problem detail creation aligned with the shared common-lib behaviour
- restored a local high-precedence `EntityNotFoundException` handler to prevent generic 404 responses from leaking internal `reason` details
- updated unit and integration coverage for the sanitized generic not-found response contract

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
