### PR TITLE
PO-9134: Delete document_instances related to defendant_accounts

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/TestingSupportControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/TestingSupportControllerIntegrationTest.java
@@ -30,12 +30,14 @@ import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserStateV2;
 import uk.gov.hmcts.opal.controllers.util.UserStateUtil;
 import uk.gov.hmcts.opal.dto.ToJsonString;
+import uk.gov.hmcts.opal.entity.AssociatedRecordType;
 import uk.gov.hmcts.opal.repository.AllocationRepository;
 import uk.gov.hmcts.opal.repository.AmendmentRepository;
 import uk.gov.hmcts.opal.repository.ChequeRepository;
 import uk.gov.hmcts.opal.repository.DefendantAccountPartiesRepository;
 import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
 import uk.gov.hmcts.opal.repository.DefendantTransactionRepository;
+import uk.gov.hmcts.opal.repository.DocumentInstanceRepository;
 import uk.gov.hmcts.opal.repository.ImpositionRepository;
 import uk.gov.hmcts.opal.repository.NoteRepository;
 import uk.gov.hmcts.opal.repository.PaymentTermsRepository;
@@ -68,6 +70,9 @@ class TestingSupportControllerIntegrationTest extends AbstractIntegrationTest {
 
     @Autowired
     private DefendantTransactionRepository defendantTransactionRepository;
+
+    @Autowired
+    private DocumentInstanceRepository documentInstanceRepository;
 
     @Autowired
     private ImpositionRepository impositionRepository;
@@ -195,6 +200,10 @@ class TestingSupportControllerIntegrationTest extends AbstractIntegrationTest {
         assertThat(reportEntryRepository.countByAssociatedRecordId(associatedRecordId)).isPositive();
         assertThat(defendantTransactionRepository.countByDefendantAccountId(defendantAccountId)).isPositive();
         assertThat(impositionRepository.countByDefendantAccountId(defendantAccountId)).isPositive();
+        assertThat(documentInstanceRepository.countByAssociatedRecordTypeAndAssociatedRecordId(
+            AssociatedRecordType.DEFENDANT_ACCOUNTS.getLabel(),
+            associatedRecordId
+        )).isPositive();
         assertThat(noteRepository.countByAssociatedRecordId(associatedRecordId)).isPositive();
         assertThat(amendmentRepository.countByAssociatedRecordId(associatedRecordId)).isPositive();
         assertThat(allocationRepository.countByImposition_DefendantAccountId(defendantAccountId)).isPositive();
@@ -218,6 +227,10 @@ class TestingSupportControllerIntegrationTest extends AbstractIntegrationTest {
         assertThat(reportEntryRepository.countByAssociatedRecordId(associatedRecordId)).isZero();
         assertThat(defendantTransactionRepository.countByDefendantAccountId(defendantAccountId)).isZero();
         assertThat(impositionRepository.countByDefendantAccountId(defendantAccountId)).isZero();
+        assertThat(documentInstanceRepository.countByAssociatedRecordTypeAndAssociatedRecordId(
+            AssociatedRecordType.DEFENDANT_ACCOUNTS.getLabel(),
+            associatedRecordId
+        )).isZero();
         assertThat(noteRepository.countByAssociatedRecordId(associatedRecordId)).isZero();
         assertThat(amendmentRepository.countByAssociatedRecordId(associatedRecordId)).isZero();
         assertThat(allocationRepository.countByImposition_DefendantAccountId(defendantAccountId)).isZero();

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/TestingSupportControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/TestingSupportControllerIntegrationTest.java
@@ -190,6 +190,7 @@ class TestingSupportControllerIntegrationTest extends AbstractIntegrationTest {
     void shouldDeleteDefendantAccountAndAssociatedData() throws Exception {
         long defendantAccountId = 1001L;
         String associatedRecordId = String.valueOf(defendantAccountId);
+        String impositionAssociatedRecordId = "9105";
 
         // Pre-check that data exists
         assertThat(defendantAccountRepository.existsById(defendantAccountId)).isTrue();
@@ -203,6 +204,10 @@ class TestingSupportControllerIntegrationTest extends AbstractIntegrationTest {
         assertThat(documentInstanceRepository.countByAssociatedRecordTypeAndAssociatedRecordId(
             AssociatedRecordType.DEFENDANT_ACCOUNTS.getLabel(),
             associatedRecordId
+        )).isPositive();
+        assertThat(documentInstanceRepository.countByAssociatedRecordTypeAndAssociatedRecordId(
+            AssociatedRecordType.IMPOSITIONS.getLabel(),
+            impositionAssociatedRecordId
         )).isPositive();
         assertThat(noteRepository.countByAssociatedRecordId(associatedRecordId)).isPositive();
         assertThat(amendmentRepository.countByAssociatedRecordId(associatedRecordId)).isPositive();
@@ -230,6 +235,10 @@ class TestingSupportControllerIntegrationTest extends AbstractIntegrationTest {
         assertThat(documentInstanceRepository.countByAssociatedRecordTypeAndAssociatedRecordId(
             AssociatedRecordType.DEFENDANT_ACCOUNTS.getLabel(),
             associatedRecordId
+        )).isZero();
+        assertThat(documentInstanceRepository.countByAssociatedRecordTypeAndAssociatedRecordId(
+            AssociatedRecordType.IMPOSITIONS.getLabel(),
+            impositionAssociatedRecordId
         )).isZero();
         assertThat(noteRepository.countByAssociatedRecordId(associatedRecordId)).isZero();
         assertThat(amendmentRepository.countByAssociatedRecordId(associatedRecordId)).isZero();

--- a/src/integrationTest/resources/db/insertData/insert_into_defendants_for_deletion_test.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_defendants_for_deletion_test.sql
@@ -29,6 +29,10 @@ VALUES ('TSTRES', 'Test Result', 'Result', true, true,
         false, false, false, false,
         false, false, false, false);
 
+INSERT INTO documents (document_id, recipient, document_language, priority)
+VALUES ('TTPLET', 'DEF', 'EN', '0')
+ON CONFLICT (document_id) DO NOTHING;
+
 -- Insert the main defendant account
 INSERT INTO defendant_accounts (defendant_account_id, business_unit_id, account_number,
                                 imposed_hearing_date, imposing_court_id, amount_imposed,
@@ -152,3 +156,12 @@ INSERT INTO amendments (amendment_id, business_unit_id, associated_record_type,
 VALUES (1, 78, 'defendant_accounts', 1001,
         '2025-10-27 15:50:42.498414+00', '01000000A', 1,
         'L', 'C', '11111111A', 'UPD');
+
+INSERT INTO document_instances (
+    document_instance_id, document_id, business_unit_id, generated_date, generated_by,
+    associated_record_type, associated_record_id, status, printed_date, document_content
+)
+VALUES (
+    9110, 'TTPLET', 78, '2025-10-27 15:51:42.498414+00', '01000000A',
+    'defendant_accounts', '1001', 'New', NULL, '<doc><account>1001</account></doc>'
+);

--- a/src/integrationTest/resources/db/insertData/insert_into_defendants_for_deletion_test.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_defendants_for_deletion_test.sql
@@ -165,3 +165,12 @@ VALUES (
     9110, 'TTPLET', 78, '2025-10-27 15:51:42.498414+00', '01000000A',
     'defendant_accounts', '1001', 'New', NULL, '<doc><account>1001</account></doc>'
 );
+
+INSERT INTO document_instances (
+    document_instance_id, document_id, business_unit_id, generated_date, generated_by,
+    associated_record_type, associated_record_id, status, printed_date, document_content
+)
+VALUES (
+    9111, 'TTPLET', 78, '2025-10-27 15:52:42.498414+00', '01000000A',
+    'impositions', '9105', 'New', NULL, '<doc><imposition>9105</imposition></doc>'
+);

--- a/src/main/java/uk/gov/hmcts/opal/repository/DocumentInstanceRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/DocumentInstanceRepository.java
@@ -1,10 +1,40 @@
 package uk.gov.hmcts.opal.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.opal.entity.DocumentInstanceEntity;
 
 @Repository
 public interface DocumentInstanceRepository extends JpaRepository<DocumentInstanceEntity, Long> {
 
+    @Modifying
+    @Query(
+        value = """
+            delete from document_instances
+            where associated_record_type = cast(:associatedRecordType as t_associated_record_type_enum)
+              and associated_record_id = :associatedRecordId
+            """,
+        nativeQuery = true
+    )
+    void deleteByAssociatedRecordTypeAndAssociatedRecordId(
+        @Param("associatedRecordType") String associatedRecordType,
+        @Param("associatedRecordId") String associatedRecordId
+    );
+
+    @Query(
+        value = """
+            select count(*)
+            from document_instances
+            where associated_record_type = cast(:associatedRecordType as t_associated_record_type_enum)
+              and associated_record_id = :associatedRecordId
+            """,
+        nativeQuery = true
+    )
+    long countByAssociatedRecordTypeAndAssociatedRecordId(
+        @Param("associatedRecordType") String associatedRecordType,
+        @Param("associatedRecordId") String associatedRecordId
+    );
 }

--- a/src/main/java/uk/gov/hmcts/opal/repository/ImpositionRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/ImpositionRepository.java
@@ -27,6 +27,13 @@ public interface ImpositionRepository extends JpaRepository<ImpositionEntity, Lo
     @EntityGraph(value = ImpositionEntity.ENTITY_GRAPH_LITE, type = EntityGraph.EntityGraphType.FETCH)
     List<ImpositionEntity> findAllByDefendantAccountId(long defendantAccountId);
 
+    @Query("""
+        SELECT imposition.impositionId
+        FROM ImpositionEntity imposition
+        WHERE imposition.defendantAccountId = :defendantAccountId
+        """)
+    List<Long> findImpositionIdsByDefendantAccountId(@Param("defendantAccountId") long defendantAccountId);
+
     long countByDefendantAccountId(long defendantAccountId);
 
     @EntityGraph(value = ImpositionEntity.ENTITY_GRAPH_LITE, type = EntityGraph.EntityGraphType.FETCH)

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/DefendantAccountDeletionService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/DefendantAccountDeletionService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.opal.entity.AssociatedRecordType;
 import uk.gov.hmcts.opal.repository.AccountTransferRepository;
 import uk.gov.hmcts.opal.repository.AllocationRepository;
 import uk.gov.hmcts.opal.repository.AmendmentRepository;
@@ -15,6 +16,7 @@ import uk.gov.hmcts.opal.repository.CommittalWarrantProgressRepository;
 import uk.gov.hmcts.opal.repository.DefendantAccountPartiesRepository;
 import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
 import uk.gov.hmcts.opal.repository.DefendantTransactionRepository;
+import uk.gov.hmcts.opal.repository.DocumentInstanceRepository;
 import uk.gov.hmcts.opal.repository.EnforcementRepository;
 import uk.gov.hmcts.opal.repository.FixedPenaltyOffenceRepository;
 import uk.gov.hmcts.opal.repository.NoteRepository;
@@ -44,6 +46,7 @@ public class DefendantAccountDeletionService {
     private final AccountTransferRepository accountTransferRepository;
     private final EnforcementRepository enforcementRepository;
     private final CommittalWarrantProgressRepository committalWarrantProgressRepository;
+    private final DocumentInstanceRepository documentInstanceRepository;
     private final CreditorAccountTransactional creditorAccountTransactional;
     private final PaymentCardRequestRepository paymentCardRequestsRepository;
     private final NoteRepository noteRepository;
@@ -98,6 +101,10 @@ public class DefendantAccountDeletionService {
 
         // Entities with @ManyToOne defendantAccount relationships
         accountTransferRepository.deleteByDefendantAccount_DefendantAccountId(defendantAccountId);
+        documentInstanceRepository.deleteByAssociatedRecordTypeAndAssociatedRecordId(
+            AssociatedRecordType.DEFENDANT_ACCOUNTS.getLabel(),
+            String.valueOf(defendantAccountId)
+        );
         defendantAccountPartiesRepository.deleteByDefendantAccount_DefendantAccountId(defendantAccountId);
         enforcementRepository.deleteByDefendantAccountId(defendantAccountId);
         creditorAccountTransactional.deleteAllByDefendantAccountId(defendantAccountId, creditorAccountTransactional);

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/DefendantAccountDeletionService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/DefendantAccountDeletionService.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.opal.repository.DefendantTransactionRepository;
 import uk.gov.hmcts.opal.repository.DocumentInstanceRepository;
 import uk.gov.hmcts.opal.repository.EnforcementRepository;
 import uk.gov.hmcts.opal.repository.FixedPenaltyOffenceRepository;
+import uk.gov.hmcts.opal.repository.ImpositionRepository;
 import uk.gov.hmcts.opal.repository.NoteRepository;
 import uk.gov.hmcts.opal.repository.PaymentCardRequestRepository;
 import uk.gov.hmcts.opal.repository.PaymentTermsRepository;
@@ -52,6 +53,7 @@ public class DefendantAccountDeletionService {
     private final NoteRepository noteRepository;
     private final ReportEntryRepository reportEntryRepository;
     private final ReportRepository reportRepository;
+    private final ImpositionRepository impositionRepository;
 
     // Level 3 - Grandchildren
     private final AllocationRepository allocationsRepository;
@@ -64,9 +66,10 @@ public class DefendantAccountDeletionService {
         log.warn("DESTRUCTIVE OPERATION: Deleting defendant account {} and ALL associated data", defendantAccountId);
 
         validateAccountExists(defendantAccountId);
+        List<Long> impositionIds = impositionRepository.findImpositionIdsByDefendantAccountId(defendantAccountId);
 
         deleteLevel3Data(defendantAccountId);
-        deleteLevel2Data(defendantAccountId);
+        deleteLevel2Data(defendantAccountId, impositionIds);
         deleteLevel1Data(defendantAccountId);
 
         log.warn("COMPLETED: Deleted defendant account {} and all associated data", defendantAccountId);
@@ -96,15 +99,12 @@ public class DefendantAccountDeletionService {
         log.debug("Completed Level 3 deletion of {} rows for defendant account {}", count, defendantAccountId);
     }
 
-    private void deleteLevel2Data(long defendantAccountId) {
+    private void deleteLevel2Data(long defendantAccountId, List<Long> impositionIds) {
         log.debug("Deleting Level 2 dependencies for defendant account {}", defendantAccountId);
 
         // Entities with @ManyToOne defendantAccount relationships
         accountTransferRepository.deleteByDefendantAccount_DefendantAccountId(defendantAccountId);
-        documentInstanceRepository.deleteByAssociatedRecordTypeAndAssociatedRecordId(
-            AssociatedRecordType.DEFENDANT_ACCOUNTS.getLabel(),
-            String.valueOf(defendantAccountId)
-        );
+        deleteAssociatedDocumentInstances(defendantAccountId, impositionIds);
         defendantAccountPartiesRepository.deleteByDefendantAccount_DefendantAccountId(defendantAccountId);
         enforcementRepository.deleteByDefendantAccountId(defendantAccountId);
         creditorAccountTransactional.deleteAllByDefendantAccountId(defendantAccountId, creditorAccountTransactional);
@@ -121,6 +121,20 @@ public class DefendantAccountDeletionService {
         amendmentRepository.deleteByAssociatedRecordId(String.valueOf(defendantAccountId));
 
         log.debug("Completed Level 2 deletion for defendant account {}", defendantAccountId);
+    }
+
+    private void deleteAssociatedDocumentInstances(long defendantAccountId, List<Long> impositionIds) {
+        documentInstanceRepository.deleteByAssociatedRecordTypeAndAssociatedRecordId(
+            AssociatedRecordType.DEFENDANT_ACCOUNTS.getLabel(),
+            String.valueOf(defendantAccountId)
+        );
+
+        impositionIds.stream()
+            .map(String::valueOf)
+            .forEach(impositionId -> documentInstanceRepository.deleteByAssociatedRecordTypeAndAssociatedRecordId(
+                AssociatedRecordType.IMPOSITIONS.getLabel(),
+                impositionId
+            ));
     }
 
     private void deleteLevel1Data(long defendantAccountId) {

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/DefendantAccountDeletionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/DefendantAccountDeletionServiceTest.java
@@ -1,0 +1,126 @@
+package uk.gov.hmcts.opal.service.opal;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.opal.entity.AssociatedRecordType;
+import uk.gov.hmcts.opal.repository.AccountTransferRepository;
+import uk.gov.hmcts.opal.repository.AllocationRepository;
+import uk.gov.hmcts.opal.repository.AmendmentRepository;
+import uk.gov.hmcts.opal.repository.BacsPaymentRepository;
+import uk.gov.hmcts.opal.repository.ChequeRepository;
+import uk.gov.hmcts.opal.repository.CommittalWarrantProgressRepository;
+import uk.gov.hmcts.opal.repository.DefendantAccountPartiesRepository;
+import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
+import uk.gov.hmcts.opal.repository.DefendantTransactionRepository;
+import uk.gov.hmcts.opal.repository.DocumentInstanceRepository;
+import uk.gov.hmcts.opal.repository.EnforcementRepository;
+import uk.gov.hmcts.opal.repository.FixedPenaltyOffenceRepository;
+import uk.gov.hmcts.opal.repository.NoteRepository;
+import uk.gov.hmcts.opal.repository.PaymentCardRequestRepository;
+import uk.gov.hmcts.opal.repository.PaymentTermsRepository;
+import uk.gov.hmcts.opal.repository.ReportEntryRepository;
+import uk.gov.hmcts.opal.repository.ReportRepository;
+import uk.gov.hmcts.opal.service.opal.jpa.CreditorAccountTransactional;
+
+@ExtendWith(MockitoExtension.class)
+class DefendantAccountDeletionServiceTest {
+
+    @Mock
+    private DefendantAccountRepository defendantAccountRepository;
+
+    @Mock
+    private DefendantAccountPartiesRepository defendantAccountPartiesRepository;
+
+    @Mock
+    private DefendantTransactionRepository defendantTransactionRepository;
+
+    @Mock
+    private PaymentTermsRepository paymentTermsRepository;
+
+    @Mock
+    private FixedPenaltyOffenceRepository fixedPenaltyOffenceRepository;
+
+    @Mock
+    private AccountTransferRepository accountTransferRepository;
+
+    @Mock
+    private EnforcementRepository enforcementRepository;
+
+    @Mock
+    private CommittalWarrantProgressRepository committalWarrantProgressRepository;
+
+    @Mock
+    private DocumentInstanceRepository documentInstanceRepository;
+
+    @Mock
+    private CreditorAccountTransactional creditorAccountTransactional;
+
+    @Mock
+    private PaymentCardRequestRepository paymentCardRequestsRepository;
+
+    @Mock
+    private NoteRepository noteRepository;
+
+    @Mock
+    private ReportEntryRepository reportEntryRepository;
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @Mock
+    private AllocationRepository allocationsRepository;
+
+    @Mock
+    private ChequeRepository chequeRepository;
+
+    @Mock
+    private BacsPaymentRepository bacsPaymentsRepository;
+
+    @Mock
+    private AmendmentRepository amendmentRepository;
+
+    @InjectMocks
+    private DefendantAccountDeletionService service;
+
+    @Test
+    void deleteDefendantAccountAndAssociatedData_deletesDocumentInstancesAfterAccountTransfers() {
+        long defendantAccountId = 1001L;
+        when(defendantAccountRepository.existsById(defendantAccountId)).thenReturn(true);
+        when(defendantTransactionRepository.findDefendantAccountTransactionIdsByDefendantAccountId(defendantAccountId))
+            .thenReturn(List.of());
+
+        service.deleteDefendantAccountAndAssociatedData(defendantAccountId);
+
+        InOrder inOrder = inOrder(accountTransferRepository, documentInstanceRepository, defendantAccountRepository);
+        inOrder.verify(accountTransferRepository).deleteByDefendantAccount_DefendantAccountId(defendantAccountId);
+        inOrder.verify(documentInstanceRepository).deleteByAssociatedRecordTypeAndAssociatedRecordId(
+            AssociatedRecordType.DEFENDANT_ACCOUNTS.getLabel(),
+            String.valueOf(defendantAccountId)
+        );
+        inOrder.verify(defendantAccountRepository).deleteById(defendantAccountId);
+    }
+
+    @Test
+    void deleteDefendantAccountAndAssociatedData_whenAccountMissing_doesNotDeleteDocumentInstances() {
+        long defendantAccountId = 1001L;
+        when(defendantAccountRepository.existsById(defendantAccountId)).thenReturn(false);
+
+        assertThrows(
+            EntityNotFoundException.class,
+            () -> service.deleteDefendantAccountAndAssociatedData(defendantAccountId)
+        );
+
+        verifyNoInteractions(documentInstanceRepository);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/DefendantAccountDeletionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/DefendantAccountDeletionServiceTest.java
@@ -26,6 +26,7 @@ import uk.gov.hmcts.opal.repository.DefendantTransactionRepository;
 import uk.gov.hmcts.opal.repository.DocumentInstanceRepository;
 import uk.gov.hmcts.opal.repository.EnforcementRepository;
 import uk.gov.hmcts.opal.repository.FixedPenaltyOffenceRepository;
+import uk.gov.hmcts.opal.repository.ImpositionRepository;
 import uk.gov.hmcts.opal.repository.NoteRepository;
 import uk.gov.hmcts.opal.repository.PaymentCardRequestRepository;
 import uk.gov.hmcts.opal.repository.PaymentTermsRepository;
@@ -79,6 +80,9 @@ class DefendantAccountDeletionServiceTest {
     private ReportRepository reportRepository;
 
     @Mock
+    private ImpositionRepository impositionRepository;
+
+    @Mock
     private AllocationRepository allocationsRepository;
 
     @Mock
@@ -97,17 +101,34 @@ class DefendantAccountDeletionServiceTest {
     void deleteDefendantAccountAndAssociatedData_deletesDocumentInstancesAfterAccountTransfers() {
         long defendantAccountId = 1001L;
         when(defendantAccountRepository.existsById(defendantAccountId)).thenReturn(true);
+        when(impositionRepository.findImpositionIdsByDefendantAccountId(defendantAccountId))
+            .thenReturn(List.of(2001L, 2002L));
         when(defendantTransactionRepository.findDefendantAccountTransactionIdsByDefendantAccountId(defendantAccountId))
             .thenReturn(List.of());
 
         service.deleteDefendantAccountAndAssociatedData(defendantAccountId);
 
-        InOrder inOrder = inOrder(accountTransferRepository, documentInstanceRepository, defendantAccountRepository);
+        InOrder inOrder = inOrder(
+            accountTransferRepository,
+            documentInstanceRepository,
+            creditorAccountTransactional,
+            defendantAccountRepository
+        );
         inOrder.verify(accountTransferRepository).deleteByDefendantAccount_DefendantAccountId(defendantAccountId);
         inOrder.verify(documentInstanceRepository).deleteByAssociatedRecordTypeAndAssociatedRecordId(
             AssociatedRecordType.DEFENDANT_ACCOUNTS.getLabel(),
             String.valueOf(defendantAccountId)
         );
+        inOrder.verify(documentInstanceRepository).deleteByAssociatedRecordTypeAndAssociatedRecordId(
+            AssociatedRecordType.IMPOSITIONS.getLabel(),
+            "2001"
+        );
+        inOrder.verify(documentInstanceRepository).deleteByAssociatedRecordTypeAndAssociatedRecordId(
+            AssociatedRecordType.IMPOSITIONS.getLabel(),
+            "2002"
+        );
+        inOrder.verify(creditorAccountTransactional)
+            .deleteAllByDefendantAccountId(defendantAccountId, creditorAccountTransactional);
         inOrder.verify(defendantAccountRepository).deleteById(defendantAccountId);
     }
 
@@ -121,6 +142,6 @@ class DefendantAccountDeletionServiceTest {
             () -> service.deleteDefendantAccountAndAssociatedData(defendantAccountId)
         );
 
-        verifyNoInteractions(documentInstanceRepository);
+        verifyNoInteractions(documentInstanceRepository, impositionRepository);
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-9134


### Change description ###
Document Instances related to Defendant Accounts and Impositions are removed when the Defendant Accounts are removed.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
