### PR TITLE
ReadMe updated, and fix for report output exists for integration tests

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -280,7 +280,6 @@ def runFunctionalStage = { stageName, shouldRunWithZephyr, reportNameSuffix ->
     stage(stageName) {
       deleteStageOutputs([
         'functional-output',
-        'functional-test-report',
         'build/reports/tests/functionalOpal',
         'build/test-results/functional',
         'target/zephyr-reports/cucumber-opal.json',
@@ -299,7 +298,7 @@ def runFunctionalStage = { stageName, shouldRunWithZephyr, reportNameSuffix ->
             'Functional Tests Report',
             'functional-output',
             'functional-output',
-            ['functional-test-report', 'build/reports/tests/functionalOpal'],
+            ['functional-output/report', 'build/reports/tests/functionalOpal'],
             reportNameSuffix,
             'build/test-results/functional/opal/*.xml',
             'functional-output/zephyr/cucumber-opal.json'
@@ -353,9 +352,9 @@ def runTaggedFunctionalStage = { enabled, stageName, shouldRunWithZephyr, report
       deleteStageOutputs([
         reportDirectory,
         'functional-output-demo',
-        'functional-test-report-demo',
         'build/reports/tests/functionalOpalTags',
         'build/test-results/functional',
+        'build/serenity-functional-demo',
         'target/zephyr-reports/cucumber-opal-tags.json',
         'target/site/serenity',
         'target/cucumber.json',
@@ -374,7 +373,7 @@ def runTaggedFunctionalStage = { enabled, stageName, shouldRunWithZephyr, report
             "${stageName} Report",
             reportDirectory,
             'functional-output-demo',
-            ['functional-test-report-demo', 'build/reports/tests/functionalOpalTags'],
+            ['functional-output-demo/report', 'build/reports/tests/functionalOpalTags'],
             reportNameSuffix,
             'build/test-results/functional/opal-tags/*.xml',
             "${reportDirectory}/zephyr/cucumber-opal-tags.json"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -130,7 +130,11 @@ def ensureReportOutputExists = { reportLabel, targetDirectory, candidateDirector
 
 def publishIntegrationResults = {
   steps.junit allowEmptyResults: true, testResults: '**/test-results/integration/*.xml'
-  ensureIntegrationReportOutputExists()
+  ensureReportOutputExists(
+    'Integration Tests Report',
+    'integration-output',
+    ['build/reports/tests/integration']
+  )
 
   if (!steps.fileExists('integration-output/zephyr/Junit5Report-IntegrationTest.json')) {
     throw new RuntimeException('Integration Zephyr report was not generated at integration-output/zephyr/Junit5Report-IntegrationTest.json')
@@ -145,14 +149,6 @@ def publishIntegrationResults = {
     reportFiles          : 'index.html',
     reportName           : 'Integration Tests Report'
   ]
-}
-
-def ensureIntegrationReportOutputExists() {
-  ensureReportOutputExists(
-    'Integration Tests Report',
-    'integration-output',
-    ['build/reports/tests/integration']
-  )
 }
 
 def packageFunctionalReportOutput = { reportLabel, reportDirectory, sourceOutputDirectory, candidateReportDirectories ->

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Use the standard functional suite for normal backend functional coverage:
 ```
 
 This runs the default Opal and Legacy functional suites and publishes the Serenity
-functional report under `functional-test-report/`.
+functional report under `functional-output/report/`.
 
 Use the tagged Opal functional suite when you need to run only scenarios for a specific
 feature-flag or business-area configuration:
@@ -245,6 +245,8 @@ execution recorded through the existing cucumber-report Zephyr flow:
 Common examples:
 
 ```bash / zsh
+  ./gradlew functionalOpalTagsR1AOnly
+  ./gradlew functionalOpalTagsR1AOff
   TAGS='@R1AOff and not @Ignore' ./gradlew functionalOpalTags
   TAGS='@R1BOff and not @Ignore' ./gradlew functionalOpalTags
   TAGS='@R1B and @R1C and not @Ignore' ./gradlew functionalWithTags
@@ -291,12 +293,17 @@ does not run the full backend functional suite.
 
 Nightly reports and artifacts:
 
-- Staging integration publishes `Integration Tests Report`.
+- Staging integration publishes the JUnit HTML `Integration Tests Report`.
 - Staging functional publishes `Serenity Functional Test Report`.
 - Staging smoke publishes `Serenity Smoke Test Report`.
 - Demo R1A publishes `Serenity Functional Test Report (Demo R1AOn Only)`.
 - Demo R1AOff publishes `Serenity Functional Test Report (Demo R1AOff)`.
-- Tagged demo runs archive to `functional-output-demo`; staging functional archives to `functional-output`, integration to `integration-output`, and smoke to `smoke-output`.
+- Generic local tagged demo Gradle runs package to `functional-output-demo`; the generic local demo Serenity HTML report is under `functional-output-demo/report`.
+- Local `functionalOpalTagsR1AOnly` packages to `functional-output-r1a-only-demo`; the local demo Serenity HTML report is under `functional-output-r1a-only-demo/report`.
+- Local `functionalOpalTagsR1AOff` packages to `functional-output-r1a-off-demo`; the local demo Serenity HTML report is under `functional-output-r1a-off-demo/report`.
+- Nightly `RunR1AOnly` archives to `functional-output-r1a-only-demo`; the nightly demo Serenity HTML report is under `functional-output-r1a-only-demo/report`.
+- Nightly `RunR1AOff` archives to `functional-output-r1a-off-demo`; the nightly demo Serenity HTML report is under `functional-output-r1a-off-demo/report`.
+- Staging functional archives to `functional-output`, integration to `integration-output`, and smoke to `smoke-output`.
 - Functional and smoke outputs are published from `*/report` with Zephyr payloads under `*/zephyr`. Integration publishes `integration-output/report` and archives `integration-output/zephyr` when the integration Zephyr JSON is generated.
 - When `ZephyrExecution=true` or the nightly run is on Friday, the nightly pipeline runs the selected test stage first, publishes its artifacts, then invokes the matching generic Zephyr execution task.
 
@@ -313,9 +320,9 @@ This repo-local Jenkinsfile does not declare its own job parameters.
 
 CNP outputs:
 
-- Integration publishes JUnit XML from `build/test-results/integration`, archives `integration-output/**/*`, and publishes `Integration Tests Report` from `integration-output/report`.
-- Functional archives `functional-output/**/*` and publishes `Serenity Functional Test Report`.
-- Smoke archives `smoke-output/**/*` and publishes `Serenity Smoke Test Report`.
+- Integration publishes JUnit XML from `build/test-results/integration`, archives `integration-output/**/*`, and publishes the JUnit HTML `Integration Tests Report` from `integration-output/report`.
+- Functional archives `functional-output/**/*` and publishes `Serenity Functional Test Report` from `functional-output/report`.
+- Smoke archives `smoke-output/**/*` and publishes `Serenity Smoke Test Report` from `smoke-output/report`.
 
 CNP failure handling:
 
@@ -345,8 +352,8 @@ Local report paths:
 | `integration` | `createJiraExecutionFromIntegrationReport` | `target/zephyr-reports/Junit5Report-IntegrationTest.json` | `integration-output/zephyr/Junit5Report-IntegrationTest.json` |
 | `functional` | `-PzephyrFunctionalStage=functional createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal.json` | `functional-output/zephyr/cucumber-opal.json` |
 | `smoke` | `-PzephyrFunctionalStage=smoke createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-smoke.json` | `smoke-output/zephyr/cucumber-smoke.json` |
-| `runR1AOnly` | `-PzephyrFunctionalStage=runR1AOnly createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal-tags.json` | `functional-output-demo/zephyr/cucumber-opal-tags.json` |
-| `runR1AOff` | `-PzephyrFunctionalStage=runR1AOff createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal-tags.json` | `functional-output-demo/zephyr/cucumber-opal-tags.json` |
+| `runR1AOnly` | `./gradlew functionalOpalTagsR1AOnly` then `-PzephyrFunctionalStage=runR1AOnly createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal-tags.json` | `functional-output-r1a-only-demo/zephyr/cucumber-opal-tags.json` |
+| `runR1AOff` | `./gradlew functionalOpalTagsR1AOff` then `-PzephyrFunctionalStage=runR1AOff createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal-tags.json` | `functional-output-r1a-off-demo/zephyr/cucumber-opal-tags.json` |
 
 Examples:
 
@@ -371,10 +378,10 @@ export TEST_URL=https://opal-fines-service.demo.platform.hmcts.net
 export OPAL_USER_SERVICE_API_URL=https://opal-user-service.demo.platform.hmcts.net
 export OPAL_LOGGING_SERVICE_API_URL=https://opal-logging-service.demo.platform.hmcts.net
 
-TAGS='(@JIRA-LABEL:manual-account-creation or (@Opal and @FeatureToggle and @R1BOff)) and not @Smoke and not @Ignore and not (@R1AOff or @R1B or @R1COff or @R1C or @R1CFinance or @R1CWriteOff or @R1CWriteOffOff or @R1CEnforcementOperationalReporting or @R1CEnforcementOperationalReportingOff or @R1CAdministration)' ./gradlew functionalOpalTags
+./gradlew functionalOpalTagsR1AOnly
 ./gradlew -PzephyrFunctionalStage=runR1AOnly createJiraExecutionFromFunctionalReport
 
-TAGS='@R1AOff and not @Ignore' ./gradlew functionalOpalTags
+./gradlew functionalOpalTagsR1AOff
 ./gradlew -PzephyrFunctionalStage=runR1AOff createJiraTicketsFromFunctionalReport
 ./gradlew -PzephyrFunctionalStage=runR1AOff updateJiraTicketsFromFunctionalReport
 ./gradlew -PzephyrFunctionalStage=runR1AOff createJiraExecutionFromFunctionalReport

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Nightly reports and artifacts:
 - Staging smoke publishes `Serenity Smoke Test Report`.
 - Demo R1A publishes `Serenity Functional Test Report (Demo R1AOn Only)`.
 - Demo R1AOff publishes `Serenity Functional Test Report (Demo R1AOff)`.
-- Archived output folders are `integration-output`, `functional-output`, `functional-output-r1a-only-demo`, `functional-output-r1a-off-demo`, and `smoke-output`.
+- Tagged demo runs archive to `functional-output-demo`; staging functional archives to `functional-output`, integration to `integration-output`, and smoke to `smoke-output`.
 - Functional and smoke outputs are published from `*/report` with Zephyr payloads under `*/zephyr`. Integration publishes `integration-output/report` and archives `integration-output/zephyr` when the integration Zephyr JSON is generated.
 - When `ZephyrExecution=true` or the nightly run is on Friday, the nightly pipeline runs the selected test stage first, publishes its artifacts, then invokes the matching generic Zephyr execution task.
 
@@ -334,6 +334,20 @@ The create and update tasks process an existing test report; they do not run the
 Run the matching functional or integration suite first if the report is not already present.
 For local tagged runs, make sure the local fines service is already configured with the intended feature-flag state before executing the test command (and LAUNCH_DARKLY_ENABLED=false)
 
+When reusing reports copied from Jenkins artifacts, place the raw Zephyr JSON in the source location that the
+Gradle sync task rebuilds from before the Jira task runs. Do not rely on copying only into the archived
+`*-output*/zephyr` folder, because the sync task will recreate that folder from the raw source path.
+
+Local report paths:
+
+| Flow | Gradle task | Raw JSON source path to populate locally | Rebuilt packaged path used by the Zephyr task |
+| --- | --- | --- | --- |
+| `integration` | `createJiraExecutionFromIntegrationReport` | `target/zephyr-reports/Junit5Report-IntegrationTest.json` | `integration-output/zephyr/Junit5Report-IntegrationTest.json` |
+| `functional` | `-PzephyrFunctionalStage=functional createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal.json` | `functional-output/zephyr/cucumber-opal.json` |
+| `smoke` | `-PzephyrFunctionalStage=smoke createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-smoke.json` | `smoke-output/zephyr/cucumber-smoke.json` |
+| `runR1AOnly` | `-PzephyrFunctionalStage=runR1AOnly createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal-tags.json` | `functional-output-demo/zephyr/cucumber-opal-tags.json` |
+| `runR1AOff` | `-PzephyrFunctionalStage=runR1AOff createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal-tags.json` | `functional-output-demo/zephyr/cucumber-opal-tags.json` |
+
 Examples:
 
 ```bash
@@ -365,6 +379,10 @@ TAGS='@R1AOff and not @Ignore' ./gradlew functionalOpalTags
 ./gradlew -PzephyrFunctionalStage=runR1AOff updateJiraTicketsFromFunctionalReport
 ./gradlew -PzephyrFunctionalStage=runR1AOff createJiraExecutionFromFunctionalReport
 ```
+
+Available Zephyr tasks:
+
+Use the task that matches the populated raw JSON source above.
 
 | Task | Purpose |
 | --- | --- |

--- a/build.gradle
+++ b/build.gradle
@@ -332,11 +332,11 @@ tasks.register('functionalOpal', Test) {
   reports.junitXml.getOutputLocation().set(layout.buildDirectory.dir("test-results/functional/opal"))
   testLogging.showStandardStreams = true
   environment("IS_LEGACY_MODE", "false")
-  systemProperty 'serenity.outputDirectory', "${rootDir}/functional-test-report"
-  systemProperty 'cucumber.plugin', "json:${rootDir}/target/zephyr-reports/cucumber-opal.json"
+  systemProperty 'cucumber.plugin',
+    "net.serenitybdd.cucumber.core.plugin.SerenityReporterParallel,pretty,json:${rootDir}/target/zephyr-reports/cucumber-opal.json,timeline:${rootDir}/target/test-results/timeline"
   include '**/OpalTestRunner.class'
 
-  finalizedBy 'copyOpalCucumberJson'
+  finalizedBy 'copyOpalCucumberJson', 'mergeFunctionalResults', 'aggregate', 'copyFunctionalReport'
 }
 
 tasks.register('copyOpalCucumberJson', Copy) {
@@ -354,8 +354,8 @@ tasks.register('functionalOpalTags', Test) {
   reports.junitXml.getOutputLocation().set(layout.buildDirectory.dir("test-results/functional/opal-tags"))
   testLogging.showStandardStreams = true
   environment("IS_LEGACY_MODE", "false")
-  systemProperty 'serenity.outputDirectory', "${rootDir}/functional-test-report-demo"
-  systemProperty 'cucumber.plugin', "json:${rootDir}/target/zephyr-reports/cucumber-opal-tags.json"
+  systemProperty 'cucumber.plugin',
+    "net.serenitybdd.cucumber.core.plugin.SerenityReporterParallel,pretty,json:${rootDir}/target/zephyr-reports/cucumber-opal-tags.json,timeline:${rootDir}/target/test-results/timeline"
 
   include '**/OpalTaggedTestRunner.class'
 
@@ -373,12 +373,67 @@ tasks.register('functionalOpalTags', Test) {
     systemProperty 'cucumber.filter.tags', cucumberTags.toString()
   }
 
-  finalizedBy 'copyOpalTagsCucumberJson'
+  finalizedBy 'copyOpalTagsCucumberJson', 'mergeFunctionalOpalTagsResults', 'aggregate', 'copyDemoFunctionalReport',
+    'packageTaggedDemoFunctionalOutput'
+}
+
+tasks.register('functionalOpalTagsR1AOnly', Test) {
+  description = "Runs the demo R1A-only tagged Opal functional tests"
+  group = "Verification"
+  testClassesDirs = sourceSets.functionalTest.output.classesDirs
+  classpath = sourceSets.functionalTest.runtimeClasspath
+  outputs.upToDateWhen { false }
+  reports.junitXml.getOutputLocation().set(layout.buildDirectory.dir("test-results/functional/opal-tags-r1a-only"))
+  testLogging.showStandardStreams = true
+  environment("IS_LEGACY_MODE", "false")
+  systemProperty 'cucumber.plugin',
+    "net.serenitybdd.cucumber.core.plugin.SerenityReporterParallel,pretty,json:${rootDir}/target/zephyr-reports/cucumber-opal-tags.json,timeline:${rootDir}/target/test-results/timeline"
+
+  include '**/OpalTaggedTestRunner.class'
+
+  doFirst {
+    systemProperty 'cucumber.filter.tags', '@JIRA-LABEL:manual-account-creation and not @Ignore'
+  }
+
+  finalizedBy 'copyR1AOnlyDemoCucumberJson', 'mergeFunctionalOpalTagsR1AOnlyResults', 'aggregate', 'copyR1AOnlyDemoFunctionalReport'
+}
+
+tasks.register('functionalOpalTagsR1AOff', Test) {
+  description = "Runs the demo R1A-off tagged Opal functional tests"
+  group = "Verification"
+  testClassesDirs = sourceSets.functionalTest.output.classesDirs
+  classpath = sourceSets.functionalTest.runtimeClasspath
+  outputs.upToDateWhen { false }
+  reports.junitXml.getOutputLocation().set(layout.buildDirectory.dir("test-results/functional/opal-tags-r1a-off"))
+  testLogging.showStandardStreams = true
+  environment("IS_LEGACY_MODE", "false")
+  systemProperty 'cucumber.plugin',
+    "net.serenitybdd.cucumber.core.plugin.SerenityReporterParallel,pretty,json:${rootDir}/target/zephyr-reports/cucumber-opal-tags.json,timeline:${rootDir}/target/test-results/timeline"
+
+  include '**/OpalTaggedTestRunner.class'
+
+  doFirst {
+    systemProperty 'cucumber.filter.tags', '@R1AOff and not @Ignore'
+  }
+
+  finalizedBy 'copyR1AOffDemoCucumberJson', 'mergeFunctionalOpalTagsR1AOffResults', 'aggregate', 'copyR1AOffDemoFunctionalReport'
 }
 
 tasks.register('copyOpalTagsCucumberJson', Copy) {
   from("${rootDir}/target/zephyr-reports/cucumber-opal-tags.json")
   into("${rootDir}/functional-output-demo/zephyr")
+  outputs.upToDateWhen { false }
+}
+
+tasks.register('copyR1AOnlyDemoCucumberJson', Copy) {
+  from("${rootDir}/target/zephyr-reports/cucumber-opal-tags.json")
+  into("${rootDir}/functional-output-r1a-only-demo/zephyr")
+  outputs.upToDateWhen { false }
+}
+
+tasks.register('copyR1AOffDemoCucumberJson', Copy) {
+  from("${rootDir}/target/zephyr-reports/cucumber-opal-tags.json")
+  into("${rootDir}/functional-output-r1a-off-demo/zephyr")
   outputs.upToDateWhen { false }
 }
 
@@ -391,8 +446,8 @@ tasks.register('functionalLegacy', Test) {
   reports.junitXml.getOutputLocation().set(layout.buildDirectory.dir("test-results/functional/legacy"))
   testLogging.showStandardStreams = true
   environment("IS_LEGACY_MODE", "true")
-  systemProperty 'serenity.outputDirectory', "${rootDir}/functional-test-report-legacy"
-  systemProperty 'cucumber.plugin', "json:${rootDir}/target/zephyr-reports/cucumber-legacy.json"
+  systemProperty 'cucumber.plugin',
+    "net.serenitybdd.cucumber.core.plugin.SerenityReporterParallel,pretty,json:${rootDir}/target/zephyr-reports/cucumber-legacy.json,timeline:${rootDir}/target/test-results/timeline"
 
   include '**/LegacyTestRunner.class'
   finalizedBy 'copyLegacyCucumberJson'
@@ -407,45 +462,45 @@ tasks.register('copyLegacyCucumberJson', Copy) {
 tasks.register('copyFunctionalReport', Copy) {
   dependsOn 'aggregate'
   from("${rootDir}/target/site/serenity")
-  into("${rootDir}/functional-test-report")
+  into("${rootDir}/functional-output/report")
   doLast {
-    logPublishedHtmlReport("Functional Test Report", "${rootDir}/functional-test-report")
+    logPublishedHtmlReport("Functional Test Report", "${rootDir}/functional-output/report")
   }
 }
 tasks.register('copyDemoFunctionalReport', Copy) {
   dependsOn 'aggregate'
   from("${rootDir}/target/site/serenity")
-  into("${rootDir}/functional-test-report-demo")
+  into("${rootDir}/functional-output-demo/report")
   doLast {
-    logPublishedHtmlReport("Demo Functional Test Report", "${rootDir}/functional-test-report-demo")
+    logPublishedHtmlReport("Demo Functional Test Report", "${rootDir}/functional-output-demo/report")
   }
 }
-tasks.register('packageFunctionalOutput', Copy) {
-  dependsOn 'copyFunctionalReport', 'copyOpalCucumberJson'
-  into("${rootDir}/functional-output")
-  from("${rootDir}/functional-test-report") {
-    into("report")
+
+tasks.register('copyR1AOnlyDemoFunctionalReport', Copy) {
+  dependsOn 'aggregate'
+  from("${rootDir}/target/site/serenity")
+  into("${rootDir}/functional-output-r1a-only-demo/report")
+  doLast {
+    logPublishedHtmlReport("Demo R1A Functional Test Report", "${rootDir}/functional-output-r1a-only-demo/report")
   }
 }
-tasks.register('packageDemoFunctionalOutput', Copy) {
-  dependsOn 'copyDemoFunctionalReport', 'copyOpalTagsCucumberJson'
-  into("${rootDir}/functional-output-demo")
-  from("${rootDir}/functional-test-report-demo") {
-    into("report")
+
+tasks.register('copyR1AOffDemoFunctionalReport', Copy) {
+  dependsOn 'aggregate'
+  from("${rootDir}/target/site/serenity")
+  into("${rootDir}/functional-output-r1a-off-demo/report")
+  doLast {
+    logPublishedHtmlReport("Demo R1AOff Functional Test Report", "${rootDir}/functional-output-r1a-off-demo/report")
   }
 }
 tasks.register('packageTaggedDemoFunctionalOutput', Copy) {
   dependsOn 'copyDemoFunctionalReport', 'copyOpalTagsCucumberJson'
-  into("${rootDir}/functional-output-demo")
-  from("${rootDir}/functional-test-report-demo") {
-    into("report")
-  }
 }
 tasks.register('syncFunctionalArtifactsFromExistingResults') {
   doLast {
     syncFunctionalArtifacts(
       'Functional Test Report',
-      "${rootDir}/functional-test-report",
+      "${rootDir}/functional-output/report",
       "${rootDir}/functional-output",
       'cucumber-opal.json'
     )
@@ -455,8 +510,28 @@ tasks.register('syncTaggedFunctionalArtifactsFromExistingResults') {
   doLast {
     syncFunctionalArtifacts(
       'Demo Functional Test Report',
-      "${rootDir}/functional-test-report-demo",
+      "${rootDir}/functional-output-demo/report",
       "${rootDir}/functional-output-demo",
+      'cucumber-opal-tags.json'
+    )
+  }
+}
+tasks.register('syncR1AOnlyTaggedFunctionalArtifactsFromExistingResults') {
+  doLast {
+    syncFunctionalArtifacts(
+      'Demo R1A Functional Test Report',
+      "${rootDir}/functional-output-r1a-only-demo/report",
+      "${rootDir}/functional-output-r1a-only-demo",
+      'cucumber-opal-tags.json'
+    )
+  }
+}
+tasks.register('syncR1AOffTaggedFunctionalArtifactsFromExistingResults') {
+  doLast {
+    syncFunctionalArtifacts(
+      'Demo R1AOff Functional Test Report',
+      "${rootDir}/functional-output-r1a-off-demo/report",
+      "${rootDir}/functional-output-r1a-off-demo",
       'cucumber-opal-tags.json'
     )
   }
@@ -484,21 +559,28 @@ tasks.register('packageIntegrationOutput', Copy) {
   }
 }
 tasks.register('mergeFunctionalResults', Copy) {
-  dependsOn 'functionalOpal'
   from layout.buildDirectory.dir("test-results/functional/opal")
   into layout.buildDirectory.dir("test-results/functional")
   include '*.xml'
 }
 tasks.register('mergeFunctionalWithTagsResults', Copy) {
-  dependsOn 'functionalOpal', 'functionalOpalTags'
   from layout.buildDirectory.dir("test-results/functional/opal")
   from layout.buildDirectory.dir("test-results/functional/opal-tags")
   into layout.buildDirectory.dir("test-results/functional")
   include '*.xml'
 }
 tasks.register('mergeFunctionalOpalTagsResults', Copy) {
-  dependsOn 'functionalOpalTags'
   from layout.buildDirectory.dir("test-results/functional/opal-tags")
+  into layout.buildDirectory.dir("test-results/functional")
+  include '*.xml'
+}
+tasks.register('mergeFunctionalOpalTagsR1AOnlyResults', Copy) {
+  from layout.buildDirectory.dir("test-results/functional/opal-tags-r1a-only")
+  into layout.buildDirectory.dir("test-results/functional")
+  include '*.xml'
+}
+tasks.register('mergeFunctionalOpalTagsR1AOffResults', Copy) {
+  from layout.buildDirectory.dir("test-results/functional/opal-tags-r1a-off")
   into layout.buildDirectory.dir("test-results/functional")
   include '*.xml'
 }
@@ -510,7 +592,6 @@ tasks.register('functional') {
   tasks.mergeFunctionalResults.mustRunAfter functionalOpal
   tasks.aggregate.mustRunAfter functionalOpal
   tasks.copyFunctionalReport.mustRunAfter aggregate
-  finalizedBy 'packageFunctionalOutput'
 }
 
 tasks.register('functionalWithTags') {
@@ -534,11 +615,11 @@ tasks.register('smokeOpal', Test) {
   classpath = sourceSets.functionalTest.runtimeClasspath
   reports.junitXml.getOutputLocation().set(layout.buildDirectory.dir("test-results/smoke"))
   testLogging.showStandardStreams = true
-  systemProperty 'serenity.outputDirectory', "${rootDir}/smoke-test-report"
-  systemProperty 'cucumber.plugin', "json:${rootDir}/target/zephyr-reports/cucumber-smoke.json"
+  systemProperty 'cucumber.plugin',
+    "net.serenitybdd.cucumber.core.plugin.SerenityReporterParallel,pretty,json:${rootDir}/target/zephyr-reports/cucumber-smoke.json,timeline:${rootDir}/target/test-results/timeline"
 
   include '**/SmokeTestRunner.class'
-  finalizedBy 'copySmokeCucumberJson'
+  finalizedBy 'copySmokeCucumberJson', 'aggregate', 'copySmokeReport', 'packageSmokeOutput'
 
 }
 tasks.register('copySmokeReport', Copy) {
@@ -589,20 +670,29 @@ tasks.named('aggregate') {
     tasks.named('functionalOpal'),
     tasks.named('functionalLegacy'),
     tasks.named('functionalOpalTags'),
+    tasks.named('functionalOpalTagsR1AOnly'),
+    tasks.named('functionalOpalTagsR1AOff'),
     tasks.named('smokeOpal'),
     tasks.named('mergeFunctionalResults'),
     tasks.named('mergeFunctionalWithTagsResults'),
-    tasks.named('mergeFunctionalOpalTagsResults')
+    tasks.named('mergeFunctionalOpalTagsResults'),
+    tasks.named('mergeFunctionalOpalTagsR1AOnlyResults'),
+    tasks.named('mergeFunctionalOpalTagsR1AOffResults')
   )
 }
 
 tasks.configureEach {
-  if (name in ['copyFunctionalReport', 'copyDemoFunctionalReport', 'copySmokeReport']) {
+  if (name in ['copyFunctionalReport', 'copyDemoFunctionalReport', 'copyR1AOnlyDemoFunctionalReport',
+               'copyR1AOffDemoFunctionalReport', 'copySmokeReport']) {
     mustRunAfter tasks.named('aggregate')
   } else if (name == 'copyOpalCucumberJson') {
     mustRunAfter tasks.named('functionalOpal')
   } else if (name == 'copyOpalTagsCucumberJson') {
     mustRunAfter tasks.named('functionalOpalTags')
+  } else if (name == 'copyR1AOnlyDemoCucumberJson') {
+    mustRunAfter tasks.named('functionalOpalTagsR1AOnly')
+  } else if (name == 'copyR1AOffDemoCucumberJson') {
+    mustRunAfter tasks.named('functionalOpalTagsR1AOff')
   } else if (name == 'copyLegacyCucumberJson') {
     mustRunAfter tasks.named('functionalLegacy')
   } else if (name == 'copySmokeCucumberJson') {

--- a/gradle/zephyr.gradle
+++ b/gradle/zephyr.gradle
@@ -36,14 +36,14 @@ Map<String, Map<String, Object>> functionalZephyrTargets = [
                 syncTask  : "syncSmokeArtifactsFromExistingResults",
         ],
         runR1AOnly: [
-                reportPath: "functional-output-demo/zephyr/cucumber-opal-tags.json",
+                reportPath: "functional-output-r1a-only-demo/zephyr/cucumber-opal-tags.json",
                 testFolder: "functionalTest/resources",
-                syncTask  : "syncTaggedFunctionalArtifactsFromExistingResults",
+                syncTask  : "syncR1AOnlyTaggedFunctionalArtifactsFromExistingResults",
         ],
         runR1AOff: [
-                reportPath: "functional-output-demo/zephyr/cucumber-opal-tags.json",
+                reportPath: "functional-output-r1a-off-demo/zephyr/cucumber-opal-tags.json",
                 testFolder: "functionalTest/resources",
-                syncTask  : "syncTaggedFunctionalArtifactsFromExistingResults",
+                syncTask  : "syncR1AOffTaggedFunctionalArtifactsFromExistingResults",
         ],
 ]
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Align local/nightly functional report outputs and fix nightly integration report publishing

This PR aligns local functional and R1A demo report outputs with the existing Zephyr upload flow, fixes nightly integration report publishing, and updates the README to document the current artifact/report paths and local Zephyr workflow.

Changes
•Fixed the nightly Jenkins integration report publish step by removing the broken ensureIntegrationReportOutputExists helper method and calling ensureReportOutputExists(...) directly.
•Standardised local functional report output to functional-output/report instead of the old functional-test-report path.
•Restored Serenity Cucumber plugin configuration on functional/smoke/legacy tasks so Serenity aggregation continues to work alongside Zephyr JSON generation.
•Ensured functional and smoke report/copy tasks still run after test execution so report artifacts are produced consistently.
•Removed hard dependsOn links from functional merge tasks so merged test results can still be assembled after failing test runs.
•Added dedicated local tagged demo tasks:
◦functionalOpalTagsR1AOnly
◦functionalOpalTagsR1AOff
•Added dedicated local R1A demo artifact/report destinations:
◦functional-output-r1a-only-demo
◦functional-output-r1a-off-demo
•Updated Zephyr stage mapping so:
◦runR1AOnly reads from functional-output-r1a-only-demo/zephyr/cucumber-opal-tags.json
◦runR1AOff reads from functional-output-r1a-off-demo/zephyr/cucumber-opal-tags.json
•Updated nightly packaging to use the new report locations and removed references to obsolete intermediate report directories.

•Updated the README to document:
◦current local and nightly report locations
◦integration being JUnit HTML rather than Serenity
◦where to place raw Zephyr JSON copied from Jenkins
◦the correct local commands for functional, runR1AOnly, and runR1AOff

Why
•Local and nightly tagged demo outputs were using different directory conventions, which made Zephyr reruns confusing.
•The nightly pipeline had a Jenkins DSL/method resolution bug in integration report publishing.
•Standard functional report output and README guidance had drifted from the actual build behavior.
•runR1AOnly and runR1AOff needed distinct local outputs so their reports/JSON do not overwrite each other.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
