### PR TITLE
PO-2351 Implement Alias Surname Starts-with Search

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsSearchIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/OpalDefendantsSearchIntegrationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.controllers;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -1094,6 +1095,87 @@ class OpalDefendantsSearchIntegrationTest extends AbstractIntegrationTest {
 
         actions.andExpect(status().isOk()).andExpect(jsonPath("$.count").value(1))
             .andExpect(jsonPath("$.defendant_accounts[0].aliases[0].surname").value("AliasSurname1"));
+    }
+
+    @ParameterizedTest(name = "consolidated={0}")
+    @ValueSource(booleans = {false, true})
+    @DisplayName("OPAL: Alias surname search only matches aliases starting with input")
+    @JiraStory("PO-2351")
+    @JiraEpic("PO-2294")
+    void testPostDefendantAccountsSearch_Opal_AliasSurnameStartsWith(boolean consolidation) throws Exception {
+        ResultActions actions = mockMvc.perform(
+            post(DEFENDANTS_SEARCH_URL)
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .contentType(MediaType.APPLICATION_JSON).content("""
+                        {
+                          "active_accounts_only": true,
+                          "business_unit_ids": [9999],
+                          "reference_number": null,
+                          "defendant": {
+                            "include_aliases": true,
+                            "organisation": false,
+                            "surname": "sent",
+                            "exact_match_surname": false,
+                            "forenames": null,
+                            "exact_match_forenames": null,
+                            "address_line_1": null,
+                            "postcode": null,
+                            "organisation_name": null,
+                            "exact_match_organisation_name": null,
+                            "birth_date": null,
+                            "national_insurance_number": null
+                         },
+                         "consolidation_search": %s
+                    }""".formatted(consolidation)));
+
+        String body = actions.andReturn().getResponse().getContentAsString();
+        log.info(":testPostDefendantAccountsSearch_Opal_AliasSurnameStartsWith: Response body:\n{}",
+            ToJsonString.toPrettyJson(body));
+
+        actions.andExpect(status().isOk()).andExpect(jsonPath("$.count").value(2))
+            .andExpect(jsonPath("$.defendant_accounts[*].defendant_account_id")
+                .value(containsInAnyOrder("235101", "235104")));
+    }
+
+    @ParameterizedTest(name = "consolidated={0}")
+    @ValueSource(booleans = {false, true})
+    @DisplayName("OPAL: Alias surname exact match does not return starts-with aliases")
+    @JiraStory("PO-2351")
+    @JiraEpic("PO-2294")
+    void testPostDefendantAccountsSearch_Opal_AliasSurnameExactMatch(boolean consolidation) throws Exception {
+        ResultActions actions = mockMvc.perform(
+            post(DEFENDANTS_SEARCH_URL)
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .contentType(MediaType.APPLICATION_JSON).content("""
+                        {
+                          "active_accounts_only": true,
+                          "business_unit_ids": [9999],
+                          "reference_number": null,
+                          "defendant": {
+                            "include_aliases": true,
+                            "organisation": false,
+                            "surname": "sent",
+                            "exact_match_surname": true,
+                            "forenames": null,
+                            "exact_match_forenames": null,
+                            "address_line_1": null,
+                            "postcode": null,
+                            "organisation_name": null,
+                            "exact_match_organisation_name": null,
+                            "birth_date": null,
+                            "national_insurance_number": null
+                         },
+                         "consolidation_search": %s
+                    }""".formatted(consolidation)));
+
+        String body = actions.andReturn().getResponse().getContentAsString();
+        log.info(":testPostDefendantAccountsSearch_Opal_AliasSurnameExactMatch: Response body:\n{}",
+            ToJsonString.toPrettyJson(body));
+
+        actions.andExpect(status().isOk()).andExpect(jsonPath("$.count").value(1))
+            .andExpect(jsonPath("$.defendant_accounts[0].defendant_account_id").value("235104"));
     }
 
     @ParameterizedTest(name = "consolidated={0}")

--- a/src/integrationTest/resources/db/deleteData/delete_from_defendant_accounts.sql
+++ b/src/integrationTest/resources/db/deleteData/delete_from_defendant_accounts.sql
@@ -5,6 +5,7 @@ WHERE alias_id IN (
                    8801, 9011,               -- existing (88, 901)
                    5551, 5552, 6661, 6662, 7771,
                    10001, 10002, 10003, 10004, 10005, 100011, 100012, 100013,
+                   2351011, 2351021, 2351031, 2351041,
                    200101, 200102,           -- org aliases for party 20010 (NEW)
                    2200401                   -- individual alias for party 22004 (NEW)
     );
@@ -13,6 +14,7 @@ WHERE alias_id IN (
 DELETE FROM aliases
 WHERE party_id IN (
                    77, 88, 901, 333, 555, 666, 777, 444, 999, 77444, 10001, 10002, 10003,
+                   235101, 235102, 235103, 235104,
                    20010, 22004, 920010      -- NEW: party used by individual-aliases IT
     );
 
@@ -20,6 +22,7 @@ WHERE party_id IN (
 DELETE FROM defendant_account_parties
 WHERE defendant_account_party_id IN (
                                      991198, 991199, 77, 78, 88, 901, 333, 555, 666, 777, 444, 999, 10001, 10002, 10003, 10004, 9077, 77444,
+                                     235101, 235102, 235103, 235104,
                                      2006, -- test for remove DAP
                                      20010, 22004, 920011 -- NEW
     );
@@ -32,6 +35,7 @@ WHERE defendant_account_id IN (262901, 262902);
 DELETE FROM fixed_penalty_offences
 WHERE defendant_account_id IN (
                                77, 88, 901, 333, 555, 666, 777, 444, 999, 9077, 77444,
+                               235101, 235102, 235103, 235104,
                                20010, 22004     -- NEW
     );
 
@@ -39,6 +43,7 @@ WHERE defendant_account_id IN (
 DELETE FROM payment_terms
 WHERE defendant_account_id IN (
                                77, 88, 901, 333, 555, 666, 777, 444, 999, 10001, 10002, 10003, 10004, 9077, 77444,
+                               235101, 235102, 235103, 235104,
                                20010, 22004,
                                262901, 262902
     );
@@ -47,6 +52,7 @@ WHERE defendant_account_id IN (
 DELETE FROM notes
 WHERE associated_record_id IN (
                                '77', '88', '901', '333', '555', '666', '777', '444', '999', '9077', '77444',
+                               '235101', '235102', '235103', '235104',
                                '20010', '22004'   -- NEW
     );
 
@@ -78,6 +84,7 @@ WHERE defendant_account_id IN (20010, 22004);
 DELETE FROM defendant_accounts
 WHERE defendant_account_id IN (
                                991198, 991199, 77, 78, 88, 901, 333, 555, 666, 777, 444, 999, 10001, 10002, 10003, 10004, 9077, 77444,
+                               235101, 235102, 235103, 235104,
                                2006, -- test for remove DAP
                                20010, 22004,
                                262901, 262902
@@ -87,6 +94,7 @@ WHERE defendant_account_id IN (
 DELETE FROM debtor_detail
 WHERE party_id IN (
                    77, 78, 88, 901, 333, 555, 666, 777, 444, 999, 10001, 10002, 10003, 10004, 77444,
+                   235101, 235102, 235103, 235104,
                    206, -- test for remove DAP
                    20010, 22004, 920010,
                    262901, 262902
@@ -96,6 +104,7 @@ WHERE party_id IN (
 DELETE FROM parties
 WHERE party_id IN (
                    991198, 991199, 77, 78, 88, 901, 333, 555, 666, 777, 444, 999, 10001, 10002, 10003, 10004, 77444,
+                   235101, 235102, 235103, 235104,
                    206, -- test for remove DAP
                    20010, 22004, 920010,
                    262901, 262902

--- a/src/integrationTest/resources/db/insertData/insert_into_defendant_accounts.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_defendant_accounts.sql
@@ -483,6 +483,44 @@ INSERT INTO defendant_account_parties (defendant_account_party_id, defendant_acc
 VALUES (999, 999, 999,
         'Defendant', 'Y');
 
+-- PO-2351 alias surname starts-with search records under BU 9999
+INSERT INTO defendant_accounts (defendant_account_id, version_number, business_unit_id, account_number,
+                                amount_paid, account_balance, amount_imposed, account_status,
+                                prosecutor_case_reference, allow_writeoffs, allow_cheques, account_type,
+                                collection_order, payment_card_requested)
+VALUES
+    (235101, 0, 9999, '235101A', 0.00, 10.00, 10.00, 'L', '235101PCR', 'N', 'N', 'Fine', 'N', 'N'),
+    (235102, 0, 9999, '235102A', 0.00, 10.00, 10.00, 'L', '235102PCR', 'N', 'N', 'Fine', 'N', 'N'),
+    (235103, 0, 9999, '235103A', 0.00, 10.00, 10.00, 'L', '235103PCR', 'N', 'N', 'Fine', 'N', 'N'),
+    (235104, 0, 9999, '235104A', 0.00, 10.00, 10.00, 'L', '235104PCR', 'N', 'N', 'Fine', 'N', 'N')
+ON CONFLICT (defendant_account_id) DO NOTHING;
+
+INSERT INTO parties (party_id, organisation, organisation_name,
+                     surname, forenames, title)
+VALUES
+    (235101, 'N', NULL, 'ControlSurname235101', 'ControlForenames235101', 'Mr'),
+    (235102, 'N', NULL, 'ControlSurname235102', 'ControlForenames235102', 'Mr'),
+    (235103, 'N', NULL, 'ControlSurname235103', 'ControlForenames235103', 'Mr'),
+    (235104, 'N', NULL, 'ControlSurname235104', 'ControlForenames235104', 'Mr')
+ON CONFLICT (party_id) DO NOTHING;
+
+INSERT INTO defendant_account_parties (defendant_account_party_id, defendant_account_id, party_id,
+                                       association_type, debtor)
+VALUES
+    (235101, 235101, 235101, 'Defendant', 'Y'),
+    (235102, 235102, 235102, 'Defendant', 'Y'),
+    (235103, 235103, 235103, 'Defendant', 'Y'),
+    (235104, 235104, 235104, 'Defendant', 'Y')
+ON CONFLICT (defendant_account_party_id) DO NOTHING;
+
+INSERT INTO aliases (alias_id, party_id, surname, forenames, sequence_number, organisation_name)
+VALUES
+    (2351011, 235101, 'Sentinel', 'AliasForenames235101', 1, NULL),
+    (2351021, 235102, 'Desenti', 'AliasForenames235102', 1, NULL),
+    (2351031, 235103, 'Crescent', 'AliasForenames235103', 1, NULL),
+    (2351041, 235104, 'Sent', 'AliasForenames235104', 1, NULL)
+ON CONFLICT (alias_id) DO NOTHING;
+
 -- Debug/inspection row: dedicated account+party with distinctive link id (77444)
 -- Placed under BU 9999 to avoid influencing BU=78 count-based tests
 INSERT INTO defendant_accounts (defendant_account_id, version_number, business_unit_id, account_number,

--- a/src/main/java/uk/gov/hmcts/opal/repository/jpa/SearchDefendantAccountSpecs.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/jpa/SearchDefendantAccountSpecs.java
@@ -214,7 +214,7 @@ public abstract class SearchDefendantAccountSpecs<E extends SearchDefendantAccou
         String orgName, boolean exactOrgName, boolean includeAliases) {
 
         return includeAliases
-            ? aliasNamePredicates(root, cb, orgName, !exactOrgName, false)
+            ? aliasNamePredicates(root, cb, orgName, !exactOrgName)
             : List.of();
     }
 
@@ -226,7 +226,7 @@ public abstract class SearchDefendantAccountSpecs<E extends SearchDefendantAccou
         String forenames, boolean exactForenames) {
 
         return hasContentToSearchOn(forenames)
-            ? aliasNamePredicates(root, cb, forenames, !exactForenames, false)
+            ? aliasNamePredicates(root, cb, forenames, !exactForenames)
             : List.of();
     }
 
@@ -234,17 +234,30 @@ public abstract class SearchDefendantAccountSpecs<E extends SearchDefendantAccou
         String surname, boolean exactSurname) {
 
         return hasContentToSearchOn(surname)
-            ? aliasNamePredicates(root, cb, surname, !exactSurname, true)
+            ? aliasSurnameNamePredicates(root, cb, surname, exactSurname)
             : List.of();
     }
 
     private List<Predicate> aliasNamePredicates(
-        From<?, E> root, CriteriaBuilder cb, String searchAlias, boolean useWildcard, boolean useEndsWith) {
+        From<?, E> root, CriteriaBuilder cb, String searchAlias, boolean useWildcard) {
 
-        // Match the Forename to the start, and the Surname to the end, of the concatenated data.
         return strippedAliasPaths(root, cb).stream()
-            .map(path -> useEndsWithOrStartsWith(path, cb, searchAlias, useWildcard, useEndsWith))
+            .map(path -> useWildcardOrStartsWith(path, cb, searchAlias, useWildcard))
             .toList();
+    }
+
+    private List<Predicate> aliasSurnameNamePredicates(
+        From<?, E> root, CriteriaBuilder cb, String surname, boolean exactSurname) {
+
+        return listOfAliasPaths(root).stream()
+            .map(path -> aliasSurnamePath(path, cb))
+            .map(path -> useEqualsOrStartsWith(path, cb, surname, exactSurname))
+            .toList();
+    }
+
+    private Expression<String> aliasSurnamePath(Path<String> aliasPath, CriteriaBuilder cb) {
+        return stripChars(cb, cb.function(
+            "regexp_replace", String.class, aliasPath, cb.literal("^.*\\s+"), cb.literal("")));
     }
 
     public Predicate matchPersonNamesPredicate(From<?, E> from, CriteriaBuilder cb,
@@ -277,14 +290,12 @@ public abstract class SearchDefendantAccountSpecs<E extends SearchDefendantAccou
             : likeLowerCaseStartsWithPredicate(dbPath, cb, comparisonText);
     }
 
-    private Predicate useEndsWithOrStartsWith(Expression<String> dbPath, CriteriaBuilder cb,
-        String comparisonText, boolean useWildcard, boolean useEndsWith) {
+    private Predicate useWildcardOrStartsWith(Expression<String> dbPath, CriteriaBuilder cb,
+        String comparisonText, boolean useWildcard) {
 
         return useWildcard
             ? likeLowerCaseWildcardPredicate(dbPath, cb, comparisonText)
-            : useEndsWith
-                ? likeLowerCaseEndsWithPredicate(dbPath, cb, comparisonText)
-                : likeLowerCaseStartsWithPredicate(dbPath, cb, comparisonText);
+            : likeLowerCaseStartsWithPredicate(dbPath, cb, comparisonText);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/opal/repository/jpa/SearchDefendantAccountSpecsTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/repository/jpa/SearchDefendantAccountSpecsTest.java
@@ -1,0 +1,103 @@
+package uk.gov.hmcts.opal.repository.jpa;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.metamodel.SingularAttribute;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.domain.Specification;
+import uk.gov.hmcts.opal.dto.search.DefendantDto;
+import uk.gov.hmcts.opal.entity.search.SearchDefendantAccount.BasicEntity;
+
+class SearchDefendantAccountSpecsTest {
+
+    @Test
+    void matchPersonNamesAndAliases_aliasSurnameUsesStartsWithWhenExactMatchIsFalse() {
+        CriteriaMocks criteria = criteriaMocks();
+        SearchBasicEntitySpecs specs = new SearchBasicEntitySpecs();
+
+        Specification<BasicEntity> specification = specs.matchPersonNamesAndAliases(DefendantDto.builder()
+            .includeAliases(true)
+            .organisation(false)
+            .surname("sent")
+            .exactMatchSurname(false)
+            .build(), true);
+
+        specification.toPredicate(criteria.root, criteria.query, criteria.cb);
+
+        verify(criteria.cb, atLeastOnce()).like(criteria.lowerAliasSurname, "sent%");
+        verify(criteria.cb, times(5)).function(eq("regexp_replace"), eq(String.class), any(Expression.class),
+            any(Expression.class), any(Expression.class));
+        verify(criteria.cb, never()).like(criteria.lowerAliasSurname, "%sent%");
+        verify(criteria.cb, never()).like(criteria.lowerAliasSurname, "%sent");
+    }
+
+    @Test
+    void matchPersonNamesAndAliases_aliasSurnameUsesEqualsWhenExactMatchIsTrue() {
+        CriteriaMocks criteria = criteriaMocks();
+        SearchBasicEntitySpecs specs = new SearchBasicEntitySpecs();
+
+        Specification<BasicEntity> specification = specs.matchPersonNamesAndAliases(DefendantDto.builder()
+            .includeAliases(true)
+            .organisation(false)
+            .surname("sent")
+            .exactMatchSurname(true)
+            .build(), true);
+
+        specification.toPredicate(criteria.root, criteria.query, criteria.cb);
+
+        verify(criteria.cb, atLeastOnce()).equal(criteria.lowerAliasSurname, "sent");
+        verify(criteria.cb, times(5)).function(eq("regexp_replace"), eq(String.class), any(Expression.class),
+            any(Expression.class), any(Expression.class));
+        verify(criteria.cb, never()).like(criteria.lowerAliasSurname, "%sent%");
+        verify(criteria.cb, never()).like(criteria.lowerAliasSurname, "%sent");
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private CriteriaMocks criteriaMocks() {
+        Root<BasicEntity> root = mock(Root.class);
+        CriteriaBuilder cb = mock(CriteriaBuilder.class);
+        Path aliasPath = mock(Path.class);
+        Expression<String> literal = mock(Expression.class);
+        Expression<String> regexpAliasSurname = mock(Expression.class);
+        Expression<String> strippedAliasSurname = mock(Expression.class);
+        Expression<String> lowerAliasSurname = mock(Expression.class);
+        Predicate predicate = mock(Predicate.class);
+
+        when(root.get((SingularAttribute) isNull(SingularAttribute.class))).thenReturn(aliasPath);
+        when(cb.literal(anyString())).thenReturn(literal);
+        when(cb.function(eq("regexp_replace"), eq(String.class), any(Expression.class), any(Expression.class),
+            any(Expression.class))).thenReturn(regexpAliasSurname);
+        when(cb.function(eq("translate"), eq(String.class), any(Expression.class), any(Expression.class),
+            any(Expression.class))).thenReturn(strippedAliasSurname);
+        when(cb.lower(strippedAliasSurname)).thenReturn(lowerAliasSurname);
+        when(cb.like(any(Expression.class), anyString())).thenReturn(predicate);
+        when(cb.equal(any(Expression.class), anyString())).thenReturn(predicate);
+        when(cb.isFalse(any(Expression.class))).thenReturn(predicate);
+        when(cb.or(any(Predicate[].class))).thenReturn(predicate);
+        when(cb.and(any(Predicate[].class))).thenReturn(predicate);
+
+        return new CriteriaMocks(root, mock(CriteriaQuery.class), cb, lowerAliasSurname);
+    }
+
+    private record CriteriaMocks(
+        Root<BasicEntity> root,
+        CriteriaQuery<?> query,
+        CriteriaBuilder cb,
+        Expression<String> lowerAliasSurname) {
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-2351


### Change description ###
- Updated alias surname search to use starts-with matching, with exact match remaining exact-only.
- Added unit and integration coverage for starts-with, exact match, and excluding mid/end alias matches.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
