### PR TITLE
Update Open API class name generator to reduce tautologies in generated names.

### DIFF
--- a/src/openApi/java/uk/gov/hmcts/opal/openapi/OpenApiBundler.java
+++ b/src/openApi/java/uk/gov/hmcts/opal/openapi/OpenApiBundler.java
@@ -19,8 +19,7 @@ public class OpenApiBundler {
     // All OpenAPI component sections that can contain $ref targets
     private static final List<String> COMPONENT_SECTIONS = List.of(
         "schemas", "responses", "parameters", "headers",
-        "requestBodies", "examples", "links", "callbacks", "securitySchemes", "pathItems"
-    );
+        "requestBodies", "examples", "links", "callbacks", "securitySchemes", "pathItems");
 
     @SuppressWarnings("unchecked")
     public static void main(String[] args) throws IOException {
@@ -71,15 +70,14 @@ public class OpenApiBundler {
                             Map<String, Object> dst = getOrCreateSection(bundledComponents, section);
                             for (Map.Entry<String, Object> e : src.entrySet()) {
                                 String oldName = e.getKey();
-                                String newName = maybeSuffix(oldName, suffix);
+                                String newName = applyFileScope(oldName, suffix);
                                 Object valueWithRewrites = rewriteRefs(e.getValue(), suffix);
 
                                 if (dst.containsKey(newName)) {
                                     // You can choose to overwrite, skip, or fail. Failing is safest.
                                     throw new IllegalStateException(
                                         "Name collision in components/" + section + ": " + newName + " (from "
-                                            + file.getFileName() + ")"
-                                    );
+                                            + file.getFileName() + ")");
                                 }
                                 dst.put(newName, valueWithRewrites);
                             }
@@ -149,13 +147,14 @@ public class OpenApiBundler {
         String name = (next == -1) ? rest : rest.substring(0, next);
         String tail = (next == -1) ? "" : rest.substring(next); // includes the '/'
 
-        String suffixedName = maybeSuffix(name, suffix);
+        String suffixedName = applyFileScope(name, suffix);
         return section + "/" + suffixedName + tail;
     }
 
-    // Only add the suffix if it's not already there
-    private static String maybeSuffix(String name, String suffix) {
-        return name.endsWith(suffix) ? name : name + suffix;
+    // Only add the file scope if it is not already present. Newer specs can use a filename prefix for clearer
+    // generated model names; older specs keep the historic suffix behaviour.
+    private static String applyFileScope(String name, String suffix) {
+        return name.startsWith(suffix) || name.endsWith(suffix) ? name : name + suffix;
     }
 
     private static String stripYaml(String fileName) {


### PR DESCRIPTION
Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
