### PR TITLE
PO-2452-Using-Optimistic-Lock-And-Automatic-Update

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/repository/DefendantAccountRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/DefendantAccountRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -35,5 +36,17 @@ public interface DefendantAccountRepository extends JpaRepository<DefendantAccou
     @Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
     @Query("select d from DefendantAccountEntity d where d.defendantAccountId = :id")
     Optional<DefendantAccountEntity> findByDefendantAccountIdForUpdate(@Param("id") Long defendantAccountId);
+
+    @Modifying
+    @Query("""
+        UPDATE DefendantAccountEntity d
+        SET d.versionNumber = d.versionNumber + 1
+        WHERE d.defendantAccountId = :defendantAccountId
+        AND d.versionNumber = :expectedVersion
+        """)
+    int incrementVersionNumber(
+        @Param("defendantAccountId") Long defendantAccountId,
+        @Param("expectedVersion") Long expectedVersion
+    );
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyService.java
@@ -219,6 +219,7 @@ public class OpalDefendantAccountPartyService implements DefendantAccountPartySe
             .languagePreferences(buildLanguagePreferences(debtorDetail))
             .build();
     }
+
     private DefendantAccountEntity bumpVersion(Long accountId) {
         DefendantAccountEntity entity = defendantAccountRepositoryService.findById(accountId);
         em.lock(entity, LockModeType.OPTIMISTIC_FORCE_INCREMENT);

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyService.java
@@ -215,11 +215,8 @@ public class OpalDefendantAccountPartyService implements DefendantAccountPartySe
             .languagePreferences(buildLanguagePreferences(debtorDetail))
             .build();
     }
-
-    // TODO - Created PO-2452 to fix bumping the version with a more atomically correct method
     private DefendantAccountEntity bumpVersion(Long accountId) {
-        DefendantAccountEntity entity = defendantAccountRepositoryService.findById(accountId);
-        entity.setVersionNumber(entity.getVersion().add(BigInteger.ONE).longValueExact());
+        DefendantAccountEntity entity = defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(accountId);
         return defendantAccountRepositoryService.saveAndFlush(entity);
     }
 

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyService.java
@@ -8,6 +8,8 @@ import static uk.gov.hmcts.opal.service.opal.OpalDefendantAccountBuilders.buildP
 import static uk.gov.hmcts.opal.service.opal.OpalDefendantAccountBuilders.buildVehicleDetails;
 
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
 import java.math.BigInteger;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -76,6 +78,8 @@ public class OpalDefendantAccountPartyService implements DefendantAccountPartySe
     private final DefendantAccountPartiesRepository defendantAccountPartiesRepository;
 
     private final DefendantAccountControlValidator defendantAccountControlValidator;
+
+    private final EntityManager em;
 
     @Override
     @Transactional(readOnly = true)
@@ -216,8 +220,10 @@ public class OpalDefendantAccountPartyService implements DefendantAccountPartySe
             .build();
     }
     private DefendantAccountEntity bumpVersion(Long accountId) {
-        DefendantAccountEntity entity = defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(accountId);
-        return defendantAccountRepositoryService.saveAndFlush(entity);
+        DefendantAccountEntity entity = defendantAccountRepositoryService.findById(accountId);
+        em.lock(entity, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
+        em.flush();
+        return entity;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountPartyService.java
@@ -8,8 +8,6 @@ import static uk.gov.hmcts.opal.service.opal.OpalDefendantAccountBuilders.buildP
 import static uk.gov.hmcts.opal.service.opal.OpalDefendantAccountBuilders.buildVehicleDetails;
 
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.LockModeType;
 import java.math.BigInteger;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -78,8 +76,6 @@ public class OpalDefendantAccountPartyService implements DefendantAccountPartySe
     private final DefendantAccountPartiesRepository defendantAccountPartiesRepository;
 
     private final DefendantAccountControlValidator defendantAccountControlValidator;
-
-    private final EntityManager em;
 
     @Override
     @Transactional(readOnly = true)
@@ -220,11 +216,11 @@ public class OpalDefendantAccountPartyService implements DefendantAccountPartySe
             .build();
     }
 
-    private DefendantAccountEntity bumpVersion(Long accountId) {
-        DefendantAccountEntity entity = defendantAccountRepositoryService.findById(accountId);
-        em.lock(entity, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
-        em.flush();
-        return entity;
+    private BigInteger bumpVersion(DefendantAccountEntity account) {
+        return defendantAccountRepositoryService.incrementVersionNumber(
+            account.getDefendantAccountId(),
+            account.getVersion()
+        );
     }
 
     @Override
@@ -339,7 +335,7 @@ public class OpalDefendantAccountPartyService implements DefendantAccountPartySe
 
         return GetDefendantAccountPartyResponse.builder()
             .defendantAccountParty(mapDefendantAccountParty(dap, aliasEntity))
-            .version(bumpVersion(accountId).getVersion())
+            .version(bumpVersion(account))
             .build();
     }
 

--- a/src/main/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountRepositoryService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountRepositoryService.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.opal.service.persistence;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
+import uk.gov.hmcts.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
 
 @Service
@@ -45,6 +47,30 @@ public class DefendantAccountRepositoryService {
     @Transactional
     public DefendantAccountEntity save(DefendantAccountEntity defendantAccountEntity) {
         return defendantAccountRepository.save(defendantAccountEntity);
+    }
+
+    @Transactional
+    public BigInteger incrementVersionNumber(long defendantAccountId, BigInteger expectedVersion) {
+        entityManager.flush();
+
+        int rowsUpdated = defendantAccountRepository.incrementVersionNumber(
+            defendantAccountId,
+            expectedVersion.longValueExact()
+        );
+
+        if (rowsUpdated == 0) {
+            throw new ResourceConflictException(
+                "DefendantAccountEntity",
+                defendantAccountId,
+                "Version has changed since it was last read",
+                null
+            );
+        }
+
+        return defendantAccountRepository.findVersionDataByDefendantAccountId(defendantAccountId)
+            .map(versionData -> BigInteger.valueOf(versionData.versionNumber()))
+            .orElseThrow(() -> new EntityNotFoundException(
+                "Defendant Account not found with id: " + defendantAccountId));
     }
 
     /**

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceTest03.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceTest03.java
@@ -10,7 +10,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -20,8 +19,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.LockModeType;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
@@ -82,9 +79,6 @@ class OpalDefendantAccountServiceTest03 {
 
     @Mock
     private DefendantAccountControlValidator defendantAccountControlValidator;
-
-    @Mock
-    private EntityManager em;
 
     // Service under test
     @InjectMocks
@@ -247,10 +241,8 @@ class OpalDefendantAccountServiceTest03 {
                 .build())
             .build();
 
-        doAnswer(invocation -> {
-            account.setVersionNumber(2L);
-            return null;
-        }).when(em).flush();
+        when(defendantAccountRepositoryService.incrementVersionNumber(accountId, account.getVersion()))
+            .thenReturn(BigInteger.valueOf(2L));
 
         try (MockedStatic<VersionUtils> vs = mockStatic(VersionUtils.class)) {
             vs.when(() -> VersionUtils.verifyIfMatch(any(), anyString(), anyLong(), anyString()))
@@ -263,8 +255,8 @@ class OpalDefendantAccountServiceTest03 {
             assertNotNull(resp);
 
             // existing debtor should be deleted (we previously retrieved it via findById)
-            verify(em).lock(account, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
-            verify(em).flush();
+            verify(defendantAccountRepositoryService)
+                .incrementVersionNumber(accountId, account.getVersion());
 
         }
     }
@@ -302,10 +294,8 @@ class OpalDefendantAccountServiceTest03 {
             .address(null).contactDetails(null).build();
 
 
-        doAnswer(invocation -> {
-            account.setVersionNumber(2L);
-            return null;
-        }).when(em).flush();
+        when(defendantAccountRepositoryService.incrementVersionNumber(accountId, account.getVersion()))
+            .thenReturn(BigInteger.valueOf(2L));
 
         try (MockedStatic<VersionUtils> vs = mockStatic(VersionUtils.class)) {
             vs.when(() -> VersionUtils.verifyIfMatch(any(), anyString(), anyLong(), anyString()))
@@ -331,8 +321,8 @@ class OpalDefendantAccountServiceTest03 {
             verify(party).setHomeTelephoneNumber(null);
             verify(party).setWorkTelephoneNumber(null);
 
-            verify(em).lock(account, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
-            verify(em).flush();
+            verify(defendantAccountRepositoryService)
+                .incrementVersionNumber(accountId, account.getVersion());
         }
     }
 
@@ -395,10 +385,8 @@ class OpalDefendantAccountServiceTest03 {
                 .build())
             .build();
 
-        doAnswer(invocation -> {
-            account.setVersionNumber(2L);
-            return null;
-        }).when(em).flush();
+        when(defendantAccountRepositoryService.incrementVersionNumber(accountId, account.getVersion()))
+            .thenReturn(BigInteger.valueOf(2L));
 
         try (MockedStatic<VersionUtils> vs = mockStatic(VersionUtils.class)) {
             vs.when(() -> VersionUtils.verifyIfMatch(eq(account), eq(ifMatch), eq(accountId), anyString()))
@@ -411,8 +399,8 @@ class OpalDefendantAccountServiceTest03 {
             assertNotNull(resp.getDefendantAccountParty());
             assertEquals(BigInteger.valueOf(2L), resp.getVersion());
 
-            verify(em).lock(account, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
-            verify(em).flush();
+            verify(defendantAccountRepositoryService)
+                .incrementVersionNumber(accountId, account.getVersion());
             verify(amendmentRepositoryService).auditInitialiseStoredProc(accountId, RecordType.DEFENDANT_ACCOUNTS);
             verify(amendmentRepositoryService).auditFinaliseStoredProc(
                 eq(accountId), eq(RecordType.DEFENDANT_ACCOUNTS),
@@ -464,10 +452,8 @@ class OpalDefendantAccountServiceTest03 {
                 .build())
             .build();
 
-        doAnswer(invocation -> {
-            account.setVersionNumber(2L);
-            return null;
-        }).when(em).flush();
+        when(defendantAccountRepositoryService.incrementVersionNumber(accountId, account.getVersion()))
+            .thenReturn(BigInteger.valueOf(2L));
 
         try (MockedStatic<VersionUtils> vs = mockStatic(VersionUtils.class)) {
             vs.when(() -> VersionUtils.verifyIfMatch(any(), anyString(), anyLong(), anyString()))
@@ -482,8 +468,8 @@ class OpalDefendantAccountServiceTest03 {
             verify(partyRepositoryService, times(2)).findById(300L); // main + aliases
             verify(aliasRepoService, times(2)).findByPartyId(300L);
             verify(defendantAccountControlValidator, never()).validateCanMutateParty(account);
-            verify(em).lock(account, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
-            verify(em).flush();
+            verify(defendantAccountRepositoryService)
+                .incrementVersionNumber(accountId, account.getVersion());
         }
     }
 
@@ -527,10 +513,8 @@ class OpalDefendantAccountServiceTest03 {
             // employer null, language null
             .build();
 
-        doAnswer(invocation -> {
-            account.setVersionNumber(2L);
-            return null;
-        }).when(em).flush();
+        when(defendantAccountRepositoryService.incrementVersionNumber(accountId, account.getVersion()))
+            .thenReturn(BigInteger.valueOf(2L));
 
         try (MockedStatic<VersionUtils> vs = mockStatic(VersionUtils.class)) {
             vs.when(() -> VersionUtils.verifyIfMatch(any(), anyString(), anyLong(), anyString()))
@@ -565,8 +549,8 @@ class OpalDefendantAccountServiceTest03 {
             assertNull(saved.getDocumentLanguageDate());
             assertNull(saved.getHearingLanguageDate());
 
-            verify(em).lock(account, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
-            verify(em).flush();
+            verify(defendantAccountRepositoryService)
+                .incrementVersionNumber(accountId, account.getVersion());
             verify(aliasRepoService, times(2)).findByPartyId(333L);
         }
     }
@@ -609,10 +593,8 @@ class OpalDefendantAccountServiceTest03 {
             .versionNumber(1L)
             .build();
 
-        doAnswer(invocation -> {
-            account.setVersionNumber(2L);
-            return null;
-        }).when(em).flush();
+        when(defendantAccountRepositoryService.incrementVersionNumber(accountId, account.getVersion()))
+            .thenReturn(BigInteger.valueOf(2L));
 
         when(defendantAccountRepositoryService.findById(accountId)).thenReturn(account);
         when(partyRepositoryService.findById(4001L)).thenReturn(defendantParty);
@@ -645,8 +627,8 @@ class OpalDefendantAccountServiceTest03 {
             assertEquals("Defendant", resp.getDefendantAccountParty().getDefendantAccountPartyType());
             assertEquals("4001", resp.getDefendantAccountParty().getPartyDetails().getPartyId());
             assertTrue(Boolean.TRUE.equals(resp.getDefendantAccountParty().getPartyDetails().getOrganisationFlag()));
-            verify(em).lock(account, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
-            verify(em).flush();
+            verify(defendantAccountRepositoryService)
+                .incrementVersionNumber(accountId, account.getVersion());
             verify(defendantAccountPartiesRepository)
                 .deleteByAccountIdAndAssociationTypeExcludingDapId(
                     accountId, AssociationType.PARENT_GUARDIAN, defendantDapId

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceTest03.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceTest03.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.persistence.EntityNotFoundException;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -231,7 +232,6 @@ class OpalDefendantAccountServiceTest03 {
         existing.setPartyId(222L);
         when(partyRepositoryService.findById(222L)).thenReturn(party);
         when(aliasRepoService.findByPartyId(222L)).thenReturn(emptyList());
-        when(defendantAccountRepositoryService.saveAndFlush(account)).thenReturn(account);
 
         DefendantAccountParty req = DefendantAccountParty.builder()
             .defendantAccountPartyType("Defendant").isDebtor(Boolean.FALSE)
@@ -240,6 +240,14 @@ class OpalDefendantAccountServiceTest03 {
                 .organisationDetails(OrganisationDetails.builder().organisationName("X").build())
                 .build())
             .build();
+
+        DefendantAccountEntity bumpedAccount = DefendantAccountEntity.builder()
+            .defendantAccountId(accountId)
+            .versionNumber(2L)
+            .build();
+
+        when(defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(accountId)).thenReturn(bumpedAccount);
+        when(defendantAccountRepositoryService.saveAndFlush(bumpedAccount)).thenReturn(bumpedAccount);
 
         try (MockedStatic<VersionUtils> vs = mockStatic(VersionUtils.class)) {
             vs.when(() -> VersionUtils.verifyIfMatch(any(), anyString(), anyLong(), anyString()))
@@ -250,9 +258,12 @@ class OpalDefendantAccountServiceTest03 {
                     accountId, dapId, req, "\"1\"", "10", "tester", "Tester Name", null);
 
             assertNotNull(resp);
+            assertEquals(BigInteger.valueOf(2L), resp.getVersion());
 
             // existing debtor should be deleted (we previously retrieved it via findById)
-            verify(defendantAccountRepositoryService).saveAndFlush(account);
+            verify(defendantAccountRepositoryService).getDefendantAccountByIdForUpdate(accountId);
+            verify(defendantAccountRepositoryService).saveAndFlush(bumpedAccount);
+
         }
     }
 
@@ -275,7 +286,6 @@ class OpalDefendantAccountServiceTest03 {
 
         when(partyRepositoryService.findById(444L)).thenReturn(party);
         when(aliasRepoService.findByPartyId(444L)).thenReturn(emptyList());
-        when(defendantAccountRepositoryService.saveAndFlush(account)).thenReturn(account);
 
         when(debtorRepoService.findById(444L)).thenReturn(Optional.of(new DebtorDetailEntity()));
 
@@ -288,6 +298,14 @@ class OpalDefendantAccountServiceTest03 {
                 .organisationDetails(OrganisationDetails.builder().organisationName("ORG").build())
                 .build())
             .address(null).contactDetails(null).build();
+
+        DefendantAccountEntity bumpedAccount = DefendantAccountEntity.builder()
+            .defendantAccountId(accountId)
+            .versionNumber(2L)
+            .build();
+
+        when(defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(accountId)).thenReturn(bumpedAccount);
+        when(defendantAccountRepositoryService.saveAndFlush(bumpedAccount)).thenReturn(bumpedAccount);
 
         try (MockedStatic<VersionUtils> vs = mockStatic(VersionUtils.class)) {
             vs.when(() -> VersionUtils.verifyIfMatch(any(), anyString(), anyLong(), anyString()))
@@ -313,7 +331,8 @@ class OpalDefendantAccountServiceTest03 {
             verify(party).setHomeTelephoneNumber(null);
             verify(party).setWorkTelephoneNumber(null);
 
-            verify(defendantAccountRepositoryService).saveAndFlush(account);
+            verify(defendantAccountRepositoryService).getDefendantAccountByIdForUpdate(accountId);
+            verify(defendantAccountRepositoryService).saveAndFlush(bumpedAccount);
         }
     }
 
@@ -350,8 +369,6 @@ class OpalDefendantAccountServiceTest03 {
 
         when(partyRepositoryService.findById(123L)).thenReturn(party);
 
-        when(defendantAccountRepositoryService.saveAndFlush(account)).thenReturn(account);
-
         when(debtorRepoService.findById(123L)).thenReturn(Optional.of(new DebtorDetailEntity()));
 
         when(defendantAccountRepositoryService.findById(accountId)).thenReturn(account);
@@ -378,6 +395,14 @@ class OpalDefendantAccountServiceTest03 {
                 .build())
             .build();
 
+        DefendantAccountEntity bumpedAccount = DefendantAccountEntity.builder()
+            .defendantAccountId(accountId)
+            .versionNumber(2L)
+            .build();
+
+        when(defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(accountId)).thenReturn(bumpedAccount);
+        when(defendantAccountRepositoryService.saveAndFlush(bumpedAccount)).thenReturn(bumpedAccount);
+
         try (MockedStatic<VersionUtils> vs = mockStatic(VersionUtils.class)) {
             vs.when(() -> VersionUtils.verifyIfMatch(eq(account), eq(ifMatch), eq(accountId), anyString()))
                 .thenAnswer(i -> null);
@@ -388,7 +413,8 @@ class OpalDefendantAccountServiceTest03 {
             assertNotNull(resp);
             assertNotNull(resp.getDefendantAccountParty());
 
-            verify(defendantAccountRepositoryService).saveAndFlush(account);
+            verify(defendantAccountRepositoryService).getDefendantAccountByIdForUpdate(accountId);
+            verify(defendantAccountRepositoryService).saveAndFlush(bumpedAccount);
             verify(amendmentRepositoryService).auditInitialiseStoredProc(accountId, RecordType.DEFENDANT_ACCOUNTS);
             verify(amendmentRepositoryService).auditFinaliseStoredProc(
                 eq(accountId), eq(RecordType.DEFENDANT_ACCOUNTS),
@@ -428,7 +454,6 @@ class OpalDefendantAccountServiceTest03 {
             .defendantAccountId(accountId).businessUnit(buEnt).parties(List.of(dap)).versionNumber(1L).build();
 
         when(partyRepositoryService.findById(300L)).thenReturn(partyProxy);
-        when(defendantAccountRepositoryService.saveAndFlush(account)).thenReturn(account);
 
         when(aliasRepoService.findByPartyId(300L)).thenReturn(emptyList());
 
@@ -441,6 +466,14 @@ class OpalDefendantAccountServiceTest03 {
                 .build())
             .build();
 
+        DefendantAccountEntity bumpedAccount = DefendantAccountEntity.builder()
+            .defendantAccountId(accountId)
+            .versionNumber(2L)
+            .build();
+
+        when(defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(accountId)).thenReturn(bumpedAccount);
+        when(defendantAccountRepositoryService.saveAndFlush(bumpedAccount)).thenReturn(bumpedAccount);
+
         try (MockedStatic<VersionUtils> vs = mockStatic(VersionUtils.class)) {
             vs.when(() -> VersionUtils.verifyIfMatch(any(), anyString(), anyLong(), anyString()))
                 .thenAnswer(i -> null);
@@ -451,7 +484,8 @@ class OpalDefendantAccountServiceTest03 {
             assertNotNull(resp);
             assertNotNull(resp.getDefendantAccountParty());
             verify(partyRepositoryService, times(2)).findById(300L); // main + aliases
-            verify(defendantAccountRepositoryService).saveAndFlush(account);
+            verify(defendantAccountRepositoryService).getDefendantAccountByIdForUpdate(accountId);
+            verify(defendantAccountRepositoryService).saveAndFlush(bumpedAccount);
             verify(aliasRepoService, times(2)).findByPartyId(300L);
             verify(defendantAccountControlValidator, never()).validateCanMutateParty(account);
         }
@@ -479,8 +513,6 @@ class OpalDefendantAccountServiceTest03 {
 
         when(partyRepositoryService.findById(333L)).thenReturn(party);
         when(aliasRepoService.findByPartyId(333L)).thenReturn(emptyList());
-
-        when(defendantAccountRepositoryService.saveAndFlush(account)).thenReturn(account);
         when(debtorRepoService.findById(333L)).thenReturn(null);
         when(debtorRepoService.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
@@ -498,6 +530,14 @@ class OpalDefendantAccountServiceTest03 {
                 .vehicleRegistration("JD02CAR").build())
             // employer null, language null
             .build();
+
+        DefendantAccountEntity bumpedAccount = DefendantAccountEntity.builder()
+            .defendantAccountId(accountId)
+            .versionNumber(2L)
+            .build();
+
+        when(defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(accountId)).thenReturn(bumpedAccount);
+        when(defendantAccountRepositoryService.saveAndFlush(bumpedAccount)).thenReturn(bumpedAccount);
 
         try (MockedStatic<VersionUtils> vs = mockStatic(VersionUtils.class)) {
             vs.when(() -> VersionUtils.verifyIfMatch(any(), anyString(), anyLong(), anyString()))
@@ -532,7 +572,8 @@ class OpalDefendantAccountServiceTest03 {
             assertNull(saved.getDocumentLanguageDate());
             assertNull(saved.getHearingLanguageDate());
 
-            verify(defendantAccountRepositoryService).saveAndFlush(account);
+            verify(defendantAccountRepositoryService).getDefendantAccountByIdForUpdate(accountId);
+            verify(defendantAccountRepositoryService).saveAndFlush(bumpedAccount);
             verify(aliasRepoService, times(2)).findByPartyId(333L);
         }
     }
@@ -575,8 +616,14 @@ class OpalDefendantAccountServiceTest03 {
             .versionNumber(1L)
             .build();
 
+        DefendantAccountEntity bumpedAccount = DefendantAccountEntity.builder()
+            .defendantAccountId(accountId)
+            .versionNumber(2L)
+            .build();
+
         when(defendantAccountRepositoryService.findById(accountId)).thenReturn(account);
-        when(defendantAccountRepositoryService.saveAndFlush(account)).thenReturn(account);
+        when(defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(accountId)).thenReturn(bumpedAccount);
+        when(defendantAccountRepositoryService.saveAndFlush(bumpedAccount)).thenReturn(bumpedAccount);
         when(partyRepositoryService.findById(4001L)).thenReturn(defendantParty);
         when(aliasRepoService.findByPartyId(4001L)).thenReturn(emptyList());
         when(debtorRepoService.findById(4001L)).thenReturn(Optional.of(new DebtorDetailEntity()));
@@ -607,6 +654,8 @@ class OpalDefendantAccountServiceTest03 {
             assertEquals("Defendant", resp.getDefendantAccountParty().getDefendantAccountPartyType());
             assertEquals("4001", resp.getDefendantAccountParty().getPartyDetails().getPartyId());
             assertTrue(Boolean.TRUE.equals(resp.getDefendantAccountParty().getPartyDetails().getOrganisationFlag()));
+            verify(defendantAccountRepositoryService).getDefendantAccountByIdForUpdate(accountId);
+            verify(defendantAccountRepositoryService).saveAndFlush(bumpedAccount);
             verify(defendantAccountPartiesRepository)
                 .deleteByAccountIdAndAssociationTypeExcludingDapId(
                     accountId, AssociationType.PARENT_GUARDIAN, defendantDapId

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceTest03.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalDefendantAccountServiceTest03.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -19,6 +20,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
@@ -79,6 +82,9 @@ class OpalDefendantAccountServiceTest03 {
 
     @Mock
     private DefendantAccountControlValidator defendantAccountControlValidator;
+
+    @Mock
+    private EntityManager em;
 
     // Service under test
     @InjectMocks
@@ -241,13 +247,10 @@ class OpalDefendantAccountServiceTest03 {
                 .build())
             .build();
 
-        DefendantAccountEntity bumpedAccount = DefendantAccountEntity.builder()
-            .defendantAccountId(accountId)
-            .versionNumber(2L)
-            .build();
-
-        when(defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(accountId)).thenReturn(bumpedAccount);
-        when(defendantAccountRepositoryService.saveAndFlush(bumpedAccount)).thenReturn(bumpedAccount);
+        doAnswer(invocation -> {
+            account.setVersionNumber(2L);
+            return null;
+        }).when(em).flush();
 
         try (MockedStatic<VersionUtils> vs = mockStatic(VersionUtils.class)) {
             vs.when(() -> VersionUtils.verifyIfMatch(any(), anyString(), anyLong(), anyString()))
@@ -258,11 +261,10 @@ class OpalDefendantAccountServiceTest03 {
                     accountId, dapId, req, "\"1\"", "10", "tester", "Tester Name", null);
 
             assertNotNull(resp);
-            assertEquals(BigInteger.valueOf(2L), resp.getVersion());
 
             // existing debtor should be deleted (we previously retrieved it via findById)
-            verify(defendantAccountRepositoryService).getDefendantAccountByIdForUpdate(accountId);
-            verify(defendantAccountRepositoryService).saveAndFlush(bumpedAccount);
+            verify(em).lock(account, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
+            verify(em).flush();
 
         }
     }
@@ -299,13 +301,11 @@ class OpalDefendantAccountServiceTest03 {
                 .build())
             .address(null).contactDetails(null).build();
 
-        DefendantAccountEntity bumpedAccount = DefendantAccountEntity.builder()
-            .defendantAccountId(accountId)
-            .versionNumber(2L)
-            .build();
 
-        when(defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(accountId)).thenReturn(bumpedAccount);
-        when(defendantAccountRepositoryService.saveAndFlush(bumpedAccount)).thenReturn(bumpedAccount);
+        doAnswer(invocation -> {
+            account.setVersionNumber(2L);
+            return null;
+        }).when(em).flush();
 
         try (MockedStatic<VersionUtils> vs = mockStatic(VersionUtils.class)) {
             vs.when(() -> VersionUtils.verifyIfMatch(any(), anyString(), anyLong(), anyString()))
@@ -331,8 +331,8 @@ class OpalDefendantAccountServiceTest03 {
             verify(party).setHomeTelephoneNumber(null);
             verify(party).setWorkTelephoneNumber(null);
 
-            verify(defendantAccountRepositoryService).getDefendantAccountByIdForUpdate(accountId);
-            verify(defendantAccountRepositoryService).saveAndFlush(bumpedAccount);
+            verify(em).lock(account, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
+            verify(em).flush();
         }
     }
 
@@ -395,13 +395,10 @@ class OpalDefendantAccountServiceTest03 {
                 .build())
             .build();
 
-        DefendantAccountEntity bumpedAccount = DefendantAccountEntity.builder()
-            .defendantAccountId(accountId)
-            .versionNumber(2L)
-            .build();
-
-        when(defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(accountId)).thenReturn(bumpedAccount);
-        when(defendantAccountRepositoryService.saveAndFlush(bumpedAccount)).thenReturn(bumpedAccount);
+        doAnswer(invocation -> {
+            account.setVersionNumber(2L);
+            return null;
+        }).when(em).flush();
 
         try (MockedStatic<VersionUtils> vs = mockStatic(VersionUtils.class)) {
             vs.when(() -> VersionUtils.verifyIfMatch(eq(account), eq(ifMatch), eq(accountId), anyString()))
@@ -412,9 +409,10 @@ class OpalDefendantAccountServiceTest03 {
 
             assertNotNull(resp);
             assertNotNull(resp.getDefendantAccountParty());
+            assertEquals(BigInteger.valueOf(2L), resp.getVersion());
 
-            verify(defendantAccountRepositoryService).getDefendantAccountByIdForUpdate(accountId);
-            verify(defendantAccountRepositoryService).saveAndFlush(bumpedAccount);
+            verify(em).lock(account, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
+            verify(em).flush();
             verify(amendmentRepositoryService).auditInitialiseStoredProc(accountId, RecordType.DEFENDANT_ACCOUNTS);
             verify(amendmentRepositoryService).auditFinaliseStoredProc(
                 eq(accountId), eq(RecordType.DEFENDANT_ACCOUNTS),
@@ -466,13 +464,10 @@ class OpalDefendantAccountServiceTest03 {
                 .build())
             .build();
 
-        DefendantAccountEntity bumpedAccount = DefendantAccountEntity.builder()
-            .defendantAccountId(accountId)
-            .versionNumber(2L)
-            .build();
-
-        when(defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(accountId)).thenReturn(bumpedAccount);
-        when(defendantAccountRepositoryService.saveAndFlush(bumpedAccount)).thenReturn(bumpedAccount);
+        doAnswer(invocation -> {
+            account.setVersionNumber(2L);
+            return null;
+        }).when(em).flush();
 
         try (MockedStatic<VersionUtils> vs = mockStatic(VersionUtils.class)) {
             vs.when(() -> VersionUtils.verifyIfMatch(any(), anyString(), anyLong(), anyString()))
@@ -483,11 +478,12 @@ class OpalDefendantAccountServiceTest03 {
 
             assertNotNull(resp);
             assertNotNull(resp.getDefendantAccountParty());
+            assertEquals(BigInteger.valueOf(2L), resp.getVersion());
             verify(partyRepositoryService, times(2)).findById(300L); // main + aliases
-            verify(defendantAccountRepositoryService).getDefendantAccountByIdForUpdate(accountId);
-            verify(defendantAccountRepositoryService).saveAndFlush(bumpedAccount);
             verify(aliasRepoService, times(2)).findByPartyId(300L);
             verify(defendantAccountControlValidator, never()).validateCanMutateParty(account);
+            verify(em).lock(account, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
+            verify(em).flush();
         }
     }
 
@@ -531,13 +527,10 @@ class OpalDefendantAccountServiceTest03 {
             // employer null, language null
             .build();
 
-        DefendantAccountEntity bumpedAccount = DefendantAccountEntity.builder()
-            .defendantAccountId(accountId)
-            .versionNumber(2L)
-            .build();
-
-        when(defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(accountId)).thenReturn(bumpedAccount);
-        when(defendantAccountRepositoryService.saveAndFlush(bumpedAccount)).thenReturn(bumpedAccount);
+        doAnswer(invocation -> {
+            account.setVersionNumber(2L);
+            return null;
+        }).when(em).flush();
 
         try (MockedStatic<VersionUtils> vs = mockStatic(VersionUtils.class)) {
             vs.when(() -> VersionUtils.verifyIfMatch(any(), anyString(), anyLong(), anyString()))
@@ -572,8 +565,8 @@ class OpalDefendantAccountServiceTest03 {
             assertNull(saved.getDocumentLanguageDate());
             assertNull(saved.getHearingLanguageDate());
 
-            verify(defendantAccountRepositoryService).getDefendantAccountByIdForUpdate(accountId);
-            verify(defendantAccountRepositoryService).saveAndFlush(bumpedAccount);
+            verify(em).lock(account, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
+            verify(em).flush();
             verify(aliasRepoService, times(2)).findByPartyId(333L);
         }
     }
@@ -616,14 +609,12 @@ class OpalDefendantAccountServiceTest03 {
             .versionNumber(1L)
             .build();
 
-        DefendantAccountEntity bumpedAccount = DefendantAccountEntity.builder()
-            .defendantAccountId(accountId)
-            .versionNumber(2L)
-            .build();
+        doAnswer(invocation -> {
+            account.setVersionNumber(2L);
+            return null;
+        }).when(em).flush();
 
         when(defendantAccountRepositoryService.findById(accountId)).thenReturn(account);
-        when(defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(accountId)).thenReturn(bumpedAccount);
-        when(defendantAccountRepositoryService.saveAndFlush(bumpedAccount)).thenReturn(bumpedAccount);
         when(partyRepositoryService.findById(4001L)).thenReturn(defendantParty);
         when(aliasRepoService.findByPartyId(4001L)).thenReturn(emptyList());
         when(debtorRepoService.findById(4001L)).thenReturn(Optional.of(new DebtorDetailEntity()));
@@ -654,8 +645,8 @@ class OpalDefendantAccountServiceTest03 {
             assertEquals("Defendant", resp.getDefendantAccountParty().getDefendantAccountPartyType());
             assertEquals("4001", resp.getDefendantAccountParty().getPartyDetails().getPartyId());
             assertTrue(Boolean.TRUE.equals(resp.getDefendantAccountParty().getPartyDetails().getOrganisationFlag()));
-            verify(defendantAccountRepositoryService).getDefendantAccountByIdForUpdate(accountId);
-            verify(defendantAccountRepositoryService).saveAndFlush(bumpedAccount);
+            verify(em).lock(account, LockModeType.OPTIMISTIC_FORCE_INCREMENT);
+            verify(em).flush();
             verify(defendantAccountPartiesRepository)
                 .deleteByAccountIdAndAssociationTypeExcludingDapId(
                     accountId, AssociationType.PARENT_GUARDIAN, defendantDapId

--- a/src/test/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountRepositoryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/persistence/DefendantAccountRepositoryServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
+import java.math.BigInteger;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +21,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
+import uk.gov.hmcts.opal.entity.projection.DefendantAccountVersionData;
+import uk.gov.hmcts.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.opal.repository.DefendantAccountRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,6 +36,51 @@ class DefendantAccountRepositoryServiceTest {
 
     @InjectMocks
     private DefendantAccountRepositoryService service;
+
+    @Test
+    void incrementVersionNumber_whenUpdateSucceeds_returnsUpdatedVersion() {
+        // arrange
+        long defendantAccountId = 77L;
+        BigInteger expectedVersion = BigInteger.ONE;
+
+        when(defendantAccountRepository.incrementVersionNumber(defendantAccountId, 1L))
+            .thenReturn(1);
+        when(defendantAccountRepository.findVersionDataByDefendantAccountId(defendantAccountId))
+            .thenReturn(Optional.of(new DefendantAccountVersionData(defendantAccountId, 2L)));
+
+        // act
+        BigInteger result = service.incrementVersionNumber(defendantAccountId, expectedVersion);
+
+        // assert
+        assertThat(result).isEqualTo(BigInteger.valueOf(2L));
+        verify(entityManager).flush();
+        verify(defendantAccountRepository).incrementVersionNumber(defendantAccountId, 1L);
+        verify(defendantAccountRepository).findVersionDataByDefendantAccountId(defendantAccountId);
+    }
+
+    @Test
+    void incrementVersionNumber_whenVersionHasChanged_throwsResourceConflictException() {
+        // arrange
+        long defendantAccountId = 77L;
+        BigInteger expectedVersion = BigInteger.ONE;
+
+        when(defendantAccountRepository.incrementVersionNumber(defendantAccountId, 1L))
+            .thenReturn(0);
+
+        // act / assert
+        ResourceConflictException exception = assertThrows(
+            ResourceConflictException.class,
+            () -> service.incrementVersionNumber(defendantAccountId, expectedVersion)
+        );
+
+        assertThat(exception.getResourceType()).isEqualTo("DefendantAccountEntity");
+        assertThat(exception.getResourceId()).isEqualTo(String.valueOf(defendantAccountId));
+        assertThat(exception.getConflictReason()).isEqualTo("Version has changed since it was last read");
+
+        verify(entityManager).flush();
+        verify(defendantAccountRepository).incrementVersionNumber(defendantAccountId, 1L);
+        verifyNoMoreInteractions(defendantAccountRepository);
+    }
 
     @Test
     void findById_whenAccountExists_returnsAccount() {


### PR DESCRIPTION
### https://tools.hmcts.net/jira/browse/PO-2452 ###



### Change description ###
Replaced the non-atomic in-memory `versionNumber + 1` logic in `bumpVersion` with an atomic repository update.

Uses the existing account loaded by `findById` for validation and mutation
- flushes pending account-party changes before bumping the version
- increments `defendant_accounts.version_number` only when the current DB version matches the expected version
- returns the newly stored version so the response `ETag` reflects the bumped version immediately
- throws a conflict if the version was changed by another transaction before the bump

Tests:
 Updated `OpalDefendantAccountServiceTest03` to verify `incrementVersionNumber(...)` is called during successful replace-party flows
-  Added `DefendantAccountRepositoryServiceTest` coverage for:
- successful atomic version increment returning the updated version
- conflict handling when no row is updated


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
