### PR TITLE
PO-2386 Centralise JSON error assertions

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/AbstractCommonDefendantsIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/AbstractCommonDefendantsIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.testutil.JsonErrorAssertions.expectEntityNotFound;
 
 import org.junit.jupiter.api.DisplayName;
 import org.slf4j.Logger;
@@ -181,9 +182,7 @@ abstract class AbstractCommonDefendantsIntegrationTest extends AbstractIntegrati
         log.info(":testGetPaymentTerms: Response body:\n" + ToJsonString.toPrettyJson(body));
 
         resultActions.andExpect(status().isNotFound()) // 404 HTTP status
-            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/entity-not-found"))
-            .andExpect(jsonPath("$.title").value("Entity Not Found")).andExpect(jsonPath("$.status").value(404))
-            .andExpect(jsonPath("$.detail").value("The requested entity could not be found"));
+            .andExpect(expectEntityNotFound());
 
     }
 
@@ -227,9 +226,7 @@ abstract class AbstractCommonDefendantsIntegrationTest extends AbstractIntegrati
 
         resultActions.andExpect(status().isNotFound())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
-            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/entity-not-found"))
-            .andExpect(jsonPath("$.title").value("Entity Not Found")).andExpect(jsonPath("$.status").value(404))
-            .andExpect(jsonPath("$.detail").value("The requested entity could not be found"))
+            .andExpect(expectEntityNotFound())
             .andExpect(jsonPath("$.retriable").value(false));
 
     }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CentralFundControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CentralFundControllerIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.opal.authorisation.model.FinesPermission.SEARCH_AND_VIEW_ACCOUNTS;
+import static uk.gov.hmcts.opal.testutil.JsonErrorAssertions.expectEntityNotFound;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -97,10 +98,7 @@ class CentralFundControllerIntegrationTest extends AbstractIntegrationTest {
         actions.andExpect(status().isNotFound())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(header().doesNotExist(HttpHeaders.ETAG))
-            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/entity-not-found"))
-            .andExpect(jsonPath("$.title").value("Entity Not Found"))
-            .andExpect(jsonPath("$.status").value(404))
-            .andExpect(jsonPath("$.detail").value("The requested entity could not be found"))
+            .andExpect(expectEntityNotFound())
             .andExpect(jsonPath("$.retriable").value(false))
             .andExpect(jsonPath("$.major_creditor").doesNotExist())
             .andExpect(jsonPath("$.business_unit_details").doesNotExist());

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountAtAGlanceIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountAtAGlanceIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.testutil.JsonErrorAssertions.expectEntityNotFound;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -61,9 +62,6 @@ class DefendantAccountAtAGlanceIntegrationTest extends AbstractOpalDefendantsInt
 
         resultActions.andExpect(status().isNotFound())
             .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
-            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/entity-not-found"))
-            .andExpect(jsonPath("$.title").value("Entity Not Found"))
-            .andExpect(jsonPath("$.status").value(404))
-            .andExpect(jsonPath("$.detail").value("The requested entity could not be found"));
+            .andExpect(expectEntityNotFound());
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerGetIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerGetIntegrationTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.testutil.JsonErrorAssertions.expectBadRequest;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -686,12 +687,10 @@ class DraftAccountControllerGetIntegrationTest extends CommonDraftAccountControl
 
         resultActions.andExpect(status().isBadRequest())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
-            .andExpect(jsonPath("$.title").value("Bad Request"))
-            .andExpect(jsonPath("$.detail")
-                .value("Invalid arguments were provided in the request"))
-            .andExpect(jsonPath("$.status").value(400))
-            .andExpect(jsonPath("$.type")
-                .value("https://hmcts.gov.uk/problems/illegal-argument"));
+            .andExpect(expectBadRequest(
+                "Invalid arguments were provided in the request",
+                "https://hmcts.gov.uk/problems/illegal-argument"
+            ));
     }
 
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPostIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPostIntegrationTest.java
@@ -9,6 +9,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.testutil.JsonErrorAssertions.expectBadRequest;
+import static uk.gov.hmcts.opal.testutil.JsonErrorAssertions.expectBadRequestWithoutStatus;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -313,9 +315,10 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
                 .content(request))
             .andExpect(status().isBadRequest())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
-            .andExpect(jsonPath("$.title").value("Bad Request"))
-            .andExpect(jsonPath("$.detail").value("The request does not conform to the required JSON schema"))
-            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/json-schema-validation"));
+            .andExpect(expectBadRequestWithoutStatus(
+                "The request does not conform to the required JSON schema",
+                "https://hmcts.gov.uk/problems/json-schema-validation"
+            ));
     }
 
     @Test
@@ -332,9 +335,10 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
                 .content(request))
             .andExpect(status().isBadRequest())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
-            .andExpect(jsonPath("$.title").value("Bad Request"))
-            .andExpect(jsonPath("$.detail").value("The request does not conform to the required JSON schema"))
-            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/json-schema-validation"));
+            .andExpect(expectBadRequestWithoutStatus(
+                "The request does not conform to the required JSON schema",
+                "https://hmcts.gov.uk/problems/json-schema-validation"
+            ));
     }
 
     @Test
@@ -352,9 +356,10 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
                 .content(invalidReferenceCreateRequestBody()))
             .andExpect(status().isBadRequest())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
-            .andExpect(jsonPath("$.title").value("Bad Request"))
-            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/invalid-reference-validation"))
-            .andExpect(jsonPath("$.detail").value(expectedReferenceValidationErrorMessage()));
+            .andExpect(expectBadRequestWithoutStatus(
+                expectedReferenceValidationErrorMessage(),
+                "https://hmcts.gov.uk/problems/invalid-reference-validation"
+            ));
 
         DraftAccountEntity after = getDraftAccount(5L);
 
@@ -394,10 +399,10 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
 
         resultActions.andExpect(status().isBadRequest())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
-            .andExpect(jsonPath("$.title").value("Bad Request"))
-            .andExpect(jsonPath("$.detail").value("The request does not conform to the required JSON schema"))
-            .andExpect(jsonPath("$.status").value(400))
-            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/json-schema-validation"));
+            .andExpect(expectBadRequest(
+                "The request does not conform to the required JSON schema",
+                "https://hmcts.gov.uk/problems/json-schema-validation"
+            ));
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPutIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPutIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.testutil.JsonErrorAssertions.expectBadRequestWithoutStatus;
 
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -471,9 +472,10 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
                 .content(invalidReferenceReplaceRequestBody(0L)))
             .andExpect(status().isBadRequest())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
-            .andExpect(jsonPath("$.title").value("Bad Request"))
-            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/invalid-reference-validation"))
-            .andExpect(jsonPath("$.detail").value(expectedReferenceValidationErrorMessage()));
+            .andExpect(expectBadRequestWithoutStatus(
+                expectedReferenceValidationErrorMessage(),
+                "https://hmcts.gov.uk/problems/invalid-reference-validation"
+            ));
 
         DraftAccountEntity after = getDraftAccount(5L);
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MajorCreditorAtGlanceIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MajorCreditorAtGlanceIntegrationTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.opal.authorisation.model.FinesPermission.SEARCH_AND_VIEW_ACCOUNTS;
+import static uk.gov.hmcts.opal.testutil.JsonErrorAssertions.expectEntityNotFound;
 
 import jakarta.persistence.QueryTimeoutException;
 import java.io.InputStream;
@@ -247,10 +248,7 @@ class MajorCreditorAtGlanceIntegrationTest extends AbstractIntegrationTest {
         actions.andExpect(status().isNotFound())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(header().doesNotExist(HttpHeaders.ETAG))
-            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/entity-not-found"))
-            .andExpect(jsonPath("$.title").value("Entity Not Found"))
-            .andExpect(jsonPath("$.status").value(404))
-            .andExpect(jsonPath("$.detail").value("The requested entity could not be found"))
+            .andExpect(expectEntityNotFound())
             .andExpect(jsonPath("$.retriable").value(false));
 
         JsonNode problem = objectMapper.readTree(actions.andReturn().getResponse().getContentAsString());

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.testutil.JsonErrorAssertions.expectBadRequestWithoutStatus;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
@@ -150,9 +151,10 @@ class MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest
 
         result.andExpect(status().isBadRequest())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
-            .andExpect(jsonPath("$.title").value("Bad Request"))
-            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/illegal-argument"))
-            .andExpect(jsonPath("$.detail").value("Invalid arguments were provided in the request"));
+            .andExpect(expectBadRequestWithoutStatus(
+                "Invalid arguments were provided in the request",
+                "https://hmcts.gov.uk/problems/illegal-argument"
+            ));
     }
 
     @Test
@@ -175,9 +177,10 @@ class MinorCreditorApiControllerFeatureFlagLocalEnabledIntegrationTest
 
         result.andExpect(status().isBadRequest())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
-            .andExpect(jsonPath("$.title").value("Bad Request"))
-            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/illegal-argument"))
-            .andExpect(jsonPath("$.detail").value("Invalid arguments were provided in the request"));
+            .andExpect(expectBadRequestWithoutStatus(
+                "Invalid arguments were provided in the request",
+                "https://hmcts.gov.uk/problems/illegal-argument"
+            ));
     }
 
     private PatchMinorCreditorAccountRequest patchMinorCreditorAccountRequest() {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsFixedPenaltyIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsFixedPenaltyIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.testutil.JsonErrorAssertions.expectEntityNotFound;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -66,10 +67,7 @@ class OpalDefendantsFixedPenaltyIntegrationTest extends AbstractOpalDefendantsIn
 
         actions.andExpect(status().isNotFound())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE))
-            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/entity-not-found"))
-            .andExpect(jsonPath("$.title").value("Entity Not Found"))
-            .andExpect(jsonPath("$.status").value(404))
-            .andExpect(jsonPath("$.detail").value("The requested entity could not be found"))
+            .andExpect(expectEntityNotFound())
             .andExpect(header().doesNotExist("ETag"));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMajorCreditorAccountHeaderSummaryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMajorCreditorAccountHeaderSummaryIntegrationTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.opal.authorisation.model.FinesPermission.SEARCH_AND_VIEW_ACCOUNTS;
+import static uk.gov.hmcts.opal.testutil.JsonErrorAssertions.expectEntityNotFound;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -158,10 +159,7 @@ class OpalMajorCreditorAccountHeaderSummaryIntegrationTest extends AbstractInteg
             .andExpect(status().isNotFound())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(header().doesNotExist(HttpHeaders.ETAG))
-            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/entity-not-found"))
-            .andExpect(jsonPath("$.title").value("Entity Not Found"))
-            .andExpect(jsonPath("$.status").value(404))
-            .andExpect(jsonPath("$.detail").value("The requested entity could not be found"))
+            .andExpect(expectEntityNotFound())
             .andExpect(jsonPath("$.retriable").value(false))
             .andExpect(jsonPath("$.major_creditor").doesNotExist())
             .andExpect(jsonPath("$.business_unit_details").doesNotExist());

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/RemoveEnforcementHoldIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/RemoveEnforcementHoldIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.testutil.JsonErrorAssertions.expectEntityNotFound;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -175,10 +176,7 @@ class RemoveEnforcementHoldIntegrationTest extends AbstractOpalDefendantsIntegra
 
         resultActions.andExpect(status().isNotFound())
             .andExpect(content().contentType(APPLICATION_PROBLEM_JSON))
-            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/entity-not-found"))
-            .andExpect(jsonPath("$.title").value("Entity Not Found"))
-            .andExpect(jsonPath("$.status").value(404))
-            .andExpect(jsonPath("$.detail").value("The requested entity could not be found"))
+            .andExpect(expectEntityNotFound())
             .andExpect(jsonPath("$.retriable").value(false));
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportInstancesApiControllerGETByIdIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportInstancesApiControllerGETByIdIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TE
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.testutil.JsonErrorAssertions.expectEntityNotFoundWithoutType;
 
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -346,9 +347,7 @@ public class ReportInstancesApiControllerGETByIdIntegrationTest extends Abstract
         log.info(":getReportInstance_404_reportInstanceNotFound response:\n{}", ToJsonString.toPrettyJson(body));
 
         result.andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.title").value("Entity Not Found"))
-            .andExpect(jsonPath("$.detail").value("The requested entity could not be found"))
-            .andExpect(jsonPath("$.status").value(404));
+            .andExpect(expectEntityNotFoundWithoutType());
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportInstancesApiControllerGetContentIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportInstancesApiControllerGetContentIntegrationTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.testutil.JsonErrorAssertions.expectEntityNotFoundWithoutType;
 import static uk.gov.hmcts.opal.authorisation.model.FinesPermission.SEARCH_AND_VIEW_ACCOUNTS;
 import static uk.gov.hmcts.opal.controllers.util.ReportInstanceContentTestData.storedReportBytes;
 
@@ -211,9 +212,7 @@ class ReportInstancesApiControllerGetContentIntegrationTest extends AbstractInte
                 .andExpectAll(
                     status().isNotFound(),
                     content().contentTypeCompatibleWith(APPLICATION_PROBLEM_JSON),
-                    jsonPath("$.title").value("Entity Not Found"),
-                    jsonPath("$.detail").value("The requested entity could not be found"),
-                    jsonPath("$.status").value(404),
+                    expectEntityNotFoundWithoutType(),
                     jsonPath("$.retriable").value(false)
                 );
         }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportInstancesControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportInstancesControllerIntegrationTest.java
@@ -13,6 +13,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.opal.entity.report.ReportInstanceGenerationStatus.REQUESTED;
+import static uk.gov.hmcts.opal.testutil.JsonErrorAssertions.expectBadRequest;
+import static uk.gov.hmcts.opal.testutil.JsonErrorAssertions.expectEntityNotFound;
 
 import java.util.HashMap;
 import java.util.List;
@@ -293,11 +295,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
 
         resultActions.andExpect(status().isNotFound())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
-            .andExpect(jsonPath("$.type")
-                .value("https://hmcts.gov.uk/problems/entity-not-found"))
-            .andExpect(jsonPath("$.title").value("Entity Not Found"))
-            .andExpect(jsonPath("$.status").value(404))
-            .andExpect(jsonPath("$.detail").value("The requested entity could not be found"))
+            .andExpect(expectEntityNotFound())
             .andExpect(jsonPath("$.retriable").value(false));
     }
 
@@ -347,12 +345,10 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
 
         resultActions.andExpect(status().isBadRequest())
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
-            .andExpect(jsonPath("$.type")
-                .value("https://hmcts.gov.uk/problems/message-not-readable"))
-            .andExpect(jsonPath("$.title").value("Bad Request"))
-            .andExpect(jsonPath("$.status").value(400))
-            .andExpect(jsonPath("$.detail").value(
-                "The request body could not be read. It may be missing or invalid JSON."))
+            .andExpect(expectBadRequest(
+                "The request body could not be read. It may be missing or invalid JSON.",
+                "https://hmcts.gov.uk/problems/message-not-readable"
+            ))
             .andExpect(jsonPath("$.retriable").value(false));
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportsApiControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportsApiControllerIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TE
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.testutil.JsonErrorAssertions.expectInternalServerErrorWithoutStatus;
 
 import java.util.Set;
 import java.util.stream.Stream;
@@ -370,10 +371,9 @@ class ReportsApiControllerIntegrationTest extends AbstractIntegrationTest {
             mockMvc.perform(get(URL_BASE + "/operational_report_enforcement")
                     .with(userStateStub.getAuthenticaitonRequestPostProcessor()))
                 .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.title").value("Internal Server Error"))
-                .andExpect(jsonPath("$.detail")
-                    .value("Missing configuration item: OPERATIONAL_REPORT_BU_WARNING_THRESHOLD"))
-                .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/internal-server-error"))
+                .andExpect(expectInternalServerErrorWithoutStatus(
+                    "Missing configuration item: OPERATIONAL_REPORT_BU_WARNING_THRESHOLD"
+                ))
                 .andExpect(jsonPath("$.retriable").value(false));
         }
 
@@ -397,10 +397,9 @@ class ReportsApiControllerIntegrationTest extends AbstractIntegrationTest {
             mockMvc.perform(get(URL_BASE + "/operational_report_enforcement")
                     .with(userStateStub.getAuthenticaitonRequestPostProcessor()))
                 .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.title").value("Internal Server Error"))
-                .andExpect(jsonPath("$.detail")
-                    .value("Invalid positive integer configuration item: OPERATIONAL_REPORT_BU_WARNING_THRESHOLD"))
-                .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/internal-server-error"))
+                .andExpect(expectInternalServerErrorWithoutStatus(
+                    "Invalid positive integer configuration item: OPERATIONAL_REPORT_BU_WARNING_THRESHOLD"
+                ))
                 .andExpect(jsonPath("$.retriable").value(false));
         }
     }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/testutil/JsonErrorAssertions.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/testutil/JsonErrorAssertions.java
@@ -1,0 +1,70 @@
+package uk.gov.hmcts.opal.testutil;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+public final class JsonErrorAssertions {
+
+    private JsonErrorAssertions() {
+    }
+
+    public static ResultMatcher expectError(HttpStatus status, String title, String detail, String type) {
+        return result -> {
+            jsonPath("$.type").value(type).match(result);
+            jsonPath("$.title").value(title).match(result);
+            jsonPath("$.status").value(status.value()).match(result);
+            jsonPath("$.detail").value(detail).match(result);
+        };
+    }
+
+    public static ResultMatcher expectError(HttpStatus status, String title, String detail) {
+        return result -> {
+            jsonPath("$.title").value(title).match(result);
+            jsonPath("$.status").value(status.value()).match(result);
+            jsonPath("$.detail").value(detail).match(result);
+        };
+    }
+
+    public static ResultMatcher expectErrorWithoutStatus(String title, String detail, String type) {
+        return result -> {
+            jsonPath("$.type").value(type).match(result);
+            jsonPath("$.title").value(title).match(result);
+            jsonPath("$.detail").value(detail).match(result);
+        };
+    }
+
+    public static ResultMatcher expectEntityNotFound() {
+        return expectError(
+            HttpStatus.NOT_FOUND,
+            "Entity Not Found",
+            "The requested entity could not be found",
+            "https://hmcts.gov.uk/problems/entity-not-found"
+        );
+    }
+
+    public static ResultMatcher expectEntityNotFoundWithoutType() {
+        return expectError(
+            HttpStatus.NOT_FOUND,
+            "Entity Not Found",
+            "The requested entity could not be found"
+        );
+    }
+
+    public static ResultMatcher expectBadRequest(String detail, String type) {
+        return expectError(HttpStatus.BAD_REQUEST, "Bad Request", detail, type);
+    }
+
+    public static ResultMatcher expectBadRequestWithoutStatus(String detail, String type) {
+        return expectErrorWithoutStatus("Bad Request", detail, type);
+    }
+
+    public static ResultMatcher expectInternalServerErrorWithoutStatus(String detail) {
+        return expectErrorWithoutStatus(
+            "Internal Server Error",
+            detail,
+            "https://hmcts.gov.uk/problems/internal-server-error"
+        );
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PO-2386

### Change description ###

- Added shared `JsonErrorAssertions` helper.
- Replaced repeated JSON error assertions in integration tests.
- Covered common 404, 400, and 500 problem responses.
- Preserved existing endpoint-specific assertions.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
