### PR TITLE
Update nightly tagged functional runs to use dedicated R1A-only, R1A+R1B, and all-flags-off tasks with aligned runner, Zephyr, and README config

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,7 +1,7 @@
 #!groovy
 import uk.gov.hmcts.contino.GithubAPI
 
-@Library("Infrastructure@master")
+@Library("Infrastructure@2.4.5")
 
 def type = "java"
 def product = "opal"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -16,7 +16,7 @@ import uk.gov.hmcts.contino.GradleBuilder
 import java.time.DayOfWeek
 import java.time.ZonedDateTime
 
-@Library("Infrastructure@master")
+@Library("Infrastructure@2.4.5")
 
 def type = "java"
 def product = "opal"

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -7,8 +7,7 @@ properties([
     booleanParam(name: 'Integration', defaultValue: true, description: 'Run integration tests'),
     booleanParam(name: 'Functional', defaultValue: true, description: 'Run functional tests'),
     booleanParam(name: 'Smoke', defaultValue: true, description: 'Run smoke tests'),
-    booleanParam(name: 'RunR1AOnly', defaultValue: true, description: 'Run R1A functional tests against demo'),
-    booleanParam(name: 'RunR1AOff', defaultValue: false, description: 'Run R1AOff functional tests against demo'),
+    choice(name: 'DemoTaggedFunctionalMode', choices: ['RunR1AOnly', 'RunR1AAndR1BOnly', 'RunAllFlagsOff'], description: 'Select which demo tagged functional stage to run'),
     booleanParam(name: 'ZephyrExecution', defaultValue: false, description: 'Create Zephyr Execution'),
   ])
 ])
@@ -24,14 +23,6 @@ def product = "opal"
 def component = "fines-service"
 
 GradleBuilder builder = new GradleBuilder(this, product)
-
-def r1ATagFilter = '(@JIRA-LABEL:manual-account-creation or (@Opal and @FeatureToggle and @R1BOff)) and ' +
-        'not @Smoke and not @Ignore and ' +
-        'not (@R1AOff or @R1B or @R1COff or @R1C or @R1CFinance or @R1CWriteOff or ' +
-        '@R1CWriteOffOff or @R1CEnforcementOperationalReporting or ' +
-        '@R1CEnforcementOperationalReportingOff or @R1CAdministration)'
-def r1AOffTagFilter = '@R1AOff and not @Ignore'
-
 def testEnvironments = [
     staging: [
         name                 : 'staging',
@@ -346,13 +337,13 @@ def runSmokeStage = { stageName, shouldRunWithZephyr, reportNameSuffix ->
   }
 }
 
-def runTaggedFunctionalStage = { enabled, stageName, shouldRunWithZephyr, reportDirectory, reportNameSuffix, tagFilter ->
+def runNamedTaggedFunctionalStage = { enabled, stageName, shouldRunWithZephyr, gradleTask, reportDirectory, reportNameSuffix,
+  candidateReportDirectories, junitPattern, buildReportDirectory, zephyrStageKey ->
   if (enabled) {
     stage(stageName) {
       deleteStageOutputs([
         reportDirectory,
-        'functional-output-demo',
-        'build/reports/tests/functionalOpalTags',
+        buildReportDirectory,
         'build/test-results/functional',
         'build/serenity-functional-demo',
         'target/zephyr-reports/cucumber-opal-tags.json',
@@ -361,28 +352,24 @@ def runTaggedFunctionalStage = { enabled, stageName, shouldRunWithZephyr, report
       ])
 
       try {
-        withEnv(["TAGS=${tagFilter}"]) {
-          builder.gradle('clearReports functionalOpalTags')
-        }
+        builder.gradle("clearReports ${gradleTask}")
       } catch (error) {
         recordStageFailure(stageName, "failed. Error: ${error.message}")
       } finally {
         try {
-          builder.gradle('syncTaggedFunctionalArtifactsFromExistingResults')
           publishFunctionalResults(
             "${stageName} Report",
             reportDirectory,
-            'functional-output-demo',
-            ['functional-output-demo/report', 'build/reports/tests/functionalOpalTags'],
+            reportDirectory,
+            candidateReportDirectories,
             reportNameSuffix,
-            'build/test-results/functional/opal-tags/*.xml',
+            junitPattern,
             "${reportDirectory}/zephyr/cucumber-opal-tags.json"
           )
         } catch (publishError) {
           recordStageFailure(stageName, "result publication failed. Error: ${publishError.message}")
         }
         if (shouldRunWithZephyr) {
-          def zephyrStageKey = reportDirectory == 'functional-output-r1a-only-demo' ? 'runR1AOnly' : 'runR1AOff'
           runFunctionalZephyrExecution(stageName, zephyrStageKey)
         }
       }
@@ -399,8 +386,7 @@ withNightlyPipeline(type, product, component) {
     echo 'Integration:' + params.Integration
     echo 'Functional:' + params.Functional
     echo 'Smoke:' + params.Smoke
-    echo 'RunR1AOnly:' + params.RunR1AOnly
-    echo 'RunR1AOff:' + params.RunR1AOff
+    echo 'DemoTaggedFunctionalMode:' + params.DemoTaggedFunctionalMode
 
     def today = ZonedDateTime.now().getDayOfWeek()
     def shouldRunWithZephyr = params.ZephyrExecution || today == DayOfWeek.FRIDAY
@@ -413,34 +399,56 @@ withNightlyPipeline(type, product, component) {
     runFunctionalStage('Functional Tests', shouldRunWithZephyr, testEnvironments.staging.reportNameSuffix)
     runSmokeStage('Smoke Tests', shouldRunWithZephyr, testEnvironments.staging.reportNameSuffix)
 
-    if (params.RunR1AOnly) {
-      configureTestEnvironment(testEnvironments.demo)
-      if (shouldRunWithZephyr) {
-        configureZephyrExecution(testEnvironments.demo)
-      }
-      runTaggedFunctionalStage(
-        params.RunR1AOnly,
-        'Demo R1A Functional Tests',
-        shouldRunWithZephyr,
-        'functional-output-r1a-only-demo',
-        testEnvironments.demo.reportNameSuffix,
-        r1ATagFilter
-      )
+    configureTestEnvironment(testEnvironments.demo)
+    if (shouldRunWithZephyr) {
+      configureZephyrExecution(testEnvironments.demo)
     }
 
-    if (params.RunR1AOff) {
-      configureTestEnvironment(testEnvironments.demo)
-      if (shouldRunWithZephyr) {
-        configureZephyrExecution(testEnvironments.demo)
-      }
-      runTaggedFunctionalStage(
-        params.RunR1AOff,
-        'R1AOff Demo Functional Tests',
-        shouldRunWithZephyr,
-        'functional-output-r1a-off-demo',
-        ' (Demo R1AOff)',
-        r1AOffTagFilter
-      )
+    switch (params.DemoTaggedFunctionalMode) {
+      case 'RunR1AOnly':
+        runNamedTaggedFunctionalStage(
+          true,
+          'Demo R1A Functional Tests',
+          shouldRunWithZephyr,
+          'functionalOpalTagsR1AOnly',
+          'functional-output-r1a-only-demo',
+          testEnvironments.demo.reportNameSuffix,
+          ['functional-output-r1a-only-demo/report', 'build/reports/tests/functionalOpalTagsR1AOnly'],
+          'build/test-results/functional/opal-tags-r1a-only/*.xml',
+          'build/reports/tests/functionalOpalTagsR1AOnly',
+          'runR1AOnly'
+        )
+        break
+      case 'RunR1AAndR1BOnly':
+        runNamedTaggedFunctionalStage(
+          true,
+          'Demo R1A and R1B Functional Tests',
+          shouldRunWithZephyr,
+          'functionalOpalTagsR1AAndR1BOnly',
+          'functional-output-r1a-r1b-only-demo',
+          ' (Demo R1A and R1B)',
+          ['functional-output-r1a-r1b-only-demo/report', 'build/reports/tests/functionalOpalTagsR1AAndR1BOnly'],
+          'build/test-results/functional/opal-tags-r1a-r1b-only/*.xml',
+          'build/reports/tests/functionalOpalTagsR1AAndR1BOnly',
+          'runR1AAndR1BOnly'
+        )
+        break
+      case 'RunAllFlagsOff':
+        runNamedTaggedFunctionalStage(
+          true,
+          'All Flags Off Demo Functional Tests',
+          shouldRunWithZephyr,
+          'functionalOpalTagsAllFlagsOff',
+          'functional-output-all-flags-off-demo',
+          ' (Demo All Flags Off)',
+          ['functional-output-all-flags-off-demo/report', 'build/reports/tests/functionalOpalTagsAllFlagsOff'],
+          'build/test-results/functional/opal-tags-all-flags-off/*.xml',
+          'build/reports/tests/functionalOpalTagsAllFlagsOff',
+          'runAllFlagsOff'
+        )
+        break
+      default:
+        error("Unsupported DemoTaggedFunctionalMode: ${params.DemoTaggedFunctionalMode}")
     }
 
     if (!stageFailures.isEmpty()) {

--- a/README.md
+++ b/README.md
@@ -246,8 +246,8 @@ Common examples:
 
 ```bash / zsh
   ./gradlew functionalOpalTagsR1AOnly
-  ./gradlew functionalOpalTagsR1AOff
-  TAGS='@R1AOff and not @Ignore' ./gradlew functionalOpalTags
+  ./gradlew functionalOpalTagsAllFlagsOff
+  TAGS='(@R1AOff or @R1BOff or @R1CWriteOffOff or @R1CEnforcementOperationalReportingOff or @R1CAdministrationOff or @R1CFinancialMovementsOff) and not @Ignore' ./gradlew functionalOpalTags
   TAGS='@R1BOff and not @Ignore' ./gradlew functionalOpalTags
   TAGS='@R1B and @R1C and not @Ignore' ./gradlew functionalWithTags
   TAGS='@JIRA-LABEL:manual-account-creation and not @Ignore' ./gradlew functionalOpalTags
@@ -266,8 +266,7 @@ Nightly parameters:
 | `Integration` | `true` | Runs the staging integration-test stage. |
 | `Functional` | `true` | Runs the staging functional-test stage. |
 | `Smoke` | `true` | Runs the staging smoke-test stage. |
-| `RunR1AOnly` | `true` | Runs the demo R1A functional stage against the demo environment. |
-| `RunR1AOff` | `false` | Runs the optional demo R1A-off functional stage. |
+| `DemoTaggedFunctionalMode` | `RunR1AOnly` | Selects exactly one demo tagged functional stage: `RunR1AOnly`, `RunR1AAndR1BOnly`, or `RunAllFlagsOff`. |
 | `ZephyrExecution` | `false` | Creates Zephyr executions; this also runs automatically on Fridays. |
 
 Nightly environments:
@@ -284,12 +283,12 @@ Nightly stages:
 | `Integration Tests` | `staging` | `Integration` | `integration`, then `createJiraExecutionFromIntegrationReport` if Zephyr is enabled |
 | `Functional Tests` | `staging` | `Functional` | `clearReports functionalOpal`, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=functional` if Zephyr is enabled |
 | `Smoke Tests` | `staging` | `Smoke` | `clearReports smokeOpal`, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=smoke` if Zephyr is enabled |
-| `Demo R1A Functional Tests` | `demo` | `RunR1AOnly` | `clearReports functionalOpalTags` with the R1A manual-account-creation tag filter, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=runR1AOnly` if Zephyr is enabled |
-| `R1AOff Demo Functional Tests` | `demo` | `RunR1AOff` | `clearReports functionalOpalTags` with `@R1AOff and not @Ignore`, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=runR1AOff` if Zephyr is enabled |
+| `Demo R1A Functional Tests` | `demo` | `DemoTaggedFunctionalMode=RunR1AOnly` | `clearReports functionalOpalTagsR1AOnly`, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=runR1AOnly` if Zephyr is enabled |
+| `Demo R1A and R1B Functional Tests` | `demo` | `DemoTaggedFunctionalMode=RunR1AAndR1BOnly` | `clearReports functionalOpalTagsR1AAndR1BOnly`, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=runR1AAndR1BOnly` if Zephyr is enabled |
+| `All Flags Off Demo Functional Tests` | `demo` | `DemoTaggedFunctionalMode=RunAllFlagsOff` | `clearReports functionalOpalTagsAllFlagsOff`, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=runAllFlagsOff` if Zephyr is enabled |
 
-The demo R1A stage is intentionally limited to manual-account-creation scenarios and
-excludes R1A-off, R1B, R1B-off, R1C, and R1C-off style release-tagged scenarios. It
-does not run the full backend functional suite.
+The demo R1A stage is intentionally limited to `@R1A` scenarios. It does not run the
+full backend functional suite.
 
 Nightly reports and artifacts:
 
@@ -297,12 +296,15 @@ Nightly reports and artifacts:
 - Staging functional publishes `Serenity Functional Test Report`.
 - Staging smoke publishes `Serenity Smoke Test Report`.
 - Demo R1A publishes `Serenity Functional Test Report (Demo R1AOn Only)`.
-- Demo R1AOff publishes `Serenity Functional Test Report (Demo R1AOff)`.
+- Demo R1A and R1B publishes `Serenity Functional Test Report (Demo R1A and R1B)`.
+- Demo all-flags-off publishes `Serenity Functional Test Report (Demo All Flags Off)`.
 - Generic local tagged demo Gradle runs package to `functional-output-demo`; the generic local demo Serenity HTML report is under `functional-output-demo/report`.
 - Local `functionalOpalTagsR1AOnly` packages to `functional-output-r1a-only-demo`; the local demo Serenity HTML report is under `functional-output-r1a-only-demo/report`.
-- Local `functionalOpalTagsR1AOff` packages to `functional-output-r1a-off-demo`; the local demo Serenity HTML report is under `functional-output-r1a-off-demo/report`.
-- Nightly `RunR1AOnly` archives to `functional-output-r1a-only-demo`; the nightly demo Serenity HTML report is under `functional-output-r1a-only-demo/report`.
-- Nightly `RunR1AOff` archives to `functional-output-r1a-off-demo`; the nightly demo Serenity HTML report is under `functional-output-r1a-off-demo/report`.
+- Local `functionalOpalTagsR1AAndR1BOnly` packages to `functional-output-r1a-r1b-only-demo`; the local demo Serenity HTML report is under `functional-output-r1a-r1b-only-demo/report`.
+- Local `functionalOpalTagsAllFlagsOff` packages to `functional-output-all-flags-off-demo`; the local demo Serenity HTML report is under `functional-output-all-flags-off-demo/report`.
+- Nightly `DemoTaggedFunctionalMode=RunR1AOnly` archives to `functional-output-r1a-only-demo`; the nightly demo Serenity HTML report is under `functional-output-r1a-only-demo/report`.
+- Nightly `DemoTaggedFunctionalMode=RunR1AAndR1BOnly` archives to `functional-output-r1a-r1b-only-demo`; the nightly demo Serenity HTML report is under `functional-output-r1a-r1b-only-demo/report`.
+- Nightly `DemoTaggedFunctionalMode=RunAllFlagsOff` archives to `functional-output-all-flags-off-demo`; the nightly demo Serenity HTML report is under `functional-output-all-flags-off-demo/report`.
 - Staging functional archives to `functional-output`, integration to `integration-output`, and smoke to `smoke-output`.
 - Functional and smoke outputs are published from `*/report` with Zephyr payloads under `*/zephyr`. Integration publishes `integration-output/report` and archives `integration-output/zephyr` when the integration Zephyr JSON is generated.
 - When `ZephyrExecution=true` or the nightly run is on Friday, the nightly pipeline runs the selected test stage first, publishes its artifacts, then invokes the matching generic Zephyr execution task.
@@ -310,8 +312,8 @@ Nightly reports and artifacts:
 Failure handling:
 
 - A Gradle stage failure marks the nightly build `FAILURE`.
-- JUnit-reported test failures for integration, functional, smoke, demo R1A, and demo R1AOff are promoted from `UNSTABLE` to `FAILURE`.
-- The demo R1A and R1AOff stages publish to separate artifact directories so the later demo-tagged run cannot overwrite the earlier one.
+- JUnit-reported test failures for integration, functional, smoke, demo R1A, demo R1A-and-R1B, and demo all-flags-off are promoted from `UNSTABLE` to `FAILURE`.
+- The demo R1A, demo R1A-and-R1B, and all-flags-off stages publish to separate artifact directories so later demo-tagged runs cannot overwrite earlier ones.
 
 ### CNP Jenkins pipeline
 
@@ -353,7 +355,8 @@ Local report paths:
 | `functional` | `-PzephyrFunctionalStage=functional createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal.json` | `functional-output/zephyr/cucumber-opal.json` |
 | `smoke` | `-PzephyrFunctionalStage=smoke createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-smoke.json` | `smoke-output/zephyr/cucumber-smoke.json` |
 | `runR1AOnly` | `./gradlew functionalOpalTagsR1AOnly` then `-PzephyrFunctionalStage=runR1AOnly createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal-tags.json` | `functional-output-r1a-only-demo/zephyr/cucumber-opal-tags.json` |
-| `runR1AOff` | `./gradlew functionalOpalTagsR1AOff` then `-PzephyrFunctionalStage=runR1AOff createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal-tags.json` | `functional-output-r1a-off-demo/zephyr/cucumber-opal-tags.json` |
+| `runR1AAndR1BOnly` | `./gradlew functionalOpalTagsR1AAndR1BOnly` then `-PzephyrFunctionalStage=runR1AAndR1BOnly createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal-tags.json` | `functional-output-r1a-r1b-only-demo/zephyr/cucumber-opal-tags.json` |
+| `runAllFlagsOff` | `./gradlew functionalOpalTagsAllFlagsOff` then `-PzephyrFunctionalStage=runAllFlagsOff createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal-tags.json` | `functional-output-all-flags-off-demo/zephyr/cucumber-opal-tags.json` |
 
 Examples:
 
@@ -381,10 +384,15 @@ export OPAL_LOGGING_SERVICE_API_URL=https://opal-logging-service.demo.platform.h
 ./gradlew functionalOpalTagsR1AOnly
 ./gradlew -PzephyrFunctionalStage=runR1AOnly createJiraExecutionFromFunctionalReport
 
-./gradlew functionalOpalTagsR1AOff
-./gradlew -PzephyrFunctionalStage=runR1AOff createJiraTicketsFromFunctionalReport
-./gradlew -PzephyrFunctionalStage=runR1AOff updateJiraTicketsFromFunctionalReport
-./gradlew -PzephyrFunctionalStage=runR1AOff createJiraExecutionFromFunctionalReport
+./gradlew functionalOpalTagsR1AAndR1BOnly
+./gradlew -PzephyrFunctionalStage=runR1AAndR1BOnly createJiraTicketsFromFunctionalReport
+./gradlew -PzephyrFunctionalStage=runR1AAndR1BOnly updateJiraTicketsFromFunctionalReport
+./gradlew -PzephyrFunctionalStage=runR1AAndR1BOnly createJiraExecutionFromFunctionalReport
+
+./gradlew functionalOpalTagsAllFlagsOff
+./gradlew -PzephyrFunctionalStage=runAllFlagsOff createJiraTicketsFromFunctionalReport
+./gradlew -PzephyrFunctionalStage=runAllFlagsOff updateJiraTicketsFromFunctionalReport
+./gradlew -PzephyrFunctionalStage=runAllFlagsOff createJiraExecutionFromFunctionalReport
 ```
 
 Available Zephyr tasks:
@@ -393,9 +401,9 @@ Use the task that matches the populated raw JSON source above.
 
 | Task | Purpose |
 | --- | --- |
-| `createJiraTicketsFromFunctionalReport` | Creates and links Jira test tickets from the selected functional-family Zephyr report. Requires `-PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AOff`. |
-| `updateJiraTicketsFromFunctionalReport` | Updates Jira test tickets from the selected functional-family Zephyr report. Requires `-PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AOff`. |
-| `createJiraExecutionFromFunctionalReport` | Creates a Zephyr execution from the selected functional-family Zephyr report. Requires `-PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AOff`. |
+| `createJiraTicketsFromFunctionalReport` | Creates and links Jira test tickets from the selected functional-family Zephyr report. Requires `-PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AAndR1BOnly|runAllFlagsOff`. |
+| `updateJiraTicketsFromFunctionalReport` | Updates Jira test tickets from the selected functional-family Zephyr report. Requires `-PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AAndR1BOnly|runAllFlagsOff`. |
+| `createJiraExecutionFromFunctionalReport` | Creates a Zephyr execution from the selected functional-family Zephyr report. Requires `-PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AAndR1BOnly|runAllFlagsOff`. |
 | `createJiraTicketsFromIntegrationReport` | Creates and links Jira test tickets from `integration-output/zephyr/Junit5Report-IntegrationTest.json`. |
 | `updateJiraTicketsFromIntegrationReport` | Updates Jira test tickets from `integration-output/zephyr/Junit5Report-IntegrationTest.json`. |
 | `createJiraExecutionFromIntegrationReport` | Creates a Zephyr execution from `integration-output/zephyr/Junit5Report-IntegrationTest.json`. |

--- a/build.gradle
+++ b/build.gradle
@@ -439,7 +439,7 @@ tasks.register('functionalOpalTagsAllFlagsOff', Test) {
 
   doFirst {
     systemProperty 'cucumber.filter.tags',
-      '(@R1AOff or @R1BOff or @R1COff or @R1CWriteOffOff or @R1CEnforcementOperationalReportingOff or @R1CAdministrationOff or @R1CFinancialMovementsOff or @R1CAutoEnforcementOff or @R1DDataRetentionOff or @R1DAutoEnforcementConfigOff or @R1CRmFinancialMovementsOff or @R1CRmFinancialChecksOff or @R1CRmSuspenseOff or @R1CRmPaymentOff or @R1CRmAdminReportsOff or @R1CRmAccountActionsOff or @R1CChecksOff or @R1CSuspenseOff or @R1CPaymentOff or @R1CR1ATidyUpOff or @R1CReferenceDataOff or @R1CBankingInterfacesOff or @R1CCppEnforcementOff or @R1CCppOff or @R1CPrintingOff) and not @Ignore'
+      '(@R1AOff or @R1BOff or @R1COff or @R1CWriteOffOff or @R1CEnforcementOperationalReportingOff or @R1CAdministrationOff or @R1CFinancialMovementsOff or @R1CAutoEnforcementOff or @R1CDataRetentionOff or @R1CAutoEnforcementConfigOff or @R1CRmFinancialMovementsOff or @R1CRmFinancialChecksOff or @R1CRmSuspenseOff or @R1CRmPaymentOff or @R1CRmAdminReportsOff or @R1CRmAccountActionsOff or @R1CChecksOff or @R1CSuspenseOff or @R1CPaymentOff or @R1CR1ATidyUpOff or @R1CReferenceDataOff or @R1CBankingInterfacesOff or @R1CCppEnforcementOff or @R1CCppOff or @R1CPrintingOff) and not @Ignore'
   }
 
   finalizedBy 'copyAllFlagsOffDemoCucumberJson', 'mergeFunctionalOpalTagsAllFlagsOffResults', 'aggregate', 'copyAllFlagsOffDemoFunctionalReport'

--- a/build.gradle
+++ b/build.gradle
@@ -370,7 +370,7 @@ tasks.register('functionalOpalTags', Test) {
 
     if (cucumberTags == null || cucumberTags.toString().trim().isEmpty()) {
       throw new GradleException(
-        "Set TAGS or -Ptags when running functionalOpalTags, for example TAGS='@FeatureToggle and @R1BOff'"
+        "Set TAGS or -Ptags when running functionalOpalTags, for example TAGS='@R1BOff'"
       )
     }
 
@@ -396,19 +396,19 @@ tasks.register('functionalOpalTagsR1AOnly', Test) {
   include '**/OpalTaggedTestRunner.class'
 
   doFirst {
-    systemProperty 'cucumber.filter.tags', '@JIRA-LABEL:manual-account-creation and not @Ignore'
+    systemProperty 'cucumber.filter.tags', '@R1A and not @Smoke and not @Ignore'
   }
 
   finalizedBy 'copyR1AOnlyDemoCucumberJson', 'mergeFunctionalOpalTagsR1AOnlyResults', 'aggregate', 'copyR1AOnlyDemoFunctionalReport'
 }
 
-tasks.register('functionalOpalTagsR1AOff', Test) {
-  description = "Runs the demo R1A-off tagged Opal functional tests"
+tasks.register('functionalOpalTagsR1AAndR1BOnly', Test) {
+  description = "Runs the demo R1A-and-R1B-only tagged Opal functional tests"
   group = "Verification"
   testClassesDirs = sourceSets.functionalTest.output.classesDirs
   classpath = sourceSets.functionalTest.runtimeClasspath
   outputs.upToDateWhen { false }
-  reports.junitXml.getOutputLocation().set(layout.buildDirectory.dir("test-results/functional/opal-tags-r1a-off"))
+  reports.junitXml.getOutputLocation().set(layout.buildDirectory.dir("test-results/functional/opal-tags-r1a-r1b-only"))
   testLogging.showStandardStreams = true
   environment("IS_LEGACY_MODE", "false")
   systemProperty 'cucumber.plugin',
@@ -417,10 +417,32 @@ tasks.register('functionalOpalTagsR1AOff', Test) {
   include '**/OpalTaggedTestRunner.class'
 
   doFirst {
-    systemProperty 'cucumber.filter.tags', '@R1AOff and not @Ignore'
+    systemProperty 'cucumber.filter.tags', '(@R1A or @R1B) and not @Ignore'
   }
 
-  finalizedBy 'copyR1AOffDemoCucumberJson', 'mergeFunctionalOpalTagsR1AOffResults', 'aggregate', 'copyR1AOffDemoFunctionalReport'
+  finalizedBy 'copyR1AAndR1BDemoCucumberJson', 'mergeFunctionalOpalTagsR1AAndR1BOnlyResults', 'aggregate', 'copyR1AAndR1BDemoFunctionalReport'
+}
+
+tasks.register('functionalOpalTagsAllFlagsOff', Test) {
+  description = "Runs the demo all-flags-off tagged Opal functional tests"
+  group = "Verification"
+  testClassesDirs = sourceSets.functionalTest.output.classesDirs
+  classpath = sourceSets.functionalTest.runtimeClasspath
+  outputs.upToDateWhen { false }
+  reports.junitXml.getOutputLocation().set(layout.buildDirectory.dir("test-results/functional/opal-tags-all-flags-off"))
+  testLogging.showStandardStreams = true
+  environment("IS_LEGACY_MODE", "false")
+  systemProperty 'cucumber.plugin',
+    "net.serenitybdd.cucumber.core.plugin.SerenityReporterParallel,pretty,json:${rootDir}/target/zephyr-reports/cucumber-opal-tags.json,timeline:${rootDir}/target/test-results/timeline"
+
+  include '**/OpalTaggedTestRunner.class'
+
+  doFirst {
+    systemProperty 'cucumber.filter.tags',
+      '(@R1AOff or @R1BOff or @R1CWriteOffOff or @R1CEnforcementOperationalReportingOff or @R1CAdministrationOff or @R1CFinancialMovementsOff) and not @Ignore'
+  }
+
+  finalizedBy 'copyAllFlagsOffDemoCucumberJson', 'mergeFunctionalOpalTagsAllFlagsOffResults', 'aggregate', 'copyAllFlagsOffDemoFunctionalReport'
 }
 
 tasks.register('copyOpalTagsCucumberJson', Copy) {
@@ -435,9 +457,15 @@ tasks.register('copyR1AOnlyDemoCucumberJson', Copy) {
   outputs.upToDateWhen { false }
 }
 
-tasks.register('copyR1AOffDemoCucumberJson', Copy) {
+tasks.register('copyR1AAndR1BDemoCucumberJson', Copy) {
   from("${rootDir}/target/zephyr-reports/cucumber-opal-tags.json")
-  into("${rootDir}/functional-output-r1a-off-demo/zephyr")
+  into("${rootDir}/functional-output-r1a-r1b-only-demo/zephyr")
+  outputs.upToDateWhen { false }
+}
+
+tasks.register('copyAllFlagsOffDemoCucumberJson', Copy) {
+  from("${rootDir}/target/zephyr-reports/cucumber-opal-tags.json")
+  into("${rootDir}/functional-output-all-flags-off-demo/zephyr")
   outputs.upToDateWhen { false }
 }
 
@@ -489,12 +517,21 @@ tasks.register('copyR1AOnlyDemoFunctionalReport', Copy) {
   }
 }
 
-tasks.register('copyR1AOffDemoFunctionalReport', Copy) {
+tasks.register('copyR1AAndR1BDemoFunctionalReport', Copy) {
   dependsOn 'aggregate'
   from("${rootDir}/target/site/serenity")
-  into("${rootDir}/functional-output-r1a-off-demo/report")
+  into("${rootDir}/functional-output-r1a-r1b-only-demo/report")
   doLast {
-    logPublishedHtmlReport("Demo R1AOff Functional Test Report", "${rootDir}/functional-output-r1a-off-demo/report")
+    logPublishedHtmlReport("Demo R1A and R1B Functional Test Report", "${rootDir}/functional-output-r1a-r1b-only-demo/report")
+  }
+}
+
+tasks.register('copyAllFlagsOffDemoFunctionalReport', Copy) {
+  dependsOn 'aggregate'
+  from("${rootDir}/target/site/serenity")
+  into("${rootDir}/functional-output-all-flags-off-demo/report")
+  doLast {
+    logPublishedHtmlReport("Demo All Flags Off Functional Test Report", "${rootDir}/functional-output-all-flags-off-demo/report")
   }
 }
 tasks.register('packageTaggedDemoFunctionalOutput', Copy) {
@@ -530,12 +567,22 @@ tasks.register('syncR1AOnlyTaggedFunctionalArtifactsFromExistingResults') {
     )
   }
 }
-tasks.register('syncR1AOffTaggedFunctionalArtifactsFromExistingResults') {
+tasks.register('syncR1AAndR1BTaggedFunctionalArtifactsFromExistingResults') {
   doLast {
     syncFunctionalArtifacts(
-      'Demo R1AOff Functional Test Report',
-      "${rootDir}/functional-output-r1a-off-demo/report",
-      "${rootDir}/functional-output-r1a-off-demo",
+      'Demo R1A and R1B Functional Test Report',
+      "${rootDir}/functional-output-r1a-r1b-only-demo/report",
+      "${rootDir}/functional-output-r1a-r1b-only-demo",
+      'cucumber-opal-tags.json'
+    )
+  }
+}
+tasks.register('syncAllFlagsOffTaggedFunctionalArtifactsFromExistingResults') {
+  doLast {
+    syncFunctionalArtifacts(
+      'Demo All Flags Off Functional Test Report',
+      "${rootDir}/functional-output-all-flags-off-demo/report",
+      "${rootDir}/functional-output-all-flags-off-demo",
       'cucumber-opal-tags.json'
     )
   }
@@ -583,8 +630,13 @@ tasks.register('mergeFunctionalOpalTagsR1AOnlyResults', Copy) {
   into layout.buildDirectory.dir("test-results/functional")
   include '*.xml'
 }
-tasks.register('mergeFunctionalOpalTagsR1AOffResults', Copy) {
-  from layout.buildDirectory.dir("test-results/functional/opal-tags-r1a-off")
+tasks.register('mergeFunctionalOpalTagsR1AAndR1BOnlyResults', Copy) {
+  from layout.buildDirectory.dir("test-results/functional/opal-tags-r1a-r1b-only")
+  into layout.buildDirectory.dir("test-results/functional")
+  include '*.xml'
+}
+tasks.register('mergeFunctionalOpalTagsAllFlagsOffResults', Copy) {
+  from layout.buildDirectory.dir("test-results/functional/opal-tags-all-flags-off")
   into layout.buildDirectory.dir("test-results/functional")
   include '*.xml'
 }
@@ -675,19 +727,22 @@ tasks.named('aggregate') {
     tasks.named('functionalLegacy'),
     tasks.named('functionalOpalTags'),
     tasks.named('functionalOpalTagsR1AOnly'),
-    tasks.named('functionalOpalTagsR1AOff'),
+    tasks.named('functionalOpalTagsR1AAndR1BOnly'),
+    tasks.named('functionalOpalTagsAllFlagsOff'),
     tasks.named('smokeOpal'),
     tasks.named('mergeFunctionalResults'),
     tasks.named('mergeFunctionalWithTagsResults'),
     tasks.named('mergeFunctionalOpalTagsResults'),
     tasks.named('mergeFunctionalOpalTagsR1AOnlyResults'),
-    tasks.named('mergeFunctionalOpalTagsR1AOffResults')
+    tasks.named('mergeFunctionalOpalTagsR1AAndR1BOnlyResults'),
+    tasks.named('mergeFunctionalOpalTagsAllFlagsOffResults')
   )
 }
 
 tasks.configureEach {
   if (name in ['copyFunctionalReport', 'copyDemoFunctionalReport', 'copyR1AOnlyDemoFunctionalReport',
-               'copyR1AOffDemoFunctionalReport', 'copySmokeReport']) {
+               'copyR1AAndR1BDemoFunctionalReport',
+               'copyAllFlagsOffDemoFunctionalReport', 'copySmokeReport']) {
     mustRunAfter tasks.named('aggregate')
   } else if (name == 'copyOpalCucumberJson') {
     mustRunAfter tasks.named('functionalOpal')
@@ -695,8 +750,10 @@ tasks.configureEach {
     mustRunAfter tasks.named('functionalOpalTags')
   } else if (name == 'copyR1AOnlyDemoCucumberJson') {
     mustRunAfter tasks.named('functionalOpalTagsR1AOnly')
-  } else if (name == 'copyR1AOffDemoCucumberJson') {
-    mustRunAfter tasks.named('functionalOpalTagsR1AOff')
+  } else if (name == 'copyR1AAndR1BDemoCucumberJson') {
+    mustRunAfter tasks.named('functionalOpalTagsR1AAndR1BOnly')
+  } else if (name == 'copyAllFlagsOffDemoCucumberJson') {
+    mustRunAfter tasks.named('functionalOpalTagsAllFlagsOff')
   } else if (name == 'copyLegacyCucumberJson') {
     mustRunAfter tasks.named('functionalLegacy')
   } else if (name == 'copySmokeCucumberJson') {

--- a/build.gradle
+++ b/build.gradle
@@ -439,7 +439,7 @@ tasks.register('functionalOpalTagsAllFlagsOff', Test) {
 
   doFirst {
     systemProperty 'cucumber.filter.tags',
-      '(@R1AOff or @R1BOff or @R1CWriteOffOff or @R1CEnforcementOperationalReportingOff or @R1CAdministrationOff or @R1CFinancialMovementsOff) and not @Ignore'
+      '(@R1AOff or @R1BOff or @R1COff or @R1CWriteOffOff or @R1CEnforcementOperationalReportingOff or @R1CAdministrationOff or @R1CFinancialMovementsOff or @R1CAutoEnforcementOff or @R1DDataRetentionOff or @R1DAutoEnforcementConfigOff or @R1CRmFinancialMovementsOff or @R1CRmFinancialChecksOff or @R1CRmSuspenseOff or @R1CRmPaymentOff or @R1CRmAdminReportsOff or @R1CRmAccountActionsOff or @R1CChecksOff or @R1CSuspenseOff or @R1CPaymentOff or @R1CR1ATidyUpOff or @R1CReferenceDataOff or @R1CBankingInterfacesOff or @R1CCppEnforcementOff or @R1CCppOff or @R1CPrintingOff) and not @Ignore'
   }
 
   finalizedBy 'copyAllFlagsOffDemoCucumberJson', 'mergeFunctionalOpalTagsAllFlagsOffResults', 'aggregate', 'copyAllFlagsOffDemoFunctionalReport'

--- a/gradle/zephyr.gradle
+++ b/gradle/zephyr.gradle
@@ -40,10 +40,15 @@ Map<String, Map<String, Object>> functionalZephyrTargets = [
                 testFolder: "functionalTest/resources",
                 syncTask  : "syncR1AOnlyTaggedFunctionalArtifactsFromExistingResults",
         ],
-        runR1AOff: [
-                reportPath: "functional-output-r1a-off-demo/zephyr/cucumber-opal-tags.json",
+        runR1AAndR1BOnly: [
+                reportPath: "functional-output-r1a-r1b-only-demo/zephyr/cucumber-opal-tags.json",
                 testFolder: "functionalTest/resources",
-                syncTask  : "syncR1AOffTaggedFunctionalArtifactsFromExistingResults",
+                syncTask  : "syncR1AAndR1BTaggedFunctionalArtifactsFromExistingResults",
+        ],
+        runAllFlagsOff: [
+                reportPath: "functional-output-all-flags-off-demo/zephyr/cucumber-opal-tags.json",
+                testFolder: "functionalTest/resources",
+                syncTask  : "syncAllFlagsOffTaggedFunctionalArtifactsFromExistingResults",
         ],
 ]
 
@@ -126,17 +131,17 @@ void configureIntegrationZephyrTask(JavaExec task, String actionType, String des
 
 tasks.register('createJiraTicketsFromFunctionalReport', JavaExec) { JavaExec task ->
     configureFunctionalZephyrTask(task, "CREATE_TICKETS",
-            "Creates and links Jira tickets from the selected functional-family Zephyr report. Requires -PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AOff")
+            "Creates and links Jira tickets from the selected functional-family Zephyr report. Requires -PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AAndR1BOnly|runAllFlagsOff")
 }
 
 tasks.register('updateJiraTicketsFromFunctionalReport', JavaExec) { JavaExec task ->
     configureFunctionalZephyrTask(task, "UPDATE_TICKETS",
-            "Updates Jira tickets from the selected functional-family Zephyr report. Requires -PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AOff")
+            "Updates Jira tickets from the selected functional-family Zephyr report. Requires -PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AAndR1BOnly|runAllFlagsOff")
 }
 
 tasks.register('createJiraExecutionFromFunctionalReport', JavaExec) { JavaExec task ->
     configureFunctionalZephyrTask(task, "CREATE_EXECUTION",
-            "Creates a Zephyr execution from the selected functional-family Zephyr report. Requires -PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AOff")
+            "Creates a Zephyr execution from the selected functional-family Zephyr report. Requires -PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AAndR1BOnly|runAllFlagsOff")
 }
 
 tasks.register('createJiraTicketsFromIntegrationReport', JavaExec) { JavaExec task ->

--- a/src/functionalTest/java/uk/gov/hmcts/opal/OpalTaggedTestRunner.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/OpalTaggedTestRunner.java
@@ -11,9 +11,9 @@ import uk.gov.hmcts.opal.steps.BaseStepDef;
  * Runs tagged Opal functional scenarios that must be selected deliberately at execution time.
  *
  * <p>This runner exists separately from {@link OpalTestRunner} because the default Opal suite
- * excludes feature-toggle scenarios tagged {@code @FeatureToggle}. Those scenarios are not safe
- * to include in the normal {@code functionalOpal} run because they depend on the target environment
- * being configured with a matching feature-flag combination.
+ * excludes the release-toggle scenarios that are not safe to include in the normal
+ * {@code functionalOpal} run. Those scenarios depend on the target environment being configured
+ * with a matching feature-flag combination.
  *
  * <p>The accompanying {@code functionalOpalTags} Gradle task supplies
  * {@code cucumber.filter.tags}, allowing a caller to run only the relevant tagged scenarios

--- a/src/functionalTest/java/uk/gov/hmcts/opal/OpalTestRunner.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/OpalTestRunner.java
@@ -18,7 +18,7 @@ import uk.gov.hmcts.opal.steps.BaseStepDef;
     value = "@Opal and not @Smoke and not @Ignore and not "
         + "(@R1AOff or @R1BOff or @R1COff or @R1CWriteOffOff or "
         + "@R1CEnforcementOperationalReportingOff or @R1CAdministrationOff or @R1CFinancialMovementsOff or "
-        + "@R1CAutoEnforcementOff or @R1DDataRetentionOff or @R1DAutoEnforcementConfigOff or "
+        + "@R1CAutoEnforcementOff or @R1CDataRetentionOff or @R1CAutoEnforcementConfigOff or "
         + "@R1CRmFinancialMovementsOff or @R1CRmFinancialChecksOff or @R1CRmSuspenseOff or "
         + "@R1CRmPaymentOff or @R1CRmAdminReportsOff or @R1CRmAccountActionsOff or @R1CChecksOff or "
         + "@R1CSuspenseOff or @R1CPaymentOff or @R1CR1ATidyUpOff or @R1CReferenceDataOff or "

--- a/src/functionalTest/java/uk/gov/hmcts/opal/OpalTestRunner.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/OpalTestRunner.java
@@ -16,8 +16,13 @@ import uk.gov.hmcts.opal.steps.BaseStepDef;
 @ConfigurationParameter(
     key = FILTER_TAGS_PROPERTY_NAME,
     value = "@Opal and not @Smoke and not @Ignore and not "
-        + "(@R1AOff or @R1BOff or @R1COff or @R1CWriteOffOff or @R1CWriteOff or "
-        + "@R1CEnforcementOperationalReportingOff or @R1CAdministrationOff or @R1CFinancialMovementsOff)"
+        + "(@R1AOff or @R1BOff or @R1COff or @R1CWriteOffOff or "
+        + "@R1CEnforcementOperationalReportingOff or @R1CAdministrationOff or @R1CFinancialMovementsOff or "
+        + "@R1CAutoEnforcementOff or @R1DDataRetentionOff or @R1DAutoEnforcementConfigOff or "
+        + "@R1CRmFinancialMovementsOff or @R1CRmFinancialChecksOff or @R1CRmSuspenseOff or "
+        + "@R1CRmPaymentOff or @R1CRmAdminReportsOff or @R1CRmAccountActionsOff or @R1CChecksOff or "
+        + "@R1CSuspenseOff or @R1CPaymentOff or @R1CR1ATidyUpOff or @R1CReferenceDataOff or "
+        + "@R1CBankingInterfacesOff or @R1CCppEnforcementOff or @R1CCppOff or @R1CPrintingOff)"
 )
 public class OpalTestRunner {
 

--- a/src/functionalTest/java/uk/gov/hmcts/opal/OpalTestRunner.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/OpalTestRunner.java
@@ -15,7 +15,9 @@ import uk.gov.hmcts.opal.steps.BaseStepDef;
 @SelectClasspathResource("features/opalMode")
 @ConfigurationParameter(
     key = FILTER_TAGS_PROPERTY_NAME,
-    value = "@Opal and not @Smoke and not @Ignore and not @FeatureToggle"
+    value = "@Opal and not @Smoke and not @Ignore and not "
+        + "(@R1AOff or @R1BOff or @R1COff or @R1CWriteOffOff or @R1CWriteOff or "
+        + "@R1CEnforcementOperationalReportingOff or @R1CAdministrationOff or @R1CFinancialMovementsOff)"
 )
 public class OpalTestRunner {
 

--- a/src/functionalTest/java/uk/gov/hmcts/opal/steps/defendantaccount/DefendantAccountSearchFeatureToggleStepDef.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/steps/defendantaccount/DefendantAccountSearchFeatureToggleStepDef.java
@@ -93,7 +93,7 @@ public class DefendantAccountSearchFeatureToggleStepDef extends BaseStepDef {
      */
     @When("I search the created defendant account without consolidation")
     public void searchCreatedDefendantAccountWithoutConsolidation() throws JSONException {
-        performSearch(prosecutorCaseReference, businessUnitId, null);
+        performSearch(prosecutorCaseReference, businessUnitId, false);
     }
 
     /**
@@ -162,7 +162,7 @@ public class DefendantAccountSearchFeatureToggleStepDef extends BaseStepDef {
         requestBody.put("account_type", "Fine");
         requestBody.put("account_status", JSONObject.NULL);
         requestBody.put("account", buildUniqueAccountFixture());
-        requestBody.put("timeline_data", requestFactory.loadDefaultTimelineFixture());
+        //requestBody.put("timeline_data", requestFactory.loadDefaultTimelineFixture());
         return requestBody;
     }
 

--- a/src/functionalTest/resources/features/opalMode/authenticationAndAuthorisation/AuthenticationAuthorisationParity.feature
+++ b/src/functionalTest/resources/features/opalMode/authenticationAndAuthorisation/AuthenticationAuthorisationParity.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:authentication-authorisation
+@Opal @JIRA-LABEL:authentication-authorisation @R1A
 Feature: Authentication And Authorisation Parity
 
   @JIRA-STORY:PO-896 @JIRA-EPIC:PO-2233 @JIRA-TEST-KEY:PO-5619

--- a/src/functionalTest/resources/features/opalMode/contentDigest/ContentDigest.feature
+++ b/src/functionalTest/resources/features/opalMode/contentDigest/ContentDigest.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:content-digest @JIRA-STORY:PO-2878 @JIRA-EPIC:PO-2675
+@Opal @JIRA-LABEL:content-digest @JIRA-STORY:PO-2878 @JIRA-EPIC:PO-2675 @R1A
 Feature: Content-Digest handling
 
   @JIRA-TEST-KEY:PO-5776

--- a/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountConsolidatedAccounts.feature
+++ b/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountConsolidatedAccounts.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:account-enquiry
+@Opal @JIRA-LABEL:account-enquiry @R1B
 Feature: Defendant Account Consolidated Accounts
 
   # NOTE: Blocked until Consolidation 2 can create or seed real consolidated-account data

--- a/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountEnforcements.feature
+++ b/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountEnforcements.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:account-enquiry
+@Opal @JIRA-LABEL:account-enquiry @R1B
 Feature: Defendant Account Enforcement Overrides
 
   @cleanUpData @JIRA-STORY:PO-1854 @JIRA-EPIC:PO-1675 @JIRA-TEST-KEY:PO-5620

--- a/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountHistory.feature
+++ b/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountHistory.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:account-enquiry
+@Opal @JIRA-LABEL:account-enquiry @R1B
 Feature: Defendant Account History
 
   @cleanUpData @JIRA-STORY:PO-2622 @JIRA-EPIC:PO-2621 @JIRA-TEST-KEY:PO-8660

--- a/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountSearchFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountSearchFeatureToggles.feature
@@ -16,7 +16,7 @@ Feature: Defendant Account Search Feature Toggles
     When I search the created defendant account without consolidation
     Then the basic defendant account search returns the created account
 
-  @R1B @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
+  @R1CWriteOffOff @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
   Scenario: Consolidated search is unavailable when release 1c is disabled
     Given a searchable defendant account exists for feature-toggle search
     When I search the created defendant account with consolidation

--- a/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountSearchFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountSearchFeatureToggles.feature
@@ -10,13 +10,13 @@ Feature: Defendant Account Search Feature Toggles
     Then the request is rejected with status 404
     And the response reports that the feature is disabled
 
-  @R1B @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
+  @R1CWriteOffOff @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
   Scenario: Basic search remains available when release 1c is disabled
     Given a searchable defendant account exists for feature-toggle search
     When I search the created defendant account without consolidation
     Then the basic defendant account search returns the created account
 
-  @R1CWriteOffOff @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
+  @R1B @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
   Scenario: Consolidated search is unavailable when release 1c is disabled
     Given a searchable defendant account exists for feature-toggle search
     When I search the created defendant account with consolidation

--- a/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountSearchFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountSearchFeatureToggles.feature
@@ -1,4 +1,4 @@
-@Opal @FeatureToggle @JIRA-LABEL:account-enquiry
+@Opal @JIRA-LABEL:account-enquiry
 Feature: Defendant Account Search Feature Toggles
 
   Background:
@@ -10,20 +10,20 @@ Feature: Defendant Account Search Feature Toggles
     Then the request is rejected with status 404
     And the response reports that the feature is disabled
 
-  @R1B @R1COff @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
+  @R1COff @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
   Scenario: Basic search remains available when release 1c is disabled
     Given a searchable defendant account exists for feature-toggle search
     When I search the created defendant account without consolidation
     Then the basic defendant account search returns the created account
 
-  @R1B @R1COff @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
+  @R1COff @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
   Scenario: Consolidated search is unavailable when release 1c is disabled
     Given a searchable defendant account exists for feature-toggle search
     When I search the created defendant account with consolidation
     Then the request is rejected with status 404
     And the response reports that the feature is disabled
 
-  @R1B @R1C @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
+  @R1B @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
   Scenario: Consolidated search is available when release 1c is enabled
     Given a searchable defendant account exists for feature-toggle search
     When I search the created defendant account with consolidation

--- a/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountSearchFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountSearchFeatureToggles.feature
@@ -10,20 +10,20 @@ Feature: Defendant Account Search Feature Toggles
     Then the request is rejected with status 404
     And the response reports that the feature is disabled
 
-  @R1COff @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
+  @R1B @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
   Scenario: Basic search remains available when release 1c is disabled
     Given a searchable defendant account exists for feature-toggle search
     When I search the created defendant account without consolidation
     Then the basic defendant account search returns the created account
 
-  @R1COff @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
+  @R1CWriteOffOff @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
   Scenario: Consolidated search is unavailable when release 1c is disabled
     Given a searchable defendant account exists for feature-toggle search
     When I search the created defendant account with consolidation
     Then the request is rejected with status 404
     And the response reports that the feature is disabled
 
-  @R1B @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
+  @R1CWriteOff @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
   Scenario: Consolidated search is available when release 1c is enabled
     Given a searchable defendant account exists for feature-toggle search
     When I search the created defendant account with consolidation

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/add/AddDraftAccount.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/add/AddDraftAccount.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:personal-data-processing-logging
+@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:personal-data-processing-logging @R1A
 Feature: Create Draft Accounts
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/add/AddDraftAccountAuthorisation.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/add/AddDraftAccountAuthorisation.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:authorisation
+@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:authorisation @R1A
 Feature: Add Draft Account Authorisation
 
   @JIRA-STORY:PO-827 @JIRA-EPIC:PO-2219 @cleanUpData @JIRA-TEST-KEY:PO-5625

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/add/AddDraftAccountErrorHandling.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/add/AddDraftAccountErrorHandling.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:error-handling
+@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:error-handling @R1A
 Feature: Add Draft Account Error Handling
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/add/AddDraftAccountSubmittedByName.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/add/AddDraftAccountSubmittedByName.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:manual-account-creation
+@Opal @JIRA-LABEL:manual-account-creation @R1A
 Feature: Draft Account Snapshot Identity
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/delete/DeleteDraftAccount.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/delete/DeleteDraftAccount.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:manual-account-creation @JIRA-STORY:PO-2117 @JIRA-EPIC:PO-2141 @JIRA-LABEL:test-support-endpoint-test
+@Opal @JIRA-LABEL:manual-account-creation @JIRA-STORY:PO-2117 @JIRA-EPIC:PO-2141 @JIRA-LABEL:test-support-endpoint-test @R1A
 Feature: Delete Draft Account
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/get/GetDraftAccount.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/get/GetDraftAccount.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:manual-account-creation
+@Opal @JIRA-LABEL:manual-account-creation @R1A
 Feature: Retrieve Draft Account
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/get/GetDraftAccountAccessTokenIdentity.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/get/GetDraftAccountAccessTokenIdentity.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:manual-account-creation
+@Opal @JIRA-LABEL:manual-account-creation @R1A
 Feature: Draft Account Access Token Identity
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/get/GetDraftAccountAuthorisation.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/get/GetDraftAccountAuthorisation.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:authorisation
+@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:authorisation @R1A
 Feature: Get Draft Account Authorisation
 
   @JIRA-STORY:PO-828 @JIRA-EPIC:PO-2219 @cleanUpData @JIRA-NFR:PO-2507 @JIRA-TEST-KEY:PO-5642

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/get/GetDraftAccountErrorHandling.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/get/GetDraftAccountErrorHandling.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:error-handling
+@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:error-handling @R1A
 Feature: Get Draft Account Error Handling
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/list/GetDraftAccounts.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/list/GetDraftAccounts.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:manual-account-creation
+@Opal @JIRA-LABEL:manual-account-creation @R1A
 Feature: List Draft Accounts
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/list/GetDraftAccountsAuthorisation.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/list/GetDraftAccountsAuthorisation.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:authorisation
+@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:authorisation @R1A
 Feature: Get Draft Accounts Authorisation
 
   @JIRA-STORY:PO-829 @JIRA-EPIC:PO-2219 @cleanUpData @JIRA-NFR:PO-2507 @JIRA-TEST-KEY:PO-5662

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/list/GetDraftAccountsErrorHandling.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/list/GetDraftAccountsErrorHandling.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:error-handling
+@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:error-handling @R1A
 Feature: Get Draft Accounts Error Handling
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/replace/ReplaceDraftAccount.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/replace/ReplaceDraftAccount.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:manual-account-creation
+@Opal @JIRA-LABEL:manual-account-creation @R1A
 Feature: Replace Draft Account
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/replace/ReplaceDraftAccountAuthorisation.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/replace/ReplaceDraftAccountAuthorisation.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:authorisation
+@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:authorisation @R1A
 Feature: Replace Draft Account Authorisation
 
   @JIRA-STORY:PO-830 @JIRA-EPIC:PO-2220 @cleanUpData @JIRA-TEST-KEY:PO-5671

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/replace/ReplaceDraftAccountErrorHandling.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/replace/ReplaceDraftAccountErrorHandling.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:error-handling
+@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:error-handling @R1A
 Feature: Replace Draft Account Error Handling
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/update/UpdateDraftAccount.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/update/UpdateDraftAccount.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:manual-account-creation
+@Opal @JIRA-LABEL:manual-account-creation @R1A
 Feature: Update Draft Accounts
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/update/UpdateDraftAccountAuthorisation.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/update/UpdateDraftAccountAuthorisation.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:authorisation
+@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:authorisation @R1A
 Feature: Update Draft Account Authorisation
 
   @JIRA-STORY:PO-831 @JIRA-EPIC:PO-2220 @cleanUpData @JIRA-TEST-KEY:PO-5692

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/update/UpdateDraftAccountErrorHandling.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/update/UpdateDraftAccountErrorHandling.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:error-handling
+@Opal @JIRA-LABEL:manual-account-creation @JIRA-LABEL:error-handling @R1A
 Feature: Update Draft Account Error Handling
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1aFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1aFeatureToggles.feature
@@ -1,4 +1,4 @@
-@Opal @FeatureToggle @JIRA-LABEL:reference-data @JIRA-LABEL:manual-account-creation
+@Opal @JIRA-LABEL:reference-data @JIRA-LABEL:manual-account-creation
 Feature: Fines Service Release 1a Feature Toggles
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1bFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1bFeatureToggles.feature
@@ -1,4 +1,4 @@
-@Opal @FeatureToggle @JIRA-LABEL:account-enquiry @JIRA-LABEL:reference-data
+@Opal @JIRA-LABEL:account-enquiry @JIRA-LABEL:reference-data
 Feature: Fines Service Release 1b Feature Toggles
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1cFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1cFeatureToggles.feature
@@ -1,21 +1,21 @@
-@Opal @FeatureToggle @Ignore @release-1c @JIRA-LABEL:account-enquiry @JIRA-LABEL:release-1c
+@Opal @Ignore @JIRA-LABEL:account-enquiry @JIRA-LABEL:release-1c @JIRA-EPIC:PO-3685
 Feature: Fines Service Release 1c Feature Toggles
 
   Background:
     Given I am testing as the "opal-test@dev.platform.hmcts.net" user
 
-  @Release1cOff @JIRA-STORY:PO-3768
+  @R1CWriteOffOff @JIRA-STORY:PO-3768
   Scenario: Consolidated defendant account search is unavailable when release 1c is disabled
     When I call the defendant account search endpoint with consolidated search enabled
     Then the request is rejected with status 405
     And the release 1c feature-disabled response is returned
 
-  @Release1cOff @JIRA-STORY:PO-3768
+  @R1CWriteOffOff @JIRA-STORY:PO-3768
   Scenario: Defendant account search remains available without consolidated search when release 1c is disabled
     When I call the defendant account search endpoint without consolidated search
     Then the response status is 200
 
-  @Release1cOn @JIRA-STORY:PO-3768
+  @R1CWriteOff @JIRA-STORY:PO-3768
   Scenario: Consolidated defendant account search is available when release 1c is enabled
     When I call the defendant account search endpoint with consolidated search enabled
     Then the response status is 200

--- a/src/functionalTest/resources/features/opalMode/majorCreditorAccounts/MajorCreditorAccountHeaderSummary.feature
+++ b/src/functionalTest/resources/features/opalMode/majorCreditorAccounts/MajorCreditorAccountHeaderSummary.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:account-enquiry
+@Opal @JIRA-LABEL:account-enquiry @R1B
 Feature: Major Creditor Account Header Summary
 
   @JIRA-STORY:PO-2136 @JIRA-EPIC:PO-1286 @JIRA-TEST-KEY:PO-8039

--- a/src/functionalTest/resources/features/opalMode/referenceData/BusinessUnits.feature
+++ b/src/functionalTest/resources/features/opalMode/referenceData/BusinessUnits.feature
@@ -1,8 +1,7 @@
 @Opal @JIRA-LABEL:reference-data
 Feature: Business Units Reference Data
 
-
-  @JIRA-STORY:PO-313 @JIRA-EPIC:PO-304 @JIRA-TEST-KEY:PO-5705
+  @JIRA-STORY:PO-313 @JIRA-EPIC:PO-304 @JIRA-TEST-KEY:PO-5705 @R1CReferenceData
   Scenario: Area business units can be retrieved
     Given I am testing as the "opal-test@dev.platform.hmcts.net" user
     When I make a request to the business unit ref data api filtering by business unit type "Area"

--- a/src/functionalTest/resources/features/opalMode/referenceData/CentralFunds.feature
+++ b/src/functionalTest/resources/features/opalMode/referenceData/CentralFunds.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:reference-data @JIRA-LABEL:authentication-authorisation
+@Opal @JIRA-LABEL:reference-data @JIRA-LABEL:authentication-authorisation @R1CReferenceData
 Feature: Central Funds Reference Data
 
   # Ignored because deployed environments do not currently contain the Central Fund

--- a/src/functionalTest/resources/features/opalMode/referenceData/Courts.feature
+++ b/src/functionalTest/resources/features/opalMode/referenceData/Courts.feature
@@ -1,8 +1,7 @@
 @Opal @JIRA-LABEL:reference-data
 Feature: Courts Reference Data
 
-  @JIRA-STORY:PO-315 @JIRA-EPIC:PO-304
-
+  @JIRA-STORY:PO-315 @JIRA-EPIC:PO-304 @R1CReferenceData
   @JIRA-TEST-KEY:PO-5706
   Scenario: Courts can be retrieved by name
     Given I am testing as the "opal-test@dev.platform.hmcts.net" user

--- a/src/functionalTest/resources/features/opalMode/referenceData/CourtsBusinessUnitFiltering.feature
+++ b/src/functionalTest/resources/features/opalMode/referenceData/CourtsBusinessUnitFiltering.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:reference-data
+@Opal @JIRA-LABEL:reference-data @R1CReferenceData
 Feature: Courts Business Unit Filtering
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/referenceData/LocalJusticeAreas.feature
+++ b/src/functionalTest/resources/features/opalMode/referenceData/LocalJusticeAreas.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:reference-data
+@Opal @JIRA-LABEL:reference-data @R1CReferenceData
 Feature: Local Justice Areas Reference Data
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/referenceData/MajorCreditors.feature
+++ b/src/functionalTest/resources/features/opalMode/referenceData/MajorCreditors.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:reference-data
+@Opal @JIRA-LABEL:reference-data @R1CReferenceData
 Feature: Major Creditors Reference Data
 
   @JIRA-STORY:PO-349 @JIRA-EPIC:PO-304 @JIRA-TEST-KEY:PO-5715

--- a/src/functionalTest/resources/features/opalMode/referenceData/MajorCreditorsBusinessUnitData.feature
+++ b/src/functionalTest/resources/features/opalMode/referenceData/MajorCreditorsBusinessUnitData.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:reference-data
+@Opal @JIRA-LABEL:reference-data @R1CReferenceData
 Feature: Major Creditors Business Unit Data
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/referenceData/OffenceAdditionalFields.feature
+++ b/src/functionalTest/resources/features/opalMode/referenceData/OffenceAdditionalFields.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:reference-data
+@Opal @JIRA-LABEL:reference-data @R1CReferenceData
 Feature: Offence Additional Fields
 
   @JIRA-STORY:PO-614 @JIRA-EPIC:PO-304 @JIRA-TEST-KEY:PO-5718

--- a/src/functionalTest/resources/features/opalMode/referenceData/OffenceSearch.feature
+++ b/src/functionalTest/resources/features/opalMode/referenceData/OffenceSearch.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:reference-data @JIRA-STORY:PO-926 @JIRA-STORY:PO-1070 @JIRA-EPIC:PO-304
+@Opal @JIRA-LABEL:reference-data @JIRA-STORY:PO-926 @JIRA-STORY:PO-1070 @JIRA-EPIC:PO-304 @R1CReferenceData
 Feature: Offence Search
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/referenceData/Offences.feature
+++ b/src/functionalTest/resources/features/opalMode/referenceData/Offences.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:reference-data
+@Opal @JIRA-LABEL:reference-data @R1CReferenceData
 Feature: Offences Reference Data
 
   @JIRA-STORY:PO-311 @JIRA-EPIC:PO-304

--- a/src/functionalTest/resources/features/opalMode/referenceData/OffencesBusinessUnitScope.feature
+++ b/src/functionalTest/resources/features/opalMode/referenceData/OffencesBusinessUnitScope.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:reference-data
+@Opal @JIRA-LABEL:reference-data @R1CReferenceData
 Feature: Offences Business Unit Scope
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/referenceData/ReferenceDataSmoke.feature
+++ b/src/functionalTest/resources/features/opalMode/referenceData/ReferenceDataSmoke.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:reference-data
+@Opal @JIRA-LABEL:reference-data @R1CReferenceData
 Feature: Reference Data Smoke Checks
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/referenceData/Reports.feature
+++ b/src/functionalTest/resources/features/opalMode/referenceData/Reports.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:reference-data
+@Opal @JIRA-LABEL:reference-data @R1CReferenceData
 Feature: Report Definition Reference Data
 
   # NOTE: E2E.01 cannot currently be covered in QA from this service alone.

--- a/src/functionalTest/resources/features/opalMode/reportInstances/GetReportInstances.feature
+++ b/src/functionalTest/resources/features/opalMode/reportInstances/GetReportInstances.feature
@@ -1,5 +1,5 @@
 # Ignored because this feature is awaiting the DB changes for get report instances.
-@Opal @Ignore @JIRA-LABEL:report-instances
+@Opal @Ignore @JIRA-LABEL:report-instances @R1CEnforcementOperationalReporting
 Feature: Get Report Instances
 
   @JIRA-STORY:PO-2251 @JIRA-EPIC:PO-2248

--- a/src/functionalTest/resources/features/opalMode/reportInstances/ReportInstances.feature
+++ b/src/functionalTest/resources/features/opalMode/reportInstances/ReportInstances.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:report-instances @JIRA-LABEL:authorisation
+@Opal @JIRA-LABEL:report-instances @JIRA-LABEL:authorisation @R1CEnforcementOperationalReportin
 Feature: Report Instances
 
   #    POST :/reports-instances/{id} Test scenarios

--- a/src/functionalTest/resources/features/opalMode/reportInstances/ReportInstances.feature
+++ b/src/functionalTest/resources/features/opalMode/reportInstances/ReportInstances.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:report-instances @JIRA-LABEL:authorisation @R1CEnforcementOperationalReportin
+@Opal @JIRA-LABEL:report-instances @JIRA-LABEL:authorisation @R1CEnforcementOperationalReporting
 Feature: Report Instances
 
   #    POST :/reports-instances/{id} Test scenarios

--- a/src/functionalTest/resources/features/opalMode/results/Results.feature
+++ b/src/functionalTest/resources/features/opalMode/results/Results.feature
@@ -4,7 +4,7 @@ Feature: Results Reference Data
   Background:
     Given I am testing as the "opal-test@dev.platform.hmcts.net" user
 
-  @JIRA-STORY:PO-703 @JIRA-EPIC:PO-304 @JIRA-TEST-KEY:PO-5738
+  @JIRA-STORY:PO-703 @JIRA-EPIC:PO-304 @JIRA-TEST-KEY:PO-5738 @R1CReferenceData
   Scenario: All results are returned when no result id filter is supplied
     When I request results for identifiers ""
     Then 60 results are returned
@@ -37,7 +37,7 @@ Feature: Results Reference Data
       | imposition_creditor         | Any          |
       | imposition_allocation_order | 1            |
 
-  @JIRA-STORY:PO-703 @JIRA-EPIC:PO-304 @JIRA-TEST-KEY:PO-5739
+  @JIRA-STORY:PO-703 @JIRA-EPIC:PO-304 @JIRA-TEST-KEY:PO-5739 @R1CReferenceData
   Scenario: Only requested results are returned when result ids are supplied
     When I request results for identifiers "FO,ABDC"
     Then 2 results are returned
@@ -60,14 +60,14 @@ Feature: Results Reference Data
       | imposition_creditor         |                                         |
       | imposition_allocation_order |                                         |
 
-  @JIRA-STORY:PO-6425 @JIRA-EPIC:PO-1674 @JIRA-TEST-KEY:PO-7869
+  @JIRA-STORY:PO-6425 @JIRA-EPIC:PO-1674 @JIRA-TEST-KEY:PO-7869 @R1B
   Scenario: Result by ID includes employment data requirement flag
     When I request result with identifier "AEO"
     Then the result response contains
       | result_id                | AEO  |
       | requires_employment_data | true |
 
-  @JIRA-STORY:PO-2985 @JIRA-EPIC:PO-2630
+  @JIRA-STORY:PO-2985 @JIRA-EPIC:PO-2630 @R1B
   Scenario: Result by ID can include Welsh text result parameters
     When I request result with identifier "SC" including Welsh parameters
     Then the result parameters contain the following entries in order
@@ -75,12 +75,12 @@ Feature: Results Reference Data
       | paymentterms    | text | true               |                                               |
       | cy_paymentterms | text | true               | Provide a welsh version for the defendant    |
 
-  @JIRA-STORY:PO-3765 @Ignore @release-1b
+  @JIRA-STORY:PO-3765 @Ignore @R1B
   Scenario: Result filtering is available when release-1b is enabled
     When I request results for identifiers "NBWT,NAP" using filter "enforcement_override" with value "true"
     Then 1 results are returned
 
-  @JIRA-STORY:PO-3765 @Ignore @release-1b
+  @JIRA-STORY:PO-3765 @Ignore @R1B
   Scenario: Result filtering is rejected when release-1b is disabled
     When I request results using filter "active" with value "true"
     Then the response status code is 404

--- a/src/functionalTest/resources/features/opalMode/results/ResultsFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/results/ResultsFeatureToggles.feature
@@ -1,4 +1,4 @@
-@Opal @FeatureToggle @JIRA-LABEL:reference-data
+@Opal @JIRA-LABEL:reference-data
 Feature: Results Feature Toggles
 
   Background:
@@ -10,7 +10,7 @@ Feature: Results Feature Toggles
     Then the request is rejected with status 404
     And the response reports that the feature is disabled
 
-  @R1A @R1BOff @JIRA-STORY:PO-3765 @JIRA-EPIC:PO-3685 @JIRA-TEST-KEY:PO-8391
+  @R1BOff @JIRA-STORY:PO-3765 @JIRA-EPIC:PO-3685 @JIRA-TEST-KEY:PO-8391
   Scenario: Results remain available without filters when release 1b is disabled
     When I request results for identifiers "FO,ABDC"
     Then 2 results are returned
@@ -33,7 +33,7 @@ Feature: Results Feature Toggles
       | imposition_creditor         |                                         |
       | imposition_allocation_order |                                         |
 
-  @R1A @R1BOff @JIRA-STORY:PO-3765 @JIRA-EPIC:PO-3685 @JIRA-TEST-KEY:PO-8392
+  @R1BOff @JIRA-STORY:PO-3765 @JIRA-EPIC:PO-3685 @JIRA-TEST-KEY:PO-8392
   Scenario: Results filters are unavailable when release 1b is disabled
     When I request results for identifiers "FO,FCOMP,ABDC" with the following filters
       | active                  | true  |
@@ -44,7 +44,7 @@ Feature: Results Feature Toggles
     Then the request is rejected with status 404
     And the response reports that the feature is disabled
 
-  @R1A @R1B @JIRA-STORY:PO-3765 @JIRA-EPIC:PO-3685
+  @R1B @JIRA-STORY:PO-3765 @JIRA-EPIC:PO-3685
   Scenario: Results filters are available when release 1b is enabled
     When I request results for identifiers "FO,FCOMP,ABDC" with the following filters
       | active                  | true  |


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Align tagged functional test execution around explicit R1A, R1A+R1B, and all-flags-off flows, remove the @FeatureToggle routing dependency, and update nightly/Zephyr/docs to match.
What changed

Added/updated dedicated tagged Gradle tasks:
◦functionalOpalTagsR1AOnly
◦functionalOpalTagsR1AAndR1BOnly
◦functionalOpalTagsAllFlagsOff

Renamed the old R1A-off path to all-flags-off across:
◦Gradle task names
◦nightly pipeline stage names/parameters
◦Zephyr stage keys
◦artifact/report output paths
◦README examples and docs

Changed nightly tagged demo execution to use one choice parameter:
◦DemoTaggedFunctionalMode
◦options: RunR1AOnly, RunR1AAndR1BOnly, RunAllFlagsOff

Switched nightly tagged demo stages to use dedicated Gradle tasks instead of ad hoc tag filters.

Updated functionalOpalTagsR1AOnly to run:
◦@R1A and not @Smoke and not @Ignore

Removed @FeatureToggle from feature-toggle feature files.

Updated OpalTestRunner to explicitly exclude the current off-tag set instead of excluding @FeatureToggle.

Updated OpalTaggedTestRunner comments to reflect the new routing model.

Updated README and Zephyr configuration to match the new task/stage names and flows.

Why
•Makes nightly tagged runs deterministic and mutually exclusive.
•Keeps R1A-only, R1A+R1B, and all-flags-off execution paths explicit.
•Removes coupling between runner behavior and the @FeatureToggle umbrella tag.
•Keeps Gradle, nightly pipeline, Zephyr upload, and documentation aligned.

Functional impact
•Default functionalOpal continues to exclude the off-tagged feature-toggle scenarios.
•Tagged demo runs are now selected through dedicated tasks and one nightly choice parameter.
•Nightly can no longer trigger multiple demo tagged modes at once.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
