### PR TITLE
PO-9114 Add business unit code to header summary

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/opal/steps/majorcreditor/MajorCreditorAccountHeaderSummaryStepDef.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/steps/majorcreditor/MajorCreditorAccountHeaderSummaryStepDef.java
@@ -40,6 +40,7 @@ public class MajorCreditorAccountHeaderSummaryStepDef extends BaseStepDef {
         "display_name"
     );
     private static final Set<String> BUSINESS_UNIT_FIELDS = Set.of(
+        "business_unit_code",
         "business_unit_id",
         "business_unit_name",
         "welsh_speaking"

--- a/src/functionalTest/java/uk/gov/hmcts/opal/steps/refdata/CentralFundRefDataStepDef.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/steps/refdata/CentralFundRefDataStepDef.java
@@ -72,7 +72,7 @@ public class CentralFundRefDataStepDef extends BaseStepDef {
         JsonNode root = OBJECT_MAPPER.readTree(response.getBody().asString());
         assertEquals(Set.of("major_creditor", "business_unit_details"), fieldNames(root));
         assertEquals(Set.of("creditor_account_id", "account_number", "name"), fieldNames(root.get("major_creditor")));
-        assertEquals(Set.of("business_unit_id", "business_unit_name", "welsh_speaking"),
+        assertEquals(Set.of("business_unit_code", "business_unit_id", "business_unit_name", "welsh_speaking"),
             fieldNames(root.get("business_unit_details")));
     }
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CentralFundControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CentralFundControllerIntegrationTest.java
@@ -198,9 +198,10 @@ class CentralFundControllerIntegrationTest extends AbstractIntegrationTest {
 
         JsonNode businessUnitDetails = response.get("business_unit_details");
         assertEquals(
-            Set.of("business_unit_id", "business_unit_name", "welsh_speaking"),
+            Set.of("business_unit_code", "business_unit_id", "business_unit_name", "welsh_speaking"),
             fieldNames(businessUnitDetails)
         );
+        assertTrue(businessUnitDetails.get("business_unit_code").isNull());
         assertEquals(String.valueOf(centralFund.getBusinessUnitId()), businessUnitDetails.get("business_unit_id")
             .asText());
         assertEquals(centralFund.getBusinessUnitName(), businessUnitDetails.get("business_unit_name").asText());

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountSummaryViewIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountSummaryViewIntegrationTest.java
@@ -69,6 +69,7 @@ class DefendantAccountSummaryViewIntegrationTest extends AbstractOpalDefendantsI
             .andExpect(jsonPath("$.payment_state_summary").exists())
             .andExpect(jsonPath("$.party_details").exists())
             .andExpect(jsonPath("$.business_unit_summary").exists())
+            .andExpect(jsonPath("$.business_unit_summary.business_unit_code").value("NE"))
             .andExpect(jsonPath("$.defendant_account_party_id").value("77"))
             .andExpect(jsonPath("$.is_youth").value(false))
             .andExpect(jsonPath("$.has_consolidated_accounts").value(false))

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMajorCreditorAccountHeaderSummaryIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalMajorCreditorAccountHeaderSummaryIntegrationTest.java
@@ -226,9 +226,10 @@ class OpalMajorCreditorAccountHeaderSummaryIntegrationTest extends AbstractInteg
 
         JsonNode businessUnitDetails = response.get("business_unit_details");
         assertEquals(
-            Set.of("business_unit_id", "business_unit_name", "welsh_speaking"),
+            Set.of("business_unit_code", "business_unit_id", "business_unit_name", "welsh_speaking"),
             fieldNames(businessUnitDetails)
         );
+        assertTrue(businessUnitDetails.get("business_unit_code").isNull());
         assertEquals("77", businessUnitDetails.get("business_unit_id").asText());
         assertEquals("Camberwell Green", businessUnitDetails.get("business_unit_name").asText());
         assertEquals("N", businessUnitDetails.get("welsh_speaking").asText());

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
@@ -309,6 +309,7 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             : BusinessUnitSummaryCommon.builder()
               .businessUnitId(Short.valueOf(response.getBusinessUnitSummary().getBusinessUnitId()))
               .businessUnitName(response.getBusinessUnitSummary().getBusinessUnitName())
+              .businessUnitCode(response.getBusinessUnitSummary().getBusinessUnitCode())
               .welshSpeaking("N")
               .build();
 

--- a/src/main/resources/openapi/common.yaml
+++ b/src/main/resources/openapi/common.yaml
@@ -565,6 +565,8 @@ components:
         business_unit_id:
           type: integer
           format: int16
+        business_unit_code:
+          type: string
         welsh_speaking:
           type: string
       required:

--- a/src/test/java/uk/gov/hmcts/opal/mapper/DefendantAccountHeaderSummaryMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/mapper/DefendantAccountHeaderSummaryMapperTest.java
@@ -93,6 +93,7 @@ class DefendantAccountHeaderSummaryMapperTest {
             .accountStatus(DefendantAccountStatus.LIVE)
             .businessUnitId((short) 77)
             .businessUnitName("BUName")
+            .businessUnitCode("0046")
             .imposed(BigDecimal.valueOf(11))
             .arrears(BigDecimal.valueOf(22))
             .paid(BigDecimal.valueOf(33))
@@ -108,6 +109,7 @@ class DefendantAccountHeaderSummaryMapperTest {
 
         DefendantAccountHeaderSummary dto = mapper.toDto(entity);
         assertEquals("ACCT100", dto.getResponse().getAccountNumber());
+        assertEquals("0046", dto.getResponse().getBusinessUnitSummary().getBusinessUnitCode());
         assertNotNull(dto.getResponse().getPartyDetails());
     }
 

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceHeaderSummaryTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceHeaderSummaryTest.java
@@ -57,6 +57,7 @@ class LegacyDefAccServiceHeaderSummaryTest extends AbstractLegacyDefAccServiceTe
             .businessUnitSummary(BusinessUnitSummaryCommon.builder()
                                      .businessUnitId((short) 1)
                                      .businessUnitName("Test BU")
+                                     .businessUnitCode("0046")
                                      .welshSpeaking("N")
                                      .build())
             .paymentStateSummary(PaymentStateSummaryCommon.builder()
@@ -82,6 +83,8 @@ class LegacyDefAccServiceHeaderSummaryTest extends AbstractLegacyDefAccServiceTe
             actual.getResponse().getAccountStatusReference().getAccountStatusCode());
         assertEquals(expected.getBusinessUnitSummary().getBusinessUnitName(),
             actual.getResponse().getBusinessUnitSummary().getBusinessUnitName());
+        assertEquals(expected.getBusinessUnitSummary().getBusinessUnitCode(),
+            actual.getResponse().getBusinessUnitSummary().getBusinessUnitCode());
         assertEquals(expected.getPaymentStateSummary().getImposedAmount(),
             actual.getResponse().getPaymentStateSummary().getImposedAmount());
     }
@@ -481,6 +484,7 @@ class LegacyDefAccServiceHeaderSummaryTest extends AbstractLegacyDefAccServiceTe
                 uk.gov.hmcts.opal.dto.legacy.common.BusinessUnitSummary.builder()
                     .businessUnitId("1")
                     .businessUnitName("Test BU")
+                    .businessUnitCode("0046")
                     .welshSpeaking("N")
                     .build()
             )


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PO-9114

### Change description ###

 Added optional `business_unit_code` to the shared `businessUnitSummary` OpenAPI schema.
- Mapped `business_unit_code` into the Defendant Account header summary response.
- Updated affected unit and integration tests.
- Supports PO-7410 FE change to display business unit code instead of business unit ID.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
