### PR TITLE
PO 1858 Account status date not updated after patching a new status of deleted

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/opal/assertions/draftaccount/DraftAccountAssertions.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/assertions/draftaccount/DraftAccountAssertions.java
@@ -2,7 +2,10 @@ package uk.gov.hmcts.opal.assertions.draftaccount;
 
 import io.restassured.response.Response;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import net.serenitybdd.rest.SerenityRest;
 import uk.gov.hmcts.opal.assertions.CommonResponseAssertions;
@@ -77,6 +80,30 @@ public class DraftAccountAssertions {
         assertTrue(
             apiAccountStatusDate.isAfter(originalAccountStatusDate),
             "Account status date is not after the initial account status date"
+        );
+    }
+
+    /**
+     * Asserts that the account-status timestamp falls on the date recorded for the Deleted
+     * timeline entry.
+     *
+     * @param response retrieved draft-account response to inspect.
+     */
+    public void assertAccountStatusDateMatchesDeletedDate(Response response) {
+        Instant accountStatusDate = Instant.parse(response.jsonPath().getString("account_status_date"));
+        List<Map<String, Object>> timelineEntries = response.jsonPath().getList("timeline_data");
+
+        Map<String, Object> deletedEntry = timelineEntries.stream()
+            .filter(entry -> "Deleted".equals(entry.get("status")))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("No Deleted timeline entry was returned"));
+
+        LocalDate deletedDate = LocalDate.parse(String.valueOf(deletedEntry.get("status_date")));
+
+        assertEquals(
+            deletedDate,
+            accountStatusDate.atZone(ZoneOffset.UTC).toLocalDate(),
+            "Account status date does not match the deleted date"
         );
     }
 

--- a/src/functionalTest/java/uk/gov/hmcts/opal/steps/draftaccount/DraftAccountPutSteps.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/steps/draftaccount/DraftAccountPutSteps.java
@@ -78,6 +78,14 @@ public class DraftAccountPutSteps extends BaseStepDef {
     }
 
     /**
+     * Asserts that the account-status date has the same calendar date as the Deleted timeline entry.
+     */
+    @Then("the account status date matches the deleted date")
+    public void accountStatusDateMatchesDeletedDate() {
+        assertions.assertAccountStatusDateMatchesDeletedDate(SerenityRest.lastResponse());
+    }
+
+    /**
      * Attempts to put a draft-account using an invalid bearer token.
      */
     @When("I attempt to put a draft account with an invalid token")

--- a/src/functionalTest/resources/features/opalMode/draftAccounts/update/UpdateDraftAccount.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/update/UpdateDraftAccount.feature
@@ -52,9 +52,9 @@ Feature: Update Draft Accounts
       | timeline_data[1].username           | PATCH002_REVIEWER    |
       | timeline_data[1].reason_text        | Reason for rejection |
 
-  @JIRA-STORY:PO-745 @cleanUpData @JIRA-EPIC:PO-2220 @JIRA-TEST-KEY:PO-5686
+  @JIRA-STORY:PO-745 @JIRA-STORY:PO-1858 @cleanUpData @JIRA-EPIC:PO-2220 @JIRA-TEST-KEY:PO-5686
   Scenario: Mark a submitted draft account as deleted
-    And a draft account exists with the following details
+    And a replaceable draft account exists with the following details
       | business_unit_id  | 73                                          |
       | account           | draftAccounts/accountJson/adultAccount.json |
       | account_type      | Fine                                        |
@@ -81,6 +81,8 @@ Feature: Update Draft Accounts
       | timeline_data[1].status             | Deleted             |
       | timeline_data[1].username           | BUUID_REVIEWER      |
       | timeline_data[1].reason_text        | Reason for deletion |
+    And I see the account status date is now after the initial account status date
+    And the account status date matches the deleted date
 
   @JIRA-STORY:PO-2358 @JIRA-LABEL:personal-data-processing-logging @cleanUpData @JIRA-EPIC:PO-2355 @JIRA-TEST-KEY:PO-5687
   Scenario: Reject publishing a parent or guardian draft account

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactional.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactional.java
@@ -208,6 +208,7 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
         if (newStatus.isDeleted()) {
             checkDeleterIsNotSubmitter(existingAccount.getSubmittedBy(), userState.getUserName(), draftAccountId,
                 userState, dto.getBusinessUnitId());
+            existingAccount.setAccountStatusDate(LocalDateTime.now(clock));
         }
 
         existingAccount.setTimelineData(

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
@@ -630,6 +630,7 @@ class DraftAccountTransactionalTest {
             draftAccountId, updateDto, draftAccountTransactional, BigInteger.ZERO, userState);
 
         assertEquals(DraftAccountStatus.DELETED, result.getAccountStatus());
+        assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), result.getAccountStatusDate());
         verify(securityEventLoggingService, never()).logEvent(any(), any(), any(), any(), any(), any());
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-1858


### Change description ###
When a status of "Deleted" is patched to an existing draft account using the draft-accounts endpoint the account_status_date is not being updated to reflect the deleted date. The PATCH flow was already updating the account status to Deleted, but it was not updating account_status_date. The fix adds that timestamp update when the deleted status is applied.
This should resolve the issue where the Deleted tab shows the wrong date for deleted draft accounts.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
