### PR TITLE
PO-2395 Create tests for Individuals addresses api

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/hmrc/AbstractHmrcIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/hmrc/AbstractHmrcIntegrationTest.java
@@ -1,0 +1,127 @@
+package uk.gov.hmcts.opal.hmrc;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static uk.gov.hmcts.opal.TestContainerConfig.POSTGRES_CONTAINER;
+import static uk.gov.hmcts.opal.TestContainerConfig.REDIS_CONTAINER;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.cloud.openfeign.FeignAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.opal.Application;
+import uk.gov.hmcts.opal.TestContainerConfig;
+
+@SpringBootTest(classes = Application.class)
+@EnableFeignClients
+@ActiveProfiles("integration")
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {WireMockConfiguration.class})
+@ImportAutoConfiguration({FeignAutoConfiguration.class})
+@ComponentScan
+public class AbstractHmrcIntegrationTest {
+
+    private static final String wiremockHost = "localhost";
+    private static final int wiremockPort = 3000;
+
+    private static String getWiremockUrl() {
+        return wiremockHost + ":" + wiremockPort;
+    }
+
+    protected static final String exampleMatchId = "57072660-1df9-4aeb-b4ea-cd2d7f96e430";
+    protected static final String exampleCorrelationId = "57072660-1df9-4aeb-b4ea-cd2d7f96e430";
+    protected static final String exampleAcceptHeader = "application/vnd.hmrc.2.0+json";
+
+    protected final Logger log = LoggerFactory.getLogger(getClass());
+
+    private static WireMockServer mockServer;
+
+    @BeforeAll
+    public static void beforeAll() {
+        mockServer = new WireMockServer(wiremockPort);
+        mockServer.start();
+    }
+
+    @AfterAll
+    public static void teardown() {
+        mockServer.stop();
+    }
+
+
+    @BeforeEach
+    public void beforeEach() {
+        resetWireMock();
+    }
+
+    private void resetWireMock() {
+        WireMock.configureFor(wiremockHost, wiremockPort);
+        try {
+            WireMock.reset();
+        } catch (RuntimeException ex) {
+            log.debug("Skipping WireMock reset because legacy gateway is unavailable at {}",
+                TestContainerConfig.legacyGatewayUrl(), ex);
+        }
+    }
+
+    protected void withSuccessfulMock(String url, String body) {
+        stubFor(get(urlPathEqualTo(url))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .withBody(body)));
+    }
+
+    protected void withUnsuccessfulMock(String url, HttpStatus status, String body) {
+        stubFor(get(urlPathEqualTo(url))
+            .willReturn(aResponse()
+                .withStatus(status.value())
+                .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .withBody(body)));
+    }
+
+    protected void withTimeoutMock(String url, int delay) {
+        stubFor(get(urlPathEqualTo(url))
+            .willReturn(aResponse()
+                .withFixedDelay(delay)));
+    }
+
+    protected void verifyRequestHeader(String authHeader) {
+        mockServer.verify(
+            getRequestedFor(anyUrl())
+                .withHeader("Authorization", equalTo(authHeader))
+        );
+    }
+
+    // Dynamically register properties to configure the datasource
+    @DynamicPropertySource
+    static void databaseProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES_CONTAINER::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES_CONTAINER::getUsername);
+        registry.add("spring.datasource.password", POSTGRES_CONTAINER::getPassword);
+        registry.add("spring.data.redis.url", REDIS_CONTAINER::getRedisURI);
+        registry.add("legacy-gateway.url", TestContainerConfig::legacyGatewayUrl);
+        registry.add("individuals.url", AbstractHmrcIntegrationTest::getWiremockUrl);
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/opal/hmrc/IndividualsDetailsApiIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/hmrc/IndividualsDetailsApiIntegrationTest.java
@@ -1,0 +1,274 @@
+package uk.gov.hmcts.opal.hmrc;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import feign.FeignException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.hmcts.opal.hmrc.generated.IndividualsDetails.client.IndividualsApiClient;
+import uk.gov.hmcts.opal.service.hmrc.HmrcAuthentication;
+import uk.gov.hmcts.opal.testdata.IndividualsDetailsApiIntegrationTestData;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
+
+@TestPropertySource(properties = {
+    "spring.cloud.openfeign.client.config.individuals-api.connectTimeout=250",
+    "spring.cloud.openfeign.client.config.individuals-api.readTimeout=250"
+})
+public class IndividualsDetailsApiIntegrationTest extends AbstractHmrcIntegrationTest {
+
+    @Service
+    public static class TestAuthKey implements HmrcAuthentication {
+        public String getToken() {
+            return "test-auth-token";
+        }
+    }
+
+    @Autowired
+    private IndividualsApiClient api;
+
+    private final String individualsAddressesApiUrl = "/individuals/details/addresses";
+
+    @Test
+    @DisplayName("PO-2372 - Minimum data test")
+    @JiraStory("PO-2372")
+    @JiraEpic("PO-1421")
+    void returnsMinData() {
+        withSuccessfulMock(individualsAddressesApiUrl, IndividualsDetailsApiIntegrationTestData.minResponse);
+
+        var response =  api.getIndividualsDetailsAddresses(exampleMatchId, exampleCorrelationId, exampleAcceptHeader);
+
+        assertAll(
+            () -> assertEquals(HttpStatus.OK, response.getStatusCode()),
+            () -> assertEquals("", response.getBody().getLinks().getSelf().getHref()),
+            () -> assertEquals("", response.getBody().getResidences().getFirst().getResidenceType()),
+            () -> assertEquals(Boolean.TRUE, response.getBody().getResidences().getFirst().getInUse()),
+            () -> assertEquals("", response.getBody().getResidences().getFirst().getAddress().getLine1()),
+            () -> assertEquals("", response.getBody().getResidences().getFirst().getAddress().getLine2()),
+            () -> assertEquals("", response.getBody().getResidences().getFirst().getAddress().getLine3()),
+            () -> assertEquals("", response.getBody().getResidences().getFirst().getAddress().getLine4()),
+            () -> assertEquals("", response.getBody().getResidences().getFirst().getAddress().getLine5()),
+            () -> assertEquals("", response.getBody().getResidences().getFirst().getAddress().getPostcode())
+        );
+
+        verifyRequestHeader("Bearer test-auth-token");
+    }
+
+    @Test
+    @DisplayName("PO-2372 - Maximum data test")
+    @JiraStory("PO-2372")
+    @JiraEpic("PO-1421")
+    void returnsMaxData() {
+        withSuccessfulMock(individualsAddressesApiUrl, IndividualsDetailsApiIntegrationTestData.maxResponse);
+
+        var response =  api.getIndividualsDetailsAddresses(exampleMatchId, exampleCorrelationId, exampleAcceptHeader);
+
+        assertAll(
+            () -> assertEquals(HttpStatus.OK, response.getStatusCode()),
+            () -> assertEquals(
+                "/individuals/details?matchId=57072660-1df9-4aeb-b4ea-cd2d7f96e430",
+                response.getBody().getLinks().getSelf().getHref()
+            ),
+            () -> assertEquals("NOMINATED", response.getBody().getResidences().getFirst().getResidenceType()),
+            () -> assertEquals(Boolean.TRUE, response.getBody().getResidences().getFirst().getInUse()),
+            () -> assertEquals(
+                "24 Trinity Street",  response.getBody().getResidences().getFirst().getAddress().getLine1()
+            ),
+            () -> assertEquals(
+                "Dawley Bank", response.getBody().getResidences().getFirst().getAddress().getLine2()
+            ),
+            () -> assertEquals(
+                "Telford",
+                response.getBody().getResidences().getFirst().getAddress().getLine3()
+            ),
+            () -> assertEquals(
+                "Shropshire", response.getBody().getResidences().getFirst().getAddress().getLine4()
+            ),
+            () -> assertEquals(
+                "UK", response.getBody().getResidences().getFirst().getAddress().getLine5()
+            ),
+            () -> assertEquals(
+                "TF3 4ER", response.getBody().getResidences().getFirst().getAddress().getPostcode()
+            )
+        );
+
+        verifyRequestHeader("Bearer test-auth-token");
+    }
+
+    @Test
+    @DisplayName("PO-2372 - Required data only test")
+    @JiraStory("PO-2372")
+    @JiraEpic("PO-1421")
+    void returnsRequiredOnly() {
+        withSuccessfulMock(individualsAddressesApiUrl, IndividualsDetailsApiIntegrationTestData.requiredOnlyResponse);
+
+        var response =  api.getIndividualsDetailsAddresses(exampleMatchId, exampleCorrelationId, exampleAcceptHeader);
+
+        assertAll(
+            () -> assertEquals(HttpStatus.OK, response.getStatusCode()),
+            () -> assertEquals(
+                "/individuals/details?matchId=57072660-1df9-4aeb-b4ea-cd2d7f96e430",
+                response.getBody().getLinks().getSelf().getHref()
+            ),
+            () -> assertNull(response.getBody().getResidences())
+        );
+
+        verifyRequestHeader("Bearer test-auth-token");
+    }
+
+    @Test
+    @DisplayName("PO-2372 - Multiple items test")
+    @JiraStory("PO-2372")
+    @JiraEpic("PO-1421")
+    void multipleItems() {
+        withSuccessfulMock(individualsAddressesApiUrl, IndividualsDetailsApiIntegrationTestData.multipleItemsResponse);
+
+        var response =  api.getIndividualsDetailsAddresses(exampleMatchId, exampleCorrelationId, exampleAcceptHeader);
+
+        assertAll(
+            () -> assertEquals(HttpStatus.OK, response.getStatusCode()),
+            () -> assertEquals(
+                "/individuals/details?matchId=57072660-1df9-4aeb-b4ea-cd2d7f96e430",
+                response.getBody().getLinks().getSelf().getHref()
+            ),
+            () -> assertEquals("NOMINATED", response.getBody().getResidences().getFirst().getResidenceType()),
+            () -> assertEquals(Boolean.TRUE, response.getBody().getResidences().getFirst().getInUse()),
+            () -> assertEquals(
+                "24 Trinity Street",  response.getBody().getResidences().getFirst().getAddress().getLine1()
+            ),
+            () -> assertEquals(
+                "Dawley Bank", response.getBody().getResidences().getFirst().getAddress().getLine2()
+            ),
+            () -> assertEquals(
+                "Telford",
+                response.getBody().getResidences().getFirst().getAddress().getLine3()
+            ),
+            () -> assertEquals(
+                "Shropshire", response.getBody().getResidences().getFirst().getAddress().getLine4()
+            ),
+            () -> assertEquals(
+                "UK", response.getBody().getResidences().getFirst().getAddress().getLine5()
+            ),
+            () -> assertEquals(
+                "TF3 4ER", response.getBody().getResidences().getFirst().getAddress().getPostcode()
+            )
+        );
+
+        verifyRequestHeader("Bearer test-auth-token");
+    }
+
+    @Test
+    @DisplayName("PO-2372 - Bad request")
+    @JiraStory("PO-2372")
+    @JiraEpic("PO-1421")
+    void badRequest() {
+        withUnsuccessfulMock(
+            individualsAddressesApiUrl,
+            HttpStatus.BAD_REQUEST,
+            IndividualsDetailsApiIntegrationTestData.badRequestResponse
+        );
+
+        FeignException e = assertThrows(
+            FeignException.class,
+            () -> api.getIndividualsDetailsAddresses(exampleMatchId, exampleCorrelationId, exampleAcceptHeader)
+        );
+
+        String resBody = new String(e.responseBody().get().array(), StandardCharsets.UTF_8);
+
+        assertAll(
+            () -> assertEquals(HttpStatus.BAD_REQUEST.value(), e.status()),
+            () -> assertEquals("{\"code\":\"INVALID_REQUEST\"}", resBody),
+            () -> assertEquals(
+                "[400 Bad Request] during [GET] to [http://localhost:3000/individuals/details/addresses?"
+                    + "matchId=57072660-1df9-4aeb-b4ea-cd2d7f96e430] [IndividualsApiClient#"
+                    + "getIndividualsDetailsAddresses(String,String,String)]: [{\"code\":\"INVALID_REQUEST\"}]",
+                e.getMessage()
+            )
+        );
+
+        verifyRequestHeader("Bearer test-auth-token");
+    }
+
+    @Test
+    @DisplayName("PO-2372 - Not found request")
+    @JiraStory("PO-2372")
+    @JiraEpic("PO-1421")
+    void notFoundRequest() {
+        withUnsuccessfulMock(
+            individualsAddressesApiUrl,
+            HttpStatus.NOT_FOUND,
+            IndividualsDetailsApiIntegrationTestData.notFoundResponse
+        );
+
+        FeignException e = assertThrows(
+            FeignException.class,
+            () -> api.getIndividualsDetailsAddresses(exampleMatchId, exampleCorrelationId, exampleAcceptHeader)
+        );
+
+        String resBody = new String(e.responseBody().get().array(), StandardCharsets.UTF_8);
+
+        assertAll(
+            () -> assertEquals(HttpStatus.NOT_FOUND.value(), e.status()),
+            () -> assertEquals("{\"code\":\"NOT_FOUND\"}", resBody),
+            () -> assertEquals(
+                "[404 Not Found] during [GET] to [http://localhost:3000/individuals/details/addresses?"
+                    + "matchId=57072660-1df9-4aeb-b4ea-cd2d7f96e430] [IndividualsApiClient#"
+                    + "getIndividualsDetailsAddresses(String,String,String)]: [{\"code\":\"NOT_FOUND\"}]",
+                e.getMessage()
+            )
+        );
+
+        verifyRequestHeader("Bearer test-auth-token");
+    }
+
+    @Test
+    @DisplayName("PO-2372 - Request times out")
+    @JiraStory("PO-2372")
+    @JiraEpic("PO-1421")
+    void timesOutRequest() {
+        withTimeoutMock(individualsAddressesApiUrl, 500);
+
+        FeignException e = assertThrows(
+            FeignException.class,
+            () -> api.getIndividualsDetailsAddresses(exampleMatchId, exampleCorrelationId, exampleAcceptHeader)
+        );
+
+        assertAll(
+            () -> assertEquals(
+                "Read timed out executing GET http://localhost:3000/individuals/details/addresses?"
+                    + "matchId=57072660-1df9-4aeb-b4ea-cd2d7f96e430",
+                e.getMessage()
+            )
+        );
+
+        verifyRequestHeader("Bearer test-auth-token");
+    }
+
+    @Test
+    @DisplayName("PO-2372 - Request returns internal server error")
+    @JiraStory("PO-2372")
+    @JiraEpic("PO-1421")
+    void handleServerErrors() {
+        withUnsuccessfulMock(individualsAddressesApiUrl, HttpStatus.INTERNAL_SERVER_ERROR, "");
+
+        FeignException e = assertThrows(
+            FeignException.class,
+            () -> api.getIndividualsDetailsAddresses(exampleMatchId, exampleCorrelationId, exampleAcceptHeader)
+        );
+
+        assertAll(
+            () -> assertEquals("Retryable PDPO response status=500", e.getMessage()),
+            () -> assertEquals(500, e.status())
+        );
+
+        verifyRequestHeader("Bearer test-auth-token");
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/opal/testdata/IndividualsDetailsApiIntegrationTestData.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/testdata/IndividualsDetailsApiIntegrationTestData.java
@@ -1,0 +1,144 @@
+package uk.gov.hmcts.opal.testdata;
+
+import static uk.gov.hmcts.opal.common.dto.ToJsonString.toJsonString;
+
+import java.util.List;
+import uk.gov.hmcts.opal.hmrc.generated.IndividualsDetails.model.Address;
+import uk.gov.hmcts.opal.hmrc.generated.IndividualsDetails.model.IndividualsDetailsAddressesResponse;
+import uk.gov.hmcts.opal.hmrc.generated.IndividualsDetails.model.IndividualsDetailsResponse400;
+import uk.gov.hmcts.opal.hmrc.generated.IndividualsDetails.model.IndividualsDetailsResponse404;
+import uk.gov.hmcts.opal.hmrc.generated.IndividualsDetails.model.Links1;
+import uk.gov.hmcts.opal.hmrc.generated.IndividualsDetails.model.Residence;
+import uk.gov.hmcts.opal.hmrc.generated.IndividualsDetails.model.Self;
+
+public final class IndividualsDetailsApiIntegrationTestData {
+    public static final String minResponse = toJsonString(
+        new IndividualsDetailsAddressesResponse.Builder()
+            .links(
+                Links1.builder()
+                    .self(
+                        Self.builder()
+                            .href("")
+                            .build()
+                    )
+                    .build()
+            )
+            .residences(List.of(
+                new Residence.Builder()
+                    .residenceType("")
+                    .inUse(Boolean.TRUE)
+                    .address(
+                        new Address.Builder()
+                            .line1("")
+                            .line2("")
+                            .line3("")
+                            .line4("")
+                            .line5("")
+                            .postcode("")
+                            .build()
+                    )
+                    .build()
+            ))
+            .build()
+    );
+
+    public static final String maxResponse = toJsonString(
+        new IndividualsDetailsAddressesResponse.Builder()
+            .links(
+                Links1.builder()
+                    .self(
+                        Self.builder()
+                            .href("/individuals/details?matchId=57072660-1df9-4aeb-b4ea-cd2d7f96e430")
+                            .build()
+                    )
+                    .build()
+            )
+            .residences(List.of(
+                new Residence.Builder()
+                    .residenceType("NOMINATED")
+                    .inUse(Boolean.TRUE)
+                    .address(
+                        new Address.Builder()
+                            .line1("24 Trinity Street")
+                            .line2("Dawley Bank")
+                            .line3("Telford")
+                            .line4("Shropshire")
+                            .line5("UK")
+                            .postcode("TF3 4ER")
+                            .build()
+                    )
+                    .build()
+            ))
+            .build()
+    );
+
+    public static final String requiredOnlyResponse = toJsonString(
+        new IndividualsDetailsAddressesResponse.Builder()
+            .links(
+                Links1.builder()
+                    .self(
+                        Self.builder()
+                            .href("/individuals/details?matchId=57072660-1df9-4aeb-b4ea-cd2d7f96e430")
+                            .build()
+                    )
+                    .build()
+            )
+            .build()
+    );
+
+    public static final String multipleItemsResponse = toJsonString(
+        new IndividualsDetailsAddressesResponse.Builder()
+            .links(
+                Links1.builder()
+                    .self(
+                        Self.builder()
+                            .href("/individuals/details?matchId=57072660-1df9-4aeb-b4ea-cd2d7f96e430")
+                            .build()
+                    )
+                    .build()
+            )
+            .residences(List.of(
+                new Residence.Builder()
+                    .residenceType("NOMINATED")
+                    .inUse(Boolean.TRUE)
+                    .address(
+                        new Address.Builder()
+                            .line1("24 Trinity Street")
+                            .line2("Dawley Bank")
+                            .line3("Telford")
+                            .line4("Shropshire")
+                            .line5("UK")
+                            .postcode("TF3 4ER")
+                            .build()
+                    )
+                    .build(),
+                new Residence.Builder()
+                    .residenceType("BASE")
+                    .inUse(Boolean.FALSE)
+                    .address(
+                        new Address.Builder()
+                            .line1("La Petite Maison")
+                            .line2("Rue de Bastille")
+                            .line3("Vieux Ville")
+                            .line4("Dordogne")
+                            .line5("Grange")
+                            .build()
+                    )
+                    .build()
+            ))
+            .build()
+    );
+
+    public static final String badRequestResponse = toJsonString(
+        new IndividualsDetailsResponse400().toBuilder()
+            .code("INVALID_REQUEST")
+            .build()
+    );
+
+    public static final String notFoundResponse = toJsonString(
+        new IndividualsDetailsResponse404().toBuilder()
+            .code("NOT_FOUND")
+            .build()
+    );
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -201,3 +201,6 @@ logging-service:
       protocol: ${SERVICEBUS_LOGGING_PDPL_PROTOCOL:amqp}
       connection-string: ${SERVICEBUS_CONNECTION_STRING:Endpoint=sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=local;UseDevelopmentEmulator=true}
       queue-name: ${SERVICEBUS_LOGGING_PDPL_QUEUE_NAME:logging-pdpl}
+
+individuals:
+  name: individuals-api

--- a/src/test/java/uk/gov/hmcts/opal/hmrc/HmrcApiClientConfig.java
+++ b/src/test/java/uk/gov/hmcts/opal/hmrc/HmrcApiClientConfig.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.opal.hmrc;
+
+import feign.Retryer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class HmrcApiClientConfig {
+
+    @Bean
+    public Retryer retryer() {
+        return new Retryer.Default(1, 20, 3);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/hmrc/IndividualsApiClientTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/hmrc/IndividualsApiClientTest.java
@@ -1,0 +1,215 @@
+package uk.gov.hmcts.opal.hmrc;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.hmcts.opal.common.dto.ToJsonString.toJsonString;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import feign.FeignException;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.cloud.openfeign.FeignAutoConfiguration;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import uk.gov.hmcts.opal.config.FeignConfiguration;
+import uk.gov.hmcts.opal.hmrc.generated.IndividualsDetails.client.IndividualsApiClient;
+import uk.gov.hmcts.opal.hmrc.generated.IndividualsDetails.model.Address;
+import uk.gov.hmcts.opal.hmrc.generated.IndividualsDetails.model.IndividualsDetailsAddressesResponse;
+import uk.gov.hmcts.opal.hmrc.generated.IndividualsDetails.model.Links1;
+import uk.gov.hmcts.opal.hmrc.generated.IndividualsDetails.model.Residence;
+import uk.gov.hmcts.opal.hmrc.generated.IndividualsDetails.model.Self;
+
+@EnableFeignClients(basePackages = "uk.gov.hmcts.opal.*", defaultConfiguration = FeignConfiguration.class)
+@ExtendWith(SpringExtension.class)
+@TestPropertySource(properties = {
+    "spring.cloud.openfeign.client.config.individuals-api.connectTimeout=250",
+    "spring.cloud.openfeign.client.config.individuals-api.readTimeout=250",
+    "individuals.name=individuals-api",
+    "user.service.url=localhost:3000",
+    "individuals.url=localhost:3000"
+})
+@ImportAutoConfiguration(FeignAutoConfiguration.class)
+public class IndividualsApiClientTest {
+
+    private static final String wiremockHost = "localhost";
+    private static final int wiremockPort = 3000;
+    private final String individualsAddressesApiUrl = "/individuals/details/addresses";
+    protected static final String exampleMatchId = "57072660-1df9-4aeb-b4ea-cd2d7f96e430";
+    protected static final String exampleCorrelationId = "57072660-1df9-4aeb-b4ea-cd2d7f96e430";
+    protected static final String exampleAcceptHeader = "application/vnd.hmrc.2.0+json";
+
+    private static WireMockServer mockServer;
+
+    @Autowired
+    private IndividualsApiClient api;
+
+    @BeforeAll
+    public static void beforeAll() {
+        mockServer = new WireMockServer(wiremockPort);
+        mockServer.start();
+    }
+
+    @AfterAll
+    public static void teardown() {
+        mockServer.stop();
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        resetWireMock();
+    }
+
+    private void resetWireMock() {
+        WireMock.configureFor(wiremockHost, wiremockPort);
+        WireMock.reset();
+    }
+
+    protected void withStub(String url, HttpStatus status, String body) {
+        stubFor(get(urlPathEqualTo(url))
+            .willReturn(aResponse()
+                .withStatus(status.value())
+                .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .withBody(body)));
+    }
+
+    protected void withTimeout(String url, int delay) {
+        stubFor(get(urlPathEqualTo(url))
+            .willReturn(aResponse()
+                .withFixedDelay(delay)));
+    }
+
+    @Test
+    public void testSuccess() {
+        withStub(individualsAddressesApiUrl, HttpStatus.OK, toJsonString(
+            new IndividualsDetailsAddressesResponse.Builder()
+                .links(new Links1.Builder()
+                    .self(new Self.Builder()
+                        .href("/individuals/details/addresses")
+                        .build()
+                    ).build()
+                )
+                .residences(List.of(
+                    new Residence.Builder()
+                        .residenceType("NOMINATED")
+                        .inUse(Boolean.TRUE)
+                        .address(new Address.Builder()
+                            .line1("123 fake st")
+                            .build()
+                        ).build()
+                ))
+                .build()
+        ));
+
+        ResponseEntity<IndividualsDetailsAddressesResponse> response = api.getIndividualsDetailsAddresses(
+            exampleMatchId, exampleCorrelationId, exampleAcceptHeader);
+
+
+        assertAll(
+            () -> assertEquals(HttpStatus.OK, response.getStatusCode()),
+            () -> assertEquals("/individuals/details/addresses", response.getBody().getLinks().getSelf().getHref()),
+            () -> assertEquals("NOMINATED", response.getBody().getResidences().getFirst().getResidenceType()),
+            () -> assertEquals(Boolean.TRUE, response.getBody().getResidences().getFirst().getInUse()),
+            () -> assertEquals("123 fake st", response.getBody().getResidences().getFirst().getAddress().getLine1()),
+            () -> assertNull(response.getBody().getResidences().getFirst().getAddress().getLine2()),
+            () -> assertNull(response.getBody().getResidences().getFirst().getAddress().getLine3()),
+            () -> assertNull(response.getBody().getResidences().getFirst().getAddress().getLine4()),
+            () -> assertNull(response.getBody().getResidences().getFirst().getAddress().getLine5()),
+            () -> assertNull(response.getBody().getResidences().getFirst().getAddress().getPostcode())
+        );
+    }
+
+    @Test
+    public void testUnauthorized() {
+        withStub(individualsAddressesApiUrl, HttpStatus.UNAUTHORIZED, "");
+
+        FeignException e = assertThrows(
+            FeignException.class,
+            () -> api.getIndividualsDetailsAddresses(exampleMatchId, exampleCorrelationId, exampleAcceptHeader)
+        );
+
+        assertAll(
+            () -> assertEquals(HttpStatus.UNAUTHORIZED.value(), e.status()),
+            () -> assertEquals(
+                "[401 Unauthorized] during [GET] to "
+                    + "[http://localhost:3000/individuals/details/addresses?matchId=57072660-1df9-4aeb-b4ea-cd2d7f96e430] "
+                    + "[IndividualsApiClient#getIndividualsDetailsAddresses(String,String,String)]: []",
+                e.getMessage()
+            )
+        );
+    }
+
+    @Test
+    public void testNotFound() {
+        withStub(individualsAddressesApiUrl, HttpStatus.NOT_FOUND, "");
+
+        FeignException e = assertThrows(
+            FeignException.class,
+            () -> api.getIndividualsDetailsAddresses(exampleMatchId, exampleCorrelationId, exampleAcceptHeader)
+        );
+
+        assertAll(
+            () -> assertEquals(HttpStatus.NOT_FOUND.value(), e.status()),
+            () -> assertEquals(
+                "[404 Not Found] during [GET] to "
+                    + "[http://localhost:3000/individuals/details/addresses?matchId=57072660-1df9-4aeb-b4ea-cd2d7f96e430] "
+                    + "[IndividualsApiClient#getIndividualsDetailsAddresses(String,String,String)]: []",
+                e.getMessage()
+            )
+        );
+    }
+
+    @Test
+    public void testInternalServerError() {
+        withStub(individualsAddressesApiUrl, HttpStatus.INTERNAL_SERVER_ERROR, "");
+
+        FeignException e = assertThrows(
+            FeignException.class,
+            () -> api.getIndividualsDetailsAddresses(exampleMatchId, exampleCorrelationId, exampleAcceptHeader)
+        );
+
+        assertAll(
+            () -> assertEquals(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.status()),
+            () -> assertEquals(
+                "[500 Server Error] during [GET] to "
+                    + "[http://localhost:3000/individuals/details/addresses?matchId=57072660-1df9-4aeb-b4ea-cd2d7f96e430] "
+                    + "[IndividualsApiClient#getIndividualsDetailsAddresses(String,String,String)]: []",
+                e.getMessage()
+            )
+        );
+    }
+
+    @Test
+    public void testTimeouts() {
+        withTimeout(individualsAddressesApiUrl, 5000);
+
+        FeignException e = assertThrows(
+            FeignException.class,
+            () -> api.getIndividualsDetailsAddresses(exampleMatchId, exampleCorrelationId, exampleAcceptHeader)
+        );
+
+        assertAll(
+            () -> assertEquals(
+                "Read timed out executing GET http://localhost:3000"
+                    + "/individuals/details/addresses?matchId=57072660-1df9-4aeb-b4ea-cd2d7f96e430",
+                e.getMessage()
+            )
+        );
+    }
+}


### PR DESCRIPTION
[### JIRA link (if applicable) ###](https://tools.hmcts.net/jira/browse/PO-2372)

Integrated & Added tests for HMRC's  individual's addresses api.

Note: The openapi spec has not been committed as there is an ongoing conversation about the secrecy required for this.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
