### PR TITLE
Po 8659 adding additional transaction history to details report

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportsApiControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportsApiControllerIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.opal.testutil.JsonErrorAssertions.expectInternalServerErrorWithoutStatus;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -183,7 +184,7 @@ class ReportsApiControllerIntegrationTest extends AbstractIntegrationTest {
             String body = actions.andReturn().getResponse().getContentAsString();
             Set<String> actualFields = objectMapper.readTree(body).properties()
                 .stream()
-                .map(entry -> entry.getKey())
+                .map(Map.Entry::getKey)
                 .collect(java.util.stream.Collectors.toSet());
 
             actions.andExpect(status().isOk());
@@ -393,9 +394,17 @@ class ReportsApiControllerIntegrationTest extends AbstractIntegrationTest {
         )
         @JiraStory("PO-7225")
         @JiraEpic("PO-2248")
-        @JiraTestKey(value = "PO-9508", name = "Get report by ID - invalid BU warning threshold '\"not-an-integer\"' returns 500 [@PO-7225]")
-        @JiraTestKey(value = "PO-9509", name = "Get report by ID - invalid BU warning threshold '\"0\"' returns 500 [@PO-7225]")
-        @JiraTestKey(value = "PO-9510", name = "Get report by ID - invalid BU warning threshold '\"-1\"' returns 500 [@PO-7225]")
+        @JiraTestKey(
+            value = "PO-9508",
+            name = "Get report by ID - invalid BU warning threshold '\"not-an-integer\"' returns 500 "
+                + "[@PO-7225]"
+        )
+        @JiraTestKey(
+            value = "PO-9509", name = "Get report by ID - invalid BU warning threshold '\"0\"' returns 500 [@PO-7225]"
+        )
+        @JiraTestKey(
+            value = "PO-9510", name = "Get report by ID - invalid BU warning threshold '\"-1\"' returns 500 [@PO-7225]"
+        )
         void getReportById_whenThresholdConfigInvalid_returns500(String invalidThresholdValue) throws Exception {
             var threshold = configurationItemRepository
                 .findByItemNameAndBusinessUnitIdIsNull(BU_WARNING_THRESHOLD_ITEM_NAME)

--- a/src/integrationTest/java/uk/gov/hmcts/opal/service/report/EnforcementDetailedReportServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/service/report/EnforcementDetailedReportServiceTest.java
@@ -183,12 +183,28 @@ public class EnforcementDetailedReportServiceTest extends AbstractIntegrationTes
         );
 
         Assertions.assertThat(report.getTransactionRows())
-            .hasSize(21)
+            .hasSize(25)
             .extracting(
                 DetailedReportTransactionRowDto::getTransactionType,
                 DetailedReportTransactionRowDto::getTransactionDetails
             )
             .containsExactlyInAnyOrder(
+                tuple(
+                    "TTPAY",
+                    "In full | 2025-10-12 | 120 days in default"
+                ),
+                tuple(
+                    "ENFT",
+                    "REGF | Warrant number: 001/25/00001 | Test enforcement"
+                ),
+                tuple(
+                    "ENFT",
+                    "ABDC | Warrant number: 001/25/00001 | Test enforcement"
+                ),
+                tuple(
+                    "NOTE",
+                    "Detailed report note"
+                ),
                 tuple(
                     DefendantTransactionType.CONSOL.getLabel(),
                     "Account consolidated | 77 | Amount credited to master account"

--- a/src/integrationTest/java/uk/gov/hmcts/opal/service/report/EnforcementDetailedReportServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/service/report/EnforcementDetailedReportServiceTest.java
@@ -183,7 +183,7 @@ public class EnforcementDetailedReportServiceTest extends AbstractIntegrationTes
         );
 
         Assertions.assertThat(report.getTransactionRows())
-            .hasSize(25)
+            .hasSize(26)
             .extracting(
                 DetailedReportTransactionRowDto::getTransactionType,
                 DetailedReportTransactionRowDto::getTransactionDetails
@@ -200,6 +200,13 @@ public class EnforcementDetailedReportServiceTest extends AbstractIntegrationTes
                 tuple(
                     "ENFT",
                     "ABDC | Warrant number: 001/25/00001 | Test enforcement"
+                ),
+                tuple(
+                    "ENFT",
+                    "ABDC | 10 days in default | Warrant number: 001/25/00001"
+                        + " | Earliest date of release: 2026-05-14T09:00"
+                        + " | Hearing: 2026-05-14T10:00 - AAA Test Court - Case: CASE-77"
+                        + " | Test enforcement"
                 ),
                 tuple(
                     "NOTE",

--- a/src/integrationTest/java/uk/gov/hmcts/opal/service/report/EnforcementSummaryReportServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/service/report/EnforcementSummaryReportServiceTest.java
@@ -104,7 +104,9 @@ public class EnforcementSummaryReportServiceTest extends AbstractIntegrationTest
             .isSorted();
         //Verify fields mapped
         Assertions.assertThat(transactions)
-            .anySatisfy(dto -> {
+            .filteredOn(dto -> "177A".equals(dto.getAccountNo()))
+            .singleElement()
+            .satisfies(dto -> {
                 assertThat(dto.getHeader1()).isEqualTo("DETAIL");
                 assertThat(dto.getCompany()).isEqualTo("N");
                 assertThat(dto.getDefendantName()).isEqualTo("Graham, Anna");
@@ -136,7 +138,7 @@ public class EnforcementSummaryReportServiceTest extends AbstractIntegrationTest
                 assertThat(dto.getEmployerTel()).isEqualTo("02079997777");
                 assertThat(dto.getEmployerEmail()).isEqualTo("employer77@company.com");
                 assertThat(dto.getEnforcementReason()).isEqualTo("Test enforcement");
-                assertThat(dto.getLastEnforcementDate()).isEqualTo(LocalDate.of(2000, 1, 2));
+                assertThat(dto.getLastEnforcementDate()).isEqualTo(LocalDate.of(2026, 5, 14));
                 assertThat(dto.getUser()).isEqualTo("L080JG");
                 assertThat(dto.getWarrantRef()).isEqualTo("001/25/00001");
                 assertThat(dto.getJailDays()).isEqualTo(101);

--- a/src/integrationTest/java/uk/gov/hmcts/opal/service/report/PaymentDetailedReportServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/service/report/PaymentDetailedReportServiceTest.java
@@ -169,7 +169,7 @@ public class PaymentDetailedReportServiceTest extends AbstractIntegrationTest {
         );
 
         Assertions.assertThat(report.getTransactionRows())
-            .hasSize(25)
+            .hasSize(26)
             .extracting(
                 DetailedReportTransactionRowDto::getTransactionType,
                 DetailedReportTransactionRowDto::getTransactionDetails
@@ -186,6 +186,13 @@ public class PaymentDetailedReportServiceTest extends AbstractIntegrationTest {
                 tuple(
                     "ENFT",
                     "ABDC | Warrant number: 001/25/00001 | Test enforcement"
+                ),
+                tuple(
+                    "ENFT",
+                    "ABDC | 10 days in default | Warrant number: 001/25/00001"
+                        + " | Earliest date of release: 2026-05-14T09:00"
+                        + " | Hearing: 2026-05-14T10:00 - AAA Test Court - Case: CASE-77"
+                        + " | Test enforcement"
                 ),
                 tuple(
                     "NOTE",

--- a/src/integrationTest/java/uk/gov/hmcts/opal/service/report/PaymentDetailedReportServiceTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/service/report/PaymentDetailedReportServiceTest.java
@@ -169,12 +169,28 @@ public class PaymentDetailedReportServiceTest extends AbstractIntegrationTest {
         );
 
         Assertions.assertThat(report.getTransactionRows())
-            .hasSize(21)
+            .hasSize(25)
             .extracting(
                 DetailedReportTransactionRowDto::getTransactionType,
                 DetailedReportTransactionRowDto::getTransactionDetails
             )
             .containsExactlyInAnyOrder(
+                tuple(
+                    "TTPAY",
+                    "In full | 2025-10-12 | 120 days in default"
+                ),
+                tuple(
+                    "ENFT",
+                    "REGF | Warrant number: 001/25/00001 | Test enforcement"
+                ),
+                tuple(
+                    "ENFT",
+                    "ABDC | Warrant number: 001/25/00001 | Test enforcement"
+                ),
+                tuple(
+                    "NOTE",
+                    "Detailed report note"
+                ),
                 tuple(
                     DefendantTransactionType.CONSOL.getLabel(),
                     "Account consolidated | 77 | Amount credited to master account"

--- a/src/integrationTest/resources/db/deleteData/delete_from_enforcements.sql
+++ b/src/integrationTest/resources/db/deleteData/delete_from_enforcements.sql
@@ -27,6 +27,11 @@ WHERE party_id = 77;
 DELETE FROM payment_terms
 WHERE defendant_account_id = 77;
 
+DELETE FROM notes
+WHERE associated_record_type = 'defendant_accounts'
+  AND associated_record_id = '77'
+  AND note_type = 'AA';
+
 DELETE FROM impositions
 WHERE defendant_account_id = 77;
 

--- a/src/integrationTest/resources/db/insertData/insert_into_enforcements.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_enforcements.sql
@@ -879,6 +879,10 @@ INSERT INTO enforcements (
     result_id,
     reason,
     warrant_reference,
+    jail_days,
+    earliest_release_date,
+    hearing_date,
+    case_reference,
     hearing_court_id,
     posted_by_name
 )
@@ -890,6 +894,10 @@ VALUES (
            'REGF',
            'Test enforcement',
            '001/25/00001',
+           NULL,
+           NULL,
+           NULL,
+           NULL,
            1,
            'opal-test'
        ),
@@ -901,6 +909,10 @@ VALUES (
            'ABDC',
            'Test enforcement',
            '001/25/00001',
+           NULL,
+           NULL,
+           NULL,
+           NULL,
            1,
            'opal-test'
        ),
@@ -912,6 +924,10 @@ VALUES (
            'ABDC',
            'Test enforcement',
            '001/25/00001',
+           NULL,
+           NULL,
+           NULL,
+           NULL,
            1,
            'opal-test'
        ),
@@ -923,6 +939,10 @@ VALUES (
            'ABDC',
            'Test enforcement',
            '001/25/00001',
+           NULL,
+           NULL,
+           NULL,
+           NULL,
            1,
            'opal-test'
        ),
@@ -934,6 +954,25 @@ VALUES (
            'REGF',
            'Test enforcement',
            '001/25/00001',
+           NULL,
+           NULL,
+           NULL,
+           NULL,
+           1,
+           'opal-test'
+       ),
+       (
+           6,
+           77,
+           TIMESTAMP '2026-05-14 10:30:30',
+           'L080JG',
+           'ABDC',
+           'Test enforcement',
+           '001/25/00001',
+           10,
+           TIMESTAMP '2026-05-14 09:00:00',
+           TIMESTAMP '2026-05-14 10:00:00',
+           'CASE-77',
            1,
            'opal-test'
        )
@@ -944,6 +983,10 @@ ON CONFLICT (enforcement_id) DO UPDATE
         result_id = EXCLUDED.result_id,
         reason = EXCLUDED.reason,
         warrant_reference = EXCLUDED.warrant_reference,
+        jail_days = EXCLUDED.jail_days,
+        earliest_release_date = EXCLUDED.earliest_release_date,
+        hearing_date = EXCLUDED.hearing_date,
+        case_reference = EXCLUDED.case_reference,
         hearing_court_id = EXCLUDED.hearing_court_id,
         posted_by_name = EXCLUDED.posted_by_name;
 

--- a/src/integrationTest/resources/db/insertData/insert_into_enforcements.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_enforcements.sql
@@ -414,15 +414,16 @@ ON CONFLICT (defendant_account_id) DO UPDATE
 
 INSERT INTO payment_terms
 ( payment_terms_id, defendant_account_id, posted_date, posted_by
-, terms_type_code, effective_date, instalment_period, instalment_amount, instalment_lump_sum
+, posted_by_name, terms_type_code, effective_date, instalment_period, instalment_amount, instalment_lump_sum
 , jail_days, extension, account_balance, active)
-VALUES ( 0077, 0077, '2023-11-03 16:05:10', '01000000A'
+VALUES ( 0077, 0077, '2023-11-03 16:05:10', '01000000A', 'Payment Report User'
        , 'B', '2025-10-12 00:00:00', 'W', NULL, NULL
        , 120, 'N', 700.58, true)
 ON CONFLICT (payment_terms_id) DO UPDATE
       SET defendant_account_id = EXCLUDED.defendant_account_id,
       posted_date = EXCLUDED.posted_date,
       posted_by = EXCLUDED.posted_by,
+      posted_by_name = EXCLUDED.posted_by_name,
       terms_type_code = EXCLUDED.terms_type_code,
       effective_date = EXCLUDED.effective_date,
       instalment_period = EXCLUDED.instalment_period,
@@ -432,6 +433,35 @@ ON CONFLICT (payment_terms_id) DO UPDATE
       extension = EXCLUDED.extension,
       account_balance = EXCLUDED.account_balance,
       active = EXCLUDED.active;
+
+INSERT INTO notes (
+    note_id,
+    note_type,
+    associated_record_type,
+    associated_record_id,
+    note_text,
+    posted_date,
+    posted_by,
+    posted_by_name
+)
+VALUES (
+    77001,
+    'AA',
+    'defendant_accounts',
+    '77',
+    'Detailed report note',
+    TIMESTAMP '2026-05-14 11:45:30',
+    '01000000A',
+    'Payment Report User'
+)
+ON CONFLICT (note_id) DO UPDATE
+    SET note_type = EXCLUDED.note_type,
+        associated_record_type = EXCLUDED.associated_record_type,
+        associated_record_id = EXCLUDED.associated_record_id,
+        note_text = EXCLUDED.note_text,
+        posted_date = EXCLUDED.posted_date,
+        posted_by = EXCLUDED.posted_by,
+        posted_by_name = EXCLUDED.posted_by_name;
 
 
 INSERT INTO defendant_account_parties (

--- a/src/integrationTest/resources/db/insertData/insert_into_enforcements.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_enforcements.sql
@@ -534,7 +534,7 @@ VALUES
         'CT'
     ),
     (
-        10003,
+        100003,
         79,
         DATE '2000-05-14',
         'enforcement.test',
@@ -851,7 +851,7 @@ VALUES
         NULL,
         'defendant_transactions',
         'X-4',
-        NULL
+        'CT'
     )
     ON CONFLICT (defendant_transaction_id)
     DO UPDATE SET

--- a/src/main/java/uk/gov/hmcts/opal/dto/report/operation/DetailedReportTransactionRowDto.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/report/operation/DetailedReportTransactionRowDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class DetailedReportTransactionRowDto {
+public class DetailedReportTransactionRowDto implements Comparable<DetailedReportTransactionRowDto> {
 
     private String accountNo;
     private String consolidatedAccountNo;
@@ -21,4 +21,8 @@ public class DetailedReportTransactionRowDto {
     private String transactionUserId;
     private BigDecimal transactionAmount;
 
+    @Override
+    public int compareTo(DetailedReportTransactionRowDto o) {
+        return this.transactionDate.compareTo(o.transactionDate);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/opal/entity/paymentterms/InstalmentPeriod.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/paymentterms/InstalmentPeriod.java
@@ -1,22 +1,31 @@
 package uk.gov.hmcts.opal.entity.paymentterms;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.stream.Stream;
 
 public enum InstalmentPeriod {
-    FORTNIGHT("F"),
-    MONTH("M"),
-    WEEK("W");
+    FORTNIGHT("F", "fortnightly"),
+    MONTH("M", "monthly"),
+    WEEK("W", "weekly");
 
     private final String code;
 
-    InstalmentPeriod(String code) {
+    private final String reportText;
+
+    InstalmentPeriod(String code, String reportText) {
         this.code = code;
+        this.reportText = reportText;
     }
 
     @JsonValue
     public String getCode() {
         return code;
+    }
+
+    @JsonIgnore
+    public String getReportText() {
+        return reportText;
     }
 
     public static InstalmentPeriod fromCode(String code) {

--- a/src/main/java/uk/gov/hmcts/opal/repository/jpa/NoteSpecs.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/jpa/NoteSpecs.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.opal.repository.jpa;
+
+import org.hibernate.query.criteria.JpaExpression;
+import org.springframework.data.jpa.domain.Specification;
+import uk.gov.hmcts.opal.entity.AssociatedRecordType;
+import uk.gov.hmcts.opal.entity.NoteEntity;
+import uk.gov.hmcts.opal.entity.NoteEntity_;
+import uk.gov.hmcts.opal.entity.NoteType;
+
+public class NoteSpecs extends EntitySpecs<NoteEntity> {
+    public static Specification<NoteEntity> equalsAssociatedRecordType(
+        AssociatedRecordType associatedRecordType) {
+        return (root, query, builder) -> builder.equal(
+            ((JpaExpression<?>) root.get(NoteEntity_.associatedRecordType)).cast(String.class),
+            associatedRecordType.getLabel());
+    }
+
+    public static Specification<NoteEntity> equalsAssociatedRecordId(String associatedRecordId) {
+        return (root, query, builder) -> builder.equal(
+            root.get(NoteEntity_.associatedRecordId), associatedRecordId);
+    }
+
+    public static Specification<NoteEntity> equalsNoteType(NoteType noteType) {
+        return (root, query, builder) -> builder.equal(
+            ((JpaExpression<?>) root.get(NoteEntity_.noteType)).cast(String.class),
+            noteType.name());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedResultMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedResultMapper.java
@@ -49,11 +49,17 @@ public abstract class DetailedResultMapper
     public void setRowMapper(DetailedRowDtoCoreMapper rowMapper,
         DetailedTransactionRowMapper transactionRowMapper,
         DefendantTransactionRepository transactionRepository,
-        ImpositionRepository impositionRepository) {
+        ImpositionRepository impositionRepository,
+        PaymentTermsRepository paymentTermsRepository,
+        EnforcementRepository enforcementRepository,
+        NoteRepository noteRepository) {
         this.rowMapper = rowMapper;
         this.transactionRowMapper = transactionRowMapper;
         this.transactionRepository = transactionRepository;
         this.impositionRepository = impositionRepository;
+        this.paymentTermsRepository = paymentTermsRepository;
+        this.enforcementRepository = enforcementRepository;
+        this.noteRepository = noteRepository;
     }
 
     @Override
@@ -61,7 +67,7 @@ public abstract class DetailedResultMapper
         ReportMetadataContext context = new ReportMetadataContext();
         List<DetailedAccountReportDto> accountTransactionReports = accounts.stream()
             .map(account -> {
-                DetailedOperationReportAccountRowDto accountRow =
+                final DetailedOperationReportAccountRowDto accountRow =
                     rowMapper.map(account, context);
                 //TTPAY
                 List<PaymentTermsEntity> paymentTermsEntities = paymentTermsRepository
@@ -107,9 +113,12 @@ public abstract class DetailedResultMapper
                         .mapFromEnforcement(enforcement, account, context))
                     .toList());
                 //transactions
-                transactionRows.addAll(transactionEntities.stream().map(transaction -> transactionRowMapper
-                        .mapFromTransaction(transaction, account, impositionsForTransactions.get(transaction.getAssociatedRecordId()),
-                            context))
+                transactionRows.addAll(transactionEntities.stream()
+                    .map(transaction -> transactionRowMapper.mapFromTransaction(
+                        transaction,
+                        account,
+                        impositionsForTransactions.get(transaction.getAssociatedRecordId()),
+                        context))
                     .toList());
                 //NOTE
                 transactionRows.addAll(noteEntities.stream().map(note -> transactionRowMapper

--- a/src/main/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedResultMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedResultMapper.java
@@ -1,21 +1,31 @@
 package uk.gov.hmcts.opal.service.report.operation.mapper;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.domain.Specification;
 import uk.gov.hmcts.opal.dto.report.operation.DetailedAccountReportDto;
 import uk.gov.hmcts.opal.dto.report.operation.DetailedOperationReportAccountRowDto;
 import uk.gov.hmcts.opal.dto.report.operation.DetailedReportDto;
 import uk.gov.hmcts.opal.dto.report.operation.DetailedReportTransactionRowDto;
 import uk.gov.hmcts.opal.entity.AssociatedRecordType;
+import uk.gov.hmcts.opal.entity.NoteEntity;
+import uk.gov.hmcts.opal.entity.NoteType;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.entity.defendanttransaction.DefendantTransactionEntity;
+import uk.gov.hmcts.opal.entity.enforcement.EnforcementEntity;
 import uk.gov.hmcts.opal.entity.imposition.ImpositionEntity;
+import uk.gov.hmcts.opal.entity.paymentterms.PaymentTermsEntity;
 import uk.gov.hmcts.opal.repository.DefendantTransactionRepository;
+import uk.gov.hmcts.opal.repository.EnforcementRepository;
 import uk.gov.hmcts.opal.repository.ImpositionRepository;
+import uk.gov.hmcts.opal.repository.NoteRepository;
+import uk.gov.hmcts.opal.repository.PaymentTermsRepository;
 import uk.gov.hmcts.opal.service.report.ReportMetaData;
 import uk.gov.hmcts.opal.service.report.ReportMetadataContext;
 import uk.gov.hmcts.opal.service.report.operation.OperationDetailedReport;
@@ -31,6 +41,9 @@ public abstract class DetailedResultMapper
     protected DetailedTransactionRowMapper transactionRowMapper;
     protected DefendantTransactionRepository transactionRepository;
     protected ImpositionRepository impositionRepository;
+    protected PaymentTermsRepository paymentTermsRepository;
+    protected EnforcementRepository enforcementRepository;
+    protected NoteRepository noteRepository;
 
     @Autowired
     public void setRowMapper(DetailedRowDtoCoreMapper rowMapper,
@@ -50,8 +63,14 @@ public abstract class DetailedResultMapper
             .map(account -> {
                 DetailedOperationReportAccountRowDto accountRow =
                     rowMapper.map(account, context);
-                //TODO include additional history here: enforcements, notes, paymentTerms and transactions (curr)
-                //todo see DefendantAccountHistoryService.getHistory() && PO-8659
+                //TTPAY
+                List<PaymentTermsEntity> paymentTermsEntities = paymentTermsRepository
+                    .findByDefendantAccount_DefendantAccountIdAndEffectiveDateIsNotNullOrderByEffectiveDateAsc(
+                        account.getDefendantAccountId());
+                //ENFT
+                List<EnforcementEntity> enforcementEntities = enforcementRepository
+                    .findHistoryRowsByDefendantAccountId(account.getDefendantAccountId());
+                //(transaction)
                 List<DefendantTransactionEntity> transactionEntities = transactionRepository
                     .findByDefendantAccountId(account.getDefendantAccountId());
                 List<Long> impositionIds = transactionEntities.stream()
@@ -65,12 +84,38 @@ public abstract class DetailedResultMapper
                     .stream().collect(Collectors.toMap(
                         imposition -> imposition.getImpositionId().toString(),
                         imposition -> imposition));
-                List<DetailedReportTransactionRowDto> transactionRows = transactionEntities
-                    .stream()
-                    .map(transaction -> transactionRowMapper.map(transaction, account,
-                        impositionsForTransactions.get(transaction.getAssociatedRecordId()), context))
-                    .toList();
+                //NOTE
+                List<NoteEntity> noteEntities = noteRepository.findAll(Specification.allOf(
+                    (root, query, builder) ->
+                        builder.and(
+                            builder.equal(
+                                root.get("associatedRecordType").as(String.class),
+                                AssociatedRecordType.DEFENDANT_ACCOUNTS.getLabel()
+                            ),
+                            builder.equal(root.get("associatedRecordId"), account.getDefendantAccountId().toString()),
+                            builder.equal(root.get("noteType").as(String.class), NoteType.AA.name())
+                        )
+                ));
 
+                //TTPAY
+                List<DetailedReportTransactionRowDto> transactionRows = new ArrayList<>(paymentTermsEntities.stream()
+                    .map(paymentTerms -> transactionRowMapper.mapFromPaymentTerms(
+                        paymentTerms, account, context))
+                    .toList());
+                //ENFT
+                transactionRows.addAll(enforcementEntities.stream().map(enforcement -> transactionRowMapper
+                        .mapFromEnforcement(enforcement, account, context))
+                    .toList());
+                //transactions
+                transactionRows.addAll(transactionEntities.stream().map(transaction -> transactionRowMapper
+                        .mapFromTransaction(transaction, account, impositionsForTransactions.get(transaction.getAssociatedRecordId()),
+                            context))
+                    .toList());
+                //NOTE
+                transactionRows.addAll(noteEntities.stream().map(note -> transactionRowMapper
+                        .mapFromNote(note, account, context))
+                    .toList());
+                Collections.sort(transactionRows);
                 return DetailedAccountReportDto.builder()
                     .accountRow(accountRow)
                     .transactionRows(transactionRows)

--- a/src/main/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedResultMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedResultMapper.java
@@ -24,8 +24,9 @@ import uk.gov.hmcts.opal.entity.paymentterms.PaymentTermsEntity;
 import uk.gov.hmcts.opal.repository.DefendantTransactionRepository;
 import uk.gov.hmcts.opal.repository.EnforcementRepository;
 import uk.gov.hmcts.opal.repository.ImpositionRepository;
-import uk.gov.hmcts.opal.repository.NoteRepository;
 import uk.gov.hmcts.opal.repository.PaymentTermsRepository;
+import uk.gov.hmcts.opal.repository.jpa.NoteSpecs;
+import uk.gov.hmcts.opal.service.persistence.NoteRepositoryService;
 import uk.gov.hmcts.opal.service.report.ReportMetaData;
 import uk.gov.hmcts.opal.service.report.ReportMetadataContext;
 import uk.gov.hmcts.opal.service.report.operation.OperationDetailedReport;
@@ -43,7 +44,7 @@ public abstract class DetailedResultMapper
     protected ImpositionRepository impositionRepository;
     protected PaymentTermsRepository paymentTermsRepository;
     protected EnforcementRepository enforcementRepository;
-    protected NoteRepository noteRepository;
+    protected NoteRepositoryService noteRepositoryService;
 
     @Autowired
     public void setRowMapper(DetailedRowDtoCoreMapper rowMapper,
@@ -52,14 +53,14 @@ public abstract class DetailedResultMapper
         ImpositionRepository impositionRepository,
         PaymentTermsRepository paymentTermsRepository,
         EnforcementRepository enforcementRepository,
-        NoteRepository noteRepository) {
+        NoteRepositoryService noteRepositoryService) {
         this.rowMapper = rowMapper;
         this.transactionRowMapper = transactionRowMapper;
         this.transactionRepository = transactionRepository;
         this.impositionRepository = impositionRepository;
         this.paymentTermsRepository = paymentTermsRepository;
         this.enforcementRepository = enforcementRepository;
-        this.noteRepository = noteRepository;
+        this.noteRepositoryService = noteRepositoryService;
     }
 
     @Override
@@ -69,61 +70,11 @@ public abstract class DetailedResultMapper
             .map(account -> {
                 final DetailedOperationReportAccountRowDto accountRow =
                     rowMapper.map(account, context);
-                //TTPAY
-                List<PaymentTermsEntity> paymentTermsEntities = paymentTermsRepository
-                    .findByDefendantAccount_DefendantAccountIdAndEffectiveDateIsNotNullOrderByEffectiveDateAsc(
-                        account.getDefendantAccountId());
-                //ENFT
-                List<EnforcementEntity> enforcementEntities = enforcementRepository
-                    .findHistoryRowsByDefendantAccountId(account.getDefendantAccountId());
-                //(transaction)
-                List<DefendantTransactionEntity> transactionEntities = transactionRepository
-                    .findByDefendantAccountId(account.getDefendantAccountId());
-                List<Long> impositionIds = transactionEntities.stream()
-                    .filter(transaction ->
-                        AssociatedRecordType.IMPOSITIONS.equals(transaction.getAssociatedRecordType()))
-                    .map(transaction ->
-                        Long.valueOf(transaction.getAssociatedRecordId()))
-                    .toList();
-                Map<String, ImpositionEntity> impositionsForTransactions = impositionRepository
-                    .findAllById(impositionIds)
-                    .stream().collect(Collectors.toMap(
-                        imposition -> imposition.getImpositionId().toString(),
-                        imposition -> imposition));
-                //NOTE
-                List<NoteEntity> noteEntities = noteRepository.findAll(Specification.allOf(
-                    (root, query, builder) ->
-                        builder.and(
-                            builder.equal(
-                                root.get("associatedRecordType").as(String.class),
-                                AssociatedRecordType.DEFENDANT_ACCOUNTS.getLabel()
-                            ),
-                            builder.equal(root.get("associatedRecordId"), account.getDefendantAccountId().toString()),
-                            builder.equal(root.get("noteType").as(String.class), NoteType.AA.name())
-                        )
-                ));
-
-                //TTPAY
-                List<DetailedReportTransactionRowDto> transactionRows = new ArrayList<>(paymentTermsEntities.stream()
-                    .map(paymentTerms -> transactionRowMapper.mapFromPaymentTerms(
-                        paymentTerms, account, context))
-                    .toList());
-                //ENFT
-                transactionRows.addAll(enforcementEntities.stream().map(enforcement -> transactionRowMapper
-                        .mapFromEnforcement(enforcement, account, context))
-                    .toList());
-                //transactions
-                transactionRows.addAll(transactionEntities.stream()
-                    .map(transaction -> transactionRowMapper.mapFromTransaction(
-                        transaction,
-                        account,
-                        impositionsForTransactions.get(transaction.getAssociatedRecordId()),
-                        context))
-                    .toList());
-                //NOTE
-                transactionRows.addAll(noteEntities.stream().map(note -> transactionRowMapper
-                        .mapFromNote(note, account, context))
-                    .toList());
+                List<DetailedReportTransactionRowDto> transactionRows = new ArrayList<>();
+                transactionRows.addAll(getPaymentTermsTransactionRows(account, context));
+                transactionRows.addAll(getEnforcementTransactionRows(account, context));
+                transactionRows.addAll(getDefendantTransactionRows(account, context));
+                transactionRows.addAll(getNoteTransactionRows(account, context));
                 Collections.sort(transactionRows);
                 return DetailedAccountReportDto.builder()
                     .accountRow(accountRow)
@@ -142,5 +93,70 @@ public abstract class DetailedResultMapper
             .detailedReport(reportDto)
             .reportMetaData(meta)
             .build();
+    }
+
+    private List<DetailedReportTransactionRowDto> getPaymentTermsTransactionRows(DefendantAccountEntity account,
+        ReportMetadataContext context) {
+        List<PaymentTermsEntity> paymentTermsEntities = paymentTermsRepository
+            .findByDefendantAccount_DefendantAccountIdAndEffectiveDateIsNotNullOrderByEffectiveDateAsc(
+                account.getDefendantAccountId());
+
+        return paymentTermsEntities.stream()
+            .map(paymentTerms -> transactionRowMapper.mapFromPaymentTerms(paymentTerms, account, context))
+            .toList();
+    }
+
+    private List<DetailedReportTransactionRowDto> getEnforcementTransactionRows(DefendantAccountEntity account,
+        ReportMetadataContext context) {
+        List<EnforcementEntity> enforcementEntities = enforcementRepository
+            .findHistoryRowsByDefendantAccountId(account.getDefendantAccountId());
+
+        return enforcementEntities.stream()
+            .map(enforcement -> transactionRowMapper.mapFromEnforcement(enforcement, account, context))
+            .toList();
+    }
+
+    private List<DetailedReportTransactionRowDto> getDefendantTransactionRows(DefendantAccountEntity account,
+        ReportMetadataContext context) {
+        List<DefendantTransactionEntity> transactionEntities = transactionRepository
+            .findByDefendantAccountId(account.getDefendantAccountId());
+        Map<String, ImpositionEntity> impositionsForTransactions = getImpositionsForTransactions(transactionEntities);
+
+        return transactionEntities.stream()
+            .map(transaction -> transactionRowMapper.mapFromTransaction(
+                transaction,
+                account,
+                impositionsForTransactions.get(transaction.getAssociatedRecordId()),
+                context))
+            .toList();
+    }
+
+    private List<DetailedReportTransactionRowDto> getNoteTransactionRows(DefendantAccountEntity account,
+        ReportMetadataContext context) {
+        List<NoteEntity> noteEntities = noteRepositoryService.findAll(Specification.allOf(
+            NoteSpecs.equalsAssociatedRecordType(AssociatedRecordType.DEFENDANT_ACCOUNTS),
+            NoteSpecs.equalsAssociatedRecordId(account.getDefendantAccountId().toString()),
+            NoteSpecs.equalsNoteType(NoteType.AA)
+        ));
+
+        return noteEntities.stream()
+            .map(note -> transactionRowMapper.mapFromNote(note, account, context))
+            .toList();
+    }
+
+    private Map<String, ImpositionEntity> getImpositionsForTransactions(
+        List<DefendantTransactionEntity> transactionEntities) {
+        List<Long> impositionIds = transactionEntities.stream()
+            .filter(transaction ->
+                AssociatedRecordType.IMPOSITIONS.equals(transaction.getAssociatedRecordType()))
+            .map(transaction -> Long.valueOf(transaction.getAssociatedRecordId()))
+            .toList();
+
+        return impositionRepository.findAllById(impositionIds)
+            .stream()
+            .collect(Collectors.toMap(
+                imposition -> imposition.getImpositionId().toString(),
+                imposition -> imposition
+            ));
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedTransactionRowMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedTransactionRowMapper.java
@@ -112,7 +112,8 @@ public abstract class DetailedTransactionRowMapper
     }
 
     protected String getEnforcementDetails(EnforcementEntity enforcement) {
-        StringBuilder sb = new StringBuilder(enforcement.getResultId());
+        StringBuilder sb = new StringBuilder();
+        sb.append(enforcement.getResultId());
         if (enforcement.getJailDays() != null) {
             sb.append(SPACED_PIPE).append(enforcement.getJailDays()).append(" days in default");
         }

--- a/src/main/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedTransactionRowMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedTransactionRowMapper.java
@@ -1,16 +1,21 @@
 package uk.gov.hmcts.opal.service.report.operation.mapper;
 
 import static uk.gov.hmcts.opal.dto.PdplIdentifierType.CONSOLIDATED_ACCOUNT;
+import static uk.gov.hmcts.opal.entity.paymentterms.TermsTypeCode.BY_DATE;
+import static uk.gov.hmcts.opal.service.report.CommonReportStringConstants.SPACED_PIPE;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.gov.hmcts.opal.dto.report.operation.DetailedReportTransactionRowDto;
 import uk.gov.hmcts.opal.entity.AssociatedRecordType;
+import uk.gov.hmcts.opal.entity.NoteEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.entity.defendanttransaction.DefendantTransactionEntity;
 import uk.gov.hmcts.opal.entity.defendanttransaction.DefendantTransactionType;
+import uk.gov.hmcts.opal.entity.enforcement.EnforcementEntity;
 import uk.gov.hmcts.opal.entity.imposition.ImpositionEntity;
+import uk.gov.hmcts.opal.entity.paymentterms.PaymentTermsEntity;
 import uk.gov.hmcts.opal.service.opal.history.defendant.DefendantTransactionDetailsService;
 import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
 import uk.gov.hmcts.opal.service.report.ReportMetadataContext;
@@ -19,6 +24,9 @@ import uk.gov.hmcts.opal.service.report.ReportMetadataContext;
 @SuppressWarnings("java:S6813")
 public abstract class DetailedTransactionRowMapper
     implements CommonMappingHelper {
+    public static final String PAYMENT_TERMS_TYPE = "TTPAY";
+    public static final String ENFORCEMENT_TYPE = "ENFT";
+    public static final String NOTE_TYPE = "NOTE";
 
     @Autowired
     protected DefendantAccountRepositoryService defendantAccountService;
@@ -34,24 +42,109 @@ public abstract class DetailedTransactionRowMapper
     @Mapping(target = "consolidatedAccountNo", expression = "java(getConsolidatedAccountNo(transaction, context))")
     @Mapping(target = "transactionDetails",
         expression = "java(getTransactionDetails(transaction, account, imposition))")
-    public abstract DetailedReportTransactionRowDto map(
+    public abstract DetailedReportTransactionRowDto mapFromTransaction(
         DefendantTransactionEntity transaction,
         DefendantAccountEntity account,
         ImpositionEntity imposition,
         ReportMetadataContext context
     );
 
+    @Mapping(target = "accountNo", source = "account.accountNumber")
+    @Mapping(target = "transactionDate", source = "paymentTerms.postedDate")
+    @Mapping(target = "transactionType", constant = PAYMENT_TERMS_TYPE)
+    @Mapping(target = "transactionUserId", source = "paymentTerms.postedByUsername")
+    @Mapping(target = "consolidatedAccountNo", expression = "java(getConsolidatedAccountNo("
+        + "paymentsTerms.getAssociatedRecordType(), paymentsTerms.getAssociatedRecordId(), context))")
+    @Mapping(target = "transactionDetails", expression = "java(getPaymentTermsDetails(paymentTerms))")
+    public abstract DetailedReportTransactionRowDto mapFromPaymentTerms(PaymentTermsEntity paymentTerms,
+        DefendantAccountEntity account,
+        ReportMetadataContext context);
+
+    @Mapping(target = "accountNo", source = "account.accountNumber")
+    @Mapping(target = "transactionDate", source = "enforcement.postedDate")
+    @Mapping(target = "transactionType", constant = ENFORCEMENT_TYPE)
+    @Mapping(target = "transactionUserId", source = "enforcement.postedByUsername")
+    @Mapping(target = "consolidatedAccountNo", expression = "java(getConsolidatedAccountNo("
+        + "enforcement.getAssociatedRecordType(), enforcement.getAssociatedRecordId(), context))")
+    @Mapping(target = "transactionDetails", expression = "java(getEnforcementDetails(enforcement))")
+    public abstract DetailedReportTransactionRowDto mapFromEnforcement(EnforcementEntity enforcement,
+        DefendantAccountEntity account,
+        ReportMetadataContext context);
+
+    @Mapping(target = "accountNo", source = "account.accountNumber")
+    @Mapping(target = "transactionDate", source = "note.postedDate")
+    @Mapping(target = "transactionType", constant = NOTE_TYPE)
+    @Mapping(target = "transactionUserId", source = "transaction.postedByUsername")
+    @Mapping(target = "transactionAmount", source = "transaction.transactionAmount")
+    @Mapping(target = "consolidatedAccountNo", expression = "java(getConsolidatedAccountNo("
+        + "note.getAssociatedRecordType(), note.getAssociatedRecordId(), context))")
+    @Mapping(target = "transactionDetails", source = "note.noteText")
+    public abstract DetailedReportTransactionRowDto mapFromNote(NoteEntity note, DefendantAccountEntity account,
+        ReportMetadataContext context);
+
+
     protected String getTransactionDetails(DefendantTransactionEntity transaction,
         DefendantAccountEntity account, ImpositionEntity imposition) {
         return defendantTransactionDetailsService.generateTransactionDetails(transaction, account, imposition);
     }
 
+    protected String getPaymentTermsDetails(PaymentTermsEntity paymentTerms) {
+        StringBuilder sb = new StringBuilder();
+        if (BY_DATE.equals(paymentTerms.getTermsTypeCode())) {
+            sb.append("In full | ");
+        } else {
+            if (paymentTerms.getInstalmentLumpSum() != null) {
+                sb.append("Lump sum: ").append(paymentTerms.getInstalmentLumpSum()).append(SPACED_PIPE);
+            }
+            if (paymentTerms.getInstalmentAmount() != null && paymentTerms.getInstalmentPeriod() != null) {
+                sb.append("Installments: ").append(paymentTerms.getInstalmentAmount()).append(" ");
+                sb.append(paymentTerms.getInstalmentPeriod().getReportText()).append(" from ");
+            }
+        }
+        sb.append(paymentTerms.getEffectiveDate());
+        if (paymentTerms.getJailDays() != null) {
+            sb.append(SPACED_PIPE).append(paymentTerms.getJailDays()).append(" days in default");
+        }
+        if (paymentTerms.getReasonForExtension() != null) {
+            sb.append(SPACED_PIPE).append(paymentTerms.getReasonForExtension());
+        }
+        return sb.toString();
+    }
+
+    protected String getEnforcementDetails(EnforcementEntity enforcement) {
+        StringBuilder sb = new StringBuilder(enforcement.getResultId());
+        if (enforcement.getJailDays() != null) {
+            sb.append(SPACED_PIPE).append(enforcement.getJailDays()).append(" days in default");
+        }
+        if (enforcement.getWarrantReference() != null) {
+            sb.append(SPACED_PIPE).append("Warrant number: ").append(enforcement.getWarrantReference());
+        }
+        if (enforcement.getEarliestReleaseDate() != null) {
+            sb.append(SPACED_PIPE).append("Earliest date of release: ").append(enforcement.getEarliestReleaseDate());
+        }
+        if (enforcement.getHearingDate() != null) {
+            sb.append(SPACED_PIPE).append("Hearing: ").append(enforcement.getHearingDate())
+                .append(" - ").append(enforcement.getHearingCourt().getName())
+                .append(" - Case: ").append(enforcement.getCaseReference());
+        }
+        if (enforcement.getReason() != null) {
+            sb.append(SPACED_PIPE).append(enforcement.getReason());
+        }
+        return sb.toString();
+    }
+
     protected String getConsolidatedAccountNo(DefendantTransactionEntity entity, ReportMetadataContext context) {
-        if (DefendantTransactionType.CONSOL.equals(entity.getTransactionType())
-            && AssociatedRecordType.DEFENDANT_ACCOUNTS.equals(entity.getAssociatedRecordType())) {
-            long accountId = Long.parseLong(entity.getAssociatedRecordId());
+        if (DefendantTransactionType.CONSOL.equals(entity.getTransactionType())) {
+            return getConsolidatedAccountNo(entity.getAssociatedRecordType(), entity.getAssociatedRecordId(), context);
+        }
+        return null;
+    }
+
+    protected String getConsolidatedAccountNo(AssociatedRecordType type, String id, ReportMetadataContext context) {
+        if (AssociatedRecordType.DEFENDANT_ACCOUNTS.equals(type)) {
+            long accountId = Long.parseLong(id);
             DefendantAccountEntity account = defendantAccountService.findById(accountId);
-            context.addParticipant(entity.getAssociatedRecordId(), CONSOLIDATED_ACCOUNT);
+            context.addParticipant(id, CONSOLIDATED_ACCOUNT);
             return account.getAccountNumber();
         }
         return null;

--- a/src/main/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedTransactionRowMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedTransactionRowMapper.java
@@ -90,7 +90,7 @@ public abstract class DetailedTransactionRowMapper
 
     protected String getPaymentTermsDetails(PaymentTermsEntity paymentTerms) {
         StringBuilder sb = new StringBuilder();
-        if (BY_DATE.equals(paymentTerms.getTermsTypeCode())) {
+        if (paymentTerms.getTermsTypeCode() == BY_DATE) {
             sb.append("In full | ");
         } else {
             if (paymentTerms.getInstalmentLumpSum() != null) {
@@ -135,14 +135,14 @@ public abstract class DetailedTransactionRowMapper
     }
 
     protected String getConsolidatedAccountNo(DefendantTransactionEntity entity, ReportMetadataContext context) {
-        if (DefendantTransactionType.CONSOL.equals(entity.getTransactionType())) {
+        if (entity.getTransactionType() == DefendantTransactionType.CONSOL) {
             return getConsolidatedAccountNo(entity.getAssociatedRecordType(), entity.getAssociatedRecordId(), context);
         }
         return null;
     }
 
     protected String getConsolidatedAccountNo(AssociatedRecordType type, String id, ReportMetadataContext context) {
-        if (AssociatedRecordType.DEFENDANT_ACCOUNTS.equals(type)) {
+        if (type == AssociatedRecordType.DEFENDANT_ACCOUNTS) {
             long accountId = Long.parseLong(id);
             DefendantAccountEntity account = defendantAccountService.findById(accountId);
             context.addParticipant(id, CONSOLIDATED_ACCOUNT);

--- a/src/main/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedTransactionRowMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedTransactionRowMapper.java
@@ -53,8 +53,8 @@ public abstract class DetailedTransactionRowMapper
     @Mapping(target = "transactionDate", source = "paymentTerms.postedDate")
     @Mapping(target = "transactionType", constant = PAYMENT_TERMS_TYPE)
     @Mapping(target = "transactionUserId", source = "paymentTerms.postedByUsername")
-    @Mapping(target = "consolidatedAccountNo", expression = "java(getConsolidatedAccountNo("
-        + "paymentsTerms.getAssociatedRecordType(), paymentsTerms.getAssociatedRecordId(), context))")
+    @Mapping(target = "transactionAmount", ignore = true)
+    @Mapping(target = "consolidatedAccountNo", ignore = true)
     @Mapping(target = "transactionDetails", expression = "java(getPaymentTermsDetails(paymentTerms))")
     public abstract DetailedReportTransactionRowDto mapFromPaymentTerms(PaymentTermsEntity paymentTerms,
         DefendantAccountEntity account,
@@ -64,8 +64,8 @@ public abstract class DetailedTransactionRowMapper
     @Mapping(target = "transactionDate", source = "enforcement.postedDate")
     @Mapping(target = "transactionType", constant = ENFORCEMENT_TYPE)
     @Mapping(target = "transactionUserId", source = "enforcement.postedByUsername")
-    @Mapping(target = "consolidatedAccountNo", expression = "java(getConsolidatedAccountNo("
-        + "enforcement.getAssociatedRecordType(), enforcement.getAssociatedRecordId(), context))")
+    @Mapping(target = "transactionAmount", ignore = true)
+    @Mapping(target = "consolidatedAccountNo", ignore = true)
     @Mapping(target = "transactionDetails", expression = "java(getEnforcementDetails(enforcement))")
     public abstract DetailedReportTransactionRowDto mapFromEnforcement(EnforcementEntity enforcement,
         DefendantAccountEntity account,
@@ -74,8 +74,8 @@ public abstract class DetailedTransactionRowMapper
     @Mapping(target = "accountNo", source = "account.accountNumber")
     @Mapping(target = "transactionDate", source = "note.postedDate")
     @Mapping(target = "transactionType", constant = NOTE_TYPE)
-    @Mapping(target = "transactionUserId", source = "transaction.postedByUsername")
-    @Mapping(target = "transactionAmount", source = "transaction.transactionAmount")
+    @Mapping(target = "transactionUserId", source = "note.postedByUsername")
+    @Mapping(target = "transactionAmount", ignore = true)
     @Mapping(target = "consolidatedAccountNo", expression = "java(getConsolidatedAccountNo("
         + "note.getAssociatedRecordType(), note.getAssociatedRecordId(), context))")
     @Mapping(target = "transactionDetails", source = "note.noteText")

--- a/src/main/java/uk/gov/hmcts/opal/service/report/operation/mapper/SummaryRowDtoCoreMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/operation/mapper/SummaryRowDtoCoreMapper.java
@@ -10,7 +10,7 @@ import uk.gov.hmcts.opal.entity.debtordetail.DebtorDetailEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.service.report.ReportMetadataContext;
 
-@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface SummaryRowDtoCoreMapper extends CommonMappingHelper {
 
     @Mapping(target = "header1", constant = "DETAIL")

--- a/src/test/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedResultMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedResultMapperTest.java
@@ -88,12 +88,14 @@ class DetailedResultMapperTest {
         when(impositionRepository.findAllById(any())).thenReturn(List.of(imposition1, imposition2));
 
         when(transactionRowMapper
-            .map(eq(transaction1), eq(account1), eq(imposition1), any(ReportMetadataContext.class)))
+            .mapFromTransaction(eq(transaction1), eq(account1), eq(imposition1), any(ReportMetadataContext.class)))
             .thenReturn(transactionRow1);
-        when(transactionRowMapper.map(eq(transaction2), eq(account1), isNull(), any(ReportMetadataContext.class)))
+        when(transactionRowMapper
+            .mapFromTransaction(eq(transaction2), eq(account1), isNull(), any(ReportMetadataContext.class)))
             .thenReturn(transactionRow2);
         when(
-            transactionRowMapper.map(eq(transaction3), eq(account2), eq(imposition2), any(ReportMetadataContext.class)))
+            transactionRowMapper
+            .mapFromTransaction(eq(transaction3), eq(account2), eq(imposition2), any(ReportMetadataContext.class)))
             .thenReturn(transactionRow3);
 
         OperationDetailedReport result = mapper.map(List.of(account1, account2));

--- a/src/test/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedResultMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedResultMapperTest.java
@@ -1,39 +1,57 @@
 package uk.gov.hmcts.opal.service.report.operation.mapper;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDate;
 import java.util.List;
-import org.assertj.core.api.Assertions;
+import org.mockito.ArgumentMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.domain.Specification;
 import uk.gov.hmcts.opal.dto.report.operation.DetailedAccountReportDto;
 import uk.gov.hmcts.opal.dto.report.operation.DetailedOperationReportAccountRowDto;
 import uk.gov.hmcts.opal.dto.report.operation.DetailedReportDto;
 import uk.gov.hmcts.opal.dto.report.operation.DetailedReportTransactionRowDto;
 import uk.gov.hmcts.opal.entity.AssociatedRecordType;
+import uk.gov.hmcts.opal.entity.AssociatedRecordType;
+import uk.gov.hmcts.opal.entity.NoteEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.entity.defendanttransaction.DefendantTransactionEntity;
+import uk.gov.hmcts.opal.entity.enforcement.EnforcementEntity;
 import uk.gov.hmcts.opal.entity.imposition.ImpositionEntity;
+import uk.gov.hmcts.opal.entity.paymentterms.PaymentTermsEntity;
 import uk.gov.hmcts.opal.repository.DefendantTransactionRepository;
 import uk.gov.hmcts.opal.repository.ImpositionRepository;
+import uk.gov.hmcts.opal.repository.EnforcementRepository;
+import uk.gov.hmcts.opal.repository.ImpositionRepository;
+import uk.gov.hmcts.opal.repository.NoteRepository;
+import uk.gov.hmcts.opal.repository.PaymentTermsRepository;
 import uk.gov.hmcts.opal.service.report.ReportMetadataContext;
 import uk.gov.hmcts.opal.service.report.operation.OperationDetailedReport;
 
 class DetailedResultMapperTest {
+
+    private static final LocalDate PAYMENT_TERMS_DATE = LocalDate.of(2024, 1, 1);
+    private static final LocalDate ENFORCEMENT_DATE = LocalDate.of(2024, 1, 2);
+    private static final LocalDate TRANSACTION_DATE = LocalDate.of(2024, 1, 3);
+    private static final LocalDate NOTE_DATE = LocalDate.of(2024, 1, 4);
+    private static final LocalDate TRANSACTION_TWO_DATE = LocalDate.of(2024, 1, 5);
 
     private DetailedResultMapper mapper;
     private DetailedRowDtoCoreMapper rowMapper;
     private DetailedTransactionRowMapper transactionRowMapper;
     private DefendantTransactionRepository transactionRepository;
     private ImpositionRepository impositionRepository;
+    private PaymentTermsRepository paymentTermsRepository;
+    private EnforcementRepository enforcementRepository;
+    private NoteRepository noteRepository;
 
     @BeforeEach
     void setUp() {
@@ -43,11 +61,22 @@ class DetailedResultMapperTest {
         transactionRowMapper = mock(DetailedTransactionRowMapper.class);
         transactionRepository = mock(DefendantTransactionRepository.class);
         impositionRepository = mock(ImpositionRepository.class);
-        mapper.setRowMapper(rowMapper, transactionRowMapper, transactionRepository, impositionRepository);
+        paymentTermsRepository = mock(PaymentTermsRepository.class);
+        enforcementRepository = mock(EnforcementRepository.class);
+        noteRepository = mock(NoteRepository.class);
+        mapper.setRowMapper(
+            rowMapper,
+            transactionRowMapper,
+            transactionRepository,
+            impositionRepository,
+            paymentTermsRepository,
+            enforcementRepository,
+            noteRepository
+        );
     }
 
     @Test
-    void map_shouldBuildReportWithAccountTransactionRowsAndMetadata() {
+    void map_shouldBuildReportWithAllTransactionRowSourcesAndMetadata() {
         DefendantAccountEntity account1 = mock(DefendantAccountEntity.class);
         DefendantAccountEntity account2 = mock(DefendantAccountEntity.class);
         when(account1.getDefendantAccountId()).thenReturn(101L);
@@ -61,77 +90,122 @@ class DetailedResultMapperTest {
         when(rowMapper.map(eq(account1), any(ReportMetadataContext.class))).thenReturn(accountRow1);
         when(rowMapper.map(eq(account2), any(ReportMetadataContext.class))).thenReturn(accountRow2);
 
+        PaymentTermsEntity paymentTerms1 = mock(PaymentTermsEntity.class);
+        EnforcementEntity enforcement1 = mock(EnforcementEntity.class);
         DefendantTransactionEntity transaction1 = mock(DefendantTransactionEntity.class);
         DefendantTransactionEntity transaction2 = mock(DefendantTransactionEntity.class);
-        DefendantTransactionEntity transaction3 = mock(DefendantTransactionEntity.class);
-
+        NoteEntity note1 = mock(NoteEntity.class);
         ImpositionEntity imposition1 = mock(ImpositionEntity.class);
         when(imposition1.getImpositionId()).thenReturn(11L);
-        ImpositionEntity imposition2 = mock(ImpositionEntity.class);
-        when(imposition2.getImpositionId()).thenReturn(12L);
+
+        when(paymentTermsRepository.findByDefendantAccount_DefendantAccountIdAndEffectiveDateIsNotNullOrderByEffectiveDateAsc(
+            101L)).thenReturn(List.of(paymentTerms1));
+        when(paymentTermsRepository.findByDefendantAccount_DefendantAccountIdAndEffectiveDateIsNotNullOrderByEffectiveDateAsc(
+            202L)).thenReturn(List.of());
+
+        when(enforcementRepository.findHistoryRowsByDefendantAccountId(101L)).thenReturn(List.of(enforcement1));
+        when(enforcementRepository.findHistoryRowsByDefendantAccountId(202L)).thenReturn(List.of());
 
         when(transactionRepository.findByDefendantAccountId(101L)).thenReturn(List.of(transaction1, transaction2));
-        when(transactionRepository.findByDefendantAccountId(202L)).thenReturn(List.of(transaction3));
+        when(transactionRepository.findByDefendantAccountId(202L)).thenReturn(List.of());
 
-        DetailedReportTransactionRowDto transactionRow1 =
-            mock(DetailedReportTransactionRowDto.class);
-        DetailedReportTransactionRowDto transactionRow2 =
-            mock(DetailedReportTransactionRowDto.class);
-        DetailedReportTransactionRowDto transactionRow3 =
-            mock(DetailedReportTransactionRowDto.class);
         when(transaction1.getAssociatedRecordType()).thenReturn(AssociatedRecordType.IMPOSITIONS);
         when(transaction1.getAssociatedRecordId()).thenReturn("11");
+        when(transaction2.getAssociatedRecordType()).thenReturn(AssociatedRecordType.DEFENDANT_ACCOUNTS);
+        when(transaction2.getAssociatedRecordId()).thenReturn("22");
+        when(impositionRepository.findAllById(List.of(11L))).thenReturn(List.of(imposition1));
 
-        when(transaction3.getAssociatedRecordType()).thenReturn(AssociatedRecordType.IMPOSITIONS);
-        when(transaction3.getAssociatedRecordId()).thenReturn("12");
+        when(noteRepository.findAll(ArgumentMatchers.<Specification<NoteEntity>>any()))
+            .thenReturn(List.of(note1))
+            .thenReturn(List.of());
 
-        when(impositionRepository.findAllById(any())).thenReturn(List.of(imposition1, imposition2));
+        DetailedReportTransactionRowDto paymentTermsRow =
+            DetailedReportTransactionRowDto.builder()
+                .transactionDate(PAYMENT_TERMS_DATE)
+                .transactionType("TTPAY")
+                .build();
+        DetailedReportTransactionRowDto enforcementRow =
+            DetailedReportTransactionRowDto.builder()
+                .transactionDate(ENFORCEMENT_DATE)
+                .transactionType("ENFT")
+                .build();
+        DetailedReportTransactionRowDto transactionRow1 =
+            DetailedReportTransactionRowDto.builder()
+                .transactionDate(TRANSACTION_DATE)
+                .transactionType("TRANSACTION-1")
+                .build();
+        DetailedReportTransactionRowDto noteRow =
+            DetailedReportTransactionRowDto.builder()
+                .transactionDate(NOTE_DATE)
+                .transactionType("NOTE")
+                .build();
+        DetailedReportTransactionRowDto transactionRow2 =
+            DetailedReportTransactionRowDto.builder()
+                .transactionDate(TRANSACTION_TWO_DATE)
+                .transactionType("TRANSACTION-2")
+                .build();
 
-        when(transactionRowMapper
-            .mapFromTransaction(eq(transaction1), eq(account1), eq(imposition1), any(ReportMetadataContext.class)))
+        when(transactionRowMapper.mapFromPaymentTerms(eq(paymentTerms1), eq(account1), any(ReportMetadataContext.class)))
+            .thenReturn(paymentTermsRow);
+        when(transactionRowMapper.mapFromEnforcement(eq(enforcement1), eq(account1), any(ReportMetadataContext.class)))
+            .thenReturn(enforcementRow);
+        when(transactionRowMapper.mapFromTransaction(
+            eq(transaction1), eq(account1), eq(imposition1), any(ReportMetadataContext.class)))
             .thenReturn(transactionRow1);
-        when(transactionRowMapper
-            .mapFromTransaction(eq(transaction2), eq(account1), isNull(), any(ReportMetadataContext.class)))
+        when(transactionRowMapper.mapFromTransaction(
+            eq(transaction2), eq(account1), isNull(), any(ReportMetadataContext.class)))
             .thenReturn(transactionRow2);
         when(
-            transactionRowMapper
-            .mapFromTransaction(eq(transaction3), eq(account2), eq(imposition2), any(ReportMetadataContext.class)))
-            .thenReturn(transactionRow3);
+            transactionRowMapper.mapFromNote(eq(note1), eq(account1), any(ReportMetadataContext.class)))
+            .thenReturn(noteRow);
 
         OperationDetailedReport result = mapper.map(List.of(account1, account2));
 
         assertThat(result).isNotNull();
         assertThat(result.getDetailedReport()).isNotNull();
         assertThat(result.getReportMetaData()).isNotNull();
+        assertThat(result.getReportMetaData().getPdpoPartyIds()).isEmpty();
 
         DetailedReportDto reportDto = result.getDetailedReport();
-        Assertions.assertThat(reportDto.getAccountTransactionReports()).hasSize(2);
+        assertThat(reportDto.getAccountTransactionReports()).hasSize(2);
 
-        DetailedAccountReportDto mappedAccount1 =
-            reportDto.getAccountTransactionReports().get(0);
-        DetailedAccountReportDto mappedAccount2 =
-            reportDto.getAccountTransactionReports().get(1);
+        DetailedAccountReportDto mappedAccount1 = reportDto.getAccountTransactionReports().get(0);
+        DetailedAccountReportDto mappedAccount2 = reportDto.getAccountTransactionReports().get(1);
 
         assertThat(mappedAccount1.getAccountRow()).isSameAs(accountRow1);
-        Assertions.assertThat(mappedAccount1.getTransactionRows()).containsExactly(transactionRow1, transactionRow2);
+        assertThat(mappedAccount1.getTransactionRows()).containsExactly(
+            paymentTermsRow,
+            enforcementRow,
+            transactionRow1,
+            noteRow,
+            transactionRow2
+        );
 
         assertThat(mappedAccount2.getAccountRow()).isSameAs(accountRow2);
-        Assertions.assertThat(mappedAccount2.getTransactionRows()).containsExactly(transactionRow3);
+        assertThat(mappedAccount2.getTransactionRows()).isEmpty();
 
         verify(rowMapper).map(eq(account1), any(ReportMetadataContext.class));
         verify(rowMapper).map(eq(account2), any(ReportMetadataContext.class));
+        verify(paymentTermsRepository).findByDefendantAccount_DefendantAccountIdAndEffectiveDateIsNotNullOrderByEffectiveDateAsc(
+            101L);
+        verify(paymentTermsRepository).findByDefendantAccount_DefendantAccountIdAndEffectiveDateIsNotNullOrderByEffectiveDateAsc(
+            202L);
+        verify(enforcementRepository).findHistoryRowsByDefendantAccountId(101L);
+        verify(enforcementRepository).findHistoryRowsByDefendantAccountId(202L);
+        verify(transactionRepository).findByDefendantAccountId(101L);
+        verify(transactionRepository).findByDefendantAccountId(202L);
+        verify(impositionRepository).findAllById(List.of(11L));
+        verify(noteRepository, times(2)).findAll(ArgumentMatchers.<Specification<NoteEntity>>any());
     }
 
     @Test
     void map_shouldReturnEmptyAccountListWhenNoAccountsProvided() {
         OperationDetailedReport result = mapper.map(List.of());
 
-        assertNotNull(result);
-        DetailedReportDto reportDto = result.getDetailedReport();
-        assertNotNull(reportDto);
-        assertEquals(List.of(), reportDto.getAccountTransactionReports());
-        assertNotNull(result.getReportMetaData());
-        assertEquals(List.of(), result.getReportMetaData().getPdpoPartyIds());
-
+        assertThat(result).isNotNull();
+        assertThat(result.getDetailedReport()).isNotNull();
+        assertThat(result.getDetailedReport().getAccountTransactionReports()).isEmpty();
+        assertThat(result.getReportMetaData()).isNotNull();
+        assertThat(result.getReportMetaData().getPdpoPartyIds()).isEmpty();
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedResultMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedResultMapperTest.java
@@ -20,7 +20,6 @@ import uk.gov.hmcts.opal.dto.report.operation.DetailedOperationReportAccountRowD
 import uk.gov.hmcts.opal.dto.report.operation.DetailedReportDto;
 import uk.gov.hmcts.opal.dto.report.operation.DetailedReportTransactionRowDto;
 import uk.gov.hmcts.opal.entity.AssociatedRecordType;
-import uk.gov.hmcts.opal.entity.AssociatedRecordType;
 import uk.gov.hmcts.opal.entity.NoteEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.entity.defendanttransaction.DefendantTransactionEntity;
@@ -30,7 +29,6 @@ import uk.gov.hmcts.opal.entity.paymentterms.PaymentTermsEntity;
 import uk.gov.hmcts.opal.repository.DefendantTransactionRepository;
 import uk.gov.hmcts.opal.repository.ImpositionRepository;
 import uk.gov.hmcts.opal.repository.EnforcementRepository;
-import uk.gov.hmcts.opal.repository.ImpositionRepository;
 import uk.gov.hmcts.opal.repository.NoteRepository;
 import uk.gov.hmcts.opal.repository.PaymentTermsRepository;
 import uk.gov.hmcts.opal.service.report.ReportMetadataContext;

--- a/src/test/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedResultMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedResultMapperTest.java
@@ -98,10 +98,12 @@ class DetailedResultMapperTest {
         ImpositionEntity imposition1 = mock(ImpositionEntity.class);
         when(imposition1.getImpositionId()).thenReturn(11L);
 
-        when(paymentTermsRepository.findByDefendantAccount_DefendantAccountIdAndEffectiveDateIsNotNullOrderByEffectiveDateAsc(
-            101L)).thenReturn(List.of(paymentTerms1));
-        when(paymentTermsRepository.findByDefendantAccount_DefendantAccountIdAndEffectiveDateIsNotNullOrderByEffectiveDateAsc(
-            202L)).thenReturn(List.of());
+        when(paymentTermsRepository
+            .findByDefendantAccount_DefendantAccountIdAndEffectiveDateIsNotNullOrderByEffectiveDateAsc(101L))
+            .thenReturn(List.of(paymentTerms1));
+        when(paymentTermsRepository
+            .findByDefendantAccount_DefendantAccountIdAndEffectiveDateIsNotNullOrderByEffectiveDateAsc(202L))
+            .thenReturn(List.of());
 
         when(enforcementRepository.findHistoryRowsByDefendantAccountId(101L)).thenReturn(List.of(enforcement1));
         when(enforcementRepository.findHistoryRowsByDefendantAccountId(202L)).thenReturn(List.of());
@@ -145,7 +147,8 @@ class DetailedResultMapperTest {
                 .transactionType("TRANSACTION-2")
                 .build();
 
-        when(transactionRowMapper.mapFromPaymentTerms(eq(paymentTerms1), eq(account1), any(ReportMetadataContext.class)))
+        when(transactionRowMapper
+            .mapFromPaymentTerms(eq(paymentTerms1), eq(account1), any(ReportMetadataContext.class)))
             .thenReturn(paymentTermsRow);
         when(transactionRowMapper.mapFromEnforcement(eq(enforcement1), eq(account1), any(ReportMetadataContext.class)))
             .thenReturn(enforcementRow);
@@ -186,16 +189,17 @@ class DetailedResultMapperTest {
 
         verify(rowMapper).map(eq(account1), any(ReportMetadataContext.class));
         verify(rowMapper).map(eq(account2), any(ReportMetadataContext.class));
-        verify(paymentTermsRepository).findByDefendantAccount_DefendantAccountIdAndEffectiveDateIsNotNullOrderByEffectiveDateAsc(
-            101L);
-        verify(paymentTermsRepository).findByDefendantAccount_DefendantAccountIdAndEffectiveDateIsNotNullOrderByEffectiveDateAsc(
-            202L);
+        verify(paymentTermsRepository)
+            .findByDefendantAccount_DefendantAccountIdAndEffectiveDateIsNotNullOrderByEffectiveDateAsc(101L);
+        verify(paymentTermsRepository)
+            .findByDefendantAccount_DefendantAccountIdAndEffectiveDateIsNotNullOrderByEffectiveDateAsc(202L);
         verify(enforcementRepository).findHistoryRowsByDefendantAccountId(101L);
         verify(enforcementRepository).findHistoryRowsByDefendantAccountId(202L);
         verify(transactionRepository).findByDefendantAccountId(101L);
         verify(transactionRepository).findByDefendantAccountId(202L);
         verify(impositionRepository).findAllById(List.of(11L));
-        verify(noteRepository, times(2)).findAll(ArgumentMatchers.<Specification<NoteEntity>>any());
+        verify(noteRepository, times(2))
+            .findAll(ArgumentMatchers.<Specification<NoteEntity>>any());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedResultMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedResultMapperTest.java
@@ -29,8 +29,8 @@ import uk.gov.hmcts.opal.entity.paymentterms.PaymentTermsEntity;
 import uk.gov.hmcts.opal.repository.DefendantTransactionRepository;
 import uk.gov.hmcts.opal.repository.ImpositionRepository;
 import uk.gov.hmcts.opal.repository.EnforcementRepository;
-import uk.gov.hmcts.opal.repository.NoteRepository;
 import uk.gov.hmcts.opal.repository.PaymentTermsRepository;
+import uk.gov.hmcts.opal.service.persistence.NoteRepositoryService;
 import uk.gov.hmcts.opal.service.report.ReportMetadataContext;
 import uk.gov.hmcts.opal.service.report.operation.OperationDetailedReport;
 
@@ -49,7 +49,7 @@ class DetailedResultMapperTest {
     private ImpositionRepository impositionRepository;
     private PaymentTermsRepository paymentTermsRepository;
     private EnforcementRepository enforcementRepository;
-    private NoteRepository noteRepository;
+    private NoteRepositoryService noteRepositoryService;
 
     @BeforeEach
     void setUp() {
@@ -61,7 +61,7 @@ class DetailedResultMapperTest {
         impositionRepository = mock(ImpositionRepository.class);
         paymentTermsRepository = mock(PaymentTermsRepository.class);
         enforcementRepository = mock(EnforcementRepository.class);
-        noteRepository = mock(NoteRepository.class);
+        noteRepositoryService = mock(NoteRepositoryService.class);
         mapper.setRowMapper(
             rowMapper,
             transactionRowMapper,
@@ -69,7 +69,7 @@ class DetailedResultMapperTest {
             impositionRepository,
             paymentTermsRepository,
             enforcementRepository,
-            noteRepository
+            noteRepositoryService
         );
     }
 
@@ -115,7 +115,7 @@ class DetailedResultMapperTest {
         when(transaction2.getAssociatedRecordId()).thenReturn("22");
         when(impositionRepository.findAllById(List.of(11L))).thenReturn(List.of(imposition1));
 
-        when(noteRepository.findAll(ArgumentMatchers.<Specification<NoteEntity>>any()))
+        when(noteRepositoryService.findAll(ArgumentMatchers.<Specification<NoteEntity>>any()))
             .thenReturn(List.of(note1))
             .thenReturn(List.of());
 
@@ -196,7 +196,7 @@ class DetailedResultMapperTest {
         verify(transactionRepository).findByDefendantAccountId(101L);
         verify(transactionRepository).findByDefendantAccountId(202L);
         verify(impositionRepository).findAllById(List.of(11L));
-        verify(noteRepository, times(2))
+        verify(noteRepositoryService, times(2))
             .findAll(ArgumentMatchers.<Specification<NoteEntity>>any());
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedTransactionRowMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedTransactionRowMapperTest.java
@@ -208,13 +208,14 @@ class DetailedTransactionRowMapperTest {
         EnforcementEntity enforcement = new EnforcementEntity();
         enforcement.setPostedDate(LocalDateTime.of(2024, 7, 8, 9, 10));
         enforcement.setPostedByUsername("enforcement.user");
+        enforcement.setResultId("RESULT_ID");
         enforcement.setReason("reason only");
 
         DetailedReportTransactionRowDto result =
             mapper.mapFromEnforcement(enforcement, account, new ReportMetadataContext());
 
         assertThat(result).isNotNull();
-        assertThat(result.getTransactionDetails()).isEqualTo("reason only");
+        assertThat(result.getTransactionDetails()).isEqualTo("RESULT_ID | reason only");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedTransactionRowMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedTransactionRowMapperTest.java
@@ -204,6 +204,20 @@ class DetailedTransactionRowMapperTest {
     }
 
     @Test
+    void mapFromEnforcement_nullResultId_shouldStillMapOtherDetails() {
+        EnforcementEntity enforcement = new EnforcementEntity();
+        enforcement.setPostedDate(LocalDateTime.of(2024, 7, 8, 9, 10));
+        enforcement.setPostedByUsername("enforcement.user");
+        enforcement.setReason("reason only");
+
+        DetailedReportTransactionRowDto result =
+            mapper.mapFromEnforcement(enforcement, account, new ReportMetadataContext());
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTransactionDetails()).isEqualTo("reason only");
+    }
+
+    @Test
     void mapFromNote_shouldMapNoteFieldsAndConsolidatedAccountNo() {
         DefendantAccountEntity consolidatedAccount = DefendantAccountEntity.builder()
             .accountNumber("CONSOLIDATED-12")

--- a/src/test/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedTransactionRowMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedTransactionRowMapperTest.java
@@ -52,7 +52,7 @@ class DetailedTransactionRowMapperTest {
     }
 
     @Test
-    void map_allFieldsIncludingConsolidatedAccountNo() {
+    void map_FromTransaction_allFieldsIncludingConsolidatedAccountNo() {
         DefendantTransactionEntity transaction = new DefendantTransactionEntity();
         transaction.setPostedDate(LocalDate.of(2024, 1, 15));
         transaction.setTransactionType(DefendantTransactionType.CONSOL);
@@ -66,7 +66,7 @@ class DetailedTransactionRowMapperTest {
             .thenReturn("txn details");
 
         DetailedReportTransactionRowDto result =
-            mapper.map(transaction, account, imposition, new ReportMetadataContext());
+            mapper.mapFromTransaction(transaction, account, imposition, new ReportMetadataContext());
 
         assertThat(result).isNotNull();
         assertThat(result.getAccountNo()).isEqualTo("ACCOUNT");
@@ -86,28 +86,28 @@ class DetailedTransactionRowMapperTest {
 
     @ParameterizedTest
     @EnumSource(value = DefendantTransactionType.class, names = {"CONSOL"}, mode = Mode.EXCLUDE)
-    void map_transactionTypeNotConsol_returnNull(DefendantTransactionType transactionType) {
+    void map_FromTransaction_transactionTypeNotConsol_returnNull(DefendantTransactionType transactionType) {
         DefendantTransactionEntity entity = new DefendantTransactionEntity();
         entity.setTransactionType(transactionType);
         entity.setAssociatedRecordType(AssociatedRecordType.DEFENDANT_ACCOUNTS);
         entity.setAssociatedRecordId("12");
 
         DetailedReportTransactionRowDto result =
-            mapper.map(entity, account, imposition, new ReportMetadataContext());
+            mapper.mapFromTransaction(entity, account, imposition, new ReportMetadataContext());
 
         assertThat(result.getConsolidatedAccountNo()).isNull();
     }
 
     @ParameterizedTest
     @EnumSource(value = AssociatedRecordType.class, names = {"DEFENDANT_ACCOUNTS"}, mode = Mode.EXCLUDE)
-    void map_associatedRecordTypeNotDefendantAccounts_returnNull() {
+    void map_FromTransaction_associatedRecordTypeNotDefendantAccounts_returnNull() {
         DefendantTransactionEntity entity = new DefendantTransactionEntity();
         entity.setTransactionType(DefendantTransactionType.CONSOL);
         entity.setAssociatedRecordType(AssociatedRecordType.IMPOSITIONS);
         entity.setAssociatedRecordId("12");
 
         DetailedReportTransactionRowDto result =
-            mapper.map(entity, account, imposition, new ReportMetadataContext());
+            mapper.mapFromTransaction(entity, account, imposition, new ReportMetadataContext());
 
         assertThat(result.getConsolidatedAccountNo()).isNull();
     }

--- a/src/test/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedTransactionRowMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/operation/mapper/DetailedTransactionRowMapperTest.java
@@ -1,10 +1,11 @@
 package uk.gov.hmcts.opal.service.report.operation.mapper;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,15 +16,23 @@ import org.mapstruct.factory.Mappers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.hmcts.opal.dto.PdplIdentifierType;
 import uk.gov.hmcts.opal.dto.report.operation.DetailedReportTransactionRowDto;
 import uk.gov.hmcts.opal.entity.AssociatedRecordType;
+import uk.gov.hmcts.opal.entity.NoteEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.entity.defendanttransaction.DefendantTransactionEntity;
 import uk.gov.hmcts.opal.entity.defendanttransaction.DefendantTransactionType;
+import uk.gov.hmcts.opal.entity.court.CourtEntity;
+import uk.gov.hmcts.opal.entity.enforcement.EnforcementEntity;
 import uk.gov.hmcts.opal.entity.imposition.ImpositionEntity;
+import uk.gov.hmcts.opal.entity.paymentterms.InstalmentPeriod;
+import uk.gov.hmcts.opal.entity.paymentterms.PaymentTermsEntity;
+import uk.gov.hmcts.opal.entity.paymentterms.TermsTypeCode;
 import uk.gov.hmcts.opal.service.opal.history.defendant.DefendantTransactionDetailsService;
 import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
 import uk.gov.hmcts.opal.service.report.ReportMetadataContext;
+import uk.gov.hmcts.opal.logging.integration.dto.ParticipantIdentifier;
 
 @ExtendWith(MockitoExtension.class)
 class DetailedTransactionRowMapperTest {
@@ -52,7 +61,7 @@ class DetailedTransactionRowMapperTest {
     }
 
     @Test
-    void map_FromTransaction_allFieldsIncludingConsolidatedAccountNo() {
+    void mapFromTransaction_allFieldsIncludingConsolidatedAccountNo() {
         DefendantTransactionEntity transaction = new DefendantTransactionEntity();
         transaction.setPostedDate(LocalDate.of(2024, 1, 15));
         transaction.setTransactionType(DefendantTransactionType.CONSOL);
@@ -86,7 +95,7 @@ class DetailedTransactionRowMapperTest {
 
     @ParameterizedTest
     @EnumSource(value = DefendantTransactionType.class, names = {"CONSOL"}, mode = Mode.EXCLUDE)
-    void map_FromTransaction_transactionTypeNotConsol_returnNull(DefendantTransactionType transactionType) {
+    void mapFromTransaction_transactionTypeNotConsol_returnNull(DefendantTransactionType transactionType) {
         DefendantTransactionEntity entity = new DefendantTransactionEntity();
         entity.setTransactionType(transactionType);
         entity.setAssociatedRecordType(AssociatedRecordType.DEFENDANT_ACCOUNTS);
@@ -100,7 +109,7 @@ class DetailedTransactionRowMapperTest {
 
     @ParameterizedTest
     @EnumSource(value = AssociatedRecordType.class, names = {"DEFENDANT_ACCOUNTS"}, mode = Mode.EXCLUDE)
-    void map_FromTransaction_associatedRecordTypeNotDefendantAccounts_returnNull() {
+    void mapFromTransaction_associatedRecordTypeNotDefendantAccounts_returnNull() {
         DefendantTransactionEntity entity = new DefendantTransactionEntity();
         entity.setTransactionType(DefendantTransactionType.CONSOL);
         entity.setAssociatedRecordType(AssociatedRecordType.IMPOSITIONS);
@@ -110,6 +119,117 @@ class DetailedTransactionRowMapperTest {
             mapper.mapFromTransaction(entity, account, imposition, new ReportMetadataContext());
 
         assertThat(result.getConsolidatedAccountNo()).isNull();
+    }
+
+    @Test
+    void mapFromPaymentTerms_byDate_shouldMapCoreFieldsAndDetails() {
+        PaymentTermsEntity paymentTerms = new PaymentTermsEntity();
+        paymentTerms.setPostedDate(LocalDateTime.of(2024, 1, 15, 10, 30));
+        paymentTerms.setPostedByUsername("payment.user");
+        paymentTerms.setTermsTypeCode(TermsTypeCode.BY_DATE);
+        paymentTerms.setEffectiveDate(LocalDate.of(2024, 2, 20));
+        paymentTerms.setJailDays(7);
+        paymentTerms.setReasonForExtension("extended by court");
+
+        DetailedReportTransactionRowDto result =
+            mapper.mapFromPaymentTerms(paymentTerms, account, new ReportMetadataContext());
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAccountNo()).isEqualTo("ACCOUNT");
+        assertThat(result.getTransactionDate()).isEqualTo(LocalDate.of(2024, 1, 15));
+        assertThat(result.getTransactionType()).isEqualTo(DetailedTransactionRowMapper.PAYMENT_TERMS_TYPE);
+        assertThat(result.getTransactionUserId()).isEqualTo("payment.user");
+        assertThat(result.getTransactionAmount()).isNull();
+        assertThat(result.getConsolidatedAccountNo()).isNull();
+        assertThat(result.getTransactionDetails())
+            .isEqualTo("In full | 2024-02-20 | 7 days in default | extended by court");
+    }
+
+    @Test
+    void mapFromPaymentTerms_instalments_shouldMapInstallmentDetails() {
+        PaymentTermsEntity paymentTerms = new PaymentTermsEntity();
+        paymentTerms.setPostedDate(LocalDateTime.of(2024, 3, 1, 8, 45));
+        paymentTerms.setPostedByUsername("instalment.user");
+        paymentTerms.setTermsTypeCode(TermsTypeCode.INSTALMENTS);
+        paymentTerms.setEffectiveDate(LocalDate.of(2024, 4, 10));
+        paymentTerms.setInstalmentLumpSum(new BigDecimal("150.00"));
+        paymentTerms.setInstalmentAmount(new BigDecimal("25.00"));
+        paymentTerms.setInstalmentPeriod(InstalmentPeriod.MONTH);
+
+        DetailedReportTransactionRowDto result =
+            mapper.mapFromPaymentTerms(paymentTerms, account, new ReportMetadataContext());
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAccountNo()).isEqualTo("ACCOUNT");
+        assertThat(result.getTransactionDate()).isEqualTo(LocalDate.of(2024, 3, 1));
+        assertThat(result.getTransactionType()).isEqualTo(DetailedTransactionRowMapper.PAYMENT_TERMS_TYPE);
+        assertThat(result.getTransactionUserId()).isEqualTo("instalment.user");
+        assertThat(result.getTransactionAmount()).isNull();
+        assertThat(result.getConsolidatedAccountNo()).isNull();
+        assertThat(result.getTransactionDetails())
+            .isEqualTo("Lump sum: 150.00 | Installments: 25.00 monthly from 2024-04-10");
+    }
+
+    @Test
+    void mapFromEnforcement_shouldMapAllFieldsAndDetails() {
+        EnforcementEntity enforcement = new EnforcementEntity();
+        enforcement.setPostedDate(LocalDateTime.of(2024, 5, 6, 7, 8));
+        enforcement.setPostedByUsername("enforcement.user");
+        enforcement.setResultId("RESULT-1");
+        enforcement.setJailDays(10);
+        enforcement.setWarrantReference("WR-123");
+        enforcement.setEarliestReleaseDate(LocalDateTime.of(2024, 5, 7, 8, 9));
+        enforcement.setHearingDate(LocalDateTime.of(2024, 5, 8, 9, 10));
+        CourtEntity court = new CourtEntity();
+        court.setName("Magistrates Court");
+        enforcement.setHearingCourt(court);
+        enforcement.setCaseReference("CASE-9");
+        enforcement.setReason("reason text");
+
+        DetailedReportTransactionRowDto result =
+            mapper.mapFromEnforcement(enforcement, account, new ReportMetadataContext());
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAccountNo()).isEqualTo("ACCOUNT");
+        assertThat(result.getTransactionDate()).isEqualTo(LocalDate.of(2024, 5, 6));
+        assertThat(result.getTransactionType()).isEqualTo(DetailedTransactionRowMapper.ENFORCEMENT_TYPE);
+        assertThat(result.getTransactionUserId()).isEqualTo("enforcement.user");
+        assertThat(result.getTransactionAmount()).isNull();
+        assertThat(result.getConsolidatedAccountNo()).isNull();
+        assertThat(result.getTransactionDetails()).isEqualTo(
+            "RESULT-1 | 10 days in default | Warrant number: WR-123"
+                + " | Earliest date of release: 2024-05-07T08:09"
+                + " | Hearing: 2024-05-08T09:10 - Magistrates Court - Case: CASE-9"
+                + " | reason text");
+    }
+
+    @Test
+    void mapFromNote_shouldMapNoteFieldsAndConsolidatedAccountNo() {
+        DefendantAccountEntity consolidatedAccount = DefendantAccountEntity.builder()
+            .accountNumber("CONSOLIDATED-12")
+            .build();
+        when(defendantAccountService.findById(12)).thenReturn(consolidatedAccount);
+
+        NoteEntity note = new NoteEntity();
+        note.setPostedDate(LocalDateTime.of(2024, 6, 2, 13, 14));
+        note.setPostedByUsername("note.user");
+        note.setNoteText("note text");
+        note.setAssociatedRecordType(AssociatedRecordType.DEFENDANT_ACCOUNTS);
+        note.setAssociatedRecordId("12");
+
+        ReportMetadataContext context = new ReportMetadataContext();
+        DetailedReportTransactionRowDto result = mapper.mapFromNote(note, account, context);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAccountNo()).isEqualTo("ACCOUNT");
+        assertThat(result.getTransactionDate()).isEqualTo(LocalDate.of(2024, 6, 2));
+        assertThat(result.getTransactionType()).isEqualTo(DetailedTransactionRowMapper.NOTE_TYPE);
+        assertThat(result.getTransactionUserId()).isEqualTo("note.user");
+        assertThat(result.getTransactionAmount()).isNull();
+        assertThat(result.getConsolidatedAccountNo()).isEqualTo("CONSOLIDATED-12");
+        assertThat(result.getTransactionDetails()).isEqualTo("note text");
+        assertThat(context.getParticipants())
+            .containsExactly(new ParticipantIdentifier("12", PdplIdentifierType.CONSOLIDATED_ACCOUNT));
     }
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PO-8659


### Change description ###

This adds additional defendant account history to the operation details reports. New transaction history includes: Payment terms, enforcements, notes, and transactions.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
