### PR TITLE
PO-8916 Add creditor account support to note creation

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/repository/CreditorAccountRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/CreditorAccountRepository.java
@@ -1,9 +1,11 @@
 package uk.gov.hmcts.opal.repository;
 
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -25,6 +27,10 @@ public interface CreditorAccountRepository extends JpaRepository<CreditorAccount
         Long creditorAccountId,
         Short businessUnitId
     );
+
+    @Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
+    @Query("select c from CreditorAccountEntity c where c.creditorAccountId = :id")
+    Optional<CreditorAccountEntity> findByCreditorAccountIdForUpdate(@Param("id") Long creditorAccountId);
 
     @Query(value = """
         SELECT ca.creditor_account_id AS "creditorAccountId",

--- a/src/main/java/uk/gov/hmcts/opal/service/AccountNoteContext.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/AccountNoteContext.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.opal.service;
+
+import uk.gov.hmcts.opal.entity.AssociatedRecordType;
+import uk.gov.hmcts.opal.util.Versioned;
+
+public record AccountNoteContext(
+    Class<? extends Versioned> accountClass,
+    Long accountId,
+    Short businessUnitId,
+    AssociatedRecordType associatedRecordType
+) {
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/AccountNoteContextFactory.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/AccountNoteContextFactory.java
@@ -1,0 +1,55 @@
+package uk.gov.hmcts.opal.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.hmcts.opal.dto.Note;
+import uk.gov.hmcts.opal.dto.RecordType;
+import uk.gov.hmcts.opal.entity.AssociatedRecordType;
+import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
+import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
+import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
+import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
+
+@Component
+@RequiredArgsConstructor
+public class AccountNoteContextFactory {
+
+    private final DefendantAccountRepository defendantAccountRepository;
+    private final CreditorAccountRepository creditorAccountRepository;
+
+    public AccountNoteContext from(Note note) {
+        Long accountId = Long.valueOf(note.getRecordId());
+        RecordType recordType = note.getRecordType();
+
+        return switch (recordType) {
+            case DEFENDANT_ACCOUNTS -> defendantAccountRepository
+                .findById(accountId)
+                .map(account -> new AccountNoteContext(
+                    DefendantAccountEntity.class,
+                    account.getDefendantAccountId(),
+                    account.getBusinessUnit().getBusinessUnitId(),
+                    AssociatedRecordType.DEFENDANT_ACCOUNTS
+                ))
+                .orElseThrow(() -> accountNotFound(note.getRecordId()));
+            case CREDITOR_ACCOUNTS -> creditorAccountRepository
+                .findById(accountId)
+                .map(account -> new AccountNoteContext(
+                    CreditorAccountEntity.class,
+                    account.getCreditorAccountId(),
+                    account.getBusinessUnitId(),
+                    AssociatedRecordType.CREDITOR_ACCOUNTS
+                ))
+                .orElseThrow(() -> accountNotFound(note.getRecordId()));
+            default -> throw new ResponseStatusException(
+                HttpStatus.BAD_REQUEST, "Record type %s is not supported".formatted(recordType)
+            );
+        };
+    }
+
+    private EntityNotFoundException accountNotFound(String accountId) {
+        return new EntityNotFoundException("Account %s not found".formatted(accountId));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/NotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/NotesService.java
@@ -1,12 +1,22 @@
 package uk.gov.hmcts.opal.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
+import uk.gov.hmcts.opal.dto.Note;
+import uk.gov.hmcts.opal.dto.RecordType;
+import uk.gov.hmcts.opal.entity.AssociatedRecordType;
+import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
+import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
+import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
+import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
 import uk.gov.hmcts.opal.service.proxy.NotesProxy;
 
 @Service
@@ -16,15 +26,53 @@ public class NotesService {
 
     private final NotesProxy notesProxy;
     private final UserStateService userStateService;
+    private final DefendantAccountRepository defendantAccountRepository;
+    private final CreditorAccountRepository creditorAccountRepository;
 
     public String addNote(AddNoteRequest request, String ifMatch, Short businessUnitId) {
         log.debug(":addNote:");
 
         UserState userState = userStateService.getUserStateV1FromSecurityContext();
+        AccountNoteContext target = getAccountNoteContext(request.getActivityNote());
+
         if (!userState.hasBusinessUnitUserWithPermission(
             businessUnitId, FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES)) {
-            throw new PermissionNotAllowedException(businessUnitId, FinesPermission.ACCOUNT_MAINTENANCE);
+            throw new PermissionNotAllowedException(businessUnitId, FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES);
         }
-        return notesProxy.addNote(request, ifMatch, userState, businessUnitId);
+
+        return notesProxy.addNote(request, ifMatch, userState, target);
+    }
+
+    private AccountNoteContext getAccountNoteContext(Note note) {
+        Long accountId = Long.valueOf(note.getRecordId());
+        RecordType recordType = note.getRecordType();
+
+        return switch (recordType) {
+            case DEFENDANT_ACCOUNTS -> defendantAccountRepository
+                .findById(accountId)
+                .map(account -> new AccountNoteContext(
+                    DefendantAccountEntity.class,
+                    account.getDefendantAccountId(),
+                    account.getBusinessUnit().getBusinessUnitId(),
+                    AssociatedRecordType.DEFENDANT_ACCOUNTS
+                ))
+                .orElseThrow(() -> accountNotFound(note.getRecordId()));
+            case CREDITOR_ACCOUNTS -> creditorAccountRepository
+                .findById(accountId)
+                .map(account -> new AccountNoteContext(
+                    CreditorAccountEntity.class,
+                    account.getCreditorAccountId(),
+                    account.getBusinessUnitId(),
+                    AssociatedRecordType.CREDITOR_ACCOUNTS
+                ))
+                .orElseThrow(() -> accountNotFound(note.getRecordId()));
+            default -> throw new ResponseStatusException(
+                HttpStatus.BAD_REQUEST, "Record type %s is not supported".formatted(recordType)
+            );
+        };
+    }
+
+    private EntityNotFoundException accountNotFound(String accountId) {
+        return new EntityNotFoundException("Account %s not found".formatted(accountId));
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/NotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/NotesService.java
@@ -1,22 +1,12 @@
 package uk.gov.hmcts.opal.service;
 
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
-import uk.gov.hmcts.opal.dto.Note;
-import uk.gov.hmcts.opal.dto.RecordType;
-import uk.gov.hmcts.opal.entity.AssociatedRecordType;
-import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
-import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
-import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
-import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
 import uk.gov.hmcts.opal.service.proxy.NotesProxy;
 
 @Service
@@ -26,14 +16,13 @@ public class NotesService {
 
     private final NotesProxy notesProxy;
     private final UserStateService userStateService;
-    private final DefendantAccountRepository defendantAccountRepository;
-    private final CreditorAccountRepository creditorAccountRepository;
+    private final AccountNoteContextFactory accountNoteContextFactory;
 
     public String addNote(AddNoteRequest request, String ifMatch, Short businessUnitId) {
         log.debug(":addNote:");
 
         UserState userState = userStateService.getUserStateV1FromSecurityContext();
-        AccountNoteContext target = getAccountNoteContext(request.getActivityNote());
+        AccountNoteContext target = accountNoteContextFactory.from(request.getActivityNote());
 
         if (!userState.hasBusinessUnitUserWithPermission(
             businessUnitId, FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES)) {
@@ -41,38 +30,5 @@ public class NotesService {
         }
 
         return notesProxy.addNote(request, ifMatch, userState, target);
-    }
-
-    private AccountNoteContext getAccountNoteContext(Note note) {
-        Long accountId = Long.valueOf(note.getRecordId());
-        RecordType recordType = note.getRecordType();
-
-        return switch (recordType) {
-            case DEFENDANT_ACCOUNTS -> defendantAccountRepository
-                .findById(accountId)
-                .map(account -> new AccountNoteContext(
-                    DefendantAccountEntity.class,
-                    account.getDefendantAccountId(),
-                    account.getBusinessUnit().getBusinessUnitId(),
-                    AssociatedRecordType.DEFENDANT_ACCOUNTS
-                ))
-                .orElseThrow(() -> accountNotFound(note.getRecordId()));
-            case CREDITOR_ACCOUNTS -> creditorAccountRepository
-                .findById(accountId)
-                .map(account -> new AccountNoteContext(
-                    CreditorAccountEntity.class,
-                    account.getCreditorAccountId(),
-                    account.getBusinessUnitId(),
-                    AssociatedRecordType.CREDITOR_ACCOUNTS
-                ))
-                .orElseThrow(() -> accountNotFound(note.getRecordId()));
-            default -> throw new ResponseStatusException(
-                HttpStatus.BAD_REQUEST, "Record type %s is not supported".formatted(recordType)
-            );
-        };
-    }
-
-    private EntityNotFoundException accountNotFound(String accountId) {
-        return new EntityNotFoundException("Account %s not found".formatted(accountId));
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/iface/NotesServiceInterface.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/iface/NotesServiceInterface.java
@@ -2,9 +2,10 @@ package uk.gov.hmcts.opal.service.iface;
 
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
+import uk.gov.hmcts.opal.service.AccountNoteContext;
 
 public interface NotesServiceInterface {
 
-    String addNote(AddNoteRequest request, String ifMatch, UserState user, Short businessUnitId);
+    String addNote(AddNoteRequest request, String ifMatch, UserState user, AccountNoteContext target);
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.opal.dto.AddNoteRequest;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyAddNoteRequest;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyAddNoteResponse;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyNote;
+import uk.gov.hmcts.opal.service.AccountNoteContext;
 import uk.gov.hmcts.opal.service.iface.NotesServiceInterface;
 
 @Service
@@ -21,13 +22,13 @@ public class LegacyNotesService implements NotesServiceInterface {
     private final GatewayService gatewayService;
 
     @Override
-    public String addNote(AddNoteRequest request, String ifMatch, UserState user, Short businessUnitId) {
+    public String addNote(AddNoteRequest request, String ifMatch, UserState user, AccountNoteContext target) {
         log.info(":LegacyAddNote");
 
         GatewayService.Response<LegacyAddNoteResponse> response = gatewayService.postToGateway(
             ADD_NOTE,
             LegacyAddNoteResponse.class,
-            createRequest(request, ifMatch, user, businessUnitId),
+            createRequest(request, ifMatch, user, target.businessUnitId()),
             null
         );
 
@@ -49,13 +50,13 @@ public class LegacyNotesService implements NotesServiceInterface {
     }
 
     private LegacyAddNoteRequest createRequest(AddNoteRequest request, String version, UserState user,
-                                               Short defendantBusinessUnitId) {
+                                               Short businessUnitId) {
 
         LegacyNote note = LegacyNote.builder().noteText(request.getActivityNote().getNoteText())
             .noteType(request.getActivityNote().getNoteType()).recordType(request.getActivityNote().getRecordType())
             .recordId(request.getActivityNote().getRecordId()).build();
 
-        return LegacyAddNoteRequest.builder().businessUnitId(defendantBusinessUnitId)
+        return LegacyAddNoteRequest.builder().businessUnitId(businessUnitId)
             .businessUnitUserId(user.getUserId()).version(new BigInteger(version)).activityNote(note).build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementService.java
@@ -24,9 +24,11 @@ import uk.gov.hmcts.opal.dto.ResultResponse;
 import uk.gov.hmcts.opal.dto.RecordType;
 import uk.gov.hmcts.opal.dto.common.EnforcementOverride;
 import uk.gov.hmcts.opal.dto.request.AddDefendantAccountPaymentTermsRequest;
+import uk.gov.hmcts.opal.entity.AssociatedRecordType;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountPartiesEntity;
 import uk.gov.hmcts.opal.entity.enforcement.EnforcementEntity;
+import uk.gov.hmcts.opal.service.AccountNoteContext;
 import uk.gov.hmcts.opal.service.UserStateService;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.opal.service.iface.DefendantAccountEnforcementServiceInterface;
@@ -220,7 +222,12 @@ public class OpalDefendantAccountEnforcementService
             buildRemoveEnforcementHoldNoteRequest(defendantAccountId, request),
             VersionUtils.createETag(savedEntity),
             userState,
-            businessUnitId
+            new AccountNoteContext(
+                DefendantAccountEntity.class,
+                savedEntity.getDefendantAccountId(),
+                businessUnitId,
+                AssociatedRecordType.DEFENDANT_ACCOUNTS
+            )
         );
 
         amendmentService.auditFinaliseStoredProc(

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalNotesService.java
@@ -1,26 +1,25 @@
 package uk.gov.hmcts.opal.service.opal;
 
-import static uk.gov.hmcts.opal.dto.RecordType.DEFENDANT_ACCOUNTS;
 import static uk.gov.hmcts.opal.util.VersionUtils.verifyIfMatch;
 
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
 import uk.gov.hmcts.opal.dto.Note;
-import uk.gov.hmcts.opal.entity.AssociatedRecordType;
 import uk.gov.hmcts.opal.entity.NoteEntity;
 import uk.gov.hmcts.opal.entity.NoteType;
-import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
+import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
 import uk.gov.hmcts.opal.repository.NoteRepository;
+import uk.gov.hmcts.opal.service.AccountNoteContext;
 import uk.gov.hmcts.opal.service.iface.NotesServiceInterface;
 import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
+import uk.gov.hmcts.opal.util.Versioned;
 
 @Service
 @Slf4j(topic = "opal.OpalNotesService")
@@ -29,47 +28,48 @@ public class OpalNotesService implements NotesServiceInterface {
 
     private final NoteRepository repository;
     private final DefendantAccountRepositoryService defendantAccountRepositoryService;
+    private final CreditorAccountRepository creditorAccountRepository;
     private final Clock clock;
 
     @Override
     @Transactional
-    public String addNote(AddNoteRequest req, String ifMatch, UserState user, Short businessUnitId) {
+    public String addNote(AddNoteRequest req, String ifMatch, UserState user, AccountNoteContext target) {
         log.info(":OpalAddNote");
 
-        String accountId = req.getActivityNote().getRecordId();
-        validateAccountId(req, accountId);
-        //Use getDefendantAccountByIdForUpdate() as this ensures the account version is increased with
-        // OPTIMISTIC_FORCE_INCREMENT locking
-        DefendantAccountEntity managed =
-            defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(Long.parseLong(accountId));
-
-        verifyIfMatch(managed, ifMatch, managed.getVersion(), "addNote");
+        final Versioned account = getAccountAndVerifyVersion(target, ifMatch);
 
         Note requestNote = req.getActivityNote();
+
         NoteEntity note = new NoteEntity();
         note.setNoteText(requestNote.getNoteText());
         note.setNoteType(NoteType.valueOf(requestNote.getNoteType()));
         note.setAssociatedRecordId(requestNote.getRecordId());
-        note.setAssociatedRecordType(AssociatedRecordType.DEFENDANT_ACCOUNTS);
-        note.setBusinessUnitUserId(managed.getBusinessUnit().getBusinessUnitId().toString());
+        note.setAssociatedRecordType(target.associatedRecordType());
+        note.setBusinessUnitUserId(target.businessUnitId().toString());
         note.setPostedDate(LocalDateTime.now(clock));
         note.setPostedByUsername(user.getDisplayName());
+
         NoteEntity entity = repository.save(note);
+
         return entity.getNoteId().toString();
     }
 
-    private static void validateAccountId(AddNoteRequest req, String accountId) {
-        if (!Objects.equals(req.getActivityNote().getRecordType(), DEFENDANT_ACCOUNTS)) {
-            throw new IllegalArgumentException(
-                "recordType must be '%s'".formatted(DEFENDANT_ACCOUNTS)
+    private Versioned getAccountAndVerifyVersion(AccountNoteContext target, String ifMatch) {
+        Versioned account = switch (target.associatedRecordType()) {
+            case DEFENDANT_ACCOUNTS -> defendantAccountRepositoryService
+                .getDefendantAccountByIdForUpdate(target.accountId());
+            case CREDITOR_ACCOUNTS -> creditorAccountRepository.findByCreditorAccountIdForUpdate(target.accountId())
+                .orElseThrow(() -> accountNotFound(target.accountId()));
+            default -> throw new IllegalArgumentException(
+                "Record type %s is not supported".formatted(target.associatedRecordType())
             );
-        }
+        };
 
-        if (!NumberUtils.isCreatable(accountId)) {
-            throw new IllegalArgumentException(
-                "recordId must be a numeric value"
-            );
-        }
+        verifyIfMatch(account, ifMatch, target.accountId(), "addNote");
+        return account;
     }
 
+    private EntityNotFoundException accountNotFound(Long accountId) {
+        return new EntityNotFoundException("Account %s not found".formatted(accountId));
+    }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/proxy/NotesProxy.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/proxy/NotesProxy.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
+import uk.gov.hmcts.opal.service.AccountNoteContext;
 import uk.gov.hmcts.opal.service.iface.NotesServiceInterface;
 import uk.gov.hmcts.opal.service.legacy.LegacyNotesService;
 import uk.gov.hmcts.opal.service.opal.DynamicConfigService;
@@ -24,8 +25,8 @@ public class NotesProxy implements NotesServiceInterface, ProxyInterface {
     }
 
     @Override
-    public String addNote(AddNoteRequest request, String ifMatch, UserState user, Short businessUnitId) {
-        return getCurrentModeService().addNote(request, ifMatch, user, businessUnitId);
+    public String addNote(AddNoteRequest request, String ifMatch, UserState user, AccountNoteContext target) {
+        return getCurrentModeService().addNote(request, ifMatch, user, target);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/NotesServiceAccountContextTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/NotesServiceAccountContextTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.opal.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -9,65 +8,45 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
-import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
-import uk.gov.hmcts.opal.dto.AddNoteRequest;
 import uk.gov.hmcts.opal.dto.Note;
 import uk.gov.hmcts.opal.dto.RecordType;
 import uk.gov.hmcts.opal.entity.AssociatedRecordType;
 import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
 import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
 import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
-import uk.gov.hmcts.opal.service.proxy.NotesProxy;
 
 @ExtendWith(MockitoExtension.class)
 class NotesServiceAccountContextTest {
 
-    @Mock private NotesProxy notesProxy;
-    @Mock private UserStateService userStateService;
     @Mock private DefendantAccountRepository defendantAccountRepository;
     @Mock private CreditorAccountRepository creditorAccountRepository;
-    @Mock private UserState userState;
 
     @Test
-    void addNote_forCreditorAccount_usesCreditorAccountContext() {
-        final NotesService service = new NotesService(
-            notesProxy,
-            userStateService,
+    void from_forCreditorAccount_usesCreditorAccountContext() {
+        final AccountNoteContextFactory factory = new AccountNoteContextFactory(
             defendantAccountRepository,
             creditorAccountRepository
         );
 
-        final AddNoteRequest request = new AddNoteRequest(Note.builder()
+        final Note note = Note.builder()
             .recordType(RecordType.CREDITOR_ACCOUNTS)
             .recordId("104")
             .noteText("creditor note")
             .noteType("AA")
-            .build());
+            .build();
 
         CreditorAccountEntity creditorAccount = new CreditorAccountEntity();
         creditorAccount.setCreditorAccountId(104L);
         creditorAccount.setBusinessUnitId((short) 10);
 
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(creditorAccountRepository.findById(104L)).thenReturn(Optional.of(creditorAccount));
-        when(userState.hasBusinessUnitUserWithPermission((short) 10, FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES))
-            .thenReturn(true);
-        when(notesProxy.addNote(eq(request), eq("\"3\""), eq(userState), org.mockito.ArgumentMatchers.any()))
-            .thenReturn("123");
 
-        String noteId = service.addNote(request, "\"3\"", (short) 10);
+        AccountNoteContext target = factory.from(note);
 
-        assertEquals("123", noteId);
         verify(defendantAccountRepository, never()).findById(104L);
 
-        ArgumentCaptor<AccountNoteContext> targetCaptor = ArgumentCaptor.forClass(AccountNoteContext.class);
-        verify(notesProxy).addNote(eq(request), eq("\"3\""), eq(userState), targetCaptor.capture());
-
-        AccountNoteContext target = targetCaptor.getValue();
         assertEquals(CreditorAccountEntity.class, target.accountClass());
         assertEquals(104L, target.accountId());
         assertEquals((short) 10, target.businessUnitId());

--- a/src/test/java/uk/gov/hmcts/opal/service/NotesServiceAccountContextTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/NotesServiceAccountContextTest.java
@@ -1,0 +1,76 @@
+package uk.gov.hmcts.opal.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
+import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
+import uk.gov.hmcts.opal.dto.AddNoteRequest;
+import uk.gov.hmcts.opal.dto.Note;
+import uk.gov.hmcts.opal.dto.RecordType;
+import uk.gov.hmcts.opal.entity.AssociatedRecordType;
+import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
+import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
+import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
+import uk.gov.hmcts.opal.service.proxy.NotesProxy;
+
+@ExtendWith(MockitoExtension.class)
+class NotesServiceAccountContextTest {
+
+    @Mock private NotesProxy notesProxy;
+    @Mock private UserStateService userStateService;
+    @Mock private DefendantAccountRepository defendantAccountRepository;
+    @Mock private CreditorAccountRepository creditorAccountRepository;
+    @Mock private UserState userState;
+
+    @Test
+    void addNote_forCreditorAccount_usesCreditorAccountContext() {
+        final NotesService service = new NotesService(
+            notesProxy,
+            userStateService,
+            defendantAccountRepository,
+            creditorAccountRepository
+        );
+
+        final AddNoteRequest request = new AddNoteRequest(Note.builder()
+            .recordType(RecordType.CREDITOR_ACCOUNTS)
+            .recordId("104")
+            .noteText("creditor note")
+            .noteType("AA")
+            .build());
+
+        CreditorAccountEntity creditorAccount = new CreditorAccountEntity();
+        creditorAccount.setCreditorAccountId(104L);
+        creditorAccount.setBusinessUnitId((short) 10);
+
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
+        when(creditorAccountRepository.findById(104L)).thenReturn(Optional.of(creditorAccount));
+        when(userState.hasBusinessUnitUserWithPermission((short) 10, FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES))
+            .thenReturn(true);
+        when(notesProxy.addNote(eq(request), eq("\"3\""), eq(userState), org.mockito.ArgumentMatchers.any()))
+            .thenReturn("123");
+
+        String noteId = service.addNote(request, "\"3\"", (short) 10);
+
+        assertEquals("123", noteId);
+        verify(defendantAccountRepository, never()).findById(104L);
+
+        ArgumentCaptor<AccountNoteContext> targetCaptor = ArgumentCaptor.forClass(AccountNoteContext.class);
+        verify(notesProxy).addNote(eq(request), eq("\"3\""), eq(userState), targetCaptor.capture());
+
+        AccountNoteContext target = targetCaptor.getValue();
+        assertEquals(CreditorAccountEntity.class, target.accountClass());
+        assertEquals(104L, target.accountId());
+        assertEquals((short) 10, target.businessUnitId());
+        assertEquals(AssociatedRecordType.CREDITOR_ACCOUNTS, target.associatedRecordType());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/NotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/NotesServiceTest.java
@@ -3,13 +3,12 @@ package uk.gov.hmcts.opal.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
@@ -19,10 +18,7 @@ import uk.gov.hmcts.opal.dto.AddNoteRequest;
 import uk.gov.hmcts.opal.dto.Note;
 import uk.gov.hmcts.opal.dto.RecordType;
 import uk.gov.hmcts.opal.entity.AssociatedRecordType;
-import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
-import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
-import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
 import uk.gov.hmcts.opal.service.proxy.NotesProxy;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,29 +30,29 @@ class NotesServiceTest {
 
     @Mock private NotesProxy notesProxy;
     @Mock private UserStateService userStateService;
-    @Mock private DefendantAccountRepository defendantAccountRepository;
-    @Mock private CreditorAccountRepository creditorAccountRepository;
+    @Mock private AccountNoteContextFactory accountNoteContextFactory;
     @Mock private UserState userState;
 
     private NotesService notesService;
     private AddNoteRequest request;
+    private AccountNoteContext target;
 
     @BeforeEach
     void setUp() {
-        notesService = new NotesService(
-            notesProxy,
-            userStateService,
-            defendantAccountRepository,
-            creditorAccountRepository
-        );
-
+        notesService = new NotesService(notesProxy, userStateService, accountNoteContextFactory);
         request = addNoteRequest();
+        target = new AccountNoteContext(
+            DefendantAccountEntity.class,
+            DEFENDANT_ACCOUNT_ID,
+            BUSINESS_UNIT_ID,
+            AssociatedRecordType.DEFENDANT_ACCOUNTS
+        );
     }
 
     @Test
     void addNote_shouldThrowPermissionNotAllowedException_whenUserLacksPermission() {
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(defendantAccountRepository.findById(DEFENDANT_ACCOUNT_ID)).thenReturn(Optional.of(defendantAccount()));
+        when(accountNoteContextFactory.from(request.getActivityNote())).thenReturn(target);
         when(userState.hasBusinessUnitUserWithPermission(
             BUSINESS_UNIT_ID, FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES)).thenReturn(false);
 
@@ -71,26 +67,15 @@ class NotesServiceTest {
         String expectedResponse = "note-id-456";
 
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(defendantAccountRepository.findById(DEFENDANT_ACCOUNT_ID)).thenReturn(Optional.of(defendantAccount()));
+        when(accountNoteContextFactory.from(request.getActivityNote())).thenReturn(target);
         when(userState.hasBusinessUnitUserWithPermission(
             BUSINESS_UNIT_ID, FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES)).thenReturn(true);
-        when(notesProxy.addNote(eq(request), eq(IF_MATCH), eq(userState), org.mockito.ArgumentMatchers.any()))
-            .thenReturn(expectedResponse);
+        when(notesProxy.addNote(eq(request), eq(IF_MATCH), eq(userState), eq(target))).thenReturn(expectedResponse);
 
         String actualResponse = notesService.addNote(request, IF_MATCH, BUSINESS_UNIT_ID);
 
         assertEquals(expectedResponse, actualResponse);
-
-        ArgumentCaptor<AccountNoteContext> targetCaptor = ArgumentCaptor.forClass(AccountNoteContext.class);
-        org.mockito.Mockito.verify(notesProxy).addNote(
-            eq(request), eq(IF_MATCH), eq(userState), targetCaptor.capture()
-        );
-
-        AccountNoteContext target = targetCaptor.getValue();
-        assertEquals(DefendantAccountEntity.class, target.accountClass());
-        assertEquals(DEFENDANT_ACCOUNT_ID, target.accountId());
-        assertEquals(BUSINESS_UNIT_ID, target.businessUnitId());
-        assertEquals(AssociatedRecordType.DEFENDANT_ACCOUNTS, target.associatedRecordType());
+        verify(notesProxy).addNote(request, IF_MATCH, userState, target);
     }
 
     private static AddNoteRequest addNoteRequest() {
@@ -101,15 +86,5 @@ class NotesServiceTest {
             .noteType("AA")
             .build();
         return new AddNoteRequest(note);
-    }
-
-    private static DefendantAccountEntity defendantAccount() {
-        BusinessUnitEntity businessUnit = new BusinessUnitEntity();
-        businessUnit.setBusinessUnitId(BUSINESS_UNIT_ID);
-
-        DefendantAccountEntity account = new DefendantAccountEntity();
-        account.setDefendantAccountId(DEFENDANT_ACCOUNT_ID);
-        account.setBusinessUnit(businessUnit);
-        return account;
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/NotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/NotesServiceTest.java
@@ -2,50 +2,64 @@ package uk.gov.hmcts.opal.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
+import uk.gov.hmcts.opal.dto.Note;
+import uk.gov.hmcts.opal.dto.RecordType;
+import uk.gov.hmcts.opal.entity.AssociatedRecordType;
+import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
+import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
+import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
+import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
 import uk.gov.hmcts.opal.service.proxy.NotesProxy;
 
 @ExtendWith(MockitoExtension.class)
 class NotesServiceTest {
 
-    public static final String IF_MATCH = "etag-123";
-    public static final Short BUSINESS_UNIT_ID = 10;
-    @Mock
-    private NotesProxy notesProxy;
+    private static final String IF_MATCH = "etag-123";
+    private static final Short BUSINESS_UNIT_ID = 10;
+    private static final Long DEFENDANT_ACCOUNT_ID = 77L;
 
-    @Mock
-    private UserStateService userStateService;
-
-    @Mock
-    private UserState userState;
+    @Mock private NotesProxy notesProxy;
+    @Mock private UserStateService userStateService;
+    @Mock private DefendantAccountRepository defendantAccountRepository;
+    @Mock private CreditorAccountRepository creditorAccountRepository;
+    @Mock private UserState userState;
 
     private NotesService notesService;
+    private AddNoteRequest request;
 
     @BeforeEach
     void setUp() {
-        notesService = new NotesService(notesProxy, userStateService);
+        notesService = new NotesService(
+            notesProxy,
+            userStateService,
+            defendantAccountRepository,
+            creditorAccountRepository
+        );
+
+        request = addNoteRequest();
     }
 
     @Test
     void addNote_shouldThrowPermissionNotAllowedException_whenUserLacksPermission() {
-        // given
-        AddNoteRequest request = new AddNoteRequest();
-
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
+        when(defendantAccountRepository.findById(DEFENDANT_ACCOUNT_ID)).thenReturn(Optional.of(defendantAccount()));
         when(userState.hasBusinessUnitUserWithPermission(
             BUSINESS_UNIT_ID, FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES)).thenReturn(false);
 
-        // when / then
         assertThrows(
             PermissionNotAllowedException.class,
             () -> notesService.addNote(request, IF_MATCH, BUSINESS_UNIT_ID)
@@ -54,19 +68,48 @@ class NotesServiceTest {
 
     @Test
     void addNote_shouldDelegateToNotesProxy_whenUserHasPermission() {
-        // given
-        AddNoteRequest request = new AddNoteRequest();
         String expectedResponse = "note-id-456";
 
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
+        when(defendantAccountRepository.findById(DEFENDANT_ACCOUNT_ID)).thenReturn(Optional.of(defendantAccount()));
         when(userState.hasBusinessUnitUserWithPermission(
             BUSINESS_UNIT_ID, FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES)).thenReturn(true);
-        when(notesProxy.addNote(request, IF_MATCH, userState, BUSINESS_UNIT_ID)).thenReturn(expectedResponse);
+        when(notesProxy.addNote(eq(request), eq(IF_MATCH), eq(userState), org.mockito.ArgumentMatchers.any()))
+            .thenReturn(expectedResponse);
 
-        // when
         String actualResponse = notesService.addNote(request, IF_MATCH, BUSINESS_UNIT_ID);
 
-        // then
         assertEquals(expectedResponse, actualResponse);
+
+        ArgumentCaptor<AccountNoteContext> targetCaptor = ArgumentCaptor.forClass(AccountNoteContext.class);
+        org.mockito.Mockito.verify(notesProxy).addNote(
+            eq(request), eq(IF_MATCH), eq(userState), targetCaptor.capture()
+        );
+
+        AccountNoteContext target = targetCaptor.getValue();
+        assertEquals(DefendantAccountEntity.class, target.accountClass());
+        assertEquals(DEFENDANT_ACCOUNT_ID, target.accountId());
+        assertEquals(BUSINESS_UNIT_ID, target.businessUnitId());
+        assertEquals(AssociatedRecordType.DEFENDANT_ACCOUNTS, target.associatedRecordType());
+    }
+
+    private static AddNoteRequest addNoteRequest() {
+        Note note = Note.builder()
+            .recordType(RecordType.DEFENDANT_ACCOUNTS)
+            .recordId(DEFENDANT_ACCOUNT_ID.toString())
+            .noteText("test")
+            .noteType("AA")
+            .build();
+        return new AddNoteRequest(note);
+    }
+
+    private static DefendantAccountEntity defendantAccount() {
+        BusinessUnitEntity businessUnit = new BusinessUnitEntity();
+        businessUnit.setBusinessUnitId(BUSINESS_UNIT_ID);
+
+        DefendantAccountEntity account = new DefendantAccountEntity();
+        account.setDefendantAccountId(DEFENDANT_ACCOUNT_ID);
+        account.setBusinessUnit(businessUnit);
+        return account;
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
@@ -28,8 +28,9 @@ import uk.gov.hmcts.opal.dto.RecordType;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyAddNoteRequest;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyAddNoteResponse;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyNote;
+import uk.gov.hmcts.opal.entity.AssociatedRecordType;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
-import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
+import uk.gov.hmcts.opal.service.AccountNoteContext;
 
 @ExtendWith(MockitoExtension.class)
 class LegacyNotesServiceTest {
@@ -63,7 +64,7 @@ class LegacyNotesServiceTest {
         AddNoteRequest req = addReq("77", "hello");
         when(user.getUserId()).thenReturn(999L);
 
-        String id = service.addNote(req, "1", user, (short) 1);
+        String id = service.addNote(req, "1", user, targetWithBu((short) 1));
         assertEquals("77", id);
 
         LegacyAddNoteRequest sent = reqCap.getValue();
@@ -109,7 +110,7 @@ class LegacyNotesServiceTest {
         AddNoteRequest req = addReq("77", "boom");
         when(user.getUserId()).thenReturn(1L);
 
-        String id = service.addNote(req, "1", user, (short) 5);
+        String id = service.addNote(req, "1", user, targetWithBu((short) 5));
         assertEquals("77", id);
 
         verify(gatewayService).postToGateway(
@@ -144,7 +145,7 @@ class LegacyNotesServiceTest {
         AddNoteRequest req = addReq("77", "world");
         when(user.getUserId()).thenReturn(42L);
 
-        String id = service.addNote(req, "1", user, (short) 9);
+        String id = service.addNote(req, "1", user, targetWithBu((short) 9));
         assertEquals("77", id);
 
         verify(gatewayService).postToGateway(
@@ -179,7 +180,7 @@ class LegacyNotesServiceTest {
         AddNoteRequest req = addReq("77", "meh");
         when(user.getUserId()).thenReturn(5L);
 
-        String id = service.addNote(req, "7", user, (short) 3);
+        String id = service.addNote(req, "7", user, targetWithBu((short) 3));
         assertEquals("77", id);
 
         verify(gatewayService).postToGateway(
@@ -193,14 +194,13 @@ class LegacyNotesServiceTest {
 
     // ---------- helpers ----------
 
-    private static BusinessUnitEntity bu(short id) {
-        return BusinessUnitEntity.builder().businessUnitId(id).build();
-    }
-
-    private static DefendantAccountEntity accountWithBu(short buId) {
-        DefendantAccountEntity acc = new DefendantAccountEntity();
-        acc.setBusinessUnit(bu(buId));
-        return acc;
+    private static AccountNoteContext targetWithBu(short buId) {
+        return new AccountNoteContext(
+            DefendantAccountEntity.class,
+            77L,
+            buId,
+            AssociatedRecordType.DEFENDANT_ACCOUNTS
+        );
     }
 
     private static AddNoteRequest addReq(String recordId, String text) {

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountEnforcementServiceTest.java
@@ -29,6 +29,7 @@ import uk.gov.hmcts.opal.dto.Note;
 import uk.gov.hmcts.opal.dto.RemoveDefendantAccountEnforcementHoldRequest;
 import uk.gov.hmcts.opal.dto.RemoveDefendantAccountEnforcementHoldResponse;
 import uk.gov.hmcts.opal.dto.request.AddDefendantAccountPaymentTermsRequest;
+import uk.gov.hmcts.opal.entity.AssociatedRecordType;
 import uk.gov.hmcts.opal.entity.EnforcerEntity;
 import uk.gov.hmcts.opal.entity.LocalJusticeAreaEntity;
 import uk.gov.hmcts.opal.entity.PartyEntity;
@@ -39,6 +40,7 @@ import uk.gov.hmcts.opal.entity.defendantaccount.AssociationType;
 import uk.gov.hmcts.opal.entity.debtordetail.DebtorDetailEntity;
 import uk.gov.hmcts.opal.entity.result.ResultEntity;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
+import uk.gov.hmcts.opal.service.AccountNoteContext;
 import uk.gov.hmcts.opal.service.UserStateService;
 import uk.gov.hmcts.opal.service.persistence.DebtorDetailRepositoryService;
 import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
@@ -678,6 +680,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
         UserState userState = allPermissionsUser();
         LocalDate expectedLastMovementDate = LocalDate.of(2026, 4, 22);
         ArgumentCaptor<AddNoteRequest> addNoteRequestCaptor = ArgumentCaptor.forClass(AddNoteRequest.class);
+        ArgumentCaptor<AccountNoteContext> accountNoteContextCaptor = ArgumentCaptor.forClass(AccountNoteContext.class);
 
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(defendantAccountRepositoryService.findById(defendantAccountId)).thenReturn(defendantEntity);
@@ -720,7 +723,7 @@ public class OpalDefendantAccountEnforcementServiceTest {
                 addNoteRequestCaptor.capture(),
                 eq(updatedIfMatch),
                 eq(userState),
-                eq((short) 10)
+                accountNoteContextCaptor.capture()
             );
             verifyNoInteractions(reportEntryService);
             verify(amendmentService).auditFinaliseStoredProc(
@@ -740,6 +743,12 @@ public class OpalDefendantAccountEnforcementServiceTest {
             assertEquals(String.valueOf(defendantAccountId), capturedNote.getRecordId());
             assertEquals("remove hold reason", capturedNote.getNoteText());
             assertEquals("AA", capturedNote.getNoteType());
+
+            AccountNoteContext capturedTarget = accountNoteContextCaptor.getValue();
+            assertEquals(DefendantAccountEntity.class, capturedTarget.accountClass());
+            assertEquals(defendantAccountId, capturedTarget.accountId());
+            assertEquals(businessUnitId, capturedTarget.businessUnitId());
+            assertEquals(AssociatedRecordType.DEFENDANT_ACCOUNTS, capturedTarget.associatedRecordType());
             versionUtils.verify(() -> VersionUtils.createETag(defendantEntity));
         }
     }

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalNotesServiceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.opal.service.opal;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -10,6 +9,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,24 +25,21 @@ import uk.gov.hmcts.opal.entity.AssociatedRecordType;
 import uk.gov.hmcts.opal.entity.NoteEntity;
 import uk.gov.hmcts.opal.entity.NoteType;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
+import uk.gov.hmcts.opal.entity.creditoraccount.CreditorAccountEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
+import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
 import uk.gov.hmcts.opal.repository.NoteRepository;
+import uk.gov.hmcts.opal.service.AccountNoteContext;
 import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
 
 @ExtendWith(MockitoExtension.class)
 class OpalNotesServiceTest {
 
-    @Mock
-    private NoteRepository repository;
-
-    @Mock
-    private DefendantAccountRepositoryService defendantAccountRepositoryService;
-
-    @Mock
-    private Clock clock;
-
-    @Mock
-    private UserState user;
+    @Mock private NoteRepository repository;
+    @Mock private DefendantAccountRepositoryService defendantAccountRepositoryService;
+    @Mock private CreditorAccountRepository creditorAccountRepository;
+    @Mock private Clock clock;
+    @Mock private UserState user;
 
     @InjectMocks
     private OpalNotesService service;
@@ -50,7 +47,6 @@ class OpalNotesServiceTest {
     @Test
     @DisplayName("addNote saves a note and returns the note id")
     void addNote_shouldSaveNoteAndReturnId() {
-        // Arrange
         when(clock.instant()).thenReturn(Instant.parse("2026-07-03T10:15:30Z"));
         when(clock.getZone()).thenReturn(ZoneOffset.UTC);
         DefendantAccountEntity managed = new DefendantAccountEntity();
@@ -66,10 +62,8 @@ class OpalNotesServiceTest {
         when(repository.save(any(NoteEntity.class))).thenReturn(saved);
         AddNoteRequest req = buildRequest("77", RecordType.DEFENDANT_ACCOUNTS);
 
-        // Act
-        String result = service.addNote(req, "\"12\"", user, (short) 78);
+        String result = service.addNote(req, "\"12\"", user, defendantTarget());
 
-        // Assert
         assertThat(result).isEqualTo("999");
         ArgumentCaptor<NoteEntity> captor = ArgumentCaptor.forClass(NoteEntity.class);
         verify(repository).save(captor.capture());
@@ -86,21 +80,30 @@ class OpalNotesServiceTest {
     }
 
     @Test
-    void addNote_shouldThrowWhenRecordTypeIsInvalid() {
-        AddNoteRequest req = buildRequest("77", RecordType.CREDITOR_ACCOUNTS);
+    void addNote_shouldSaveCreditorAccountNote() {
+        when(clock.instant()).thenReturn(Instant.parse("2026-07-03T10:15:30Z"));
+        when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+        CreditorAccountEntity managed = new CreditorAccountEntity();
+        managed.setCreditorAccountId(104L);
+        managed.setVersionNumber(3L);
+        NoteEntity saved = new NoteEntity();
+        saved.setNoteId(1001L);
+        when(creditorAccountRepository.findByCreditorAccountIdForUpdate(104L)).thenReturn(Optional.of(managed));
+        when(user.getDisplayName()).thenReturn("Creditor User");
+        when(repository.save(any(NoteEntity.class))).thenReturn(saved);
+        AddNoteRequest req = buildRequest("104", RecordType.CREDITOR_ACCOUNTS);
 
-        assertThatThrownBy(() -> service.addNote(req, "\"12\"", user, (short) 78))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("recordType must be 'defendant_accounts'");
-    }
+        String result = service.addNote(req, "\"3\"", user, creditorTarget());
 
-    @Test
-    void addNote_shouldThrowWhenRecordIdIsNotNumeric() {
-        AddNoteRequest req = buildRequest("abc", RecordType.DEFENDANT_ACCOUNTS);
-
-        assertThatThrownBy(() -> service.addNote(req, "\"12\"", user, (short) 78))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("recordId must be a numeric value");
+        assertThat(result).isEqualTo("1001");
+        ArgumentCaptor<NoteEntity> captor = ArgumentCaptor.forClass(NoteEntity.class);
+        verify(repository).save(captor.capture());
+        NoteEntity entity = captor.getValue();
+        assertThat(entity.getAssociatedRecordId()).isEqualTo("104");
+        assertThat(entity.getAssociatedRecordType()).isEqualTo(AssociatedRecordType.CREDITOR_ACCOUNTS);
+        assertThat(entity.getBusinessUnitUserId()).isEqualTo("78");
+        assertThat(entity.getPostedByUsername()).isEqualTo("Creditor User");
+        verify(creditorAccountRepository).findByCreditorAccountIdForUpdate(104L);
     }
 
     private static AddNoteRequest buildRequest(String recordId, RecordType recordType) {
@@ -112,5 +115,23 @@ class OpalNotesServiceTest {
         AddNoteRequest req = new AddNoteRequest();
         req.setActivityNote(note);
         return req;
+    }
+
+    private static AccountNoteContext defendantTarget() {
+        return new AccountNoteContext(
+            DefendantAccountEntity.class,
+            77L,
+            (short) 78,
+            AssociatedRecordType.DEFENDANT_ACCOUNTS
+        );
+    }
+
+    private static AccountNoteContext creditorTarget() {
+        return new AccountNoteContext(
+            CreditorAccountEntity.class,
+            104L,
+            (short) 78,
+            AssociatedRecordType.CREDITOR_ACCOUNTS
+        );
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PO-8916

### Change description ###

- Updated note creation to resolve the account target from `record_type`
- Added support for saving notes against `creditor_accounts`
- Preserved existing `defendant_accounts` note creation behaviour
- Added test coverage for creditor account note creation


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
