### PR TITLE
PO-3956 Handle User Service token rejection during auth

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/JwtControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/JwtControllerIntegrationTest.java
@@ -125,4 +125,24 @@ class JwtControllerIntegrationTest extends AbstractIntegrationWithSecurityTest {
                 .header(AUTHORIZATION, "Bearer "))
             .andExpect(status().isUnauthorized());
     }
+
+    @Test
+    @DisplayName("Returns 401 when User Service rejects the token")
+    @JiraStory("PO-3956")
+    @JiraEpic("PO-2485")
+    void testUserServiceReturns401DuringAuthentication() throws Exception {
+        StubMapping unauthorizedUserStateStub = stubFor(get("/opal/v2/users/0/state")
+            .withHeader("Authorization", equalTo("Bearer " + validToken))
+            .atPriority(1)
+            .willReturn(aResponse().withStatus(401)));
+
+        try {
+            mockMvc.perform(MockMvcRequestBuilders.get(URL)
+                    .header(AUTHORIZATION, "Bearer " + validToken))
+                .andExpect(status().isUnauthorized());
+        } finally {
+            WireMock.removeStub(unauthorizedUserStateStub);
+        }
+    }
+
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/JwtControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/JwtControllerIntegrationTest.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.gov.hmcts.opal.AbstractIntegrationWithSecurityTest;
@@ -134,7 +135,7 @@ class JwtControllerIntegrationTest extends AbstractIntegrationWithSecurityTest {
         StubMapping unauthorizedUserStateStub = stubFor(get("/opal/v2/users/0/state")
             .withHeader("Authorization", equalTo("Bearer " + validToken))
             .atPriority(1)
-            .willReturn(aResponse().withStatus(401)));
+            .willReturn(aResponse().withStatus(HttpStatus.UNAUTHORIZED.value())));
 
         try {
             mockMvc.perform(MockMvcRequestBuilders.get(URL)

--- a/src/main/java/uk/gov/hmcts/opal/authentication/config/SecurityConfig.java
+++ b/src/main/java/uk/gov/hmcts/opal/authentication/config/SecurityConfig.java
@@ -1,11 +1,13 @@
 package uk.gov.hmcts.opal.authentication.config;
 
+import feign.FeignException;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.security.autoconfigure.web.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -20,6 +22,7 @@ import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtIssuerAuthenticationManagerResolver;
+import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
 import org.springframework.security.web.SecurityFilterChain;
 import uk.gov.hmcts.opal.authentication.config.internal.InternalAuthConfigurationProperties;
 import uk.gov.hmcts.opal.authentication.config.internal.InternalAuthProviderConfigurationProperties;
@@ -85,9 +88,22 @@ public class SecurityConfig {
         InternalAuthConfigurationProperties authProps,
         OpalJwtAuthenticationProvider finesJwtAuthenticationProvider) {
 
-        AuthenticationManager manager = finesJwtAuthenticationProvider::authenticate;
+        AuthenticationManager manager = authentication ->
+            authenticateWithUserServiceUnauthorizedHandling(finesJwtAuthenticationProvider, authentication);
+
         Map<String, AuthenticationManager> managers = Map.of(authProps.getIssuerUri(), manager);
         return new JwtIssuerAuthenticationManagerResolver(managers::get);
+    }
+
+    private Authentication authenticateWithUserServiceUnauthorizedHandling(
+        OpalJwtAuthenticationProvider finesJwtAuthenticationProvider,
+        Authentication authentication) {
+
+        try {
+            return finesJwtAuthenticationProvider.authenticate(authentication);
+        } catch (FeignException.Unauthorized ex) {
+            throw new InvalidBearerTokenException("User Service rejected bearer token", ex);
+        }
     }
 
     @Bean


### PR DESCRIPTION
### https://tools.hmcts.net/jira/browse/PO-3956 ###



### User Service returns 401 during authentication
- Handle User Service 401 responses during authentication as invalid bearer tokens
- Add integration coverage for PO-3956 token-expiry race scenario ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
