### PR TITLE
PO-5752 Validate draft enforcement result IDs

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1a/CommonDraftAccountControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1a/CommonDraftAccountControllerIntegrationTest.java
@@ -119,4 +119,17 @@ class CommonDraftAccountControllerIntegrationTest extends AbstractIntegrationTes
         return draftAccountRepository.findById(draftAccountId).orElseThrow();
     }
 
+    protected static String withPaymentTermsEnforcement(String requestBody, String resultId) {
+        return requestBody.replace(
+            "\"default_days_in_jail\": 5",
+            """
+                "default_days_in_jail": 5,
+                            "enforcements": [
+                              {
+                                "result_id": "%s"
+                              }
+                            ]
+                """.formatted(resultId).stripIndent().trim()
+        );
+    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1a/DraftAccountControllerPostIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1a/DraftAccountControllerPostIntegrationTest.java
@@ -23,7 +23,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.opal.dto.AddDraftAccountRequestDto;
 import uk.gov.hmcts.opal.dto.ToJsonString;
 import uk.gov.hmcts.opal.entity.draft.DraftAccountEntity;
@@ -152,7 +154,7 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
         + "[@PO-973, @PO-591]")
     @JiraStory("PO-973")
     @JiraStory("PO-591")
-    @JiraEpic("PO-2219")
+    @JiraEpic("PO-8248")
     @JiraTestKey("PO-5863")
     void testPostDraftAccount_permission() throws Exception {
 
@@ -186,7 +188,7 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
     @Test
     @DisplayName("Should ignore blank submitted_by_name")
     @JiraStory("PO-691")
-    @JiraEpic("PO-2219")
+    @JiraEpic("PO-8248")
     @JiraTestKey("PO-5853")
     void shouldIgnoreBlankSubmittedByName() throws Exception {
         String request = validCreateRequestBody()
@@ -202,7 +204,7 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
     @Test
     @DisplayName("Should ignore blank submitted_by")
     @JiraStory("PO-691")
-    @JiraEpic("PO-2219")
+    @JiraEpic("PO-8248")
     @JiraTestKey("PO-5864")
     void shouldIgnoreBlankSubmittedBy() throws Exception {
         String request = validCreateRequestBody()
@@ -397,7 +399,70 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
             .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/invalid-reference-validation"))
             .andExpect(jsonPath("$.detail").value(containsString("$.offences[0].impositions[0].result_id")))
             .andExpect(jsonPath("$.detail").value(containsString("result id COLLO is not an imposition result")));
+    }
 
+    @Test
+    @DisplayName("Create draft account - Should return 400 when payment term enforcement result is missing")
+    @JiraStory("PO-5752")
+    @JiraEpic("PO-8248")
+    @Sql(scripts = "classpath:db/deleteData/delete_from_results_collo.sql",
+        executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Transactional
+    void shouldReturn400WhenPaymentTermEnforcementResultIsMissing() throws Exception {
+        mockMvc.perform(post(URL_BASE)
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(withPaymentTermsEnforcement(validCreateRequestBody(), "COLLO")))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(expectBadRequestWithoutStatus(
+                expectedPaymentTermsEnforcementValidationErrorMessage("COLLO does not exist"),
+                "https://hmcts.gov.uk/problems/invalid-reference-validation"
+            ));
+    }
+
+    @Test
+    @DisplayName("Create draft account - Should return 400 when payment term enforcement result is not an enforcement")
+    @JiraStory("PO-5752")
+    @JiraEpic("PO-8248")
+    @Sql(scripts = "classpath:db/insertData/insert_into_results_collo_non_enforcement.sql",
+        executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Transactional
+    void shouldReturn400WhenPaymentTermEnforcementResultIsNotAnEnforcement() throws Exception {
+        mockMvc.perform(post(URL_BASE)
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(withPaymentTermsEnforcement(validCreateRequestBody(), "COLLO")))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(expectBadRequestWithoutStatus(
+                expectedPaymentTermsEnforcementValidationErrorMessage("COLLO is not an enforcement result"),
+                "https://hmcts.gov.uk/problems/invalid-reference-validation"
+            ));
+    }
+
+    @Test
+    @DisplayName("Create draft account - Should return 400 when payment term enforcement result is inactive")
+    @JiraStory("PO-5752")
+    @JiraEpic("PO-8248")
+    @Sql(scripts = "classpath:db/insertData/insert_into_results_collo_inactive.sql",
+        executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Transactional
+    void shouldReturn400WhenPaymentTermEnforcementResultIsInactive() throws Exception {
+        mockMvc.perform(post(URL_BASE)
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(withPaymentTermsEnforcement(validCreateRequestBody(), "COLLO")))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(expectBadRequestWithoutStatus(
+                expectedPaymentTermsEnforcementValidationErrorMessage("COLLO is not an active result"),
+                "https://hmcts.gov.uk/problems/invalid-reference-validation"
+            ));
+>>>>>>> 73904a486 (PO-5752 Add integration coverage for invalid draft enforcement results)
     }
 
     @Test
@@ -798,6 +863,13 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
              - $.offences[0].impositions[0].result_id: result id NOT-A-RESULT does not exist
              - $.offences[0].impositions[0].major_creditor_id: major creditor id 999996 does not exist
             """.stripIndent().stripTrailing();
+    }
+
+    private static String expectedPaymentTermsEnforcementValidationErrorMessage(String resultError) {
+        return """
+            Draft account reference validation failed with 1 error(s):
+             - $.payment_terms.enforcements[0].result_id: result id %s
+            """.formatted(resultError).stripIndent().stripTrailing();
     }
 
     private static String invalidCreateRequestBody() {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1a/DraftAccountControllerPostIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1a/DraftAccountControllerPostIntegrationTest.java
@@ -462,7 +462,6 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
                 expectedPaymentTermsEnforcementValidationErrorMessage("COLLO is not an active result"),
                 "https://hmcts.gov.uk/problems/invalid-reference-validation"
             ));
->>>>>>> 73904a486 (PO-5752 Add integration coverage for invalid draft enforcement results)
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1a/DraftAccountControllerPutIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1a/DraftAccountControllerPutIntegrationTest.java
@@ -517,6 +517,8 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
         assertEquals(before.getValidatedByName(), after.getValidatedByName());
         assertEquals(before.getAccountSnapshot(), after.getAccountSnapshot());
         assertEquals(before.getTimelineData(), after.getTimelineData());
+    }
+
     @Test
     @DisplayName("PO-5746: Replace draft account - Should return 400 for an invalid offence ID")
     @JiraStory("PO-5746")
@@ -607,30 +609,6 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
             .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
             .andExpect(expectBadRequestWithoutStatus(
                 expectedPaymentTermsEnforcementValidationErrorMessage("COLLO is not an active result"),
-                "https://hmcts.gov.uk/problems/invalid-reference-validation"
-            ));
-    }
-
-    @Test
-    @DisplayName("Replace draft account - Should return 400 when payment term enforcement result is inactive")
-    @JiraStory("PO-5752")
-    @JiraEpic("PO-8248")
-    @Sql(scripts = "classpath:db/insertData/insert_into_results_collo_inactive.sql",
-        executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
-    @Transactional
-    void shouldReturn400WhenPutPaymentTermEnforcementResultIsInactive() throws Exception {
-        String ifMatch = getIfMatchForDraftAccount(5L);
-        mockMvc.perform(put(URL_BASE + "/5")
-                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
-                .header("authorization", userStateStub.getBearerToken())
-                .header("If-Match", ifMatch)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(withPaymentTermsEnforcement(validReplaceRequestBody(0L), "COLLO")))
-            .andExpect(status().isBadRequest())
-            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
-            .andExpect(expectBadRequestWithoutStatus(
-                expectedPaymentTermsEnforcementValidationErrorMessage("COLLO is not an active result"),
->>>>>>> 4480d3016 (PO-5752 Add integration coverage for invalid draft enforcement results):src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPutIntegrationTest.java
                 "https://hmcts.gov.uk/problems/invalid-reference-validation"
             ));
     }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1a/DraftAccountControllerPutIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1a/DraftAccountControllerPutIntegrationTest.java
@@ -21,7 +21,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.opal.dto.DraftAccountResponseDto;
 import uk.gov.hmcts.opal.dto.PdplIdentifierType;
 import uk.gov.hmcts.opal.dto.ToJsonString;
@@ -40,7 +42,7 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
     @DisplayName("Replace draft account - Should return updated draft account [@PO-973, @PO-746]")
     @JiraStory("PO-973")
     @JiraStory("PO-746")
-    @JiraEpic("PO-2220")
+    @JiraEpic("PO-8248")
     @JiraTestKey("PO-5869")
     void testReplaceDraftAccount_success() throws Exception {
         String requestBody = validReplaceRequestBody(0L);
@@ -78,7 +80,7 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
     @Test
     @DisplayName("Replace draft account - Should return 400 when originator_type is missing")
     @JiraStory("PO-747")
-    @JiraEpic("PO-2220")
+    @JiraEpic("PO-8248")
     @JiraTestKey("PO-5872")
     void testReplaceDraftAccount_originatorTypeIsMissing() throws Exception {
         String request = validCreateRequestBody()
@@ -96,7 +98,7 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
     @Test
     @DisplayName("Replace draft account - Should return 400 when originator_type is blank")
     @JiraStory("PO-747")
-    @JiraEpic("PO-2220")
+    @JiraEpic("PO-8248")
     @JiraTestKey("PO-5874")
     void testReplaceDraftAccount_originatorTypeIsBlank() throws Exception {
         String request = validCreateRequestBody()
@@ -515,8 +517,6 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
         assertEquals(before.getValidatedByName(), after.getValidatedByName());
         assertEquals(before.getAccountSnapshot(), after.getAccountSnapshot());
         assertEquals(before.getTimelineData(), after.getTimelineData());
-    }
-
     @Test
     @DisplayName("PO-5746: Replace draft account - Should return 400 for an invalid offence ID")
     @JiraStory("PO-5746")
@@ -538,6 +538,99 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
                 Draft account reference validation failed with 1 error(s):
                  - account.offences[0].offence_id: offence id 999998 does not exist
                 """.stripIndent().stripTrailing(),
+                "https://hmcts.gov.uk/problems/invalid-reference-validation"
+            ));
+    }
+
+    @Test
+    @DisplayName("Replace draft account - Should return 400 when payment term enforcement result is missing")
+    @JiraStory("PO-5752")
+    @JiraEpic("PO-8248")
+    @Sql(scripts = "classpath:db/deleteData/delete_from_results_collo.sql",
+        executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Transactional
+    void shouldReturn400WhenPutPaymentTermEnforcementResultIsMissing() throws Exception {
+        String ifMatch = getIfMatchForDraftAccount(5L);
+        mockMvc.perform(put(URL_BASE + "/5")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .header("If-Match", ifMatch)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(withPaymentTermsEnforcement(validReplaceRequestBody(0L), "COLLO")))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(expectBadRequestWithoutStatus(
+                expectedPaymentTermsEnforcementValidationErrorMessage("COLLO does not exist"),
+                "https://hmcts.gov.uk/problems/invalid-reference-validation"
+            ));
+    }
+
+    @Test
+    @DisplayName("Replace draft account - Should return 400 when payment term enforcement result is not an enforcement")
+    @JiraStory("PO-5752")
+    @JiraEpic("PO-8248")
+    @Sql(scripts = "classpath:db/insertData/insert_into_results_collo_non_enforcement.sql",
+        executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Transactional
+    void shouldReturn400WhenPutPaymentTermEnforcementResultIsNotAnEnforcement() throws Exception {
+        String ifMatch = getIfMatchForDraftAccount(5L);
+        mockMvc.perform(put(URL_BASE + "/5")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .header("If-Match", ifMatch)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(withPaymentTermsEnforcement(validReplaceRequestBody(0L), "COLLO")))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(expectBadRequestWithoutStatus(
+                expectedPaymentTermsEnforcementValidationErrorMessage("COLLO is not an enforcement result"),
+                "https://hmcts.gov.uk/problems/invalid-reference-validation"
+            ));
+    }
+
+    @Test
+    @DisplayName("Replace draft account - Should return 400 when payment term enforcement result is inactive")
+    @JiraStory("PO-5752")
+    @JiraEpic("PO-8248")
+    @Sql(scripts = "classpath:db/insertData/insert_into_results_collo_inactive.sql",
+        executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Transactional
+    void shouldReturn400WhenPutPaymentTermEnforcementResultIsInactive() throws Exception {
+        String ifMatch = getIfMatchForDraftAccount(5L);
+        mockMvc.perform(put(URL_BASE + "/5")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .header("If-Match", ifMatch)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(withPaymentTermsEnforcement(validReplaceRequestBody(0L), "COLLO")))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(expectBadRequestWithoutStatus(
+                expectedPaymentTermsEnforcementValidationErrorMessage("COLLO is not an active result"),
+                "https://hmcts.gov.uk/problems/invalid-reference-validation"
+            ));
+    }
+
+    @Test
+    @DisplayName("Replace draft account - Should return 400 when payment term enforcement result is inactive")
+    @JiraStory("PO-5752")
+    @JiraEpic("PO-8248")
+    @Sql(scripts = "classpath:db/insertData/insert_into_results_collo_inactive.sql",
+        executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Transactional
+    void shouldReturn400WhenPutPaymentTermEnforcementResultIsInactive() throws Exception {
+        String ifMatch = getIfMatchForDraftAccount(5L);
+        mockMvc.perform(put(URL_BASE + "/5")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .header("If-Match", ifMatch)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(withPaymentTermsEnforcement(validReplaceRequestBody(0L), "COLLO")))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(expectBadRequestWithoutStatus(
+                expectedPaymentTermsEnforcementValidationErrorMessage("COLLO is not an active result"),
+>>>>>>> 4480d3016 (PO-5752 Add integration coverage for invalid draft enforcement results):src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPutIntegrationTest.java
                 "https://hmcts.gov.uk/problems/invalid-reference-validation"
             ));
     }
@@ -751,6 +844,13 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
              - $.offences[0].impositions[0].result_id: result id NOT-A-RESULT does not exist
              - $.offences[0].impositions[0].major_creditor_id: major creditor id 999996 does not exist
             """.stripIndent().stripTrailing();
+    }
+
+    private static String expectedPaymentTermsEnforcementValidationErrorMessage(String resultError) {
+        return """
+            Draft account reference validation failed with 1 error(s):
+             - $.payment_terms.enforcements[0].result_id: result id %s
+            """.formatted(resultError).stripIndent().stripTrailing();
     }
 
     private static String validReplaceRequestBodyForPdpl(Long version) {

--- a/src/integrationTest/resources/db/deleteData/delete_from_results_collo.sql
+++ b/src/integrationTest/resources/db/deleteData/delete_from_results_collo.sql
@@ -1,0 +1,8 @@
+DELETE FROM result_documents
+WHERE result_id = 'COLLO';
+
+DELETE FROM enforcements
+WHERE result_id = 'COLLO';
+
+DELETE FROM results
+WHERE result_id = 'COLLO';

--- a/src/integrationTest/resources/db/insertData/insert_into_results_collo_inactive.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_results_collo_inactive.sql
@@ -1,0 +1,75 @@
+DELETE FROM result_documents
+WHERE result_id = 'COLLO';
+
+DELETE FROM enforcements
+WHERE result_id = 'COLLO';
+
+DELETE FROM results
+WHERE result_id = 'COLLO';
+
+INSERT INTO results
+(
+    result_id,
+    result_title,
+    result_title_cy,
+    result_type,
+    active,
+    imposition,
+    imposition_category,
+    imposition_allocation_priority,
+    imposition_accruing,
+    imposition_creditor,
+    enforcement,
+    enforcement_override,
+    further_enforcement_warn,
+    further_enforcement_disallow,
+    enforcement_hold,
+    requires_enforcer,
+    generates_hearing,
+    generates_warrant,
+    collection_order,
+    extend_ttp_disallow,
+    extend_ttp_preserve_last_enf,
+    prevent_payment_card,
+    lists_monies,
+    result_parameters,
+    allow_payment_terms,
+    requires_employment_data,
+    allow_additional_action,
+    enf_next_permitted_actions,
+    requires_lja,
+    manual_enforcement
+)
+VALUES
+    (
+        'COLLO',
+        'Payment terms enforcement test result',
+        'Canlyniad prawf termau talu',
+        'Action',
+        FALSE,
+        FALSE,
+        NULL,
+        NULL,
+        FALSE,
+        NULL,
+        TRUE,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        NULL,
+        FALSE,
+        NULL,
+        FALSE,
+        NULL,
+        NULL,
+        FALSE
+    );

--- a/src/integrationTest/resources/db/insertData/insert_into_results_collo_non_enforcement.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_results_collo_non_enforcement.sql
@@ -1,0 +1,75 @@
+DELETE FROM result_documents
+WHERE result_id = 'COLLO';
+
+DELETE FROM enforcements
+WHERE result_id = 'COLLO';
+
+DELETE FROM results
+WHERE result_id = 'COLLO';
+
+INSERT INTO results
+(
+    result_id,
+    result_title,
+    result_title_cy,
+    result_type,
+    active,
+    imposition,
+    imposition_category,
+    imposition_allocation_priority,
+    imposition_accruing,
+    imposition_creditor,
+    enforcement,
+    enforcement_override,
+    further_enforcement_warn,
+    further_enforcement_disallow,
+    enforcement_hold,
+    requires_enforcer,
+    generates_hearing,
+    generates_warrant,
+    collection_order,
+    extend_ttp_disallow,
+    extend_ttp_preserve_last_enf,
+    prevent_payment_card,
+    lists_monies,
+    result_parameters,
+    allow_payment_terms,
+    requires_employment_data,
+    allow_additional_action,
+    enf_next_permitted_actions,
+    requires_lja,
+    manual_enforcement
+)
+VALUES
+    (
+        'COLLO',
+        'Payment terms enforcement test result',
+        'Canlyniad prawf termau talu',
+        'Action',
+        TRUE,
+        FALSE,
+        NULL,
+        NULL,
+        FALSE,
+        NULL,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE,
+        NULL,
+        FALSE,
+        NULL,
+        FALSE,
+        NULL,
+        NULL,
+        FALSE
+    );

--- a/src/main/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.opal.entity.result.ResultEntity;
 import uk.gov.hmcts.opal.exception.InvalidReferenceValidationException;
 import uk.gov.hmcts.opal.exception.JsonSchemaValidationException;
+import uk.gov.hmcts.opal.entity.result.ResultEntity;
 import uk.gov.hmcts.opal.repository.CourtLiteRepository;
 import uk.gov.hmcts.opal.repository.MajorCreditorRepository;
 import uk.gov.hmcts.opal.repository.OffenceRepository;
@@ -25,6 +26,8 @@ public class DraftAccountReferenceValidationService {
 
     private static final String ROOT_PATH = "$";
     private static final String DOES_NOT_EXIST = " does not exist";
+    private static final String IS_NOT_AN_ENFORCEMENT_RESULT = " is not an enforcement result";
+    private static final String IS_NOT_AN_ACTIVE_RESULT = " is not an active result";
 
     private final CourtLiteRepository courtLiteRepository;
     private final OffenceRepository offenceRepository;
@@ -133,8 +136,23 @@ public class DraftAccountReferenceValidationService {
             String enforcementPath = ROOT_PATH + ".payment_terms.enforcements[" + enforcementIndex + "]";
 
             String resultId = safeReadString(docContext, enforcementPath + ".result_id", null);
-            if (resultId != null && !resultRepository.existsById(resultId)) {
+            if (resultId == null) {
+                continue;
+            }
+
+            ResultEntity result = resultRepository.findById(resultId).orElse(null);
+            if (result == null) {
                 failures.add(enforcementPath + ".result_id: result id " + resultId + DOES_NOT_EXIST);
+                continue;
+            }
+
+            if (!result.isEnforcement()) {
+                failures.add(enforcementPath + ".result_id: result id " + resultId + IS_NOT_AN_ENFORCEMENT_RESULT);
+                continue;
+            }
+
+            if (!result.isActive()) {
+                failures.add(enforcementPath + ".result_id: result id " + resultId + IS_NOT_AN_ACTIVE_RESULT);
             }
         }
     }

--- a/src/main/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationService.java
@@ -26,6 +26,7 @@ public class DraftAccountReferenceValidationService {
 
     private static final String ROOT_PATH = "$";
     private static final String DOES_NOT_EXIST = " does not exist";
+    private static final String RESULT_ID_PREFIX = ".result_id: result id ";
     private static final String IS_NOT_AN_ENFORCEMENT_RESULT = " is not an enforcement result";
     private static final String IS_NOT_AN_ACTIVE_RESULT = " is not an active result";
 
@@ -95,7 +96,13 @@ public class DraftAccountReferenceValidationService {
                 String impositionPath = offencePath + ".impositions[" + impositionIndex + "]";
 
                 String resultId = safeReadString(docContext, impositionPath + ".result_id", null);
+<<<<<<< HEAD
                 validateImpositionResult(resultId, impositionPath + ".result_id", failures);
+=======
+                if (resultId != null && !resultRepository.existsById(resultId)) {
+                    failures.add(impositionPath + RESULT_ID_PREFIX + resultId + DOES_NOT_EXIST);
+                }
+>>>>>>> 8435c8eb9 (PO-5752 SonarQube)
 
                 Long majorCreditorId = safeReadLong(docContext, impositionPath + ".major_creditor_id");
                 if (majorCreditorId != null && !majorCreditorRepository.existsById(majorCreditorId)) {
@@ -136,23 +143,15 @@ public class DraftAccountReferenceValidationService {
             String enforcementPath = ROOT_PATH + ".payment_terms.enforcements[" + enforcementIndex + "]";
 
             String resultId = safeReadString(docContext, enforcementPath + ".result_id", null);
-            if (resultId == null) {
-                continue;
-            }
-
-            ResultEntity result = resultRepository.findById(resultId).orElse(null);
-            if (result == null) {
-                failures.add(enforcementPath + ".result_id: result id " + resultId + DOES_NOT_EXIST);
-                continue;
-            }
-
-            if (!result.isEnforcement()) {
-                failures.add(enforcementPath + ".result_id: result id " + resultId + IS_NOT_AN_ENFORCEMENT_RESULT);
-                continue;
-            }
-
-            if (!result.isActive()) {
-                failures.add(enforcementPath + ".result_id: result id " + resultId + IS_NOT_AN_ACTIVE_RESULT);
+            if (resultId != null) {
+                ResultEntity result = resultRepository.findById(resultId).orElse(null);
+                if (result == null) {
+                    failures.add(enforcementPath + RESULT_ID_PREFIX + resultId + DOES_NOT_EXIST);
+                } else if (!result.isEnforcement()) {
+                    failures.add(enforcementPath + RESULT_ID_PREFIX + resultId + IS_NOT_AN_ENFORCEMENT_RESULT);
+                } else if (!result.isActive()) {
+                    failures.add(enforcementPath + RESULT_ID_PREFIX + resultId + IS_NOT_AN_ACTIVE_RESULT);
+                }
             }
         }
     }

--- a/src/main/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationService.java
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.opal.entity.result.ResultEntity;
 import uk.gov.hmcts.opal.exception.InvalidReferenceValidationException;
 import uk.gov.hmcts.opal.exception.JsonSchemaValidationException;
-import uk.gov.hmcts.opal.entity.result.ResultEntity;
 import uk.gov.hmcts.opal.repository.CourtLiteRepository;
 import uk.gov.hmcts.opal.repository.MajorCreditorRepository;
 import uk.gov.hmcts.opal.repository.OffenceRepository;
@@ -96,13 +95,7 @@ public class DraftAccountReferenceValidationService {
                 String impositionPath = offencePath + ".impositions[" + impositionIndex + "]";
 
                 String resultId = safeReadString(docContext, impositionPath + ".result_id", null);
-<<<<<<< HEAD
                 validateImpositionResult(resultId, impositionPath + ".result_id", failures);
-=======
-                if (resultId != null && !resultRepository.existsById(resultId)) {
-                    failures.add(impositionPath + RESULT_ID_PREFIX + resultId + DOES_NOT_EXIST);
-                }
->>>>>>> 8435c8eb9 (PO-5752 SonarQube)
 
                 Long majorCreditorId = safeReadLong(docContext, impositionPath + ".major_creditor_id");
                 if (majorCreditorId != null && !majorCreditorRepository.existsById(majorCreditorId)) {

--- a/src/test/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -48,12 +47,12 @@ class DraftAccountReferenceValidationServiceTest {
         when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), eq((short) 77))).thenReturn(true);
         when(resultRepository.existsById(anyString())).thenReturn(true);
         when(majorCreditorRepository.existsById(anyLong())).thenReturn(true);
-        when(resultRepository.findById(eq("COLLO"))).thenReturn(Optional.of(ResultEntity.builder()
+        when(resultRepository.findById("COLLO")).thenReturn(Optional.of(ResultEntity.builder()
             .resultId("COLLO")
             .enforcement(true)
             .active(true)
             .build()));
-        when(resultRepository.findById(eq("NOENF"))).thenReturn(Optional.of(ResultEntity.builder()
+        when(resultRepository.findById("NOENF")).thenReturn(Optional.of(ResultEntity.builder()
             .resultId("NOENF")
             .enforcement(true)
             .active(true)
@@ -187,23 +186,24 @@ class DraftAccountReferenceValidationServiceTest {
 
     @Test
     void validateReferences_whenPaymentTermsEnforcementResultIsNotAnEnforcement_shouldFail() {
+        String accountJson = validAccountJson();
         when(courtLiteRepository.existsById(anyLong())).thenReturn(true);
         when(offenceRepository.existsById(anyLong())).thenReturn(true);
         when(resultRepository.existsById(anyString())).thenReturn(true);
         when(majorCreditorRepository.existsById(anyLong())).thenReturn(true);
-        when(resultRepository.findById(eq("COLLO"))).thenReturn(Optional.of(ResultEntity.builder()
+        when(resultRepository.findById("COLLO")).thenReturn(Optional.of(ResultEntity.builder()
             .resultId("COLLO")
             .enforcement(false)
             .active(true)
             .build()));
-        when(resultRepository.findById(eq("NOENF"))).thenReturn(Optional.of(ResultEntity.builder()
+        when(resultRepository.findById("NOENF")).thenReturn(Optional.of(ResultEntity.builder()
             .resultId("NOENF")
             .enforcement(true)
             .active(true)
             .build()));
 
         InvalidReferenceValidationException exception = assertThrows(InvalidReferenceValidationException.class,
-            () -> service.validateReferences(validAccountJson()));
+            () -> service.validateReferences(accountJson));
 
         assertContains(exception.getMessage(), "$.payment_terms.enforcements[0].result_id");
         assertContains(exception.getMessage(), "result id COLLO is not an enforcement result");
@@ -211,23 +211,24 @@ class DraftAccountReferenceValidationServiceTest {
 
     @Test
     void validateReferences_whenPaymentTermsEnforcementResultIsInactive_shouldFail() {
+        String accountJson = validAccountJson();
         when(courtLiteRepository.existsById(anyLong())).thenReturn(true);
         when(offenceRepository.existsById(anyLong())).thenReturn(true);
         when(resultRepository.existsById(anyString())).thenReturn(true);
         when(majorCreditorRepository.existsById(anyLong())).thenReturn(true);
-        when(resultRepository.findById(eq("COLLO"))).thenReturn(Optional.of(ResultEntity.builder()
+        when(resultRepository.findById("COLLO")).thenReturn(Optional.of(ResultEntity.builder()
             .resultId("COLLO")
             .enforcement(true)
             .active(false)
             .build()));
-        when(resultRepository.findById(eq("NOENF"))).thenReturn(Optional.of(ResultEntity.builder()
+        when(resultRepository.findById("NOENF")).thenReturn(Optional.of(ResultEntity.builder()
             .resultId("NOENF")
             .enforcement(true)
             .active(true)
             .build()));
 
         InvalidReferenceValidationException exception = assertThrows(InvalidReferenceValidationException.class,
-            () -> service.validateReferences(validAccountJson()));
+            () -> service.validateReferences(accountJson));
 
         assertContains(exception.getMessage(), "$.payment_terms.enforcements[0].result_id");
         assertContains(exception.getMessage(), "result id COLLO is not an active result");

--- a/src/test/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationServiceTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.opal.service;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -24,6 +23,8 @@ import uk.gov.hmcts.opal.repository.ResultRepository;
 @ExtendWith(MockitoExtension.class)
 class DraftAccountReferenceValidationServiceTest {
 
+    private static final short BUSINESS_UNIT_ID = 77;
+
     @Mock
     private CourtLiteRepository courtLiteRepository;
 
@@ -42,29 +43,19 @@ class DraftAccountReferenceValidationServiceTest {
     @Test
     void validateReferences_whenAllReferencesExist_shouldPass() {
         when(courtLiteRepository.existsById(anyLong())).thenReturn(true);
+        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), BUSINESS_UNIT_ID)).thenReturn(true);
         when(resultRepository.findById("FO")).thenReturn(Optional.of(activeImpositionResult("FO")));
         when(resultRepository.findById("FVS")).thenReturn(Optional.of(activeImpositionResult("FVS")));
-        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), eq((short) 77))).thenReturn(true);
-        when(resultRepository.existsById(anyString())).thenReturn(true);
         when(majorCreditorRepository.existsById(anyLong())).thenReturn(true);
-        when(resultRepository.findById("COLLO")).thenReturn(Optional.of(ResultEntity.builder()
-            .resultId("COLLO")
-            .enforcement(true)
-            .active(true)
-            .build()));
-        when(resultRepository.findById("NOENF")).thenReturn(Optional.of(ResultEntity.builder()
-            .resultId("NOENF")
-            .enforcement(true)
-            .active(true)
-            .build()));
+        when(resultRepository.findById("COLLO")).thenReturn(Optional.of(activeEnforcementResult("COLLO")));
+        when(resultRepository.findById("NOENF")).thenReturn(Optional.of(activeEnforcementResult("NOENF")));
 
-        assertDoesNotThrow(() -> service.validateReferences(validAccountJson(), (short) 77));
+        assertDoesNotThrow(() -> service.validateReferences(validAccountJson(), BUSINESS_UNIT_ID));
     }
 
     @Test
     void validateReferences_whenOffenceDoesNotExist_shouldReportOffencePath() {
-        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(999L, (short) 77))
-            .thenReturn(false);
+        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(999L, BUSINESS_UNIT_ID)).thenReturn(false);
 
         InvalidReferenceValidationException exception = assertThrows(
             InvalidReferenceValidationException.class,
@@ -76,24 +67,17 @@ class DraftAccountReferenceValidationServiceTest {
                 }
               ]
             }
-            """, (short) 77)
+            """, BUSINESS_UNIT_ID)
         );
 
-        assertContains(
-            exception.getMessage(),
-            "account.offences[0].offence_id: offence id 999 does not exist"
-        );
-
-        verify(offenceRepository)
-            .existsByOffenceIdAvailableToBusinessUnit(999L, (short) 77);
+        assertContains(exception.getMessage(), "account.offences[0].offence_id: offence id 999 does not exist");
+        verify(offenceRepository).existsByOffenceIdAvailableToBusinessUnit(999L, BUSINESS_UNIT_ID);
     }
 
     @Test
     void validateReferences_whenMultipleOffencesAreInvalid_shouldReportEachOffencePath() {
-        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(999L, (short) 77))
-            .thenReturn(false);
-        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(998L, (short) 77))
-            .thenReturn(false);
+        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(999L, BUSINESS_UNIT_ID)).thenReturn(false);
+        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(998L, BUSINESS_UNIT_ID)).thenReturn(false);
 
         InvalidReferenceValidationException exception = assertThrows(
             InvalidReferenceValidationException.class,
@@ -108,30 +92,30 @@ class DraftAccountReferenceValidationServiceTest {
                 }
               ]
             }
-            """, (short) 77)
+            """, BUSINESS_UNIT_ID)
         );
 
         String message = exception.getMessage();
-
         assertContains(message, "Draft account reference validation failed with 2 error(s):");
         assertContains(message, "account.offences[0].offence_id: offence id 999 does not exist");
         assertContains(message, "account.offences[1].offence_id: offence id 998 does not exist");
 
-        verify(offenceRepository).existsByOffenceIdAvailableToBusinessUnit(999L, (short) 77);
-        verify(offenceRepository).existsByOffenceIdAvailableToBusinessUnit(998L, (short) 77);
+        verify(offenceRepository).existsByOffenceIdAvailableToBusinessUnit(999L, BUSINESS_UNIT_ID);
+        verify(offenceRepository).existsByOffenceIdAvailableToBusinessUnit(998L, BUSINESS_UNIT_ID);
     }
 
     @Test
     void validateReferences_whenSomeReferencesAreMissing_shouldReportAllFailures() {
         when(courtLiteRepository.existsById(anyLong())).thenReturn(false);
+        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), BUSINESS_UNIT_ID)).thenReturn(false);
         when(resultRepository.findById("FO")).thenReturn(Optional.empty());
         when(resultRepository.findById("FVS")).thenReturn(Optional.empty());
-        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), eq((short) 77))).thenReturn(false);
-        when(resultRepository.existsById(anyString())).thenReturn(false);
+        when(resultRepository.findById("COLLO")).thenReturn(Optional.empty());
+        when(resultRepository.findById("NOENF")).thenReturn(Optional.empty());
         when(majorCreditorRepository.existsById(anyLong())).thenReturn(false);
 
         InvalidReferenceValidationException exception = assertThrows(InvalidReferenceValidationException.class,
-            () -> service.validateReferences(validAccountJson(), (short) 77));
+            () -> service.validateReferences(validAccountJson(), BUSINESS_UNIT_ID));
 
         String message = exception.getMessage();
         assertContains(message, "$.enforcement_court_id");
@@ -147,24 +131,24 @@ class DraftAccountReferenceValidationServiceTest {
         assertContains(message, "$.payment_terms.enforcements[1].result_id");
 
         verify(courtLiteRepository, times(3)).existsById(anyLong());
-        verify(resultRepository, times(2)).findById(anyString());
-        verify(resultRepository, times(2)).existsById(anyString());
-        verify(offenceRepository).existsByOffenceIdAvailableToBusinessUnit(21L, (short) 77);
-        verify(offenceRepository).existsByOffenceIdAvailableToBusinessUnit(22L, (short) 77);
+        verify(offenceRepository).existsByOffenceIdAvailableToBusinessUnit(21L, BUSINESS_UNIT_ID);
+        verify(offenceRepository).existsByOffenceIdAvailableToBusinessUnit(22L, BUSINESS_UNIT_ID);
+        verify(resultRepository, times(4)).findById(org.mockito.ArgumentMatchers.anyString());
         verify(majorCreditorRepository, times(2)).existsById(anyLong());
     }
 
     @Test
     void validateReferences_whenImpositionResultIsNotAnImposition_shouldReportFailure() {
         when(courtLiteRepository.existsById(anyLong())).thenReturn(true);
+        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), BUSINESS_UNIT_ID)).thenReturn(true);
         when(resultRepository.findById("FO")).thenReturn(Optional.of(activeNonImpositionResult("FO")));
         when(resultRepository.findById("FVS")).thenReturn(Optional.of(activeImpositionResult("FVS")));
-        when(resultRepository.existsById("COLLO")).thenReturn(true);
-        when(resultRepository.existsById("MISSING")).thenReturn(true);
         when(majorCreditorRepository.existsById(anyLong())).thenReturn(true);
+        when(resultRepository.findById("COLLO")).thenReturn(Optional.of(activeEnforcementResult("COLLO")));
+        when(resultRepository.findById("NOENF")).thenReturn(Optional.of(activeEnforcementResult("NOENF")));
 
         InvalidReferenceValidationException exception = assertThrows(InvalidReferenceValidationException.class,
-            () -> service.validateReferences(validAccountJson(), (short) 77));
+            () -> service.validateReferences(validAccountJson(), BUSINESS_UNIT_ID));
 
         assertContains(exception.getMessage(), "$.offences[0].impositions[0].result_id");
     }
@@ -172,38 +156,35 @@ class DraftAccountReferenceValidationServiceTest {
     @Test
     void validateReferences_whenImpositionResultIsInactive_shouldReportFailure() {
         when(courtLiteRepository.existsById(anyLong())).thenReturn(true);
+        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), BUSINESS_UNIT_ID)).thenReturn(true);
         when(resultRepository.findById("FO")).thenReturn(Optional.of(inactiveImpositionResult("FO")));
         when(resultRepository.findById("FVS")).thenReturn(Optional.of(activeImpositionResult("FVS")));
-        when(resultRepository.existsById("COLLO")).thenReturn(true);
-        when(resultRepository.existsById("MISSING")).thenReturn(true);
         when(majorCreditorRepository.existsById(anyLong())).thenReturn(true);
+        when(resultRepository.findById("COLLO")).thenReturn(Optional.of(activeEnforcementResult("COLLO")));
+        when(resultRepository.findById("NOENF")).thenReturn(Optional.of(activeEnforcementResult("NOENF")));
 
         InvalidReferenceValidationException exception = assertThrows(InvalidReferenceValidationException.class,
-            () -> service.validateReferences(validAccountJson(), (short) 77));
+            () -> service.validateReferences(validAccountJson(), BUSINESS_UNIT_ID));
 
         assertContains(exception.getMessage(), "$.offences[0].impositions[0].result_id");
     }
 
     @Test
     void validateReferences_whenPaymentTermsEnforcementResultIsNotAnEnforcement_shouldFail() {
-        String accountJson = validAccountJson();
         when(courtLiteRepository.existsById(anyLong())).thenReturn(true);
-        when(offenceRepository.existsById(anyLong())).thenReturn(true);
-        when(resultRepository.existsById(anyString())).thenReturn(true);
+        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), BUSINESS_UNIT_ID)).thenReturn(true);
         when(majorCreditorRepository.existsById(anyLong())).thenReturn(true);
+        when(resultRepository.findById("FO")).thenReturn(Optional.of(activeImpositionResult("FO")));
+        when(resultRepository.findById("FVS")).thenReturn(Optional.of(activeImpositionResult("FVS")));
         when(resultRepository.findById("COLLO")).thenReturn(Optional.of(ResultEntity.builder()
             .resultId("COLLO")
             .enforcement(false)
             .active(true)
             .build()));
-        when(resultRepository.findById("NOENF")).thenReturn(Optional.of(ResultEntity.builder()
-            .resultId("NOENF")
-            .enforcement(true)
-            .active(true)
-            .build()));
+        when(resultRepository.findById("NOENF")).thenReturn(Optional.of(activeEnforcementResult("NOENF")));
 
         InvalidReferenceValidationException exception = assertThrows(InvalidReferenceValidationException.class,
-            () -> service.validateReferences(accountJson));
+            () -> service.validateReferences(validAccountJson(), BUSINESS_UNIT_ID));
 
         assertContains(exception.getMessage(), "$.payment_terms.enforcements[0].result_id");
         assertContains(exception.getMessage(), "result id COLLO is not an enforcement result");
@@ -211,24 +192,20 @@ class DraftAccountReferenceValidationServiceTest {
 
     @Test
     void validateReferences_whenPaymentTermsEnforcementResultIsInactive_shouldFail() {
-        String accountJson = validAccountJson();
         when(courtLiteRepository.existsById(anyLong())).thenReturn(true);
-        when(offenceRepository.existsById(anyLong())).thenReturn(true);
-        when(resultRepository.existsById(anyString())).thenReturn(true);
+        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), BUSINESS_UNIT_ID)).thenReturn(true);
         when(majorCreditorRepository.existsById(anyLong())).thenReturn(true);
+        when(resultRepository.findById("FO")).thenReturn(Optional.of(activeImpositionResult("FO")));
+        when(resultRepository.findById("FVS")).thenReturn(Optional.of(activeImpositionResult("FVS")));
         when(resultRepository.findById("COLLO")).thenReturn(Optional.of(ResultEntity.builder()
             .resultId("COLLO")
             .enforcement(true)
             .active(false)
             .build()));
-        when(resultRepository.findById("NOENF")).thenReturn(Optional.of(ResultEntity.builder()
-            .resultId("NOENF")
-            .enforcement(true)
-            .active(true)
-            .build()));
+        when(resultRepository.findById("NOENF")).thenReturn(Optional.of(activeEnforcementResult("NOENF")));
 
         InvalidReferenceValidationException exception = assertThrows(InvalidReferenceValidationException.class,
-            () -> service.validateReferences(accountJson));
+            () -> service.validateReferences(validAccountJson(), BUSINESS_UNIT_ID));
 
         assertContains(exception.getMessage(), "$.payment_terms.enforcements[0].result_id");
         assertContains(exception.getMessage(), "result id COLLO is not an active result");
@@ -301,6 +278,14 @@ class DraftAccountReferenceValidationServiceTest {
             .resultId(resultId)
             .active(false)
             .imposition(true)
+            .build();
+    }
+
+    private static ResultEntity activeEnforcementResult(String resultId) {
+        return ResultEntity.builder()
+            .resultId(resultId)
+            .active(true)
+            .enforcement(true)
             .build();
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationServiceTest.java
@@ -48,6 +48,16 @@ class DraftAccountReferenceValidationServiceTest {
         when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), eq((short) 77))).thenReturn(true);
         when(resultRepository.existsById(anyString())).thenReturn(true);
         when(majorCreditorRepository.existsById(anyLong())).thenReturn(true);
+        when(resultRepository.findById(eq("COLLO"))).thenReturn(Optional.of(ResultEntity.builder()
+            .resultId("COLLO")
+            .enforcement(true)
+            .active(true)
+            .build()));
+        when(resultRepository.findById(eq("NOENF"))).thenReturn(Optional.of(ResultEntity.builder()
+            .resultId("NOENF")
+            .enforcement(true)
+            .active(true)
+            .build()));
 
         assertDoesNotThrow(() -> service.validateReferences(validAccountJson(), (short) 77));
     }
@@ -175,6 +185,54 @@ class DraftAccountReferenceValidationServiceTest {
         assertContains(exception.getMessage(), "$.offences[0].impositions[0].result_id");
     }
 
+    @Test
+    void validateReferences_whenPaymentTermsEnforcementResultIsNotAnEnforcement_shouldFail() {
+        when(courtLiteRepository.existsById(anyLong())).thenReturn(true);
+        when(offenceRepository.existsById(anyLong())).thenReturn(true);
+        when(resultRepository.existsById(anyString())).thenReturn(true);
+        when(majorCreditorRepository.existsById(anyLong())).thenReturn(true);
+        when(resultRepository.findById(eq("COLLO"))).thenReturn(Optional.of(ResultEntity.builder()
+            .resultId("COLLO")
+            .enforcement(false)
+            .active(true)
+            .build()));
+        when(resultRepository.findById(eq("NOENF"))).thenReturn(Optional.of(ResultEntity.builder()
+            .resultId("NOENF")
+            .enforcement(true)
+            .active(true)
+            .build()));
+
+        InvalidReferenceValidationException exception = assertThrows(InvalidReferenceValidationException.class,
+            () -> service.validateReferences(validAccountJson()));
+
+        assertContains(exception.getMessage(), "$.payment_terms.enforcements[0].result_id");
+        assertContains(exception.getMessage(), "result id COLLO is not an enforcement result");
+    }
+
+    @Test
+    void validateReferences_whenPaymentTermsEnforcementResultIsInactive_shouldFail() {
+        when(courtLiteRepository.existsById(anyLong())).thenReturn(true);
+        when(offenceRepository.existsById(anyLong())).thenReturn(true);
+        when(resultRepository.existsById(anyString())).thenReturn(true);
+        when(majorCreditorRepository.existsById(anyLong())).thenReturn(true);
+        when(resultRepository.findById(eq("COLLO"))).thenReturn(Optional.of(ResultEntity.builder()
+            .resultId("COLLO")
+            .enforcement(true)
+            .active(false)
+            .build()));
+        when(resultRepository.findById(eq("NOENF"))).thenReturn(Optional.of(ResultEntity.builder()
+            .resultId("NOENF")
+            .enforcement(true)
+            .active(true)
+            .build()));
+
+        InvalidReferenceValidationException exception = assertThrows(InvalidReferenceValidationException.class,
+            () -> service.validateReferences(validAccountJson()));
+
+        assertContains(exception.getMessage(), "$.payment_terms.enforcements[0].result_id");
+        assertContains(exception.getMessage(), "result id COLLO is not an active result");
+    }
+
     private static void assertContains(String message, String fragment) {
         org.junit.jupiter.api.Assertions.assertTrue(message.contains(fragment),
             () -> "Expected message to contain: " + fragment + "\nActual message:\n" + message);
@@ -213,7 +271,7 @@ class DraftAccountReferenceValidationServiceTest {
                     "result_id": "COLLO"
                   },
                   {
-                    "result_id": "MISSING"
+                    "result_id": "NOENF"
                   }
                 ]
               }

--- a/src/test/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DraftAccountReferenceValidationServiceTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.opal.service;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,7 +44,9 @@ class DraftAccountReferenceValidationServiceTest {
     @Test
     void validateReferences_whenAllReferencesExist_shouldPass() {
         when(courtLiteRepository.existsById(anyLong())).thenReturn(true);
-        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), BUSINESS_UNIT_ID)).thenReturn(true);
+        when(
+            offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), eq(BUSINESS_UNIT_ID))
+        ).thenReturn(true);
         when(resultRepository.findById("FO")).thenReturn(Optional.of(activeImpositionResult("FO")));
         when(resultRepository.findById("FVS")).thenReturn(Optional.of(activeImpositionResult("FVS")));
         when(majorCreditorRepository.existsById(anyLong())).thenReturn(true);
@@ -107,7 +110,9 @@ class DraftAccountReferenceValidationServiceTest {
     @Test
     void validateReferences_whenSomeReferencesAreMissing_shouldReportAllFailures() {
         when(courtLiteRepository.existsById(anyLong())).thenReturn(false);
-        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), BUSINESS_UNIT_ID)).thenReturn(false);
+        when(
+            offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), eq(BUSINESS_UNIT_ID))
+        ).thenReturn(false);
         when(resultRepository.findById("FO")).thenReturn(Optional.empty());
         when(resultRepository.findById("FVS")).thenReturn(Optional.empty());
         when(resultRepository.findById("COLLO")).thenReturn(Optional.empty());
@@ -140,7 +145,9 @@ class DraftAccountReferenceValidationServiceTest {
     @Test
     void validateReferences_whenImpositionResultIsNotAnImposition_shouldReportFailure() {
         when(courtLiteRepository.existsById(anyLong())).thenReturn(true);
-        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), BUSINESS_UNIT_ID)).thenReturn(true);
+        when(
+            offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), eq(BUSINESS_UNIT_ID))
+        ).thenReturn(true);
         when(resultRepository.findById("FO")).thenReturn(Optional.of(activeNonImpositionResult("FO")));
         when(resultRepository.findById("FVS")).thenReturn(Optional.of(activeImpositionResult("FVS")));
         when(majorCreditorRepository.existsById(anyLong())).thenReturn(true);
@@ -156,7 +163,9 @@ class DraftAccountReferenceValidationServiceTest {
     @Test
     void validateReferences_whenImpositionResultIsInactive_shouldReportFailure() {
         when(courtLiteRepository.existsById(anyLong())).thenReturn(true);
-        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), BUSINESS_UNIT_ID)).thenReturn(true);
+        when(
+            offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), eq(BUSINESS_UNIT_ID))
+        ).thenReturn(true);
         when(resultRepository.findById("FO")).thenReturn(Optional.of(inactiveImpositionResult("FO")));
         when(resultRepository.findById("FVS")).thenReturn(Optional.of(activeImpositionResult("FVS")));
         when(majorCreditorRepository.existsById(anyLong())).thenReturn(true);
@@ -172,7 +181,9 @@ class DraftAccountReferenceValidationServiceTest {
     @Test
     void validateReferences_whenPaymentTermsEnforcementResultIsNotAnEnforcement_shouldFail() {
         when(courtLiteRepository.existsById(anyLong())).thenReturn(true);
-        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), BUSINESS_UNIT_ID)).thenReturn(true);
+        when(
+            offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), eq(BUSINESS_UNIT_ID))
+        ).thenReturn(true);
         when(majorCreditorRepository.existsById(anyLong())).thenReturn(true);
         when(resultRepository.findById("FO")).thenReturn(Optional.of(activeImpositionResult("FO")));
         when(resultRepository.findById("FVS")).thenReturn(Optional.of(activeImpositionResult("FVS")));
@@ -193,7 +204,9 @@ class DraftAccountReferenceValidationServiceTest {
     @Test
     void validateReferences_whenPaymentTermsEnforcementResultIsInactive_shouldFail() {
         when(courtLiteRepository.existsById(anyLong())).thenReturn(true);
-        when(offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), BUSINESS_UNIT_ID)).thenReturn(true);
+        when(
+            offenceRepository.existsByOffenceIdAvailableToBusinessUnit(anyLong(), eq(BUSINESS_UNIT_ID))
+        ).thenReturn(true);
         when(majorCreditorRepository.existsById(anyLong())).thenReturn(true);
         when(resultRepository.findById("FO")).thenReturn(Optional.of(activeImpositionResult("FO")));
         when(resultRepository.findById("FVS")).thenReturn(Optional.of(activeImpositionResult("FVS")));


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PO-5752


### Change description ###

- Validate draft enforcement result IDs
- Reject missing, non-enforcement, and inactive results
- Add unit tests


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
