### PR TITLE
PO-2592 : Interfaces Files Consumer

### DIFF
--- a/src/functionalTest/resources/features/opalMode/reportInstances/ReportInstances.feature
+++ b/src/functionalTest/resources/features/opalMode/reportInstances/ReportInstances.feature
@@ -47,7 +47,7 @@ Feature: Report Instances
   @JIRA-STORY:PO-2252 @JIRA-EPIC:PO-2248 @JIRA-TEST-KEY:PO-7868
   Scenario: Create report instance with multiple business units for a single-BU report is rejected
     Given I am testing as the "opal-test@dev.platform.hmcts.net" user
-    When I create a report instance with report id "operational_report_enforcement" for business units 73 and 1001
+    When I create a report instance with report id "operational_report_enforcement" for business units 73 and 65
     Then the request is rejected with status 422
     And latest report instance create error response matches the standard problem detail contract for status 422
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportInstancesControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/ReportInstancesControllerIntegrationTest.java
@@ -90,17 +90,16 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
             "decimal-param", 5.0,
             "integer-param", 5,
             "radio-param", List.of("one"),
-            "checkbox-param", List.of("one","two"),
+            "checkbox-param", List.of("one", "two"),
             "text-60-param", "value",
             "text-100-param", "value",
-            "text-1000-param", "value"
-        );
+            "text-1000-param", "value");
         CreateReportInstanceRequestReports request = CreateReportInstanceRequestReports.builder()
-                .reportId(REPORT_1BU_ID)
-                .reportName(null)
-                .businessUnitIds(List.of((short) 1))
-                .reportParameters(parameterMap)
-                .build();
+            .reportId(REPORT_1BU_ID)
+            .reportName(null)
+            .businessUnitIds(List.of((short) 1))
+            .reportParameters(parameterMap)
+            .build();
 
         String payload = objectMapper.writeValueAsString(request);
         log.info(":createReportInstance_singleBU payload: {}", payload);
@@ -277,6 +276,12 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
     @JiraEpic("PO-2248")
     @JiraTestKey("PO-7745")
     void createReportInstance_reportIDNotFound_404() throws Exception {
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
+        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
+        when(userState.getUserId()).thenReturn(USER_ID);
+        when(userState.getUserName()).thenReturn(USER_NAME);
+        when(businessUnitUser1.getBusinessUnitId()).thenReturn((short)1);
+
         CreateReportInstanceRequestReports request = CreateReportInstanceRequestReports.builder()
             .reportId("unknown-report-id")
             .reportName(null)
@@ -347,8 +352,7 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(expectBadRequest(
                 "The request body could not be read. It may be missing or invalid JSON.",
-                "https://hmcts.gov.uk/problems/message-not-readable"
-            ))
+                "https://hmcts.gov.uk/problems/message-not-readable"))
             .andExpect(jsonPath("$.retriable").value(false));
     }
 
@@ -375,11 +379,10 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
                 "decimal-param", 5.0,
                 "integer-param", 5L,
                 "radio-param", List.of("one"),
-                "checkbox-param", List.of("one","two"),
+                "checkbox-param", List.of("one", "two"),
                 "text-60-param", "value",
                 "text-100-param", "value",
-                "text-1000-param", "value"
-            ))
+                "text-1000-param", "value"))
             .build();
 
         String payload = objectMapper.writeValueAsString(request);
@@ -453,11 +456,10 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
                 "decimal-param", 5.0,
                 "integer-param", 5L,
                 "radio-param", List.of("one"),
-                "checkbox-param", List.of("one","two"),
+                "checkbox-param", List.of("one", "two"),
                 "text-60-param", "value",
                 "text-100-param", "value",
-                "text-1000-param", "value"
-            ))
+                "text-1000-param", "value"))
             .build();
 
         String payload = objectMapper.writeValueAsString(request);
@@ -495,11 +497,10 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
                 "decimal-param", 5.0,
                 "integer-param", 5L,
                 "radio-param", List.of("one"),
-                "checkbox-param", List.of("one","two"),
+                "checkbox-param", List.of("one", "two"),
                 "text-60-param", "value",
                 "text-100-param", "value",
-                "text-1000-param", "value"
-            ))
+                "text-1000-param", "value"))
             .build();
 
         String payload = objectMapper.writeValueAsString(request);
@@ -537,11 +538,10 @@ public class ReportInstancesControllerIntegrationTest extends AbstractIntegratio
                 "decimal-param", 5.0,
                 "integer-param", 5L,
                 "radio-param", List.of("one"),
-                "checkbox-param", List.of("one","two"),
+                "checkbox-param", List.of("one", "two"),
                 "text-60-param", "value",
                 "text-100-param", "value",
-                "text-1000-param", "value"
-            ))
+                "text-1000-param", "value"))
             .build();
 
         String payload = objectMapper.writeValueAsString(request);

--- a/src/integrationTest/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobQueueConsumerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobQueueConsumerIntegrationTest.java
@@ -1,0 +1,345 @@
+package uk.gov.hmcts.opal.service.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
+
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import jakarta.jms.JMSException;
+import jakarta.jms.TextMessage;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.time.LocalDateTime;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.apache.qpid.jms.provider.amqp.message.AmqpJmsTextMessageFacade;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import uk.gov.hmcts.opal.AbstractIntegrationTest;
+import uk.gov.hmcts.opal.entity.InterfaceJobEntity;
+import uk.gov.hmcts.opal.entity.InterfaceJobStatus;
+import uk.gov.hmcts.opal.exception.ReportGenerationException;
+import uk.gov.hmcts.opal.repository.InterfaceJobRepository;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
+
+@Sql(scripts = "classpath:db/insertData/insert_into_interface_job_queue_processing.sql",
+    executionPhase = BEFORE_TEST_METHOD)
+@Sql(scripts = "classpath:db/deleteData/delete_from_interface_job_queue_processing.sql",
+    executionPhase = AFTER_TEST_METHOD)
+@DisplayName("Interface Job Queue Consumer Integration Tests")
+class InterfaceJobQueueConsumerIntegrationTest extends AbstractIntegrationTest {
+
+    private static final Long INTERFACE_JOB_ID = 99000000401000L;
+    private static final BigDecimal EXPECTED_PAYMENT_AMOUNT = new BigDecimal("123.45");
+
+    @Autowired
+    protected InterfaceJobRepository interfaceJobRepository;
+
+    @Autowired
+    protected InterfaceJobQueueIntegrationTestHelper helper;
+
+    @Autowired
+    private BlobServiceClient blobServiceClient;
+
+    @Value("${opal.report.storage.container}")
+    private String reportContainerName;
+
+    private final InterfaceJobQueueListener listener;
+
+    @Autowired
+    private TransientFailureHelper transientFailureHelper;
+
+    @Autowired
+    private PlatformTransactionManager platformTransactionManager;
+
+    private TextMessage validTextMessage;
+
+    @BeforeEach
+    void setUpReportStorage() throws JMSException {
+        BlobContainerClient blobContainerClient = blobServiceClient.getBlobContainerClient(reportContainerName);
+        if (!blobContainerClient.exists()) {
+            blobContainerClient.create();
+        }
+        validTextMessage = new AmqpJmsTextMessageFacade().asJmsMessage();
+        validTextMessage.setText("{\"interface_job_id\":" + INTERFACE_JOB_ID + "}");
+    }
+
+    @Autowired
+    InterfaceJobQueueConsumerIntegrationTest(InterfaceJobQueueConsumerService interfaceJobQueueConsumerService) {
+        this.listener = new InterfaceJobQueueListener(interfaceJobQueueConsumerService);
+    }
+
+    @Test
+    @DisplayName("PO-2592 INT.01/INT.03 - Processing message completes job and creates cash till output")
+    @JiraStory("PO-2592") // INT.01 and INT.03
+    @JiraEpic("PO-2468")
+    void int01ValidProcessingMessageInvokesPaymentsInProcedureOnce() throws JMSException {
+        listener.onMessage(validTextMessage);
+
+        assertThat(interfaceJobRepository.findById(INTERFACE_JOB_ID))
+            .map(InterfaceJobEntity::getStatus)
+            .contains(InterfaceJobStatus.COMPLETED);
+        helper.assertSideEffects();
+        assertThat(helper.findPaymentAmountForDefendantAccount())
+            .isEqualByComparingTo(EXPECTED_PAYMENT_AMOUNT);
+    }
+
+    @Test
+    @DisplayName("PO-2592 INT.02 - Non-processing job rejects message without side effects")
+    @JiraStory("PO-2592") // INT.02
+    @JiraEpic("PO-2468")
+    void int02NonProcessingMessageIsAbandonedImmediately() throws JMSException {
+        InterfaceJobEntity interfaceJob = interfaceJobRepository.findById(INTERFACE_JOB_ID)
+            .orElseThrow();
+        interfaceJob.setStatus(InterfaceJobStatus.COMPLETED);
+        interfaceJobRepository.saveAndFlush(interfaceJob);
+
+        assertThatThrownBy(() -> listener.onMessage(validTextMessage))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Interface job " + INTERFACE_JOB_ID + " is not PROCESSING");
+
+        InterfaceJobEntity savedJob = interfaceJobRepository.findById(INTERFACE_JOB_ID)
+            .orElseThrow();
+        assertThat(savedJob.getStatus()).isEqualTo(InterfaceJobStatus.COMPLETED);
+        assertThat(savedJob.getCompletedDateTime()).isNull();
+        helper.assertNoSideEffects();
+    }
+
+    @Test
+    @DisplayName("PO-2592 INT.04 - Report failure rolls back and remains retryable")
+    @JiraStory("PO-2592") // INT.04
+    @JiraEpic("PO-2468")
+    void int04TillReturnedButReportFailureRollsBackAndIsRetryable() throws JMSException {
+        // Remove the report container so report creation fails after the till is returned,
+        // which drives the rollback-and-abandon branch.
+        blobServiceClient.getBlobContainerClient(reportContainerName).deleteIfExists();
+
+        assertThatThrownBy(() -> listener.onMessage(validTextMessage))
+            .isInstanceOf(ReportGenerationException.class);
+
+        InterfaceJobEntity savedJob = interfaceJobRepository.findById(INTERFACE_JOB_ID)
+            .orElseThrow();
+        assertThat(savedJob.getStatus()).isEqualTo(InterfaceJobStatus.PROCESSING);
+        assertThat(savedJob.getCompletedDateTime()).isNull();
+        helper.assertNoSideEffects();
+    }
+
+    @Test
+    @DisplayName("PO-2592 INT.05 - No till marks job ignored and commits")
+    @JiraStory("PO-2592") // INT.05
+    @JiraEpic("PO-2468")
+    void int05TillReturnedNullMarksJobIgnoredAndCommits() throws JMSException {
+        helper.replaceInterfaceFileRecords(99000000401001L, RECORD_TO_TRIGGER_IGNORED);
+
+        listener.onMessage(validTextMessage);
+
+        InterfaceJobEntity savedJob = interfaceJobRepository.findById(INTERFACE_JOB_ID)
+            .orElseThrow();
+        assertThat(savedJob.getStatus()).isEqualTo(InterfaceJobStatus.IGNORED);
+        assertThat(savedJob.getCompletedDateTime()).isNotNull();
+        helper.assertNoSideEffects();
+    }
+
+    @Test
+    @DisplayName("PO-2592 INT.06 - Stored procedure failure marks job failed and stores message")
+    @JiraStory("PO-2592") // INT.06
+    @JiraEpic("PO-2468")
+    void int06StoredProcedureFailurePersistsFailedMessageAndMarksJobFailed() {
+        helper.replaceInterfaceFileRecords(99000000401001L, RECORD_TO_TRIGGER_FAILED);
+
+        assertThatCode(() -> listener.onMessage(validTextMessage))
+            .doesNotThrowAnyException();
+
+        InterfaceJobEntity savedJob = interfaceJobRepository.findById(INTERFACE_JOB_ID)
+            .orElseThrow();
+        assertThat(savedJob.getStatus()).isEqualTo(InterfaceJobStatus.FAILED);
+        assertThat(savedJob.getCompletedDateTime()).isNotNull();
+        helper.assertNoSideEffects();
+        assertThat(helper.findFailedInterfaceMessagesForJob())
+            .singleElement()
+                .satisfies(message -> {
+                    assertThat(message.getMessageType()).isEqualTo("Error");
+                    assertThat(message.getMessageText()).contains("invalid input syntax for type bigint");
+                });
+    }
+
+    @Test
+    @DisplayName("PO-2592 INT.07 - Transient DB failure rolls back without failure message")
+    @JiraStory("PO-2592") // INT.07
+    @JiraEpic("PO-2468")
+    void int07TransientDbFailureRollsBackAndAbandonsMessage() throws Exception {
+        // Hold the job row in a separate session so the consumer transaction blocks on update,
+        // then apply a short lock timeout in the consumer transaction to force a transient failure.
+        try (Connection ignored = helper.lockInterfaceJobForUpdate(INTERFACE_JOB_ID)) {
+            Throwable thrown = catchThrowable(() -> new TransactionTemplate(platformTransactionManager)
+                .executeWithoutResult(status -> {
+                    jdbcTemplate.execute("SET lock_timeout = '1s'");
+                    try {
+                        listener.onMessage(validTextMessage);
+                    } catch (JMSException ex) {
+                        throw new RuntimeException(ex);
+                    }
+                }));
+
+            assertThat(thrown).isInstanceOf(RuntimeException.class);
+            assertThat(transientFailureHelper.isTransientFailure((RuntimeException) thrown)).isTrue();
+        }
+
+        helper.assertJobStatus(InterfaceJobStatus.PROCESSING, false);
+        helper.assertNoSideEffects();
+        assertThat(helper.findFailedInterfaceMessagesForJob()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("PO-2592 INT.08 - Commit waits for report success")
+    @JiraStory("PO-2592") // INT.08
+    @JiraEpic("PO-2468")
+    void int08Scenario1CommitWaitsForReportSuccess() throws Exception {
+        assertCommitBoundary(InterfaceJobStatus.COMPLETED, true);
+    }
+
+    @Test
+    @DisplayName("PO-2592 INT.08 - Commit waits for ignored outcome")
+    @JiraStory("PO-2592") // INT.08
+    @JiraEpic("PO-2468")
+    void int08Scenario2CommitWaitsForIgnoredOutcome() throws Exception {
+        helper.replaceInterfaceFileRecords(99000000401001L, RECORD_TO_TRIGGER_IGNORED);
+
+        assertCommitBoundary(InterfaceJobStatus.IGNORED, false);
+    }
+
+    @Test
+    @DisplayName("PO-2592 INT.10 - Failure only updates documented fields")
+    @JiraStory("PO-2592") // INT.10
+    @JiraEpic("PO-2468")
+    void int10StoredProcedureFailureOnlyUpdatesDocumentedFields() {
+        final InterfaceJobEntity beforeJob = interfaceJobRepository.findById(INTERFACE_JOB_ID)
+            .orElseThrow();
+        final String interfaceNameBefore = beforeJob.getInterfaceName();
+        final LocalDateTime createdDateTimeBefore = beforeJob.getCreatedDateTime();
+        final LocalDateTime startedDateTimeBefore = beforeJob.getStartedDateTime();
+
+        helper.replaceInterfaceFileRecords(99000000401001L, RECORD_TO_TRIGGER_FAILED);
+
+        assertThatCode(() -> listener.onMessage(validTextMessage))
+            .doesNotThrowAnyException();
+
+        InterfaceJobEntity afterJob = interfaceJobRepository.findById(INTERFACE_JOB_ID)
+            .orElseThrow();
+        assertThat(afterJob.getInterfaceJobId()).isEqualTo(INTERFACE_JOB_ID);
+        assertThat(afterJob.getInterfaceName()).isEqualTo(interfaceNameBefore);
+        assertThat(afterJob.getCreatedDateTime()).isEqualTo(createdDateTimeBefore);
+        assertThat(afterJob.getStartedDateTime()).isEqualTo(startedDateTimeBefore);
+        assertThat(afterJob.getStatus()).isEqualTo(InterfaceJobStatus.FAILED);
+        assertThat(afterJob.getCompletedDateTime()).isNotNull();
+
+        assertThat(helper.countTillsCreatedForInterfaceFile()).isZero();
+        assertThat(helper.countPaymentsCreatedForDefendantAccount()).isZero();
+        assertThat(helper.countPreAllocatedCashTillReports()).isZero();
+
+        assertThat(helper.findFailedInterfaceMessagesForJob())
+            .singleElement()
+            .satisfies(message -> {
+                assertThat(message.getInterfaceJobId()).isEqualTo(INTERFACE_JOB_ID);
+                assertThat(message.getInterfaceFileId()).isEqualTo(99000000401001L);
+                assertThat(message.getMessageType()).isEqualTo("Error");
+                assertThat(message.getMessageText()).contains("invalid input syntax for type bigint");
+                assertThat(message.getMessageText()).doesNotContain("p_int_payments_in");
+                assertThat(message.getMessageText()).doesNotContain("org.postgresql");
+                assertThat(message.getRecordIndex()).isNull();
+                assertThat(message.getRecordDetail()).isNull();
+                assertThat(message.getMessageData()).isNull();
+            });
+    }
+
+    // INT.11
+    // We have coverage apart from some queue aspects we cannot write a local integration test for.
+    // What is still not covered is a true JMS/session commit failure on message completion.
+    // That would need broker-level fault injection, not just the current consumer harness.
+
+    // INT.12
+    // Unable to write this as a local integration test because it uses the real queue directly.
+
+    private void assertCommitBoundary(InterfaceJobStatus expectedStatus, boolean expectReportSideEffects)
+        throws Exception {
+
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Future<?> listenerFuture = null;
+        try (Connection ignored = helper.lockInterfaceJobForUpdate(INTERFACE_JOB_ID)) {
+            // Hold the job row in a separate session so the consumer work finishes but cannot
+            // commit yet; that lets the test observe the pre-commit state explicitly.
+            listenerFuture = executor.submit(() -> {
+                try {
+                    listener.onMessage(validTextMessage);
+                } catch (JMSException ex) {
+                    throw new RuntimeException(ex);
+                }
+            });
+
+            Thread.sleep(500);
+            helper.assertJobStatus(InterfaceJobStatus.PROCESSING, false);
+            helper.assertNoSideEffects();
+            assertThat(listenerFuture.isDone()).isFalse();
+        }
+
+        assertThat(listenerFuture).isNotNull();
+        listenerFuture.get(5, TimeUnit.SECONDS);
+        try {
+            helper.assertJobStatus(expectedStatus, true);
+            if (expectReportSideEffects) {
+                helper.assertSideEffects();
+            } else {
+                helper.assertNoSideEffects();
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    // amount_pence = 0 makes p_int_payments_in succeed without returning a till_id,
+    // which drives the IGNORED branch.
+    private static final String RECORD_TO_TRIGGER_IGNORED = """
+                [{
+                    "receiving_sort_code":"123456",
+                    "receiving_bank_account_number":"01234567",
+                    "receiving_account_type":"5",
+                    "transaction_code":"68",
+                    "originator_sort_code":"654321",
+                    "originator_bank_account_number":"98765432",
+                    "amount_pence":0,
+                    "originator_name":"Test Payer",
+                    "originator_reference":"99000001A",
+                    "originator_beneficiary_name":"Test Court"
+                }]
+                """;
+
+    // amount_pence = "abc" is intentionally invalid so the stored procedure fails
+    // with a non-transient database error and the FAILED-message path is exercised.
+    private static final String RECORD_TO_TRIGGER_FAILED = """
+                [{
+                    "receiving_sort_code":"123456",
+                    "receiving_bank_account_number":"01234567",
+                    "receiving_account_type":"5",
+                    "transaction_code":"68",
+                    "originator_sort_code":"654321",
+                    "originator_bank_account_number":"98765432",
+                    "amount_pence":"abc",
+                    "originator_name":"Test Payer",
+                    "originator_reference":"99000001A",
+                    "originator_beneficiary_name":"Test Court"
+                }]
+                """;
+}

--- a/src/integrationTest/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobQueueIntegrationTestHelper.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobQueueIntegrationTestHelper.java
@@ -1,0 +1,210 @@
+package uk.gov.hmcts.opal.service.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.opal.service.report.ReportId.CASH_TILL;
+
+import com.azure.storage.blob.BlobServiceClient;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.JsonNode;
+import uk.gov.hmcts.opal.dto.ToJsonString;
+import uk.gov.hmcts.opal.entity.InterfaceFileEntity;
+import uk.gov.hmcts.opal.entity.InterfaceJobEntity;
+import uk.gov.hmcts.opal.entity.InterfaceJobStatus;
+import uk.gov.hmcts.opal.entity.InterfaceMessageEntity;
+import uk.gov.hmcts.opal.entity.PaymentInEntity;
+import uk.gov.hmcts.opal.entity.ReportInstanceEntity;
+import uk.gov.hmcts.opal.entity.TillEntity;
+import uk.gov.hmcts.opal.entity.report.ReportInstanceGenerationStatus;
+import uk.gov.hmcts.opal.repository.InterfaceFileRepository;
+import uk.gov.hmcts.opal.repository.InterfaceJobRepository;
+import uk.gov.hmcts.opal.repository.InterfaceMessageRepository;
+import uk.gov.hmcts.opal.repository.PaymentInRepository;
+import uk.gov.hmcts.opal.repository.ReportInstanceRepository;
+import uk.gov.hmcts.opal.repository.TillRepository;
+
+@Service
+class InterfaceJobQueueIntegrationTestHelper {
+
+    private static final Long INTERFACE_JOB_ID = 99000000401000L;
+    private static final Long INTERFACE_FILE_ID = 99000000401001L;
+    private static final Long DEFENDANT_ACCOUNT_ID = 99000000401002L;
+    private static final String SYSTEM_POSTED_BY_NAME = "interface-jobs";
+
+    @Autowired
+    private PaymentInRepository paymentInRepository;
+
+    @Autowired
+    private ReportInstanceRepository reportInstanceRepository;
+
+    @Autowired
+    private TillRepository tillRepository;
+
+    @Autowired
+    private InterfaceFileRepository interfaceFileRepository;
+
+    @Autowired
+    private InterfaceMessageRepository interfaceMessageRepository;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @Autowired
+    private InterfaceJobRepository interfaceJobRepository;
+
+    @Autowired
+    private BlobServiceClient blobServiceClient;
+
+    @Value("${opal.report.storage.container}")
+    private String reportContainerName;
+
+    @Transactional
+    void replaceInterfaceFileRecords(Long interfaceFileId, String recordsJson) {
+        InterfaceFileEntity interfaceFile = interfaceFileRepository.findById(interfaceFileId)
+            .orElseThrow();
+        interfaceFile.setRecords(recordsJson);
+        interfaceFileRepository.saveAndFlush(interfaceFile);
+    }
+
+    Connection lockInterfaceJobForUpdate(Long interfaceJobId) throws SQLException {
+        Connection connection = dataSource.getConnection();
+        connection.setAutoCommit(false);
+        try (PreparedStatement statement = connection.prepareStatement("""
+                SELECT interface_job_id
+                FROM interface_jobs
+                WHERE interface_job_id = ?
+                FOR UPDATE
+                """)) {
+            statement.setLong(1, interfaceJobId);
+            try (ResultSet ignored = statement.executeQuery()) {
+                if (!ignored.next()) {
+                    throw new IllegalStateException("Interface job not found with id: " + interfaceJobId);
+                }
+            }
+        } catch (SQLException ex) {
+            connection.close();
+            throw ex;
+        }
+        return connection;
+    }
+
+    public int countTillsCreatedForInterfaceFile() {
+        return Math.toIntExact(tillsCreatedForInterfaceFile().size());
+    }
+
+    public int countPaymentsCreatedForDefendantAccount() {
+        return Math.toIntExact(paymentsCreatedForDefendantAccount().size());
+    }
+
+    public BigDecimal findPaymentAmountForDefendantAccount() {
+        return paymentsCreatedForDefendantAccount().stream()
+            .findFirst()
+            .map(PaymentInEntity::getPaymentAmount)
+            .orElse(null);
+    }
+
+    public int countPreAllocatedCashTillReports() {
+        return Math.toIntExact(findPreAllocatedCashTillReports().size());
+    }
+
+    public void assertNoSideEffects() {
+        assertThat(countTillsCreatedForInterfaceFile()).isZero();
+        assertThat(countPaymentsCreatedForDefendantAccount()).isZero();
+        assertThat(countPreAllocatedCashTillReports()).isZero();
+    }
+
+    public void assertSideEffects() {
+        assertThat(countTillsCreatedForInterfaceFile()).isEqualTo(1);
+        assertThat(countPaymentsCreatedForDefendantAccount()).isEqualTo(1);
+        assertThat(countPreAllocatedCashTillReports()).isEqualTo(1);
+        assertThat(findPreAllocatedCashTillReports())
+            .singleElement()
+            .satisfies(report -> {
+                assertThat(report.getGenerationStatus()).isEqualTo(ReportInstanceGenerationStatus.READY);
+                assertThat(report.getLocation()).isNotBlank();
+                assertThat(report.getErrors()).isNull();
+                assertThat(reportBlobExists(report.getLocation())).isTrue();
+                assertThat(reportReferencesTill(report,
+                    tillsCreatedForInterfaceFile().stream().map(TillEntity::getTillId).collect(Collectors.toSet())))
+                    .isTrue();
+            });
+    }
+
+    public Set<InterfaceMessageEntity> findFailedInterfaceMessagesForJob() {
+        return interfaceMessageRepository.findAll().stream()
+            .filter(message -> INTERFACE_JOB_ID.equals(message.getInterfaceJobId()))
+            .filter(message -> "Error".equals(message.getMessageType()))
+            .collect(Collectors.toSet());
+    }
+
+    public void assertJobStatus(InterfaceJobStatus expectedStatus, boolean expectCompletedDateTime) {
+        InterfaceJobEntity savedJob = interfaceJobRepository.findById(INTERFACE_JOB_ID)
+            .orElseThrow();
+        assertThat(savedJob.getStatus()).isEqualTo(expectedStatus);
+        if (expectCompletedDateTime) {
+            assertThat(savedJob.getCompletedDateTime()).isNotNull();
+        } else {
+            assertThat(savedJob.getCompletedDateTime()).isNull();
+        }
+    }
+
+    public Set<ReportInstanceEntity> findPreAllocatedCashTillReports() {
+        Set<Long> tillIds = tillsCreatedForInterfaceFile().stream()
+            .map(TillEntity::getTillId)
+            .collect(Collectors.toSet());
+
+        return reportInstanceRepository.findAll().stream()
+            .filter(report -> SYSTEM_POSTED_BY_NAME.equals(report.getRequestedByName()))
+            .filter(report -> CASH_TILL.getReportId().equals(report.getReportId()))
+            .filter(report -> reportReferencesTill(report, tillIds))
+            .collect(Collectors.toSet());
+    }
+
+    private Set<TillEntity> tillsCreatedForInterfaceFile() {
+        return tillRepository.findAll().stream()
+            .filter(till -> INTERFACE_FILE_ID.equals(interfaceFileId(till)))
+            .collect(Collectors.toSet());
+    }
+
+    private Long interfaceFileId(TillEntity till) {
+        return Optional.ofNullable(till.getInterfaceFile())
+            .map(InterfaceFileEntity::getInterfaceFileId).orElse(null);
+    }
+
+    private Set<PaymentInEntity> paymentsCreatedForDefendantAccount() {
+        Set<Long> tillIds = tillsCreatedForInterfaceFile().stream()
+            .map(TillEntity::getTillId)
+            .collect(Collectors.toSet());
+
+        return paymentInRepository.findAll().stream()
+            .filter(payment -> payment.getTillEntity() != null)
+            .filter(payment -> tillIds.contains(payment.getTillEntity().getTillId()))
+            .filter(payment -> DEFENDANT_ACCOUNT_ID.toString().equals(payment.getAssociatedRecordId()))
+            .collect(Collectors.toSet());
+    }
+
+    private boolean reportReferencesTill(ReportInstanceEntity report, Set<Long> tillIds) {
+        return ToJsonString.toOptionalJsonNode(report.getReportParameters())
+            .map(parameters -> parameters.get("till_id"))
+            .map(JsonNode::asLong)
+            .filter(tillIds::contains)
+            .isPresent();
+    }
+
+    private boolean reportBlobExists(String location) {
+        return blobServiceClient.getBlobContainerClient(reportContainerName)
+            .getBlobClient(location)
+            .exists();
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobRealQueueIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobRealQueueIntegrationTest.java
@@ -1,0 +1,207 @@
+package uk.gov.hmcts.opal.service.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
+
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import jakarta.jms.JMSContext;
+import jakarta.jms.JMSConsumer;
+import jakarta.jms.Message;
+import jakarta.jms.Queue;
+import jakarta.jms.QueueBrowser;
+import jakarta.jms.TextMessage;
+import java.util.Enumeration;
+import java.util.concurrent.TimeUnit;
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.jdbc.Sql;
+import uk.gov.hmcts.opal.AbstractIntegrationTest;
+import uk.gov.hmcts.opal.config.ServiceBusConnectionStringParser;
+import uk.gov.hmcts.opal.config.ServiceBusConnectionStringParser.ConnectionDetails;
+import uk.gov.hmcts.opal.entity.InterfaceJobStatus;
+import uk.gov.hmcts.opal.repository.InterfaceJobRepository;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
+
+/**
+ * Real queue set up with the external Service Bus emulator.
+ *
+ * <p>
+ * cd ../opal-shared-infrastructure
+ * docker compose -f docker-compose-service-bus.yml up -d
+ *
+ * <p>
+ * These tests use a queue-size baseline because there does not seem to be a reliable way of
+ * draining the queue in {@code @BeforeEach}.
+ */
+
+@Disabled //Needs a real queue which is not currently available with our test container set-up
+@TestPropertySource(properties = {
+    "opal.interface-jobs.service-bus.consumer-enabled=false",
+    "opal.report.service-bus.consumer-enabled=false"
+})
+@Sql(scripts = "classpath:db/insertData/insert_into_interface_job_queue_processing.sql",
+    executionPhase = BEFORE_TEST_METHOD)
+@Sql(scripts = "classpath:db/deleteData/delete_from_interface_job_queue_processing.sql",
+    executionPhase = AFTER_TEST_METHOD)
+@DisplayName("Interface Job Queue Service Bus Integration Tests")
+class InterfaceJobRealQueueIntegrationTest extends AbstractIntegrationTest {
+
+    private static final Long INTERFACE_JOB_ID = 99000000401000L;
+    private static final String DEFAULT_CONNECTION_STRING =
+        "Endpoint=sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=local;"
+            + "UseDevelopmentEmulator=true";
+    private static final String QUEUE_NAME = "auto-payments-process-interface-files";
+
+    @Autowired
+    private InterfaceJobQueueConsumerService interfaceJobQueueConsumerService;
+
+    @Autowired
+    private InterfaceJobRepository interfaceJobRepository;
+
+    @Autowired
+    private InterfaceJobQueueIntegrationTestHelper helper;
+
+    @Autowired
+    private BlobServiceClient blobServiceClient;
+
+    @Value("${opal.report.storage.container}")
+    private String reportContainerName;
+
+    private JmsConnectionFactory connectionFactory;
+
+    @BeforeEach
+    void setUp() {
+        BlobContainerClient blobContainerClient = blobServiceClient.getBlobContainerClient(reportContainerName);
+        if (!blobContainerClient.exists()) {
+            blobContainerClient.create();
+        }
+
+        String serviceBusConnectionString = optionalEnv("SERVICEBUS_CONNECTION_STRING", DEFAULT_CONNECTION_STRING);
+        String protocol = optionalEnv("SERVICEBUS_PROTOCOL", "amqp");
+        ConnectionDetails details = new ServiceBusConnectionStringParser().parse(serviceBusConnectionString);
+
+        String remoteUri = "%s://%s".formatted(protocol, details.fullyQualifiedNamespace());
+        connectionFactory = new JmsConnectionFactory(remoteUri);
+        connectionFactory.setUsername(details.sharedAccessKeyName());
+        connectionFactory.setPassword(details.sharedAccessKey());
+    }
+
+    @Test
+    @DisplayName("PO-2592 INT.03/INT.09 - Queue commit removes message")
+    @JiraStory("PO-2592") // INT.03 / INT.09
+    @JiraEpic("PO-2468")
+    void completionRemovesMessageFromQueue() throws Exception {
+        int beforeCount = queueMessageCount();
+
+        sendInterfaceJobMessage();
+        awaitQueueCount(beforeCount + 1);
+
+        try (JMSContext context = connectionFactory.createContext(JMSContext.SESSION_TRANSACTED)) {
+            TextMessage message = receiveInterfaceJobMessage(context);
+            interfaceJobQueueConsumerService.consume(message.getText());
+            context.commit();
+        }
+
+        awaitQueueCount(beforeCount);
+        assertThat(interfaceJobRepository.findById(INTERFACE_JOB_ID))
+            .map(job -> job.getStatus())
+            .contains(InterfaceJobStatus.COMPLETED);
+        helper.assertSideEffects();
+        assertThat(helper.findFailedInterfaceMessagesForJob()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("PO-2592 INT.09 - Queue rollback leaves message available for retry")
+    @JiraStory("PO-2592") // INT.09
+    @JiraEpic("PO-2468")
+    void transientFailureLeavesMessageOnQueue() throws Exception {
+        int beforeCount = queueMessageCount();
+
+        blobServiceClient.getBlobContainerClient(reportContainerName).deleteIfExists();
+
+        sendInterfaceJobMessage();
+        awaitQueueCount(beforeCount + 1);
+
+        try (JMSContext context = connectionFactory.createContext(JMSContext.SESSION_TRANSACTED)) {
+            TextMessage message = receiveInterfaceJobMessage(context);
+
+            assertThatThrownBy(() -> interfaceJobQueueConsumerService.consume(message.getText()))
+                .isInstanceOf(uk.gov.hmcts.opal.exception.ReportGenerationException.class);
+
+            context.rollback();
+        }
+
+        awaitQueueCount(beforeCount + 1);
+        helper.assertJobStatus(InterfaceJobStatus.PROCESSING, false);
+        helper.assertNoSideEffects();
+        assertThat(helper.findFailedInterfaceMessagesForJob()).isEmpty();
+    }
+
+    private void sendInterfaceJobMessage() {
+        try (JMSContext context = connectionFactory.createContext(JMSContext.AUTO_ACKNOWLEDGE)) {
+            Queue queue = context.createQueue(QUEUE_NAME);
+            context.createProducer().send(queue, "{\"interface_job_id\":" + INTERFACE_JOB_ID + "}");
+        }
+    }
+
+    private TextMessage receiveInterfaceJobMessage(JMSContext context) {
+        context.start();
+        Queue queue = context.createQueue(QUEUE_NAME);
+        JMSConsumer consumer = context.createConsumer(queue);
+        Message message = consumer.receive(10_000);
+        assertThat(message)
+            .as("Expected a message on queue %s".formatted(QUEUE_NAME))
+            .isInstanceOf(TextMessage.class);
+        return (TextMessage) message;
+    }
+
+    private int queueMessageCount() {
+        try (JMSContext context = connectionFactory.createContext(JMSContext.AUTO_ACKNOWLEDGE)) {
+            Queue queue = context.createQueue(QUEUE_NAME);
+            try (QueueBrowser browser = context.createBrowser(queue)) {
+                Enumeration<?> messages = browser.getEnumeration();
+
+                int count = 0;
+                while (messages.hasMoreElements()) {
+                    messages.nextElement();
+                    count++;
+                }
+                return count;
+            }
+        } catch (Exception ex) {
+            throw new IllegalStateException("Unable to browse queue " + QUEUE_NAME, ex);
+        }
+    }
+
+    private void awaitQueueCount(int expectedCount) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (System.nanoTime() < deadline) {
+            if (queueMessageCount() == expectedCount) {
+                return;
+            }
+            Thread.sleep(250);
+        }
+
+        assertThat(queueMessageCount())
+            .as("Expected queue %s to contain %d messages".formatted(QUEUE_NAME, expectedCount))
+            .isEqualTo(expectedCount);
+    }
+
+    private static String optionalEnv(String name, String defaultValue) {
+        String value = System.getenv(name);
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        return value;
+    }
+}

--- a/src/integrationTest/resources/db/deleteData/delete_from_interface_job_queue_processing.sql
+++ b/src/integrationTest/resources/db/deleteData/delete_from_interface_job_queue_processing.sql
@@ -1,0 +1,33 @@
+DELETE FROM report_instances
+WHERE requested_by_name = 'interface-jobs'
+AND report_parameters ->> 'till_id' IN (
+    SELECT till_id::text
+    FROM tills
+    WHERE interface_file_id = 99000000401001
+);
+
+DELETE FROM payments_in
+WHERE associated_record_id = '99000000401002'
+OR till_id IN (
+    SELECT till_id
+    FROM tills
+    WHERE interface_file_id = 99000000401001
+);
+
+DELETE FROM interface_messages
+WHERE interface_job_id = 99000000401000;
+
+DELETE FROM tills
+WHERE interface_file_id = 99000000401001;
+
+DELETE FROM interface_files
+WHERE interface_file_id = 99000000401001;
+
+DELETE FROM interface_jobs
+WHERE interface_job_id = 99000000401000;
+
+DELETE FROM defendant_accounts
+WHERE defendant_account_id = 99000000401002;
+
+DELETE FROM configuration_items
+WHERE configuration_item_id IN (99000000401003, 99000000401004);

--- a/src/integrationTest/resources/db/deleteData/delete_from_report_instance_content_cash_till_data.sql
+++ b/src/integrationTest/resources/db/deleteData/delete_from_report_instance_content_cash_till_data.sql
@@ -14,7 +14,7 @@ DELETE FROM business_units
 WHERE business_unit_id = 1778;
 
 UPDATE reports
-SET retention_period = '14',
+SET retention_period = 'P14D',
     permission = NULL,
     supported_file_types = '{CSV,PDF}'
 WHERE report_id = 'cash_till';

--- a/src/integrationTest/resources/db/insertData/insert_into_interface_job_queue_processing.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_interface_job_queue_processing.sql
@@ -1,0 +1,77 @@
+INSERT INTO configuration_items (
+    configuration_item_id,
+    item_name,
+    business_unit_id,
+    item_values
+) VALUES (
+    99000000401003,
+    'BANK_ACCOUNTS',
+    77,
+    '[{"sort_code":"123456","account_number":"01234567","name":"Interface Job Test Bank"}]'::json
+), (
+    99000000401004,
+    'RESULTS_TO_INHIBIT_PAYMENTS',
+    77,
+    '[]'::json
+);
+
+INSERT INTO defendant_accounts (
+    defendant_account_id,
+    business_unit_id,
+    account_number,
+    amount_imposed,
+    amount_paid,
+    account_balance,
+    account_status,
+    account_type,
+    version_number
+) VALUES (
+    99000000401002,
+    77,
+    '99000001A',
+    100.00,
+    0.00,
+    100.00,
+    'L',
+    'Fine',
+    1
+);
+
+INSERT INTO interface_jobs (
+    interface_job_id,
+    business_unit_id,
+    interface_name,
+    status,
+    started_datetime
+) VALUES (
+    99000000401000,
+    77,
+    'PAYMENTS_IN',
+    'PROCESSING',
+    CURRENT_TIMESTAMP
+);
+
+INSERT INTO interface_files (
+    interface_file_id,
+    interface_job_id,
+    file_name,
+    source,
+    records
+) VALUES (
+    99000000401001,
+    99000000401000,
+    'payments-in-int-01.json',
+    'NATWEST',
+    '[{
+        "receiving_sort_code": "123456",
+        "receiving_bank_account_number": "01234567",
+        "receiving_account_type": "5",
+        "transaction_code": "68",
+        "originator_sort_code": "654321",
+        "originator_bank_account_number": "98765432",
+        "amount_pence": "12345",
+        "originator_name": "Test Payer",
+        "originator_reference": "99000001A",
+        "originator_beneficiary_name": "Test Court"
+    }]'::json
+);

--- a/src/main/java/uk/gov/hmcts/opal/config/InterfaceJobQueueJmsConfig.java
+++ b/src/main/java/uk/gov/hmcts/opal/config/InterfaceJobQueueJmsConfig.java
@@ -1,0 +1,47 @@
+package uk.gov.hmcts.opal.config;
+
+import jakarta.jms.ConnectionFactory;
+import lombok.RequiredArgsConstructor;
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jms.annotation.EnableJms;
+import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
+import org.springframework.jms.connection.CachingConnectionFactory;
+
+@EnableJms
+@Configuration
+@ConditionalOnProperty(prefix = "opal.interface-jobs.service-bus", name = "consumer-enabled", havingValue = "true")
+@EnableConfigurationProperties(ServiceBusProperties.class)
+@RequiredArgsConstructor
+public class InterfaceJobQueueJmsConfig {
+
+    private final ServiceBusConnectionStringParser serviceBusConnectionStringParser;
+
+    @Bean
+    public ConnectionFactory interfaceJobConsumerConnectionFactory(ServiceBusProperties properties) {
+        ServiceBusConnectionStringParser.ConnectionDetails details =
+            serviceBusConnectionStringParser.parse(properties.getConnectionString());
+
+        String remoteUri = "%s://%s?amqp.idleTimeout=%d".formatted(
+            properties.getProtocol(),
+            details.fullyQualifiedNamespace(),
+            properties.getIdleTimeoutMs());
+
+        JmsConnectionFactory qpidFactory = new JmsConnectionFactory(remoteUri);
+        qpidFactory.setUsername(details.sharedAccessKeyName());
+        qpidFactory.setPassword(details.sharedAccessKey());
+        return new CachingConnectionFactory(qpidFactory);
+    }
+
+    @Bean
+    public DefaultJmsListenerContainerFactory interfaceJobListenerContainerFactory(
+        ConnectionFactory interfaceJobConsumerConnectionFactory) {
+        DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
+        factory.setConnectionFactory(interfaceJobConsumerConnectionFactory);
+        factory.setSessionTransacted(true);
+        return factory;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/controllers/ReportInstancesApiController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/ReportInstancesApiController.java
@@ -26,6 +26,7 @@ import uk.gov.hmcts.opal.generated.model.ReportInstanceListReportsInner;
 import uk.gov.hmcts.opal.generated.model.ReportInstanceReports;
 import uk.gov.hmcts.opal.service.report.FileType;
 import uk.gov.hmcts.opal.service.report.GenericReportService;
+import uk.gov.hmcts.opal.service.report.ReportInstanceCreationService;
 import uk.gov.hmcts.opal.util.FeatureFlags;
 
 @RestController
@@ -34,6 +35,7 @@ import uk.gov.hmcts.opal.util.FeatureFlags;
 public class ReportInstancesApiController implements ReportInstancesApi {
 
     private final GenericReportService genericReportService;
+    private final ReportInstanceCreationService reportInstanceCreationService;
     private final HttpServletRequest request;
 
     @Override
@@ -55,7 +57,8 @@ public class ReportInstancesApiController implements ReportInstancesApi {
         defaultValueProperty = RELEASE_1C_ENFORCEMENT_OPERATIONAL_REPORTING_ENABLED_PROPERTY)
     public ResponseEntity<CreateReportInstanceResponseReports> createReportInstance(
         CreateReportInstanceRequestReports createReportInstanceRequestReports) {
-        return buildCreatedResponse(genericReportService.addReportInstance(createReportInstanceRequestReports, true));
+        return buildCreatedResponse(reportInstanceCreationService.createReportInstance(
+            createReportInstanceRequestReports));
     }
 
     @FeatureToggle(feature = RELEASE_1C_ENFORCEMENT_OPERATIONAL_REPORTING,
@@ -73,10 +76,8 @@ public class ReportInstancesApiController implements ReportInstancesApi {
     public ResponseEntity<Map<String, Object>> getReportInstanceContent(Long id) {
         FileType fileType = resolveFileType(request.getHeader(ACCEPT));
         if (fileType == null) {
-            throw new ResponseStatusException(
-                NOT_ACCEPTABLE,
-                "The requested media type cannot be produced by the server"
-            );
+            throw new ResponseStatusException(NOT_ACCEPTABLE,
+                "The requested media type cannot be produced by the server");
         }
 
         log.debug(":GET:getReportInstanceContent: for report instance id={}", id);

--- a/src/main/java/uk/gov/hmcts/opal/entity/InterfaceJobEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/InterfaceJobEntity.java
@@ -1,5 +1,13 @@
 package uk.gov.hmcts.opal.entity;
 
+import static uk.gov.hmcts.opal.entity.interfacejob.InterfaceJobStoredProcedureNames.BUSINESS_UNIT_ID;
+import static uk.gov.hmcts.opal.entity.interfacejob.InterfaceJobStoredProcedureNames.DB_PROC_NAME;
+import static uk.gov.hmcts.opal.entity.interfacejob.InterfaceJobStoredProcedureNames.INTERFACE_JOB_ID;
+import static uk.gov.hmcts.opal.entity.interfacejob.InterfaceJobStoredProcedureNames.JPA_PROC_NAME;
+import static uk.gov.hmcts.opal.entity.interfacejob.InterfaceJobStoredProcedureNames.POSTED_BY;
+import static uk.gov.hmcts.opal.entity.interfacejob.InterfaceJobStoredProcedureNames.POSTED_BY_NAME;
+import static uk.gov.hmcts.opal.entity.interfacejob.InterfaceJobStoredProcedureNames.TILL_ID;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -12,8 +20,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedStoredProcedureQuery;
+import jakarta.persistence.ParameterMode;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.StoredProcedureParameter;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -35,6 +46,13 @@ import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+@NamedStoredProcedureQuery(name = JPA_PROC_NAME, procedureName = DB_PROC_NAME, parameters = {
+    @StoredProcedureParameter(mode = ParameterMode.IN, name = INTERFACE_JOB_ID, type = Long.class),
+    @StoredProcedureParameter(mode = ParameterMode.IN, name = BUSINESS_UNIT_ID, type = Short.class),
+    @StoredProcedureParameter(mode = ParameterMode.IN, name = POSTED_BY, type = String.class),
+    @StoredProcedureParameter(mode = ParameterMode.IN, name = POSTED_BY_NAME, type = String.class),
+    @StoredProcedureParameter(mode = ParameterMode.OUT, name = TILL_ID, type = Long.class)
+})
 public class InterfaceJobEntity {
 
     @Id

--- a/src/main/java/uk/gov/hmcts/opal/entity/InterfaceJobStatus.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/InterfaceJobStatus.java
@@ -2,7 +2,7 @@ package uk.gov.hmcts.opal.entity;
 
 public enum InterfaceJobStatus {
     CREATED,
-    PROCESSED,
+    PROCESSING,
     IGNORED,
     FAILED,
     COMPLETED

--- a/src/main/java/uk/gov/hmcts/opal/entity/InterfaceMessageEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/InterfaceMessageEntity.java
@@ -1,5 +1,15 @@
 package uk.gov.hmcts.opal.entity;
 
+import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.DB_PROC_NAME;
+import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.INTERFACE_FILE_ID;
+import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.INTERFACE_JOB_ID;
+import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.JPA_PROC_NAME;
+import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.MESSAGE_DATA;
+import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.MESSAGE_TEXT;
+import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.MESSAGE_TYPE;
+import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.RECORD_DETAIL;
+import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.RECORD_INDEX;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -8,27 +18,42 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedStoredProcedureQuery;
+import jakarta.persistence.ParameterMode;
 import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.StoredProcedureParameter;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 @Entity
 @Table(name = "interface_messages")
-@Builder
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@NamedStoredProcedureQuery(name = JPA_PROC_NAME, procedureName = DB_PROC_NAME, parameters = {
+    @StoredProcedureParameter(mode = ParameterMode.IN, name = INTERFACE_JOB_ID, type = Long.class),
+    @StoredProcedureParameter(mode = ParameterMode.IN, name = MESSAGE_TYPE, type = String.class),
+    @StoredProcedureParameter(mode = ParameterMode.IN, name = MESSAGE_TEXT, type = String.class),
+    @StoredProcedureParameter(mode = ParameterMode.IN, name = INTERFACE_FILE_ID, type = Long.class),
+    @StoredProcedureParameter(mode = ParameterMode.IN, name = RECORD_INDEX, type = Long.class),
+    @StoredProcedureParameter(mode = ParameterMode.IN, name = RECORD_DETAIL, type = String.class),
+    @StoredProcedureParameter(mode = ParameterMode.IN, name = MESSAGE_DATA, type = String.class)
+})
 public class InterfaceMessageEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "interface_message_id_seq")
-    @SequenceGenerator(name = "interface_message_id_seq", sequenceName = "interface_message_id_seq", allocationSize = 1)
-    @Column(name = "interface_message_id")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "interface_message_id_seq_generator")
+    @SequenceGenerator(name = "interface_message_id_seq_generator",
+        sequenceName = "interface_message_id_seq", allocationSize = 1)
+    @Column(name = "interface_message_id", nullable = false)
     private Long interfaceMessageId;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -39,10 +64,10 @@ public class InterfaceMessageEntity {
     @JoinColumn(name = "interface_file_id")
     private InterfaceFileEntity interfaceFile;
 
-    @Column(name = "message_type", nullable = false, length = 10)
+    @Column(name = "message_type", length = 10, nullable = false)
     private String messageType;
 
-    @Column(name = "message_text", nullable = false, length = 500)
+    @Column(name = "message_text", length = 500, nullable = false)
     private String messageText;
 
     @Column(name = "record_index")
@@ -50,4 +75,16 @@ public class InterfaceMessageEntity {
 
     @Column(name = "record_detail")
     private String recordDetail;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "message_data", columnDefinition = "json")
+    private String messageData;
+
+    public Long getInterfaceJobId() {
+        return interfaceJob == null ? null : interfaceJob.getInterfaceJobId();
+    }
+
+    public Long getInterfaceFileId() {
+        return interfaceFile == null ? null : interfaceFile.getInterfaceFileId();
+    }
 }

--- a/src/main/java/uk/gov/hmcts/opal/entity/interfacejob/InterfaceJobStoredProcedureNames.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/interfacejob/InterfaceJobStoredProcedureNames.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.opal.entity.interfacejob;
+
+public interface InterfaceJobStoredProcedureNames {
+
+    String DB_PROC_NAME = "p_int_payments_in";
+    String JPA_PROC_NAME = "InterfaceJob.ProcessPaymentsIn";
+    String INTERFACE_JOB_ID = "pi_interface_job_id";
+    String BUSINESS_UNIT_ID = "pi_business_unit_id";
+    String POSTED_BY = "pi_posted_by";
+    String POSTED_BY_NAME = "pi_posted_by_name";
+    String TILL_ID = "po_till_id";
+}

--- a/src/main/java/uk/gov/hmcts/opal/entity/interfacemessage/InterfaceMessageStoredProcedureNames.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/interfacemessage/InterfaceMessageStoredProcedureNames.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.opal.entity.interfacemessage;
+
+public interface InterfaceMessageStoredProcedureNames {
+
+    String DB_PROC_NAME = "p_insert_interface_message";
+    String JPA_PROC_NAME = "InterfaceMessage.Insert";
+    String INTERFACE_JOB_ID = "pi_interface_job_id";
+    String MESSAGE_TYPE = "pi_message_type";
+    String MESSAGE_TEXT = "pi_message_text";
+    String INTERFACE_FILE_ID = "pi_interface_file_id";
+    String RECORD_INDEX = "pi_record_index";
+    String RECORD_DETAIL = "pi_record_detail";
+    String MESSAGE_DATA = "pi_message_data";
+}

--- a/src/main/java/uk/gov/hmcts/opal/repository/InterfaceJobRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/InterfaceJobRepository.java
@@ -1,10 +1,18 @@
 package uk.gov.hmcts.opal.repository;
 
+import static uk.gov.hmcts.opal.entity.interfacejob.InterfaceJobStoredProcedureNames.INTERFACE_JOB_ID;
+import static uk.gov.hmcts.opal.entity.interfacejob.InterfaceJobStoredProcedureNames.BUSINESS_UNIT_ID;
+import static uk.gov.hmcts.opal.entity.interfacejob.InterfaceJobStoredProcedureNames.JPA_PROC_NAME;
+import static uk.gov.hmcts.opal.entity.interfacejob.InterfaceJobStoredProcedureNames.POSTED_BY;
+import static uk.gov.hmcts.opal.entity.interfacejob.InterfaceJobStoredProcedureNames.POSTED_BY_NAME;
+
 import java.util.function.Function;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.query.Procedure;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.opal.entity.InterfaceJobEntity;
 
@@ -17,4 +25,11 @@ public interface InterfaceJobRepository extends JpaRepository<InterfaceJobEntity
     <S extends InterfaceJobEntity, R> R findBy(
         Specification<InterfaceJobEntity> specification,
         Function<? super JpaSpecificationExecutor.SpecificationFluentQuery<S>, R> queryFunction);
+
+    @Procedure(name = JPA_PROC_NAME)
+    Long processPaymentsInJob(@Param(INTERFACE_JOB_ID) Long interfaceJobId,
+                              @Param(BUSINESS_UNIT_ID) Short businessUnitId,
+                              @Param(POSTED_BY) String postedBy,
+                              @Param(POSTED_BY_NAME) String postedByName);
+
 }

--- a/src/main/java/uk/gov/hmcts/opal/repository/InterfaceMessageRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/InterfaceMessageRepository.java
@@ -1,10 +1,41 @@
 package uk.gov.hmcts.opal.repository;
 
+import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.INTERFACE_FILE_ID;
+import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.INTERFACE_JOB_ID;
+import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.MESSAGE_DATA;
+import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.MESSAGE_TEXT;
+import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.MESSAGE_TYPE;
+import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.RECORD_DETAIL;
+import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.RECORD_INDEX;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.opal.entity.InterfaceMessageEntity;
 
 @Repository
 public interface InterfaceMessageRepository extends JpaRepository<InterfaceMessageEntity, Long> {
 
+    // @Procedure binds pi_message_data as varchar; the procedure requires json, so keep the explicit cast here.
+    @Modifying
+    @Query(value = """
+        CALL p_insert_interface_message(
+            :pi_interface_job_id,
+            :pi_message_type,
+            :pi_message_text,
+            :pi_interface_file_id,
+            :pi_record_index,
+            :pi_record_detail,
+            CAST(:pi_message_data AS json)
+        )
+        """, nativeQuery = true)
+    void insertInterfaceMessage(@Param(INTERFACE_JOB_ID) Long interfaceJobId,
+                                @Param(MESSAGE_TYPE) String messageType,
+                                @Param(MESSAGE_TEXT) String messageText,
+                                @Param(INTERFACE_FILE_ID) Long interfaceFileId,
+                                @Param(RECORD_INDEX) Long recordIndex,
+                                @Param(RECORD_DETAIL) String recordDetail,
+                                @Param(MESSAGE_DATA) String messageData);
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/interfacejob/InterfaceJobFailurePersistenceService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/interfacejob/InterfaceJobFailurePersistenceService.java
@@ -1,0 +1,65 @@
+package uk.gov.hmcts.opal.service.interfacejob;
+
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.opal.entity.InterfaceFileEntity;
+import uk.gov.hmcts.opal.entity.InterfaceJobEntity;
+import uk.gov.hmcts.opal.repository.InterfaceJobRepository;
+import uk.gov.hmcts.opal.repository.InterfaceMessageRepository;
+
+@Service
+@RequiredArgsConstructor
+public class InterfaceJobFailurePersistenceService {
+
+    private static final String MESSAGE_TYPE_ERROR = "Error";
+
+    private final InterfaceJobRepository interfaceJobRepository;
+    private final InterfaceMessageRepository interfaceMessageRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void insertFailureMessage(Long interfaceJobId, Exception exception) {
+        InterfaceJobEntity interfaceJob = interfaceJobRepository.findById(interfaceJobId)
+            .orElseThrow(() -> new IllegalStateException("Interface job not found with id: " + interfaceJobId));
+        Long interfaceFileId = interfaceJob.getInterfaceFiles().stream()
+            .filter(Objects::nonNull)
+            .map(InterfaceFileEntity::getInterfaceFileId)
+            .findFirst()
+            .orElse(null);
+        interfaceMessageRepository.insertInterfaceMessage(
+            interfaceJobId,
+            MESSAGE_TYPE_ERROR,
+            failureMessage(exception),
+            interfaceFileId,
+            null,
+            null,
+            null);
+    }
+
+    private String failureMessage(Exception exception) {
+        Throwable rootCause = exception;
+        while (rootCause.getCause() != null) {
+            rootCause = rootCause.getCause();
+        }
+        String message = rootCause.getMessage();
+        if (message == null || message.isBlank()) {
+            message = exception.getMessage();
+        }
+        if (message == null || message.isBlank()) {
+            message = rootCause.getClass().getSimpleName();
+        }
+        message = message.replace('\n', ' ').replace('\r', ' ');
+        message = stripSqlLocationDetails(message);
+        return message.length() > 500 ? message.substring(0, 500) : message;
+    }
+
+    private String stripSqlLocationDetails(String message) {
+        int whereIndex = message.indexOf(" Where:");
+        if (whereIndex < 0) {
+            whereIndex = message.indexOf(" where:");
+        }
+        return whereIndex >= 0 ? message.substring(0, whereIndex) : message;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/interfacejob/InterfaceJobProcessorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/interfacejob/InterfaceJobProcessorService.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.opal.service.interfacejob;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.opal.entity.InterfaceJobEntity;
+import uk.gov.hmcts.opal.repository.InterfaceJobRepository;
+
+@Service
+@RequiredArgsConstructor
+public class InterfaceJobProcessorService {
+
+    private static final String SYSTEM_POSTED_BY = "interface-jobs";
+    private static final String SYSTEM_POSTED_BY_NAME = "interface-jobs";
+
+    private final InterfaceJobRepository interfaceJobRepository;
+
+    @Transactional
+    public Optional<Long> processPaymentsInJob(Long interfaceJobId) {
+        try {
+            InterfaceJobEntity interfaceJob = interfaceJobRepository.findById(interfaceJobId)
+                .orElseThrow(() -> new IllegalStateException("Interface job not found with id: " + interfaceJobId));
+            return Optional.ofNullable(interfaceJobRepository.processPaymentsInJob(
+                interfaceJob.getInterfaceJobId(),
+                interfaceJob.getBusinessUnit().getBusinessUnitId(),
+                SYSTEM_POSTED_BY,
+                SYSTEM_POSTED_BY_NAME));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to process interface job " + interfaceJobId, e);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/interfacejob/InterfaceJobStatusService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/interfacejob/InterfaceJobStatusService.java
@@ -1,0 +1,50 @@
+package uk.gov.hmcts.opal.service.interfacejob;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.opal.entity.InterfaceJobEntity;
+import uk.gov.hmcts.opal.entity.InterfaceJobStatus;
+import uk.gov.hmcts.opal.repository.InterfaceJobRepository;
+
+@Service
+@RequiredArgsConstructor
+public class InterfaceJobStatusService {
+
+    private final InterfaceJobRepository interfaceJobRepository;
+    private final Clock clock;
+
+    @Transactional(readOnly = true)
+    public boolean isProcessing(Long interfaceJobId) {
+        return getJob(interfaceJobId).getStatus() == InterfaceJobStatus.PROCESSING;
+    }
+
+    @Transactional
+    public void markCompleted(Long interfaceJobId) {
+        InterfaceJobEntity interfaceJob = getJob(interfaceJobId);
+        interfaceJob.setStatus(InterfaceJobStatus.COMPLETED);
+        interfaceJob.setCompletedDateTime(LocalDateTime.now(clock));
+    }
+
+    @Transactional
+    public void markIgnored(Long interfaceJobId) {
+        InterfaceJobEntity interfaceJob = getJob(interfaceJobId);
+        interfaceJob.setStatus(InterfaceJobStatus.IGNORED);
+        interfaceJob.setCompletedDateTime(LocalDateTime.now(clock));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markFailed(Long interfaceJobId) {
+        InterfaceJobEntity interfaceJob = getJob(interfaceJobId);
+        interfaceJob.setStatus(InterfaceJobStatus.FAILED);
+        interfaceJob.setCompletedDateTime(LocalDateTime.now(clock));
+    }
+
+    private InterfaceJobEntity getJob(Long interfaceJobId) {
+        return interfaceJobRepository.findById(interfaceJobId)
+            .orElseThrow(() -> new IllegalStateException("Interface job not found with id: " + interfaceJobId));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobQueueConsumerService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobQueueConsumerService.java
@@ -1,0 +1,55 @@
+package uk.gov.hmcts.opal.service.messaging;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import uk.gov.hmcts.opal.service.interfacejob.InterfaceJobStatusService;
+
+@Service
+@Slf4j(topic = "opal.InterfaceJobQueueConsumer")
+@RequiredArgsConstructor
+public class InterfaceJobQueueConsumerService implements QueueConsumerInterface {
+
+    private final ObjectMapper objectMapper;
+    private final InterfaceJobStatusService interfaceJobStatusService;
+    private final InterfaceJobQueueProcessingService interfaceJobQueueProcessingService;
+    private final TransientFailureHelper transientFailureHelper;
+
+    @Override
+    public void consume(String messagePayload) {
+        InterfaceJobQueueMessage message = parse(messagePayload);
+        Long interfaceJobId = message.interfaceJobId();
+        if (!interfaceJobStatusService.isProcessing(interfaceJobId)) {
+            log.error("Interface job {} is not PROCESSING, rejecting message", interfaceJobId);
+            throw new IllegalStateException("Interface job " + interfaceJobId + " is not PROCESSING");
+        }
+        try {
+            interfaceJobQueueProcessingService.processProcessingJob(interfaceJobId);
+        } catch (RuntimeException ex) {
+            if (transientFailureHelper.isTransientFailure(ex)) {
+                throw ex;
+            }
+            log.error("Interface job {} failed non-transiently, marking failed", interfaceJobId, ex);
+            try {
+                interfaceJobQueueProcessingService.handleProcessingFailure(interfaceJobId, ex);
+            } catch (RuntimeException persistenceException) {
+                log.error("Unable to persist non-transient failure for interface job {}", interfaceJobId,
+                    persistenceException);
+            }
+        }
+    }
+
+    private InterfaceJobQueueMessage parse(String messagePayload) {
+        if (messagePayload == null || messagePayload.isBlank()) {
+            throw new IllegalArgumentException("Interface job message payload is blank");
+        }
+        try {
+            return objectMapper.readValue(messagePayload, InterfaceJobQueueMessage.class);
+        } catch (JacksonException ex) {
+            log.error("Interface job message parse failed", ex);
+            throw new IllegalArgumentException("Unable to parse interface job message payload", ex);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobQueueListener.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobQueueListener.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.opal.service.messaging;
+
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.TextMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.jms.annotation.JmsListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j(topic = "opal.InterfaceJobQueueListener")
+@ConditionalOnProperty(prefix = "opal.interface-jobs.service-bus", name = "consumer-enabled", havingValue = "true")
+public class InterfaceJobQueueListener {
+
+    private final InterfaceJobQueueConsumerService consumer;
+
+    @JmsListener(
+        destination = "${opal.interface-jobs.service-bus.queue-name}",
+        containerFactory = "interfaceJobListenerContainerFactory"
+    )
+    public void onMessage(Message message) throws JMSException {
+        if (message instanceof TextMessage textMessage) {
+            consumer.consume(textMessage.getText());
+        } else {
+            throw new IllegalArgumentException("Message must be of type TextMessage");
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobQueueMessage.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobQueueMessage.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.opal.service.messaging;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record InterfaceJobQueueMessage(
+    @JsonProperty("interface_job_id")
+    Long interfaceJobId
+) {
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobQueueProcessingService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobQueueProcessingService.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.opal.service.messaging;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.opal.service.interfacejob.InterfaceJobFailurePersistenceService;
+import uk.gov.hmcts.opal.service.interfacejob.InterfaceJobProcessorService;
+import uk.gov.hmcts.opal.service.interfacejob.InterfaceJobStatusService;
+import uk.gov.hmcts.opal.service.report.PreAllocatedCashTillService;
+
+@Service
+@Slf4j(topic = "opal.InterfaceJobQueueConsumer")
+@RequiredArgsConstructor
+public class InterfaceJobQueueProcessingService {
+
+    private static final Long SYSTEM_REQUESTED_BY = 0L;
+    private static final String SYSTEM_REQUESTED_BY_NAME = "interface-jobs";
+
+    private final InterfaceJobProcessorService interfaceJobProcessorService;
+    private final InterfaceJobStatusService interfaceJobStatusService;
+    private final InterfaceJobFailurePersistenceService interfaceJobFailurePersistenceService;
+    private final PreAllocatedCashTillService preAllocatedCashTillService;
+
+    @Transactional
+    public void processProcessingJob(Long interfaceJobId) {
+        Optional<Long> tillId = interfaceJobProcessorService.processPaymentsInJob(interfaceJobId);
+        if (tillId.isPresent()) {
+            Long reportInstanceId = preAllocatedCashTillService.createPreAllocatedReportInstance(
+                tillId.get(), SYSTEM_REQUESTED_BY, SYSTEM_REQUESTED_BY_NAME);
+            interfaceJobStatusService.markCompleted(interfaceJobId);
+            log.info("Interface job {} completed and created report instance {}", interfaceJobId, reportInstanceId);
+        } else {
+            interfaceJobStatusService.markIgnored(interfaceJobId);
+            log.info("Interface job {} completed with no till created", interfaceJobId);
+        }
+    }
+
+    public void handleProcessingFailure(Long interfaceJobId, RuntimeException ex) {
+        interfaceJobStatusService.markFailed(interfaceJobId);
+        interfaceJobFailurePersistenceService.insertFailureMessage(interfaceJobId, ex);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/messaging/TransientFailureHelper.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/messaging/TransientFailureHelper.java
@@ -1,0 +1,72 @@
+package uk.gov.hmcts.opal.service.messaging;
+
+import java.net.ConnectException;
+import java.net.UnknownHostException;
+import org.postgresql.util.PSQLException;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.TransactionSystemException;
+import uk.gov.hmcts.opal.exception.ReportGenerationException;
+import uk.gov.hmcts.opal.exception.UnprocessableException;
+
+@Component
+public class TransientFailureHelper {
+
+    public boolean isTransientFailure(RuntimeException ex) {
+        if (ex instanceof ReportGenerationException) {
+            return true;
+        }
+        if (ex instanceof UnprocessableException unprocessableException) {
+            return unprocessableException.isRetriable();
+        }
+        if (ex instanceof DataAccessResourceFailureException || ex instanceof QueryTimeoutException) {
+            return true;
+        }
+        if (ex instanceof TransactionSystemException || ex instanceof JpaSystemException) {
+            PSQLException psqlException = findPsqlException(ex);
+            return psqlException != null
+                && (isTransientConnectionFailure(psqlException) || isTransientSqlState(psqlState(psqlException)));
+        }
+
+        PSQLException psqlException = findPsqlException(ex);
+        if (psqlException != null) {
+            return isTransientConnectionFailure(psqlException) || isTransientSqlState(psqlState(psqlException));
+        }
+
+        return false;
+    }
+
+    private static boolean isTransientConnectionFailure(PSQLException psqlException) {
+        return psqlException.getCause() instanceof ConnectException
+            || psqlException.getCause() instanceof UnknownHostException;
+    }
+
+    private static PSQLException findPsqlException(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof PSQLException psqlException) {
+                return psqlException;
+            }
+            current = current.getCause();
+        }
+        return null;
+    }
+
+    private static String psqlState(Throwable throwable) {
+        if (throwable instanceof PSQLException psqlException) {
+            return psqlException.getSQLState();
+        }
+        return null;
+    }
+
+    private static boolean isTransientSqlState(String state) {
+        if (state == null) {
+            return false;
+        }
+        return state.equals("40001")
+            || state.equals("40P01")
+            || state.equals("55P03");
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/report/GenericReportService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/GenericReportService.java
@@ -127,53 +127,29 @@ public class GenericReportService implements GenericReportServiceInterface {
 
     @Transactional
     public CreateReportInstanceResponseReports addReportInstance(CreateReportInstanceRequestReports request,
-        boolean generateReportContentAsync) {
+        Long requestedBy, String requestedByName, boolean generateReportContentAsync) {
         ReportEntity reportEntity = reportRepository.findById(request.getReportId())
             .orElseThrow(EntityNotFoundException::new);
         if (!reportEntity.isSupportsMultiBu() && request.getBusinessUnitIds().size() > 1) {
             throw new UnprocessableException("Too many business units supplied, this report only allows 1");
         }
-        if (!reportEntity.isCanManuallyCreate()) {
+        if (generateReportContentAsync && !reportEntity.isCanManuallyCreate()) {
             throw new UnprocessableException("This report cannot be manually created");
         }
 
-        UserState userState = userStateService.getUserStateV1FromSecurityContext();
+        validateReportInstanceParameters(request, reportEntity);
 
-        if (!userState.getBusinessUnitUser().stream()
-            .map(BusinessUnitUser::getBusinessUnitId).collect(Collectors.toSet())
-            .containsAll(request.getBusinessUnitIds())) {
-            throw new AccessDeniedException("You cannot generate reports for other business units");
+        CreateReportInstanceResponseReports response = createReportInstance(
+            request,
+            reportEntity,
+            requestedBy,
+            requestedByName);
+        if (generateReportContentAsync) {
+            reportQueuePublisher.publish(response.getReportInstanceId());
+        } else {
+            generateReportInstanceContent(response.getReportInstanceId());
         }
-
-        if (!reportParameterValidator.validateReportInstanceParameterValues(
-            request.getReportParameters(), reportEntity)) {
-            throw new UnprocessableException("Validation failed for report instance parameters", true);
-        }
-
-        try {
-            ReportInstanceEntity reportInstanceEntity = ReportInstanceEntity.builder()
-                .report(reportEntity)
-                .businessUnit(request.getBusinessUnitIds())
-                .requestedBy(userState.getUserId())
-                .requestedByName(userState.getUserName())
-                .reportParameters(mapper.writeValueAsString(request.getReportParameters()))
-                .requestedAt(LocalDateTime.now())
-                .generationStatus(REQUESTED)
-                .reportName(request.getReportName())
-                .build();
-
-            reportInstanceEntity = saveReportInstance(reportInstanceEntity);
-            if (generateReportContentAsync) {
-                reportQueuePublisher.publish(reportInstanceEntity.getReportInstanceId());
-            } else {
-                //TODO future ticket generateReportContentAsync false
-                throw new UnprocessableException("generateReportContentAsync cannot be false");
-            }
-
-            return reportInstanceMapper.toResponseDto(reportInstanceEntity);
-        } catch (JacksonException e) {
-            throw new IllegalArgumentException("Report parameters badly formatted", e);
-        }
+        return response;
     }
 
     @Override
@@ -220,13 +196,41 @@ public class GenericReportService implements GenericReportServiceInterface {
         }
     }
 
+    private void validateReportInstanceParameters(CreateReportInstanceRequestReports request,
+        ReportEntity reportEntity) {
+        if (!reportParameterValidator.validateReportInstanceParameterValues(
+            request.getReportParameters(), reportEntity)) {
+            throw new UnprocessableException("Validation failed for report instance parameters", true);
+        }
+    }
+
+    private CreateReportInstanceResponseReports createReportInstance(CreateReportInstanceRequestReports request,
+        ReportEntity reportEntity, Long requestedBy, String requestedByName) {
+        try {
+            ReportInstanceEntity reportInstanceEntity = ReportInstanceEntity.builder()
+                .report(reportEntity)
+                .businessUnit(request.getBusinessUnitIds())
+                .requestedBy(requestedBy)
+                .requestedByName(requestedByName)
+                .reportParameters(mapper.writeValueAsString(request.getReportParameters()))
+                .requestedAt(LocalDateTime.now())
+                .generationStatus(REQUESTED)
+                .reportName(request.getReportName())
+                .build();
+
+            reportInstanceEntity = saveReportInstance(reportInstanceEntity);
+            return reportInstanceMapper.toResponseDto(reportInstanceEntity);
+        } catch (JacksonException e) {
+            throw new IllegalArgumentException("Report parameters badly formatted", e);
+        }
+    }
+
     private String getDataAsJson(ReportDataInterface data) throws JacksonException {
         return mapper.writeValueAsString(
             Data.builder()
                 .reportData(data)
                 .reportMetaData(data.getReportMetaData())
-                .build()
-        );
+                .build());
     }
 
     @Builder

--- a/src/main/java/uk/gov/hmcts/opal/service/report/GenericReportServiceInterface.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/GenericReportServiceInterface.java
@@ -13,16 +13,16 @@ public interface GenericReportServiceInterface {
 
     CreateReportInstanceResponseReports addReportInstance(
         CreateReportInstanceRequestReports request,
-        boolean generateReportContentAsync
-    );
+        Long requestedBy,
+        String requestedByName,
+        boolean generateReportContentAsync);
 
     List<ReportInstanceListReportsInner> searchReportInstances(
         LocalDate fromDate,
         LocalDate toDate,
         List<Short> businessUnits,
         Long userId,
-        String reportId
-    );
+        String reportId);
 
     ReportInstanceReports getReportInstance(Long id);
 

--- a/src/main/java/uk/gov/hmcts/opal/service/report/PreAllocatedCashTillService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/PreAllocatedCashTillService.java
@@ -1,28 +1,18 @@
 package uk.gov.hmcts.opal.service.report;
 
-import static uk.gov.hmcts.opal.entity.report.ReportInstanceGenerationStatus.REQUESTED;
 import static uk.gov.hmcts.opal.service.report.ReportId.CASH_TILL;
 
 import jakarta.persistence.EntityNotFoundException;
-import java.time.Clock;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import tools.jackson.core.JacksonException;
-import tools.jackson.databind.ObjectMapper;
-import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
-import uk.gov.hmcts.opal.entity.ReportEntity;
-import uk.gov.hmcts.opal.entity.ReportInstanceEntity;
 import uk.gov.hmcts.opal.entity.TillEntity;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
-import uk.gov.hmcts.opal.exception.EntityNotSavedException;
-import uk.gov.hmcts.opal.repository.ReportInstanceRepository;
-import uk.gov.hmcts.opal.repository.ReportRepository;
+import uk.gov.hmcts.opal.generated.model.CreateReportInstanceRequestReports;
+import uk.gov.hmcts.opal.generated.model.CreateReportInstanceResponseReports;
 import uk.gov.hmcts.opal.repository.TillRepository;
-import uk.gov.hmcts.opal.service.UserStateService;
 
 @Service
 @RequiredArgsConstructor
@@ -30,35 +20,23 @@ public class PreAllocatedCashTillService {
 
     private static final String PRE_ALLOCATED_REPORT_NAME = "Cash till report - Pre-allocated (%s)";
 
-    private final Clock clock;
-    private final ObjectMapper objectMapper;
-    private final ReportInstanceRepository reportInstanceRepository;
-    private final ReportRepository reportRepository;
     private final TillRepository tillRepository;
-    private final UserStateService userStateService;
     private final GenericReportService genericReportService;
 
     @Transactional
-    public Long createPreAllocatedReportInstance(Long tillId) {
+    public Long createPreAllocatedReportInstance(Long tillId, Long requestedBy, String requestedByName) {
         TillEntity till = findTill(tillId);
-        ReportEntity report = reportRepository.findById(CASH_TILL.getReportId())
-            .orElseThrow(() -> new EntityNotFoundException("Report not found with id: " + CASH_TILL.getReportId()));
-        UserState userState = userStateService.getUserStateV1FromSecurityContext();
-
-        ReportInstanceEntity reportInstance = ReportInstanceEntity.builder()
-            .report(report)
-            .businessUnit(List.of(getBusinessUnit(till, tillId).getBusinessUnitId()))
-            .requestedBy(userState.getUserId())
-            .requestedByName(userState.getUserName())
-            .reportParameters(toReportParameters(tillId))
-            .requestedAt(LocalDateTime.now(clock))
-            .generationStatus(REQUESTED)
-            .reportName(PRE_ALLOCATED_REPORT_NAME.formatted(till.getTillNumber()))
-            .build();
-
-        ReportInstanceEntity savedReportInstance = saveReportInstance(reportInstance);
-        genericReportService.generateReportInstanceContent(savedReportInstance.getReportInstanceId());
-        return savedReportInstance.getReportInstanceId();
+        CreateReportInstanceResponseReports response = genericReportService.addReportInstance(
+            CreateReportInstanceRequestReports.builder()
+                .reportId(CASH_TILL.getReportId())
+                .businessUnitIds(List.of(getBusinessUnit(till, tillId).getBusinessUnitId()))
+                .reportParameters(toReportParameters(tillId))
+                .reportName(PRE_ALLOCATED_REPORT_NAME.formatted(till.getTillNumber()))
+            .build(),
+            requestedBy,
+            requestedByName,
+            false);
+        return response.getReportInstanceId();
     }
 
     private TillEntity findTill(Long tillId) {
@@ -77,21 +55,7 @@ public class PreAllocatedCashTillService {
         return businessUnit;
     }
 
-    private String toReportParameters(Long tillId) {
-        try {
-            return objectMapper.writeValueAsString(Map.of(
-                "till_id", tillId,
-                "allocated_report", false));
-        } catch (JacksonException e) {
-            throw new IllegalArgumentException("Report parameters badly formatted", e);
-        }
-    }
-
-    private ReportInstanceEntity saveReportInstance(ReportInstanceEntity reportInstance) {
-        try {
-            return reportInstanceRepository.save(reportInstance);
-        } catch (Exception e) {
-            throw new EntityNotSavedException("Unable to save report instance", e);
-        }
+    private Map<String, Object> toReportParameters(Long tillId) {
+        return Map.of("till_id", tillId, "allocated_report", false);
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/report/ReportInstanceCreationService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/ReportInstanceCreationService.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.opal.service.report;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.opal.common.user.authorisation.model.BusinessUnitUser;
+import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
+import uk.gov.hmcts.opal.generated.model.CreateReportInstanceRequestReports;
+import uk.gov.hmcts.opal.generated.model.CreateReportInstanceResponseReports;
+import uk.gov.hmcts.opal.service.UserStateService;
+
+@Service
+@RequiredArgsConstructor
+public class ReportInstanceCreationService {
+
+    private final UserStateService userStateService;
+    private final GenericReportService genericReportService;
+
+    public CreateReportInstanceResponseReports createReportInstance(CreateReportInstanceRequestReports request) {
+        UserState userState = userStateService.getUserStateV1FromSecurityContext();
+        validateCreateReportInstanceRequest(request, userState);
+        return genericReportService.addReportInstance(request, userState.getUserId(), userState.getUserName(), true);
+    }
+
+    private void validateCreateReportInstanceRequest(CreateReportInstanceRequestReports request,
+        UserState userState) {
+        Set<Short> permittedBusinessUnits = userState.getBusinessUnitUser().stream()
+            .map(BusinessUnitUser::getBusinessUnitId)
+            .collect(Collectors.toSet());
+        if (!permittedBusinessUnits.containsAll(request.getBusinessUnitIds())) {
+            throw new AccessDeniedException("You cannot generate reports for other business units");
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/report/ReportParameterType.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/ReportParameterType.java
@@ -8,6 +8,7 @@ import uk.gov.hmcts.opal.exception.ReportNotFoundException;
 
 @Getter
 public enum ReportParameterType {
+    BOOLEAN("boolean"),
     DATE("date"),
     DECIMAL("decimal-2dp"),
     INTEGER("integer"),

--- a/src/main/java/uk/gov/hmcts/opal/service/report/ReportParameterValidator.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/report/ReportParameterValidator.java
@@ -43,6 +43,11 @@ public class ReportParameterValidator {
                             report.getReportId()), true));
                 //see if given value for
                 switch (ReportParameterType.fromParameterName(reportParameterData.type())) {
+                    case BOOLEAN -> {
+                        if (!(reportInstanceParameters.get(parameterName) instanceof Boolean)) {
+                            return false;
+                        }
+                    }
                     case DATE -> {
                         if (reportInstanceParameters.get(parameterName) instanceof String dateString) {
                             if (isInvalidDate(dateString, reportParameterData)) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -167,6 +167,10 @@ opal:
       queue-name: ${SERVICEBUS_REPORT_QUEUE_NAME:report}
       consumer-enabled: ${REPORT_CONSUMER_ENABLED:true}
       publisher-enabled: ${REPORT_PUBLISHER_ENABLED:true}
+  interface-jobs:
+    service-bus:
+      queue-name: ${SERVICEBUS_INTERFACE_JOBS_QUEUE_NAME:auto-payments-process-interface-files}
+      consumer-enabled: ${INTERFACE_JOBS_CONSUMER_ENABLED:true}
 
   hmrc:
     url: ${OPAL_HMRC_URL:http://localhost:4455}

--- a/src/main/resources/openapi/InterfaceJobs.yaml
+++ b/src/main/resources/openapi/InterfaceJobs.yaml
@@ -141,7 +141,7 @@ paths:
               type: string
               enum:
                 - CREATED
-                - PROCESSED
+                - PROCESSING
                 - IGNORED
                 - FAILED
                 - COMPLETED
@@ -493,7 +493,7 @@ components:
       type: string
       enum:
         - CREATED
-        - PROCESSED
+        - PROCESSING
         - IGNORED
         - FAILED
         - COMPLETED

--- a/src/test/java/uk/gov/hmcts/opal/controllers/ReportInstancesApiControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/ReportInstancesApiControllerTest.java
@@ -38,9 +38,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.server.ResponseStatusException;
+import uk.gov.hmcts.opal.generated.model.CreateReportInstanceRequestReports;
+import uk.gov.hmcts.opal.generated.model.CreateReportInstanceResponseReports;
 import uk.gov.hmcts.opal.generated.model.ReportInstanceListReportsInner;
 import uk.gov.hmcts.opal.service.report.FileType;
 import uk.gov.hmcts.opal.service.report.GenericReportService;
+import uk.gov.hmcts.opal.service.report.ReportInstanceCreationService;
 
 @ExtendWith(MockitoExtension.class)
 class ReportInstancesApiControllerTest {
@@ -49,6 +52,9 @@ class ReportInstancesApiControllerTest {
 
     @Mock
     private GenericReportService genericReportService;
+
+    @Mock
+    private ReportInstanceCreationService reportInstanceCreationService;
 
     @Mock
     private HttpServletRequest request;
@@ -83,8 +89,33 @@ class ReportInstancesApiControllerTest {
                     assertEquals(dto, response.getBody().getFirst());
                 },
                 () -> verify(genericReportService)
-                    .searchReportInstances(FROM_DATE, TO_DATE, BUSINESS_UNITS, USER_ID, DEFAULT_REPORT_ID)
-            );
+                    .searchReportInstances(FROM_DATE, TO_DATE, BUSINESS_UNITS, USER_ID, DEFAULT_REPORT_ID));
+        }
+    }
+
+    @Nested
+    class CreateReportInstance {
+
+        @Test
+        void whenRequestProvided_returnsCreatedResult_happyPath() {
+            CreateReportInstanceResponseReports response =
+                CreateReportInstanceResponseReports.builder().reportInstanceId(REPORT_INSTANCE_ID).build();
+            CreateReportInstanceRequestReports request = CreateReportInstanceRequestReports.builder()
+                .reportId(DEFAULT_REPORT_ID)
+                .businessUnitIds(BUSINESS_UNITS)
+                .reportParameters(Map.of())
+                .build();
+
+            when(reportInstanceCreationService.createReportInstance(request)).thenReturn(response);
+
+            ResponseEntity<CreateReportInstanceResponseReports> actual =
+                reportInstancesApiController.createReportInstance(request);
+
+            assertAll(
+                () -> assertEquals(HttpStatus.CREATED, actual.getStatusCode()),
+                () -> assertEquals(response, actual.getBody()),
+                () -> verify(reportInstanceCreationService).createReportInstance(request),
+                () -> verifyNoInteractions(genericReportService));
         }
     }
 
@@ -102,8 +133,7 @@ class ReportInstancesApiControllerTest {
             assertAll(
                 () -> assertEquals(OK, actual.getStatusCode()),
                 () -> assertEquals(expected, actual.getBody()),
-                () -> verify(genericReportService).getReportInstanceContent(REPORT_INSTANCE_ID, JSON)
-            );
+                () -> verify(genericReportService).getReportInstanceContent(REPORT_INSTANCE_ID, JSON));
         }
 
         @Test
@@ -145,23 +175,19 @@ class ReportInstancesApiControllerTest {
 
             ResponseStatusException exception = assertThrows(
                 ResponseStatusException.class,
-                () -> reportInstancesApiController.getReportInstanceContent(REPORT_INSTANCE_ID)
-            );
+                () -> reportInstancesApiController.getReportInstanceContent(REPORT_INSTANCE_ID));
 
             assertAll(
                 () -> assertEquals(NOT_ACCEPTABLE, exception.getStatusCode()),
                 () -> assertEquals("The requested media type cannot be produced by the server",
                     exception.getReason()),
-                () -> verifyNoInteractions(genericReportService)
-            );
+                () -> verifyNoInteractions(genericReportService));
         }
     }
 
     private void mock_reportContentRequest(String acceptHeader, FileType fileType, Object expectedContent) {
         when(request.getHeader(ACCEPT)).thenReturn(acceptHeader);
-        when(genericReportService.getReportInstanceContent(REPORT_INSTANCE_ID, fileType)).thenReturn(
-            expectedContent
-        );
+        when(genericReportService.getReportInstanceContent(REPORT_INSTANCE_ID, fileType)).thenReturn(expectedContent);
     }
 
     @SuppressWarnings("unchecked")
@@ -174,7 +200,6 @@ class ReportInstancesApiControllerTest {
             () -> assertEquals(OK, actual.getStatusCode()),
             () -> assertEquals(expectedContentType, actual.getHeaders().getContentType()),
             () -> assertArrayEquals(expectedBody, (byte[]) (Object) actual.getBody()),
-            () -> verify(genericReportService).getReportInstanceContent(REPORT_INSTANCE_ID, expectedFileType)
-        );
+            () -> verify(genericReportService).getReportInstanceContent(REPORT_INSTANCE_ID, expectedFileType));
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/interfacejob/InterfaceJobFailurePersistenceServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/interfacejob/InterfaceJobFailurePersistenceServiceTest.java
@@ -1,0 +1,159 @@
+package uk.gov.hmcts.opal.service.interfacejob;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.opal.entity.InterfaceFileEntity;
+import uk.gov.hmcts.opal.entity.InterfaceJobEntity;
+import uk.gov.hmcts.opal.repository.InterfaceJobRepository;
+import uk.gov.hmcts.opal.repository.InterfaceMessageRepository;
+
+@ExtendWith(MockitoExtension.class)
+class InterfaceJobFailurePersistenceServiceTest {
+
+    @Mock
+    private InterfaceJobRepository interfaceJobRepository;
+
+    @Mock
+    private InterfaceMessageRepository interfaceMessageRepository;
+
+    @InjectMocks
+    private InterfaceJobFailurePersistenceService interfaceJobFailurePersistenceService;
+
+    @Test
+    void insertFailureMessage_stripsStoredProcedureDetailsFromPersistedMessage() {
+        // Arrange
+        InterfaceJobEntity interfaceJob = InterfaceJobEntity.builder()
+            .interfaceJobId(123L)
+            .interfaceFiles(List.of(InterfaceFileEntity.builder()
+            .interfaceFileId(456L)
+                .build()))
+            .build();
+        when(interfaceJobRepository.findById(123L)).thenReturn(Optional.of(interfaceJob));
+
+        // Act
+        interfaceJobFailurePersistenceService.insertFailureMessage(123L, new RuntimeException(
+            "ERROR: invalid input syntax for type bigint: \"abc\"   Where: PL/pgSQL function "
+                + "p_int_payments_in(bigint,smallint,character varying,character varying) line "
+                + "107 at FOR over SELECT rows"));
+
+        // Assert
+        ArgumentCaptor<String> messageTextCaptor = ArgumentCaptor.forClass(String.class);
+        verify(interfaceMessageRepository).insertInterfaceMessage(
+            eq(123L),
+            eq("Error"),
+            messageTextCaptor.capture(),
+            eq(456L),
+            isNull(),
+            isNull(),
+            isNull());
+
+        assertThat(messageTextCaptor.getValue())
+            .contains("invalid input syntax for type bigint")
+            .doesNotContain("p_int_payments_in")
+            .doesNotContain("Where:");
+    }
+
+    @Test
+    void insertFailureMessage_fallsBackToOuterExceptionMessageWhenRootCauseMessageBlank() {
+        // Arrange
+        InterfaceJobEntity interfaceJob = InterfaceJobEntity.builder()
+            .interfaceJobId(123L)
+            .interfaceFiles(List.of())
+            .build();
+        when(interfaceJobRepository.findById(123L)).thenReturn(Optional.of(interfaceJob));
+
+        // Act
+        interfaceJobFailurePersistenceService.insertFailureMessage(123L,
+            new RuntimeException("outer failure message", new RuntimeException()));
+
+        // Assert
+        assertPersistedMessageText("outer failure message");
+    }
+
+    @Test
+    void insertFailureMessage_fallsBackToRootCauseClassNameWhenMessagesBlank() {
+        // Arrange
+        InterfaceJobEntity interfaceJob = InterfaceJobEntity.builder()
+            .interfaceJobId(123L)
+            .interfaceFiles(List.of())
+            .build();
+        when(interfaceJobRepository.findById(123L)).thenReturn(Optional.of(interfaceJob));
+
+        // Act
+        interfaceJobFailurePersistenceService.insertFailureMessage(123L,
+            new RuntimeException("", new RuntimeException()));
+
+        // Assert
+        assertPersistedMessageText("RuntimeException");
+    }
+
+    @Test
+    void insertFailureMessage_replacesNewlinesWithSpaces() {
+        // Arrange
+        InterfaceJobEntity interfaceJob = InterfaceJobEntity.builder()
+            .interfaceJobId(123L)
+            .interfaceFiles(List.of())
+            .build();
+        when(interfaceJobRepository.findById(123L)).thenReturn(Optional.of(interfaceJob));
+
+        // Act
+        interfaceJobFailurePersistenceService.insertFailureMessage(123L,
+            new RuntimeException("line one\nline two\rline three"));
+
+        // Assert
+        assertPersistedMessageText("line one line two line three");
+    }
+
+    @Test
+    void insertFailureMessage_truncatesMessagesLongerThan500Characters() {
+        // Arrange
+        InterfaceJobEntity interfaceJob = InterfaceJobEntity.builder()
+            .interfaceJobId(123L)
+            .interfaceFiles(List.of())
+            .build();
+        when(interfaceJobRepository.findById(123L)).thenReturn(Optional.of(interfaceJob));
+        String longMessage = "x".repeat(501);
+
+        // Act
+        interfaceJobFailurePersistenceService.insertFailureMessage(123L, new RuntimeException(longMessage));
+
+        // Assert
+        ArgumentCaptor<String> messageTextCaptor = ArgumentCaptor.forClass(String.class);
+        verify(interfaceMessageRepository).insertInterfaceMessage(
+            eq(123L),
+            eq("Error"),
+            messageTextCaptor.capture(),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull());
+
+        assertThat(messageTextCaptor.getValue()).hasSize(500).isEqualTo(longMessage.substring(0, 500));
+    }
+
+    private void assertPersistedMessageText(String expectedMessageText) {
+        ArgumentCaptor<String> messageTextCaptor = ArgumentCaptor.forClass(String.class);
+        verify(interfaceMessageRepository).insertInterfaceMessage(
+            eq(123L),
+            eq("Error"),
+            messageTextCaptor.capture(),
+            isNull(),
+            isNull(),
+            isNull(),
+            isNull());
+
+        assertThat(messageTextCaptor.getValue()).isEqualTo(expectedMessageText);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/interfacejob/InterfaceJobProcessorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/interfacejob/InterfaceJobProcessorServiceTest.java
@@ -1,0 +1,116 @@
+package uk.gov.hmcts.opal.service.interfacejob;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.opal.entity.InterfaceJobEntity;
+import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
+import uk.gov.hmcts.opal.repository.InterfaceJobRepository;
+
+@ExtendWith(MockitoExtension.class)
+class InterfaceJobProcessorServiceTest {
+
+    private static final Long INTERFACE_JOB_ID = 123L;
+    private static final Short BUSINESS_UNIT_ID = 77;
+
+    @Mock
+    private InterfaceJobRepository interfaceJobRepository;
+
+    @InjectMocks
+    private InterfaceJobProcessorService interfaceJobProcessorService;
+
+    @Test
+    void processPaymentsInJob_isTransactional() throws NoSuchMethodException {
+        // Arrange
+        Method method = InterfaceJobProcessorService.class.getMethod("processPaymentsInJob", Long.class);
+
+        // Act
+        Transactional transactional = method.getAnnotation(Transactional.class);
+
+        // Assert
+        assertThat(transactional).isNotNull();
+    }
+
+    @Test
+    void processPaymentsInJob_returnsTillIdWhenStoredProcedureSucceeds() {
+        // Arrange
+        InterfaceJobEntity interfaceJob = interfaceJob();
+        when(interfaceJobRepository.findById(INTERFACE_JOB_ID)).thenReturn(Optional.of(interfaceJob));
+        when(interfaceJobRepository.processPaymentsInJob(INTERFACE_JOB_ID, BUSINESS_UNIT_ID,
+            "interface-jobs", "interface-jobs")).thenReturn(456L);
+
+        // Act
+        Optional<Long> tillId = interfaceJobProcessorService.processPaymentsInJob(INTERFACE_JOB_ID);
+
+        // Assert
+        assertThat(tillId).contains(456L);
+        verify(interfaceJobRepository).findById(INTERFACE_JOB_ID);
+        verify(interfaceJobRepository).processPaymentsInJob(INTERFACE_JOB_ID, BUSINESS_UNIT_ID,
+            "interface-jobs", "interface-jobs");
+    }
+
+    @Test
+    void processPaymentsInJob_returnsEmptyWhenStoredProcedureReturnsNull() {
+        // Arrange
+        InterfaceJobEntity interfaceJob = interfaceJob();
+        when(interfaceJobRepository.findById(INTERFACE_JOB_ID)).thenReturn(Optional.of(interfaceJob));
+        when(interfaceJobRepository.processPaymentsInJob(INTERFACE_JOB_ID, BUSINESS_UNIT_ID,
+            "interface-jobs", "interface-jobs")).thenReturn(null);
+
+        // Act
+        Optional<Long> tillId = interfaceJobProcessorService.processPaymentsInJob(INTERFACE_JOB_ID);
+
+        // Assert
+        assertThat(tillId).isEmpty();
+    }
+
+    @Test
+    void processPaymentsInJob_whenJobCannotBeFound_throwsException() {
+        // Arrange
+        when(interfaceJobRepository.findById(INTERFACE_JOB_ID)).thenReturn(Optional.empty());
+
+        // Act / Assert
+        assertThatThrownBy(() -> interfaceJobProcessorService.processPaymentsInJob(INTERFACE_JOB_ID))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Failed to process interface job 123")
+            .hasCauseInstanceOf(IllegalStateException.class)
+            .hasRootCauseMessage("Interface job not found with id: 123");
+    }
+
+    @Test
+    void processPaymentsInJob_whenRepositoryThrows_wrapsException() {
+        // Arrange
+        InterfaceJobEntity interfaceJob = interfaceJob();
+        when(interfaceJobRepository.findById(INTERFACE_JOB_ID)).thenReturn(Optional.of(interfaceJob));
+        when(interfaceJobRepository.processPaymentsInJob(eq(INTERFACE_JOB_ID), eq(BUSINESS_UNIT_ID),
+            eq("interface-jobs"), eq("interface-jobs")))
+            .thenThrow(new RuntimeException("db down"));
+
+        // Act / Assert
+        assertThatThrownBy(() -> interfaceJobProcessorService.processPaymentsInJob(INTERFACE_JOB_ID))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Failed to process interface job 123")
+            .hasCauseInstanceOf(RuntimeException.class)
+            .hasRootCauseMessage("db down");
+    }
+
+    private static InterfaceJobEntity interfaceJob() {
+        return InterfaceJobEntity.builder()
+            .interfaceJobId(INTERFACE_JOB_ID)
+            .businessUnit(BusinessUnitEntity.builder()
+                .businessUnitId(BUSINESS_UNIT_ID)
+                .build())
+            .build();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/interfacejob/InterfaceJobStatusServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/interfacejob/InterfaceJobStatusServiceTest.java
@@ -1,0 +1,149 @@
+package uk.gov.hmcts.opal.service.interfacejob;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.opal.entity.InterfaceJobEntity;
+import uk.gov.hmcts.opal.entity.InterfaceJobStatus;
+import uk.gov.hmcts.opal.repository.InterfaceJobRepository;
+
+@ExtendWith(MockitoExtension.class)
+class InterfaceJobStatusServiceTest {
+
+    private static final Long INTERFACE_JOB_ID = 123L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 7, 30, 10, 15);
+
+    @Mock
+    private InterfaceJobRepository interfaceJobRepository;
+
+    private final Clock clock = Clock.fixed(Instant.parse("2026-07-30T10:15:00Z"), ZoneOffset.UTC);
+
+    @Test
+    void isProcessing_returnsTrueWhenJobIsProcessing() {
+        // Arrange
+        InterfaceJobEntity interfaceJob = InterfaceJobEntity.builder()
+            .interfaceJobId(INTERFACE_JOB_ID)
+            .status(InterfaceJobStatus.PROCESSING)
+            .build();
+        when(interfaceJobRepository.findById(INTERFACE_JOB_ID)).thenReturn(Optional.of(interfaceJob));
+
+        // Act
+        boolean processing = new InterfaceJobStatusService(interfaceJobRepository, clock)
+            .isProcessing(INTERFACE_JOB_ID);
+
+        // Assert
+        assertThat(processing)
+            .isTrue();
+    }
+
+    @Test
+    void isProcessing_returnsFalseWhenJobIsNotProcessing() {
+        // Arrange
+        InterfaceJobEntity interfaceJob = InterfaceJobEntity.builder()
+            .interfaceJobId(INTERFACE_JOB_ID)
+            .status(InterfaceJobStatus.COMPLETED)
+            .build();
+        when(interfaceJobRepository.findById(INTERFACE_JOB_ID)).thenReturn(Optional.of(interfaceJob));
+
+        // Act
+        boolean processing = new InterfaceJobStatusService(interfaceJobRepository, clock)
+            .isProcessing(INTERFACE_JOB_ID);
+
+        // Assert
+        assertThat(processing)
+            .isFalse();
+    }
+
+    @Test
+    void isProcessing_whenJobCannotBeFound_throwsException() {
+        // Arrange
+        when(interfaceJobRepository.findById(INTERFACE_JOB_ID)).thenReturn(Optional.empty());
+
+        // Act / Assert
+        assertThatThrownBy(() -> new InterfaceJobStatusService(interfaceJobRepository, clock)
+            .isProcessing(INTERFACE_JOB_ID))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Interface job not found with id: 123");
+    }
+
+    @Test
+    void markCompleted_updatesStatusAndCompletedDateTime() {
+        // Arrange
+        InterfaceJobEntity interfaceJob = InterfaceJobEntity.builder()
+            .interfaceJobId(INTERFACE_JOB_ID)
+            .status(InterfaceJobStatus.PROCESSING)
+            .build();
+        when(interfaceJobRepository.findById(INTERFACE_JOB_ID)).thenReturn(Optional.of(interfaceJob));
+
+        // Act
+        new InterfaceJobStatusService(interfaceJobRepository, clock).markCompleted(INTERFACE_JOB_ID);
+
+        // Assert
+        assertThat(interfaceJob.getStatus()).isEqualTo(InterfaceJobStatus.COMPLETED);
+        assertThat(interfaceJob.getCompletedDateTime()).isEqualTo(NOW);
+        verify(interfaceJobRepository).findById(INTERFACE_JOB_ID);
+    }
+
+    @Test
+    void markIgnored_updatesStatusAndCompletedDateTime() {
+        // Arrange
+        InterfaceJobEntity interfaceJob = InterfaceJobEntity.builder()
+            .interfaceJobId(INTERFACE_JOB_ID)
+            .status(InterfaceJobStatus.PROCESSING)
+            .build();
+        when(interfaceJobRepository.findById(INTERFACE_JOB_ID)).thenReturn(Optional.of(interfaceJob));
+
+        // Act
+        new InterfaceJobStatusService(interfaceJobRepository, clock).markIgnored(INTERFACE_JOB_ID);
+
+        // Assert
+        assertThat(interfaceJob.getStatus()).isEqualTo(InterfaceJobStatus.IGNORED);
+        assertThat(interfaceJob.getCompletedDateTime()).isEqualTo(NOW);
+        verify(interfaceJobRepository).findById(INTERFACE_JOB_ID);
+    }
+
+    @Test
+    void markFailed_updatesStatusAndCompletedDateTime() {
+        // Arrange
+        InterfaceJobEntity interfaceJob = InterfaceJobEntity.builder()
+            .interfaceJobId(INTERFACE_JOB_ID)
+            .status(InterfaceJobStatus.PROCESSING)
+            .build();
+        when(interfaceJobRepository.findById(INTERFACE_JOB_ID)).thenReturn(Optional.of(interfaceJob));
+
+        // Act
+        new InterfaceJobStatusService(interfaceJobRepository, clock).markFailed(INTERFACE_JOB_ID);
+
+        // Assert
+        assertThat(interfaceJob.getStatus()).isEqualTo(InterfaceJobStatus.FAILED);
+        assertThat(interfaceJob.getCompletedDateTime()).isEqualTo(NOW);
+        verify(interfaceJobRepository).findById(INTERFACE_JOB_ID);
+    }
+
+    @Test
+    void markFailed_isRequiresNewTransactional() throws NoSuchMethodException {
+        // Arrange
+        Method method = InterfaceJobStatusService.class.getMethod("markFailed", Long.class);
+
+        // Act
+        Transactional transactional = method.getAnnotation(Transactional.class);
+
+        // Assert
+        assertThat(transactional).isNotNull();
+        assertThat(transactional.propagation()).isEqualTo(Propagation.REQUIRES_NEW);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobQueueConsumerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobQueueConsumerServiceTest.java
@@ -1,0 +1,110 @@
+package uk.gov.hmcts.opal.service.messaging;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessResourceFailureException;
+import tools.jackson.databind.ObjectMapper;
+import uk.gov.hmcts.opal.service.interfacejob.InterfaceJobStatusService;
+
+@ExtendWith(MockitoExtension.class)
+class InterfaceJobQueueConsumerServiceTest {
+
+    @Mock
+    private InterfaceJobStatusService interfaceJobStatusService;
+    @Mock
+    private InterfaceJobQueueProcessingService interfaceJobQueueProcessingService;
+    @Mock
+    private TransientFailureHelper transientFailureHelper;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void consume_processesWhenJobIsProcessing() {
+        // Arrange
+        when(interfaceJobStatusService.isProcessing(123L)).thenReturn(true);
+
+        // Act
+        assertThatCode(() -> service().consume("{\"interface_job_id\":123}"))
+            .doesNotThrowAnyException();
+
+        // Assert
+        verify(interfaceJobStatusService).isProcessing(123L);
+        verify(interfaceJobQueueProcessingService).processProcessingJob(123L);
+    }
+
+    @Test
+    void consume_failsWhenJobIsNotProcessing() {
+        // Arrange
+        when(interfaceJobStatusService.isProcessing(123L)).thenReturn(false);
+
+        // Act / Assert
+        assertThatThrownBy(() -> service().consume("{\"interface_job_id\":123}"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Interface job 123 is not PROCESSING");
+
+        // Assert
+        verify(interfaceJobStatusService).isProcessing(123L);
+        verifyNoInteractions(interfaceJobQueueProcessingService);
+    }
+
+    @Test
+    void consume_marksFailedForNonTransientFailure() {
+        // Arrange
+        when(interfaceJobStatusService.isProcessing(123L)).thenReturn(true);
+        doThrow(new IllegalArgumentException("Cash till report failed"))
+            .when(interfaceJobQueueProcessingService).processProcessingJob(123L);
+
+        // Act
+        assertThatCode(() -> service().consume("{\"interface_job_id\":123}"))
+            .doesNotThrowAnyException();
+
+        // Assert
+        verify(interfaceJobStatusService).isProcessing(123L);
+        verify(interfaceJobQueueProcessingService).processProcessingJob(123L);
+        verify(interfaceJobQueueProcessingService).handleProcessingFailure(eq(123L),
+            any(IllegalArgumentException.class));
+    }
+
+    @Test
+    void consume_rethrowsTransientFailure() {
+        // Arrange
+        DataAccessResourceFailureException failure = new DataAccessResourceFailureException("database unavailable");
+
+        when(interfaceJobStatusService.isProcessing(123L)).thenReturn(true);
+        doThrow(failure).when(interfaceJobQueueProcessingService).processProcessingJob(123L);
+        when(transientFailureHelper.isTransientFailure(failure)).thenReturn(true);
+
+        // Act / Assert
+        assertThatThrownBy(() -> service().consume("{\"interface_job_id\":123}"))
+            .isInstanceOf(DataAccessResourceFailureException.class);
+
+        // Assert
+        verify(interfaceJobStatusService).isProcessing(123L);
+        verify(interfaceJobQueueProcessingService).processProcessingJob(123L);
+        verify(transientFailureHelper).isTransientFailure(failure);
+        verify(interfaceJobStatusService, never()).markFailed(anyLong());
+        verify(interfaceJobQueueProcessingService, never()).handleProcessingFailure(anyLong(),
+            any(RuntimeException.class));
+    }
+
+    private InterfaceJobQueueConsumerService service() {
+        return new InterfaceJobQueueConsumerService(
+            objectMapper,
+            interfaceJobStatusService,
+            interfaceJobQueueProcessingService,
+            transientFailureHelper);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobQueueListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobQueueListenerTest.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.opal.service.messaging;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.TextMessage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InterfaceJobQueueListenerTest {
+
+    public static final String MESSAGE_PAYLOAD = "{\"interface_job_id\":123}";
+
+    @Mock
+    private TextMessage textMessage;
+
+    @Mock
+    private Message message;
+
+    @Mock
+    private InterfaceJobQueueConsumerService consumer;
+
+    @InjectMocks
+    private InterfaceJobQueueListener listener;
+
+    @Test
+    void onMessage_delegatesMessageToConsumer() throws JMSException {
+        // Arrange
+        when(textMessage.getText()).thenReturn(MESSAGE_PAYLOAD);
+
+        // Act
+        listener.onMessage(textMessage);
+
+        // Assert
+        verify(consumer).consume(MESSAGE_PAYLOAD);
+    }
+
+    @Test
+    void onMessage_messageIsNotText_throwException() {
+        // Arrange
+
+        // Act / Assert
+        assertThrows(IllegalArgumentException.class, () -> listener.onMessage(message));
+
+        // Assert
+        verifyNoInteractions(consumer);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobQueueProcessingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/messaging/InterfaceJobQueueProcessingServiceTest.java
@@ -1,0 +1,97 @@
+package uk.gov.hmcts.opal.service.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.opal.service.interfacejob.InterfaceJobFailurePersistenceService;
+import uk.gov.hmcts.opal.service.interfacejob.InterfaceJobProcessorService;
+import uk.gov.hmcts.opal.service.interfacejob.InterfaceJobStatusService;
+import uk.gov.hmcts.opal.service.report.PreAllocatedCashTillService;
+
+@ExtendWith(MockitoExtension.class)
+class InterfaceJobQueueProcessingServiceTest {
+
+    @Mock
+    private InterfaceJobProcessorService interfaceJobProcessorService;
+    @Mock
+    private InterfaceJobStatusService interfaceJobStatusService;
+    @Mock
+    private InterfaceJobFailurePersistenceService interfaceJobFailurePersistenceService;
+    @Mock
+    private PreAllocatedCashTillService preAllocatedCashTillService;
+
+    @Test
+    void processProcessingJob_isTransactional() throws NoSuchMethodException {
+        // Arrange
+        Method method = InterfaceJobQueueProcessingService.class.getMethod("processProcessingJob", Long.class);
+
+        // Act
+        Transactional transactional = method.getAnnotation(Transactional.class);
+
+        // Assert
+        assertThat(transactional).isNotNull();
+    }
+
+    @Test
+    void processProcessingJob_marksCompletedWhenTillCreated() {
+        // Arrange
+        when(interfaceJobProcessorService.processPaymentsInJob(123L)).thenReturn(Optional.of(456L));
+        when(preAllocatedCashTillService.createPreAllocatedReportInstance(456L, 0L, "interface-jobs"))
+            .thenReturn(789L);
+
+        // Act
+        service().processProcessingJob(123L);
+
+        // Assert
+        verify(interfaceJobProcessorService).processPaymentsInJob(123L);
+        verify(preAllocatedCashTillService).createPreAllocatedReportInstance(456L, 0L, "interface-jobs");
+        verify(interfaceJobStatusService).markCompleted(123L);
+    }
+
+    @Test
+    void processProcessingJob_marksIgnoredWhenNoTillCreated() {
+        // Arrange
+        when(interfaceJobProcessorService.processPaymentsInJob(123L)).thenReturn(Optional.empty());
+
+        // Act
+        service().processProcessingJob(123L);
+
+        // Assert
+        verify(interfaceJobProcessorService).processPaymentsInJob(123L);
+        verify(interfaceJobStatusService).markIgnored(123L);
+        verifyNoInteractions(preAllocatedCashTillService);
+    }
+
+    @Test
+    void handleProcessingFailure_marksFailedAndInsertsFailureMessage() {
+        // Arrange
+        IllegalArgumentException exception = new IllegalArgumentException("Cash till report failed");
+
+        // Act
+        service().handleProcessingFailure(123L, exception);
+
+        // Assert
+        verify(interfaceJobStatusService).markFailed(123L);
+        verify(interfaceJobFailurePersistenceService).insertFailureMessage(123L, exception);
+        verifyNoMoreInteractions(interfaceJobStatusService, interfaceJobFailurePersistenceService);
+        verifyNoInteractions(interfaceJobProcessorService, preAllocatedCashTillService);
+    }
+
+    private InterfaceJobQueueProcessingService service() {
+        return new InterfaceJobQueueProcessingService(
+            interfaceJobProcessorService,
+            interfaceJobStatusService,
+            interfaceJobFailurePersistenceService,
+            preAllocatedCashTillService);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/messaging/TransientFailureHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/messaging/TransientFailureHelperTest.java
@@ -1,0 +1,134 @@
+package uk.gov.hmcts.opal.service.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.ConnectException;
+import java.net.UnknownHostException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.transaction.TransactionSystemException;
+import uk.gov.hmcts.opal.exception.ReportGenerationException;
+import uk.gov.hmcts.opal.exception.UnprocessableException;
+
+class TransientFailureHelperTest {
+
+    private final TransientFailureHelper transientFailureHelper = new TransientFailureHelper();
+
+    @ParameterizedTest
+    @MethodSource("transientFailures")
+    void isTransientFailure_returnsTrueForTransientFailures(RuntimeException failure) {
+        // Arrange
+        RuntimeException transientFailure = failure;
+
+        // Act
+        boolean result = transientFailureHelper.isTransientFailure(transientFailure);
+
+        // Assert
+        assertThat(result).isTrue();
+    }
+
+    @ParameterizedTest
+    @MethodSource("nonTransientFailures")
+    void isTransientFailure_returnsFalseForNonTransientFailures(RuntimeException failure) {
+        // Arrange
+        RuntimeException nonTransientFailure = failure;
+
+        // Act
+        boolean result = transientFailureHelper.isTransientFailure(nonTransientFailure);
+
+        // Assert
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isTransientFailure_returnsTrueForLockNotAvailableSqlState() {
+        // Arrange
+        PSQLException psqlException = lockNotAvailableException();
+
+        // Act
+        boolean result = transientFailureHelper.isTransientFailure(new JpaSystemException(
+            new RuntimeException("wrap", psqlException)));
+
+        // Assert
+        assertThat(result).isTrue();
+    }
+
+    @ParameterizedTest
+    @MethodSource("psqlConnectionFailures")
+    void isTransientFailure_returnsTrueForConnectionExceptionsNestedUnderPsql(RuntimeException failure) {
+        // Arrange
+        RuntimeException nestedPsqlFailure = failure;
+
+        // Act
+        boolean result = transientFailureHelper.isTransientFailure(nestedPsqlFailure);
+
+        // Assert
+        assertThat(result).isTrue();
+    }
+
+    private static Stream<RuntimeException> transientFailures() {
+        PSQLException serializationFailure = new PSQLException("serial", PSQLState.SERIALIZATION_FAILURE);
+        PSQLException deadlockFailure = new PSQLException("deadlock", PSQLState.DEADLOCK_DETECTED);
+
+        return Stream.of(
+            new UnprocessableException("validation failed", true),
+            new ReportGenerationException("report failed", new IllegalArgumentException("blob container missing")),
+            new DataAccessResourceFailureException("database unavailable"),
+            new QueryTimeoutException("database timeout"),
+            new TransactionSystemException("tx", deadlockFailure),
+            new JpaSystemException(new RuntimeException("wrap", serializationFailure)),
+            new RuntimeException(serializationFailure));
+    }
+
+    private static Stream<RuntimeException> nonTransientFailures() {
+        PSQLException syntaxFailure = new PSQLException("syntax", PSQLState.SYNTAX_ERROR);
+        PSQLException unexpectedFailure = new PSQLException("unexpected", PSQLState.UNEXPECTED_ERROR);
+
+        return Stream.of(
+            new UnprocessableException("validation failed"),
+            new IllegalArgumentException("bad request"),
+            new TransactionSystemException("tx", syntaxFailure),
+            new JpaSystemException(new RuntimeException("plain")),
+            new RuntimeException(unexpectedFailure));
+    }
+
+    private static Stream<RuntimeException> psqlConnectionFailures() {
+        return Stream.of(
+            new RuntimeException(connectionExceptionPsql()),
+            new RuntimeException(unknownHostExceptionPsql()));
+    }
+
+    private static PSQLException lockNotAvailableException() {
+        return new PSQLException("locked", PSQLState.UNKNOWN_STATE) {
+            @Override
+            public String getSQLState() {
+                return "55P03";
+            }
+        };
+    }
+
+    private static PSQLException connectionExceptionPsql() {
+        return new PSQLException("locked", PSQLState.UNKNOWN_STATE) {
+            @Override
+            public Throwable getCause() {
+                return new ConnectException("connect failed");
+            }
+        };
+    }
+
+    private static PSQLException unknownHostExceptionPsql() {
+        return new PSQLException("locked", PSQLState.UNKNOWN_STATE) {
+            @Override
+            public Throwable getCause() {
+                return new UnknownHostException("unknown host");
+            }
+        };
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/report/GenericReportServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/GenericReportServiceTest.java
@@ -42,8 +42,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.access.AccessDeniedException;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.core.exc.StreamConstraintsException;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.hmcts.opal.common.user.authorisation.model.BusinessUnitUser;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.entity.ReportEntity;
@@ -144,8 +144,7 @@ class GenericReportServiceTest {
             mapper,
             businessUnitRepository,
             reportInstanceSearchService,
-            getReportInstanceContentService
-        );
+            getReportInstanceContentService);
     }
 
     @Test
@@ -309,8 +308,6 @@ class GenericReportServiceTest {
     @Test
     void addReportInstance_success_singleBU() {
         //setup
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
         when(reportRepository.findById(reportId)).thenReturn(Optional.of(reportEntity));
         when(reportEntity.isSupportsMultiBu()).thenReturn(false);
         when(reportEntity.isCanManuallyCreate()).thenReturn(true);
@@ -319,8 +316,6 @@ class GenericReportServiceTest {
         when(reportInstanceMapper.toResponseDto(reportInstance)).thenReturn(reportInstanceResponse);
         when(reportParameterValidator.validateReportInstanceParameterValues(reportParameters, reportEntity))
             .thenReturn(true);
-
-        when(businessUnitUser1.getBusinessUnitId()).thenReturn((short) 1);
         reportInstance.setReportInstanceId(123L);
 
         //test
@@ -330,7 +325,7 @@ class GenericReportServiceTest {
                 .reportName(null)
                 .businessUnitIds(List.of((short) 1))
                 .reportParameters(reportParameters)
-                .build(), true)).isEqualTo(reportInstanceResponse);
+                .build(), USER_ID, "test-user", true)).isEqualTo(reportInstanceResponse);
 
         verify(reportQueuePublisher).publish(123L);
     }
@@ -338,8 +333,6 @@ class GenericReportServiceTest {
     @Test
     void addReportInstance_success_multiBU() {
         //setup
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1, businessUnitUser2));
         when(reportRepository.findById(reportId)).thenReturn(Optional.of(reportEntity));
         when(reportEntity.isSupportsMultiBu()).thenReturn(true);
         when(reportEntity.isCanManuallyCreate()).thenReturn(true);
@@ -348,9 +341,6 @@ class GenericReportServiceTest {
         when(reportInstanceMapper.toResponseDto(reportInstance)).thenReturn(reportInstanceResponse);
         when(reportParameterValidator.validateReportInstanceParameterValues(reportParameters, reportEntity))
             .thenReturn(true);
-
-        when(businessUnitUser1.getBusinessUnitId()).thenReturn((short) 1);
-        when(businessUnitUser2.getBusinessUnitId()).thenReturn((short) 2);
 
         reportInstance.setReportInstanceId(123L);
 
@@ -361,7 +351,7 @@ class GenericReportServiceTest {
                 .reportName(null)
                 .businessUnitIds(List.of((short) 1, (short) 2))
                 .reportParameters(reportParameters)
-                .build(), true)).isEqualTo(reportInstanceResponse);
+                .build(), USER_ID, "test-user", true)).isEqualTo(reportInstanceResponse);
 
         verify(reportQueuePublisher).publish(123L);
     }
@@ -380,7 +370,7 @@ class GenericReportServiceTest {
                     .reportName(null)
                     .businessUnitIds(List.of((short) 1, (short) 2))
                     .reportParameters(reportParameters)
-                    .build(), true));
+                    .build(), USER_ID, "test-user", true));
         assertEquals("Too many business units supplied, this report only allows 1", exception.getDetailedReason());
     }
 
@@ -399,44 +389,18 @@ class GenericReportServiceTest {
                     .reportName(null)
                     .businessUnitIds(List.of((short) 1))
                     .reportParameters(reportParameters)
-                    .build(), true));
+                    .build(), USER_ID, "test-user", true));
         assertEquals("This report cannot be manually created", exception.getDetailedReason());
-    }
-
-    @Test
-    void addReportInstance_userNotAuthorizedWithBU_throwsException() {
-        //setup
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1, businessUnitUser2));
-        when(reportRepository.findById(reportId)).thenReturn(Optional.of(reportEntity));
-        when(reportEntity.isSupportsMultiBu()).thenReturn(true);
-        when(reportEntity.isCanManuallyCreate()).thenReturn(true);
-
-        when(businessUnitUser1.getBusinessUnitId()).thenReturn((short) 1);
-        //test
-        AccessDeniedException exception = assertThrows(AccessDeniedException.class,
-            () -> genericReportService.addReportInstance(
-                CreateReportInstanceRequestReports.builder()
-                    .reportId(reportId)
-                    .reportName(null)
-                    .businessUnitIds(List.of((short) 1, (short) 2))
-                    .reportParameters(reportParameters)
-                    .build(), true));
-        assertEquals("You cannot generate reports for other business units", exception.getMessage());
     }
 
     @Test
     void addReportInstance_failsValidation_throwsException() {
         //setup
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1, businessUnitUser2));
         when(reportRepository.findById(reportId)).thenReturn(Optional.of(reportEntity));
         when(reportEntity.isSupportsMultiBu()).thenReturn(true);
         when(reportEntity.isCanManuallyCreate()).thenReturn(true);
         when(reportParameterValidator.validateReportInstanceParameterValues(reportParameters, reportEntity))
             .thenReturn(false);
-
-        when(businessUnitUser1.getBusinessUnitId()).thenReturn((short) 1);
         //test
         UnprocessableException exception = assertThrows(UnprocessableException.class,
             () -> genericReportService.addReportInstance(
@@ -445,50 +409,51 @@ class GenericReportServiceTest {
                     .reportName(null)
                     .businessUnitIds(List.of((short) 1))
                     .reportParameters(reportParameters)
-                    .build(), true));
+                    .build(), USER_ID, "test-user", true));
         assertEquals("Validation failed for report instance parameters", exception.getDetailedReason());
     }
 
     @Test
-    void addReportInstance_genReportAsyncFalse_throwsException() {
+    void addReportInstance_genReportAsyncFalse_generatesImmediately() {
         //setup
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
         when(reportRepository.findById(reportId)).thenReturn(Optional.of(reportEntity));
         when(reportEntity.isSupportsMultiBu()).thenReturn(false);
-        when(reportEntity.isCanManuallyCreate()).thenReturn(true);
         when(mapper.writeValueAsString(any())).thenReturn("{}");
         when(reportInstanceRepository.save(any())).thenReturn(reportInstance);
+        when(reportInstanceRepository.findById(123L)).thenReturn(Optional.of(reportInstance));
         when(reportParameterValidator.validateReportInstanceParameterValues(reportParameters, reportEntity))
             .thenReturn(true);
-
-        when(businessUnitUser1.getBusinessUnitId()).thenReturn((short) 1);
+        when(reportEntity.getReportId()).thenReturn(reportId);
+        //noinspection rawtypes
+        when((ReportInterface) reportRegistry.get(reportId)).thenReturn(reportInterfaceImplementation);
+        when(reportInterfaceImplementation.generateReportData(reportInstance)).thenReturn(reportData);
+        when(reportData.getNumberOfRecords()).thenReturn(2L);
+        when(reportBlobStore.storeReport(any())).thenReturn(LOCATION);
+        when(reportEntity.getRetentionPeriod()).thenReturn(Duration.ofDays(1));
+        when(reportInstanceMapper.toResponseDto(reportInstance)).thenReturn(reportInstanceResponse);
+        reportInstance.setReportInstanceId(123L);
 
         //test
-        UnprocessableException exception = assertThrows(UnprocessableException.class,
-            () -> genericReportService.addReportInstance(
-                CreateReportInstanceRequestReports.builder()
-                    .reportId(reportId)
-                    .reportName(null)
-                    .businessUnitIds(List.of((short) 1))
-                    .reportParameters(reportParameters)
-                    .build(), false));
-        assertEquals("generateReportContentAsync cannot be false", exception.getDetailedReason());
+        assertThat(genericReportService.addReportInstance(
+            CreateReportInstanceRequestReports.builder()
+                .reportId(reportId)
+                .reportName(null)
+                .businessUnitIds(List.of((short) 1))
+                .reportParameters(reportParameters)
+                .build(), USER_ID, "test-user", false)).isEqualTo(reportInstanceResponse);
+
+        verify(reportBlobStore).storeReport(any());
+        verify(reportQueuePublisher, never()).publish(any());
     }
 
     @Test
     void addReportInstance_invalidJson_throwsException() {
         //setup
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser1));
         when(reportRepository.findById(reportId)).thenReturn(Optional.of(reportEntity));
         when(reportEntity.isSupportsMultiBu()).thenReturn(false);
-        when(reportEntity.isCanManuallyCreate()).thenReturn(true);
         when(mapper.writeValueAsString(any())).thenThrow(new StreamConstraintsException("unit test"));
         when(reportParameterValidator.validateReportInstanceParameterValues(reportParameters, reportEntity))
             .thenReturn(true);
-
-        when(businessUnitUser1.getBusinessUnitId()).thenReturn((short) 1);
         reportInstance.setReportInstanceId(123L);
 
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
@@ -498,7 +463,7 @@ class GenericReportServiceTest {
                     .reportName(null)
                     .businessUnitIds(List.of((short) 1))
                     .reportParameters(reportParameters)
-                    .build(), false));
+                    .build(), USER_ID, "test-user", false));
         assertEquals("Report parameters badly formatted", exception.getMessage());
     }
 
@@ -547,15 +512,13 @@ class GenericReportServiceTest {
             AccessDeniedException exception = assertThrows(
                 AccessDeniedException.class,
                 () -> genericReportService.searchReportInstances(FROM_DATE, TO_DATE, null, USER_ID,
-                    RESTRICTED_REPORT_ID)
-            );
+                    RESTRICTED_REPORT_ID));
 
             assertAll(
                 () -> Assertions.assertThat(exception.getMessage())
                     .isEqualTo("User does not have permission for reportId: " + RESTRICTED_REPORT_ID),
                 () -> verify(reportInstanceSearchService).findRequestedReportElseThrowError(RESTRICTED_REPORT_ID),
-                () -> verify(reportInstanceRepository, never()).findAll(specificationMatcher())
-            );
+                () -> verify(reportInstanceRepository, never()).findAll(specificationMatcher()));
         }
 
         @Test
@@ -567,15 +530,13 @@ class GenericReportServiceTest {
             AccessDeniedException exception = assertThrows(
                 AccessDeniedException.class,
                 () -> genericReportService.searchReportInstances(
-                    FROM_DATE, TO_DATE, List.of((short) 10, (short) 20), USER_ID, null)
-            );
+                    FROM_DATE, TO_DATE, List.of((short) 10, (short) 20), USER_ID, null));
 
             assertAll(
                 () -> Assertions.assertThat(exception.getMessage())
                     .isEqualTo("User does not have permission for business unit: 20"),
                 () -> verify(reportInstanceSearchService).validateBusinessUnitIds(List.of((short) 10, (short) 20)),
-                () -> verify(reportInstanceRepository, never()).findAll(specificationMatcher())
-            );
+                () -> verify(reportInstanceRepository, never()).findAll(specificationMatcher()));
         }
 
         @Test
@@ -593,8 +554,7 @@ class GenericReportServiceTest {
                 TO_DATE,
                 List.of((short) 10),
                 USER_ID,
-                PERMITTED_REPORT_ID
-            );
+                PERMITTED_REPORT_ID);
 
             assertAll(
                 () -> Assertions.assertThat(result).hasSize(1),
@@ -602,20 +562,16 @@ class GenericReportServiceTest {
                 () -> verify(reportInstanceSearchService).findRequestedReportElseThrowError(PERMITTED_REPORT_ID),
                 () -> verify(reportInstanceSearchService).findPermittedReportForBusinessUnits(
                     List.of(report),
-                    List.of((short) 10)
-                ),
+                    List.of((short) 10)),
                 () -> verify(reportInstanceRepository).findAll(specificationMatcher()),
-                () -> verify(reportInstanceMapper).toReportInstanceListReportsInnerDto(matching)
-            );
+                () -> verify(reportInstanceMapper).toReportInstanceListReportsInnerDto(matching));
         }
 
         @Test
         void whenReportIdNotProvided_filtersOnlyPermittedReportIds_happyPath() {
             when(reportInstanceSearchService.findPermittedReports()).thenReturn(List.of(report));
             when(reportInstanceSearchService.validateBusinessUnitIds(null)).thenReturn(List.of((short) 10));
-            mock_permittedReportForBusinessUnits(
-                Map.of(PERMITTED_REPORT_ID, List.of((short) 10))
-            );
+            mock_permittedReportForBusinessUnits(Map.of(PERMITTED_REPORT_ID, List.of((short) 10)));
             mockReportInstancesFound(List.of(matching));
             mockDtoMapped();
 
@@ -624,16 +580,14 @@ class GenericReportServiceTest {
                 TO_DATE,
                 null,
                 USER_ID,
-                null
-            );
+                null);
 
             assertAll(
                 () -> Assertions.assertThat(result).hasSize(1),
                 () -> Assertions.assertThat(result).containsExactly(dto),
                 () -> verify(reportInstanceSearchService).findPermittedReports(),
                 () -> verify(reportInstanceRepository).findAll(specificationMatcher()),
-                () -> verify(reportInstanceMapper).toReportInstanceListReportsInnerDto(matching)
-            );
+                () -> verify(reportInstanceMapper).toReportInstanceListReportsInnerDto(matching));
         }
 
         @Test
@@ -655,10 +609,8 @@ class GenericReportServiceTest {
                 () -> verify(reportInstanceSearchService).validateBusinessUnitIds(null),
                 () -> verify(reportInstanceSearchService).findPermittedReportForBusinessUnits(
                     List.of(report),
-                    List.of((short) 10, (short) 20)
-                ),
-                () -> verify(reportInstanceRepository).findAll(specificationMatcher())
-            );
+                    List.of((short) 10, (short) 20)),
+                () -> verify(reportInstanceRepository).findAll(specificationMatcher()));
         }
 
         @Test
@@ -673,8 +625,7 @@ class GenericReportServiceTest {
             assertAll(
                 () -> Assertions.assertThat(result).isEmpty(),
                 () -> verify(reportInstanceRepository, never()).findAll(specificationMatcher()),
-                () -> verify(reportInstanceMapper, never()).toReportInstanceListReportsInnerDto(any())
-            );
+                () -> verify(reportInstanceMapper, never()).toReportInstanceListReportsInnerDto(any()));
         }
 
         private void mockReportInstancesFound(List<ReportInstanceEntity> reportInstances) {
@@ -686,9 +637,8 @@ class GenericReportServiceTest {
         }
 
         private void mock_permittedReportForBusinessUnits(Map<String, List<Short>> permittedReports) {
-            when(reportInstanceSearchService.findPermittedReportForBusinessUnits(any(), any())).thenReturn(
-                permittedReports
-            );
+            when(reportInstanceSearchService.findPermittedReportForBusinessUnits(any(), any()))
+                .thenReturn(permittedReports);
         }
 
         private Specification<ReportInstanceEntity> specificationMatcher() {

--- a/src/test/java/uk/gov/hmcts/opal/service/report/PreAllocatedCashTillServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/PreAllocatedCashTillServiceTest.java
@@ -3,42 +3,27 @@ package uk.gov.hmcts.opal.service.report;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.opal.entity.report.ReportInstanceGenerationStatus.REQUESTED;
 import static uk.gov.hmcts.opal.service.report.ReportId.CASH_TILL;
 
 import jakarta.persistence.EntityNotFoundException;
-import java.time.Clock;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.Month;
-import java.time.ZoneOffset;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import tools.jackson.databind.ObjectMapper;
-import tools.jackson.databind.json.JsonMapper;
-import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
-import uk.gov.hmcts.opal.entity.ReportEntity;
-import uk.gov.hmcts.opal.entity.ReportInstanceEntity;
 import uk.gov.hmcts.opal.entity.TillEntity;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
-import uk.gov.hmcts.opal.exception.EntityNotSavedException;
-import uk.gov.hmcts.opal.repository.ReportInstanceRepository;
-import uk.gov.hmcts.opal.repository.ReportRepository;
+import uk.gov.hmcts.opal.generated.model.CreateReportInstanceRequestReports;
+import uk.gov.hmcts.opal.generated.model.CreateReportInstanceResponseReports;
 import uk.gov.hmcts.opal.repository.TillRepository;
-import uk.gov.hmcts.opal.service.UserStateService;
 
 @ExtendWith(MockitoExtension.class)
 class PreAllocatedCashTillServiceTest {
@@ -47,19 +32,9 @@ class PreAllocatedCashTillServiceTest {
     private static final Long REPORT_INSTANCE_ID = 1234L;
     private static final Long USER_ID = 987L;
     private static final String USER_NAME = "report.user";
-    private static final LocalDateTime REQUESTED_AT = LocalDateTime.of(2026, Month.JUNE, 23, 10, 15, 30);
 
-    private final Clock clock = Clock.fixed(Instant.parse("2026-06-23T10:15:30Z"), ZoneOffset.UTC);
-    private final ObjectMapper objectMapper = JsonMapper.builder().build();
-
-    @Mock
-    private ReportInstanceRepository reportInstanceRepository;
-    @Mock
-    private ReportRepository reportRepository;
     @Mock
     private TillRepository tillRepository;
-    @Mock
-    private UserStateService userStateService;
     @Mock
     private GenericReportService genericReportService;
 
@@ -67,110 +42,82 @@ class PreAllocatedCashTillServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new PreAllocatedCashTillService(clock, objectMapper, reportInstanceRepository, reportRepository,
-            tillRepository, userStateService, genericReportService);
+        service = new PreAllocatedCashTillService(tillRepository, genericReportService);
     }
 
     @Test
-    void createPreAllocatedReportInstance_savesInstanceAndGeneratesReport() throws Exception {
-        ReportEntity report = cashTillReport();
+    void createPreAllocatedReportInstance_buildsRequestAndDelegatesToGrsSynchronously() {
         TillEntity till = tillWithBusinessUnit();
-        UserState userState = UserState.builder().userId(USER_ID).userName(USER_NAME).build();
-        ArgumentCaptor<ReportInstanceEntity> reportInstanceCaptor = ArgumentCaptor.forClass(ReportInstanceEntity.class);
+        CreateReportInstanceResponseReports response =
+            CreateReportInstanceResponseReports.builder().reportInstanceId(REPORT_INSTANCE_ID).build();
+        ArgumentCaptor<CreateReportInstanceRequestReports> requestCaptor =
+            ArgumentCaptor.forClass(CreateReportInstanceRequestReports.class);
 
         when(tillRepository.findById(TILL_ID)).thenReturn(Optional.of(till));
-        when(reportRepository.findById(CASH_TILL.getReportId())).thenReturn(Optional.of(report));
-        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(reportInstanceRepository.save(any(ReportInstanceEntity.class))).thenAnswer(invocation -> {
-            ReportInstanceEntity reportInstance = invocation.getArgument(0);
-            reportInstance.setReportInstanceId(REPORT_INSTANCE_ID);
-            return reportInstance;
-        });
+        when(genericReportService.addReportInstance(
+            any(CreateReportInstanceRequestReports.class), eq(USER_ID), eq(USER_NAME), eq(false))).thenReturn(response);
 
-        Long reportInstanceId = service.createPreAllocatedReportInstance(TILL_ID);
+        Long reportInstanceId = service.createPreAllocatedReportInstance(TILL_ID, USER_ID, USER_NAME);
 
         assertThat(reportInstanceId).isEqualTo(REPORT_INSTANCE_ID);
-        verify(reportInstanceRepository).save(reportInstanceCaptor.capture());
-        ReportInstanceEntity savedReportInstance = reportInstanceCaptor.getValue();
-        assertThat(savedReportInstance.getReport()).isSameAs(report);
-        assertThat(savedReportInstance.getBusinessUnit()).containsExactly((short) 77);
-        assertThat(savedReportInstance.getRequestedBy()).isEqualTo(USER_ID);
-        assertThat(savedReportInstance.getRequestedByName()).isEqualTo(USER_NAME);
-        assertThat(savedReportInstance.getRequestedAt()).isEqualTo(REQUESTED_AT);
-        assertThat(savedReportInstance.getGenerationStatus()).isEqualTo(REQUESTED);
-        assertThat(savedReportInstance.getReportName()).isEqualTo("Cash till report - Pre-allocated (17)");
-
-        Map parameters = objectMapper.readValue(savedReportInstance.getReportParameters(), Map.class);
-        assertThat(((Number) parameters.get("till_id")).longValue()).isEqualTo(TILL_ID);
-        assertThat(parameters.get("allocated_report")).isEqualTo(false);
-        verify(genericReportService).generateReportInstanceContent(REPORT_INSTANCE_ID);
+        verify(genericReportService).addReportInstance(requestCaptor.capture(), eq(USER_ID), eq(USER_NAME), eq(false));
+        CreateReportInstanceRequestReports request = requestCaptor.getValue();
+        assertThat(request.getReportId()).isEqualTo(CASH_TILL.getReportId());
+        assertThat(request.getBusinessUnitIds()).containsExactly((short) 77);
+        assertThat(request.getReportName()).isEqualTo("Cash till report - Pre-allocated (17)");
+        assertThat(request.getReportParameters()).isEqualTo(Map.of("till_id", TILL_ID, "allocated_report", false));
     }
 
-    @ParameterizedTest
-    @NullSource
-    @ValueSource(longs = {0L, -1L})
-    void createPreAllocatedReportInstance_whenTillIdIsMissingOrInvalid_throwsException(Long tillId) {
-        assertThatThrownBy(() -> service.createPreAllocatedReportInstance(tillId))
+    @Test
+    void createPreAllocatedReportInstance_whenTillIdIsMissingOrInvalid_throwsException() {
+        assertThatThrownBy(() -> service.createPreAllocatedReportInstance(null, USER_ID, USER_NAME))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Cash Till report till_id is required");
 
-        verifyNoInteractions(tillRepository, reportRepository, reportInstanceRepository, genericReportService);
+        assertThatThrownBy(() -> service.createPreAllocatedReportInstance(0L, USER_ID, USER_NAME))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cash Till report till_id is required");
+
+        assertThatThrownBy(() -> service.createPreAllocatedReportInstance(-1L, USER_ID, USER_NAME))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Cash Till report till_id is required");
+
+        verifyNoInteractions(tillRepository, genericReportService);
     }
 
     @Test
     void createPreAllocatedReportInstance_whenTillCannotBeFound_throwsException() {
         when(tillRepository.findById(TILL_ID)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.createPreAllocatedReportInstance(TILL_ID))
+        assertThatThrownBy(() -> service.createPreAllocatedReportInstance(TILL_ID, USER_ID, USER_NAME))
             .isInstanceOf(EntityNotFoundException.class)
             .hasMessage("Cash Till report till not found for till_id 321");
 
-        verifyNoInteractions(reportRepository, reportInstanceRepository, genericReportService);
-    }
-
-    @Test
-    void createPreAllocatedReportInstance_whenReportCannotBeFound_throwsException() {
-        when(tillRepository.findById(TILL_ID)).thenReturn(Optional.of(tillWithBusinessUnit()));
-        when(reportRepository.findById(CASH_TILL.getReportId())).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> service.createPreAllocatedReportInstance(TILL_ID))
-            .isInstanceOf(EntityNotFoundException.class)
-            .hasMessage("Report not found with id: cash_till");
-
-        verifyNoInteractions(reportInstanceRepository, genericReportService);
+        verifyNoInteractions(genericReportService);
     }
 
     @Test
     void createPreAllocatedReportInstance_whenTillHasNoBusinessUnit_throwsException() {
         when(tillRepository.findById(TILL_ID)).thenReturn(Optional.of(TillEntity.builder().tillId(TILL_ID).build()));
-        when(reportRepository.findById(CASH_TILL.getReportId())).thenReturn(Optional.of(cashTillReport()));
-        when(userStateService.getUserStateV1FromSecurityContext())
-            .thenReturn(UserState.builder().userId(USER_ID).userName(USER_NAME).build());
 
-        assertThatThrownBy(() -> service.createPreAllocatedReportInstance(TILL_ID))
+        assertThatThrownBy(() -> service.createPreAllocatedReportInstance(TILL_ID, USER_ID, USER_NAME))
             .isInstanceOf(EntityNotFoundException.class)
             .hasMessage("Cash Till report business unit not found for till_id 321");
 
-        verifyNoInteractions(reportInstanceRepository, genericReportService);
+        verifyNoInteractions(genericReportService);
     }
 
     @Test
-    void createPreAllocatedReportInstance_whenSaveFails_doesNotGenerateReport() {
+    void createPreAllocatedReportInstance_whenGrsFails_doesNotContinue() {
         when(tillRepository.findById(TILL_ID)).thenReturn(Optional.of(tillWithBusinessUnit()));
-        when(reportRepository.findById(CASH_TILL.getReportId())).thenReturn(Optional.of(cashTillReport()));
-        when(userStateService.getUserStateV1FromSecurityContext())
-            .thenReturn(UserState.builder().userId(USER_ID).userName(USER_NAME).build());
-        when(reportInstanceRepository.save(any(ReportInstanceEntity.class))).thenThrow(new RuntimeException("db down"));
+        when(genericReportService.addReportInstance(any(CreateReportInstanceRequestReports.class), eq(USER_ID),
+            eq(USER_NAME), eq(false))).thenThrow(new RuntimeException("db down"));
 
-        assertThatThrownBy(() -> service.createPreAllocatedReportInstance(TILL_ID))
-            .isInstanceOf(EntityNotSavedException.class)
-            .hasMessage("Unable to save report instance");
+        assertThatThrownBy(() -> service.createPreAllocatedReportInstance(TILL_ID, USER_ID, USER_NAME))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessage("db down");
 
         verify(genericReportService, never()).generateReportInstanceContent(any());
-    }
-
-    private static ReportEntity cashTillReport() {
-        return ReportEntity.builder().reportId(CASH_TILL.getReportId()).build();
     }
 
     private static TillEntity tillWithBusinessUnit() {

--- a/src/test/java/uk/gov/hmcts/opal/service/report/ReportInstanceCreationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/ReportInstanceCreationServiceTest.java
@@ -1,0 +1,86 @@
+package uk.gov.hmcts.opal.service.report;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.opal.testdata.ReportInstanceTestData.USER_ID;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import uk.gov.hmcts.opal.common.user.authorisation.model.BusinessUnitUser;
+import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
+import uk.gov.hmcts.opal.generated.model.CreateReportInstanceRequestReports;
+import uk.gov.hmcts.opal.generated.model.CreateReportInstanceResponseReports;
+import uk.gov.hmcts.opal.service.UserStateService;
+
+@ExtendWith(MockitoExtension.class)
+class ReportInstanceCreationServiceTest {
+
+    @Mock
+    private UserStateService userStateService;
+    @Mock
+    private GenericReportService genericReportService;
+    @Mock
+    private UserState userState;
+    @Mock
+    private BusinessUnitUser businessUnitUser;
+
+    @Test
+    void createReportInstance_whenUserHasBusinessUnit_accessesGrs() {
+        // Arrange
+        ReportInstanceCreationService service =
+            new ReportInstanceCreationService(userStateService, genericReportService);
+        CreateReportInstanceRequestReports request = CreateReportInstanceRequestReports.builder()
+            .reportId("cash_till")
+            .businessUnitIds(List.of((short) 1))
+            .reportParameters(Map.of())
+            .build();
+        CreateReportInstanceResponseReports response =
+            CreateReportInstanceResponseReports.builder().reportInstanceId(123L).build();
+
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
+        when(userState.getUserId()).thenReturn(USER_ID);
+        when(userState.getUserName()).thenReturn("test-user");
+        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser));
+        when(businessUnitUser.getBusinessUnitId()).thenReturn((short) 1);
+        when(genericReportService.addReportInstance(request, USER_ID, "test-user", true)).thenReturn(response);
+
+        // Act
+        CreateReportInstanceResponseReports actual = service.createReportInstance(request);
+
+        // Assert
+        assertThat(actual).isEqualTo(response);
+        verify(genericReportService).addReportInstance(request, USER_ID, "test-user", true);
+    }
+
+    @Test
+    void createReportInstance_whenUserLacksBusinessUnit_throwsAccessDenied() {
+        // Arrange
+        ReportInstanceCreationService service =
+            new ReportInstanceCreationService(userStateService, genericReportService);
+        CreateReportInstanceRequestReports request = CreateReportInstanceRequestReports.builder()
+            .reportId("cash_till")
+            .businessUnitIds(List.of((short) 1, (short) 2))
+            .reportParameters(Map.of())
+            .build();
+
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
+        when(userState.getBusinessUnitUser()).thenReturn(Set.of(businessUnitUser));
+        when(businessUnitUser.getBusinessUnitId()).thenReturn((short) 1);
+
+        // Act / Assert
+        assertThatThrownBy(() -> service.createReportInstance(request))
+            .isInstanceOf(AccessDeniedException.class)
+            .hasMessage("You cannot generate reports for other business units");
+
+        verifyNoInteractions(genericReportService);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/report/ReportParameterValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/report/ReportParameterValidatorTest.java
@@ -51,6 +51,7 @@ class ReportParameterValidatorTest {
             .thenReturn(radioList);
 
         when(report.getReportParameters()).thenReturn(List.of(
+            parameter("boolean-param", "boolean", true, null, null, null),
             parameter("date-param", "date", true, null, null, null),
             parameter("decimal-param", "decimal-2dp", true, 1.0, 10.0, null),
             parameter("integer-param", "integer", true, 1L, 10L, null),
@@ -59,10 +60,10 @@ class ReportParameterValidatorTest {
             parameter("autocomplete-param", "menu-autocomplete", true, null, null, null),
             parameter("text-60-param", "text-60", true, 1, 60, null),
             parameter("text-100-param", "text-100", true, 1, 100, null),
-            parameter("text-1000-param", "text-1000", true, 1, 1000, null)
-        ));
+            parameter("text-1000-param", "text-1000", true, 1, 1000, null)));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(Map.of(
+            "boolean-param", true,
             "date-param", "2026-05-26",
             "decimal-param", 5.0,
             "integer-param", 5L,
@@ -79,9 +80,8 @@ class ReportParameterValidatorTest {
 
     @Test
     void validate_nullParametersWithMandatoryParameters_returnsFalse() {
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("text-param", "text-60", true, null, null, null)
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("text-param", "text-60", true, null, null,
+            null)));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(null, report);
 
@@ -90,9 +90,8 @@ class ReportParameterValidatorTest {
 
     @Test
     void validate_nullParametersWithNoMandatoryParameters_returnsTrue() {
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("text-param", "text-60", false, null, null, null)
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("text-param", "text-60", false, null, null,
+            null)));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(null, report);
 
@@ -101,9 +100,8 @@ class ReportParameterValidatorTest {
 
     @Test
     void validate_emptyParametersWithNoMandatoryParameters_returnsTrue() {
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("text-param", "text-60", false, null, null, null)
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("text-param", "text-60", false, null, null,
+            null)));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(Map.of(), report);
 
@@ -112,9 +110,8 @@ class ReportParameterValidatorTest {
 
     @Test
     void validate_emptyParametersWithMandatoryParameters_returnsFalse() {
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("text-param", "text-60", true, null, null, null)
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("text-param", "text-60", true, null, null,
+            null)));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(Map.of(), report);
 
@@ -123,9 +120,8 @@ class ReportParameterValidatorTest {
 
     @Test
     void validate_unknownParameterName_throwsException() {
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("text-param", "text-60", false, null, null, null)
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("text-param", "text-60", false, null, null,
+            null)));
 
         assertThrows(UnprocessableException.class,
             () -> reportParameterValidator.validateReportInstanceParameterValues(Map.of("unknown-param", "value"),
@@ -134,9 +130,8 @@ class ReportParameterValidatorTest {
 
     @Test
     void validate_unknownParameterType_throwsException() {
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("text-param", "unknown-type", false, null, null, null)
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("text-param", "unknown-type", false, null,
+            null, null)));
 
         assertThrows(ReportNotFoundException.class,
             () -> reportParameterValidator.validateReportInstanceParameterValues(
@@ -144,10 +139,20 @@ class ReportParameterValidatorTest {
     }
 
     @Test
+    void validateReportInstanceParameterValues_booleanValueIsNotBoolean_returnsFalse() {
+        when(report.getReportParameters()).thenReturn(List.of(parameter("boolean-param", "boolean", false, null, null,
+            null)));
+
+        boolean result = reportParameterValidator.validateReportInstanceParameterValues(
+            Map.of("boolean-param", "true"), report);
+
+        assertFalse(result);
+    }
+
+    @Test
     void validate_dateValueIsNotString_returnsFalse() {
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("date-param", "date", false, null, null, null)
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("date-param", "date", false, null, null,
+            null)));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(Map.of("date-param", 123L),
                                                                                      report);
@@ -157,9 +162,8 @@ class ReportParameterValidatorTest {
 
     @Test
     void validate_dateValueWithinConfiguredRange_returnsFalse() {
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("date-param", "date", false, "2026-01-01", "2026-12-31", null)
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("date-param", "date", false, "2026-01-01",
+            "2026-12-31", null)));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(
             Map.of("date-param", "2026-05-26"), report);
@@ -169,9 +173,8 @@ class ReportParameterValidatorTest {
 
     @Test
     void validate_dateValueCannotBeParsed_throwsException() {
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("date-param", "date", false, null, null, null)
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("date-param", "date", false, null, null,
+            null)));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(
             Map.of("date-param", "not-a-date"), report);
@@ -181,9 +184,8 @@ class ReportParameterValidatorTest {
 
     @Test
     void validate_decimalValueIsNotDouble_returnsFalse() {
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("decimal-param", "decimal-2dp", false, null, null, null)
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("decimal-param", "decimal-2dp", false, null,
+            null, null)));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(Map.of("decimal-param", 5L),
                                                                                      report);
@@ -193,9 +195,8 @@ class ReportParameterValidatorTest {
 
     @Test
     void validate_decimalValueOutsideRange_returnsFalse() {
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("decimal-param", "decimal-2dp", false, 1.0, 10.0, null)
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("decimal-param", "decimal-2dp", false, 1.0,
+            10.0, null)));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(Map.of("decimal-param", 11.0),
                                                                                      report);
@@ -205,9 +206,8 @@ class ReportParameterValidatorTest {
 
     @Test
     void validate_integerValueIsNotInteger_returnsFalse() {
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("integer-param", "integer", false, null, null, null)
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("integer-param", "integer", false, null, null,
+            null)));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(Map.of("integer-param", 1.23),
                                                                                      report);
@@ -217,9 +217,8 @@ class ReportParameterValidatorTest {
 
     @Test
     void validate_integerValueOutsideRange_returnsFalse() {
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("integer-param", "integer", false, 1L, 10L, null)
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("integer-param", "integer", false, 1L, 10L,
+            null)));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(Map.of("integer-param", 11L),
                                                                                      report);
@@ -234,9 +233,8 @@ class ReportParameterValidatorTest {
             TypeFactory.createDefaultInstance().constructCollectionType(List.class, String.class)))
             .thenReturn(menuChoiceList);
 
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("menu-param", "menu-checkbox", false, 0, 1, List.of("one", "two"))
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("menu-param", "menu-checkbox", false, 0, 1,
+            List.of("one", "two"))));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(
             Map.of("menu-param", menuChoiceList), report);
@@ -250,9 +248,8 @@ class ReportParameterValidatorTest {
         when(objectMapper.convertValue(menuChoiceList,
             TypeFactory.createDefaultInstance().constructCollectionType(List.class, String.class)))
             .thenReturn(menuChoiceList);
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("menu-param", "menu-checkbox", false, 1, 2, List.of("one", "two"))
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("menu-param", "menu-checkbox", false, 1, 2,
+            List.of("one", "two"))));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(
             Map.of("menu-param", menuChoiceList), report);
@@ -267,9 +264,8 @@ class ReportParameterValidatorTest {
             TypeFactory.createDefaultInstance().constructCollectionType(List.class, String.class)))
             .thenReturn(menuChoiceList);
 
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("menu-param", "menu-radio", false, 1, 1, List.of("one", "two"))
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("menu-param", "menu-radio", false, 1, 1,
+            List.of("one", "two"))));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(
             Map.of("menu-param", menuChoiceList), report);
@@ -285,9 +281,8 @@ class ReportParameterValidatorTest {
                 TypeFactory.createDefaultInstance().constructCollectionType(List.class, String.class)))
             .thenThrow(IllegalArgumentException.class);
 
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("menu-param", "menu-radio", false, 0, 2, List.of("one", "two"))
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("menu-param", "menu-radio", false, 0, 2,
+            List.of("one", "two"))));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(
             Map.of("menu-param", notAList), report);
@@ -297,9 +292,8 @@ class ReportParameterValidatorTest {
 
     @Test
     void validate_textValueIsNotString_returnsFalse() {
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("text-param", "text-60", false, null, null, null)
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("text-param", "text-60", false, null, null,
+            null)));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(
             Map.of("text-param", 123L), report);
@@ -309,9 +303,8 @@ class ReportParameterValidatorTest {
 
     @Test
     void validate_textValueShorterThanMin_returnsFalse() {
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("text-param", "text-100", false, 5, 100, null)
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("text-param", "text-100", false, 5, 100,
+            null)));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(Map.of("text-param", "abcd"),
                                                                                      report);
@@ -321,9 +314,8 @@ class ReportParameterValidatorTest {
 
     @Test
     void validate_textValueLongerThanMax_returnsFalse() {
-        when(report.getReportParameters()).thenReturn(List.of(
-            parameter("text-param", "text-1000", false, 0, 5, null)
-        ));
+        when(report.getReportParameters()).thenReturn(List.of(parameter("text-param", "text-1000", false, 0, 5,
+            null)));
 
         boolean result = reportParameterValidator.validateReportInstanceParameterValues(Map.of("text-param", "abcdef"),
                                                                                      report);


### PR DESCRIPTION
[https://tools.hmcts.net/jira/browse/PO-2592](https://tools.hmcts.net/jira/browse/PO-2592)
"BE - Process Interface Files queue consumer (New Internal Service)"

This branch adds a Service Bus-backed interface-job queue consumer that processes PROCESSING jobs, marks them complete or ignored, persists failures, and writes the associated cash-till report instance.

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

NB. THIS PR CONTAINS A DATABASE SCRIPT - DO NOT MERGE!!!!!
`resources/db/migration/data/allEnvs/V1_999__update_cash_till_report_retention_period_iso_8601.sql`
At present this ticket is dependant on 2 db tickets to be completed. Once they are done we can rebase and remove this database script.

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

Changes:

- Interface Job messages are now processed and reports generated.
- ReportInstanceCreationService introduced so that GenericReportService can now be used by non-request-context callers.
- Reports created are labeled with user id 0, requestedByName=interface-jobs
- Added new boolean report parameter type to support allocated_report param
- InterfaceJobQueueConsumerIntegrationTest - IT that verify completion/abandonment of messages only by DB state and side effects, without using a real queue. 
- InterfaceJobRealQueueIntegrationTest - IT that uses a real queue. (Disabled as no queue available currently with test containers)