### PR TITLE
PO-2969: align defendant account header summary with R1b contract

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/opal/steps/defendantaccount/DefendantAccountHeaderSummaryStepDef.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/steps/defendantaccount/DefendantAccountHeaderSummaryStepDef.java
@@ -1,0 +1,269 @@
+package uk.gov.hmcts.opal.steps.defendantaccount;
+
+import static net.serenitybdd.rest.SerenityRest.lastResponse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.HttpHeaders;
+import static net.serenitybdd.rest.SerenityRest.given;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import uk.gov.hmcts.opal.steps.BaseStepDef;
+import uk.gov.hmcts.opal.steps.BearerTokenStepDef;
+import uk.gov.hmcts.opal.workflows.defendantaccount.DefendantAccountEnforcementWorkflow;
+
+/**
+ * Defines Cucumber steps for the defendant-account header-summary endpoint.
+ */
+public class DefendantAccountHeaderSummaryStepDef extends BaseStepDef {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String BUSINESS_UNIT_ID = "77";
+    private static final String SUBMITTED_BY_NAME = "Laura Clerk";
+    private static final String HEADER_SUMMARY_PATH = "/defendant-accounts/%d/header-summary";
+    private static final long NON_EXISTENT_ACCOUNT_ID = 90_000_000_000_000L;
+    private static final List<String> INTERNAL_ERROR_TERMS = List.of(
+        "stackTrace",
+        "\"trace\"",
+        "\"exception\"",
+        "jakarta.persistence",
+        "org.hibernate",
+        "java.lang",
+        "uk.gov.hmcts"
+    );
+
+    private final DefendantAccountEnforcementWorkflow enforcementWorkflow =
+        new DefendantAccountEnforcementWorkflow();
+
+    @Given("a defendant account with header summary data exists for submitted by {string} using fixture {string}")
+    public void defendantAccountWithHeaderSummaryDataExistsForSubmittedByUsingFixture(
+        String submittedBy,
+        String accountFixture
+    ) throws Exception {
+        actAs(BearerTokenStepDef.DEFAULT_USER);
+        enforcementWorkflow.createEnforceableDefendantAccount(headerSummaryAccountData(submittedBy, accountFixture));
+    }
+
+    @When("I request defendant account header summary for the created defendant account")
+    public void requestDefendantAccountHeaderSummaryForTheCreatedDefendantAccount() {
+        getHeaderSummary(BearerTokenStepDef.getToken(), createdDefendantAccountId());
+    }
+
+    @When("I request defendant account header summary for the created defendant account without a token")
+    public void requestDefendantAccountHeaderSummaryForTheCreatedDefendantAccountWithoutAToken() {
+        getHeaderSummary(null, createdDefendantAccountId());
+    }
+
+    @When("I request defendant account header summary for the created defendant account with an invalid token")
+    public void requestDefendantAccountHeaderSummaryForTheCreatedDefendantAccountWithAnInvalidToken() {
+        getHeaderSummary("invalid-token", createdDefendantAccountId());
+    }
+
+    @When("the {string} user requests defendant account header summary for the created defendant account")
+    public void userRequestsDefendantAccountHeaderSummaryForTheCreatedDefendantAccount(String user) {
+        getHeaderSummary(BearerTokenStepDef.getAccessTokenForUser(user), createdDefendantAccountId());
+    }
+
+    @When("I request defendant account header summary for a non-existent defendant account")
+    public void requestDefendantAccountHeaderSummaryForANonExistentDefendantAccount() {
+        getHeaderSummary(BearerTokenStepDef.getToken(), NON_EXISTENT_ACCOUNT_ID);
+    }
+
+    @Then("the defendant account header summary response is returned as documented")
+    public void defendantAccountHeaderSummaryResponseIsReturnedAsDocumented() throws Exception {
+        Response response = lastResponse();
+        assertEquals(200, response.statusCode(), "Unexpected header-summary status");
+
+        JsonNode root = OBJECT_MAPPER.readTree(response.getBody().asString());
+        assertTrue(root.isObject(), "header-summary response should be a JSON object");
+        assertEquals(createdDefendantAccountId(), root.path("defendant_account_id").asLong(),
+            "Unexpected defendant_account_id");
+        assertTrue(root.path("account_number").isTextual(), "account_number should be present");
+        assertTrue(root.path("account_status_reference").isObject(), "account_status_reference should be present");
+        assertTrue(root.path("account_type").isTextual(), "account_type should be present");
+        assertTrue(root.path("business_unit_summary").isObject(), "business_unit_summary should be present");
+        assertTrue(root.path("defendant_account_party_id").isTextual(),
+            "defendant_account_party_id should be present");
+        assertTrue(root.path("is_youth").isBoolean(), "is_youth should be present");
+        assertTrue(root.path("has_consolidated_accounts").isBoolean(),
+            "has_consolidated_accounts should be present");
+        assertTrue(root.path("debtor_type").isTextual(), "debtor_type should be present");
+        assertTrue(root.path("payment_state_summary").isObject(), "payment_state_summary should be present");
+        assertTrue(root.path("party_details").isObject(), "party_details should be present");
+        assertTrue(root.path("prosecutor_case_reference").isTextual(),
+            "prosecutor_case_reference should be present");
+        assertTrue(root.path("originator_type").isTextual(), "originator_type should be present");
+        assertTrue(root.path("originator_name").isTextual(), "originator_name should be present");
+        assertTrue(root.path("collection_order").isBoolean(), "collection_order should be present");
+    }
+
+    @Then("the defendant account header summary contains originator type {string}")
+    public void defendantAccountHeaderSummaryContainsOriginatorType(String expectedOriginatorType) {
+        assertEquals(expectedOriginatorType, lastResponse().jsonPath().getString("originator_type"));
+    }
+
+    @Then("the defendant account header summary contains originator name {string}")
+    public void defendantAccountHeaderSummaryContainsOriginatorName(String expectedOriginatorName) {
+        assertEquals(expectedOriginatorName, lastResponse().jsonPath().getString("originator_name"));
+    }
+
+    @Then("the defendant account header summary contains collection order {string}")
+    public void defendantAccountHeaderSummaryContainsCollectionOrder(String expectedCollectionOrder) {
+        assertEquals(Boolean.parseBoolean(expectedCollectionOrder),
+            lastResponse().jsonPath().getBoolean("collection_order"));
+    }
+
+    @Then("the defendant account header summary contains party details organisation flag {string}")
+    public void defendantAccountHeaderSummaryContainsPartyDetailsOrganisationFlag(String expectedOrganisationFlag) {
+        assertEquals(Boolean.parseBoolean(expectedOrganisationFlag),
+            lastResponse().jsonPath().getBoolean("party_details.organisation_flag"));
+    }
+
+    @Then("the defendant account header summary contains party details forenames {string} surname {string}")
+    public void defendantAccountHeaderSummaryContainsPartyDetailsForenamesSurname(
+        String expectedForenames,
+        String expectedSurname
+    ) {
+        String actualForenames = lastResponse().jsonPath()
+            .getString("party_details.individual_details.forenames");
+        String actualSurname = lastResponse().jsonPath().getString("party_details.individual_details.surname");
+        assertEquals(expectedForenames, actualForenames);
+        assertEquals(expectedSurname, actualSurname);
+    }
+
+    @Then("the defendant account header summary contains the expected live values")
+    public void defendantAccountHeaderSummaryContainsTheExpectedLiveValues(io.cucumber.datatable.DataTable dataTable)
+        throws Exception {
+
+        Map<String, String> expectedValues = dataTable.asMap(String.class, String.class);
+        JsonNode root = OBJECT_MAPPER.readTree(lastResponse().getBody().asString());
+
+        for (Map.Entry<String, String> entry : expectedValues.entrySet()) {
+            JsonNode actual = root.path(entry.getKey());
+            if (actual.isMissingNode() || actual.isNull()) {
+                throw new AssertionError("Expected field to be present: " + entry.getKey());
+            }
+            if ("collection_order".equals(entry.getKey())) {
+                assertEquals(Boolean.parseBoolean(entry.getValue()), actual.asBoolean(),
+                    "Unexpected value for collection_order");
+            } else {
+                assertEquals(entry.getValue(), actual.asText(), "Unexpected value for " + entry.getKey());
+            }
+        }
+    }
+
+    @Then("the defendant account header summary error response matches the standard problem detail contract "
+        + "for status {int}")
+    public void defendantAccountHeaderSummaryErrorResponseMatchesTheStandardProblemDetailContractForStatus(
+        int expectedStatus
+    ) throws Exception {
+        Response response = lastResponse();
+        assertEquals(expectedStatus, response.statusCode(), "Unexpected HTTP status");
+
+        JsonNode root = OBJECT_MAPPER.readTree(response.getBody().asString());
+        assertTrue(root.isObject(), "Problem detail response should be an object");
+        assertTrue(root.path("title").isTextual(), "title should be a string");
+        assertTrue(root.path("detail").isTextual(), "detail should be a string");
+        assertTrue(root.path("status").isInt(), "status should be an integer");
+        assertEquals(expectedStatus, root.path("status").asInt(), "Unexpected status in problem detail");
+
+        assertOptionalText(root.path("type"), "type");
+        assertOptionalText(root.path("instance"), "instance");
+        assertOptionalText(root.path("operation_id"), "operation_id");
+        if (!root.path("retriable").isMissingNode() && !root.path("retriable").isNull()) {
+            assertTrue(root.path("retriable").isBoolean(), "retriable should be a boolean");
+        }
+    }
+
+    @Then("the defendant account header summary error title contains {string}")
+    public void defendantAccountHeaderSummaryErrorTitleContains(String expectedText) {
+        assertContainsIgnoringCase(lastResponse().jsonPath().getString("title"), expectedText, "title");
+    }
+
+    @Then("the defendant account header summary error detail contains {string}")
+    public void defendantAccountHeaderSummaryErrorDetailContains(String expectedText) {
+        assertContainsIgnoringCase(lastResponse().jsonPath().getString("detail"), expectedText, "detail");
+    }
+
+    @Then("the defendant account header summary error is non-retriable")
+    public void defendantAccountHeaderSummaryErrorIsNonRetriable() {
+        JsonNode root;
+        try {
+            root = OBJECT_MAPPER.readTree(lastResponse().getBody().asString());
+        } catch (Exception exception) {
+            throw new AssertionError("Failed to parse problem detail response", exception);
+        }
+        JsonNode field = root.path("retriable");
+        if (field.isMissingNode() || field.isNull()) {
+            field = root.path("properties").path("retriable");
+        }
+        assertTrue(field.isBoolean(), "retriable should be a boolean");
+        assertFalse(field.asBoolean(), "retriable should be false");
+    }
+
+    @Then("the defendant account header summary error response does not leak internal details")
+    public void defendantAccountHeaderSummaryErrorResponseDoesNotLeakInternalDetails() {
+        String body = lastResponse().getBody().asString();
+        for (String term : INTERNAL_ERROR_TERMS) {
+            assertFalse(body.contains(term), "Error response leaked internal detail: " + term);
+        }
+        assertFalse(body.contains(String.valueOf(NON_EXISTENT_ACCOUNT_ID)),
+            "Error response leaked requested account id");
+    }
+
+    private Response getHeaderSummary(String token, long defendantAccountId) {
+        RequestSpecification request = given()
+            .accept("*/*")
+            .contentType("application/json");
+
+        if (token != null && !token.isBlank()) {
+            request.header(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+        }
+
+        return request
+            .when()
+            .get(getTestUrl() + HEADER_SUMMARY_PATH.formatted(defendantAccountId));
+    }
+
+    private Map<String, String> headerSummaryAccountData(String submittedBy, String accountFixture) {
+        Map<String, String> accountData = new LinkedHashMap<>();
+        accountData.put("business_unit_id", BUSINESS_UNIT_ID);
+        accountData.put("account", accountFixture);
+        accountData.put("account_type", "Fine");
+        accountData.put("account_status", "Submitted");
+        accountData.put("submitted_by", submittedBy);
+        accountData.put("submitted_by_name", SUBMITTED_BY_NAME);
+        return accountData;
+    }
+
+    private long createdDefendantAccountId() {
+        return Long.parseLong(scenarioContext().getCreatedDefendantAccountIdOrFail());
+    }
+
+    private void actAs(String user) {
+        BearerTokenStepDef.setTokenOverride(BearerTokenStepDef.getAccessTokenForUser(user));
+        scenarioContext().setCurrentUser(user);
+    }
+
+    private void assertOptionalText(JsonNode field, String fieldName) {
+        if (!field.isMissingNode() && !field.isNull()) {
+            assertTrue(field.isTextual(), fieldName + " should be a string when present");
+        }
+    }
+
+    private void assertContainsIgnoringCase(String actual, String expected, String fieldName) {
+        assertTrue(
+            actual.toLowerCase().contains(expected.toLowerCase()),
+            fieldName + " should contain '" + expected + "' but was '" + actual + "'"
+        );
+    }
+}

--- a/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountHeaderSummary.feature
+++ b/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountHeaderSummary.feature
@@ -1,0 +1,56 @@
+@Opal @JIRA-LABEL:account-enquiry @R1B
+Feature: Defendant Account Header Summary
+
+  @cleanUpData @JIRA-STORY:PO-2964 @JIRA-EPIC:PO-2630
+  Scenario: E2E.01 Header summary returns stored values for a live adult defendant account
+    Given a defendant account with header summary data exists for submitted by "PO2964-TFO-001" using fixture "draftAccounts/accountJson/adultAccount.json"
+    When I request defendant account header summary for the created defendant account
+    Then the defendant account header summary response is returned as documented
+    And the defendant account header summary contains originator type "TFO"
+    And the defendant account header summary contains originator name "Humber Magistrates' Court"
+    And the defendant account header summary contains collection order "true"
+    And the defendant account header summary contains party details organisation flag "false"
+    And the defendant account header summary contains party details forenames "FNAME" surname "LNAME"
+    And the defendant account header summary contains the expected live values
+      | prosecutor_case_reference | 12345 |
+
+  @cleanUpData @JIRA-STORY:PO-2964 @JIRA-EPIC:PO-2630
+  Scenario: E2E.02 Header summary returns stored values for a live parent or guardian defendant account
+    Given a defendant account with header summary data exists for submitted by "PO2964-TFO-002" using fixture "draftAccounts/accountJson/parentOrGuardianAccount.json"
+    When I request defendant account header summary for the created defendant account
+    Then the defendant account header summary response is returned as documented
+    And the defendant account header summary contains originator type "TFO"
+    And the defendant account header summary contains originator name "Humber Magistrates' Court"
+    And the defendant account header summary contains collection order "false"
+    And the defendant account header summary contains party details organisation flag "false"
+    And the defendant account header summary contains party details forenames "FNAME" surname "LNAME"
+    And the defendant account header summary contains the expected live values
+      | prosecutor_case_reference | 33333 |
+
+  @cleanUpData @JIRA-STORY:PO-2964 @JIRA-EPIC:PO-2630
+  Scenario: E2E.03 Header summary requests without a token are rejected
+    Given a defendant account with header summary data exists for submitted by "PO2964-AUTH-001" using fixture "draftAccounts/accountJson/adultAccount.json"
+    When I request defendant account header summary for the created defendant account without a token
+    Then the response status code is 401
+    And the defendant account header summary error response matches the standard problem detail contract for status 401
+    And the defendant account header summary error title contains "Unauthorized"
+    And the defendant account header summary error is non-retriable
+
+  @cleanUpData @JIRA-STORY:PO-2964 @JIRA-EPIC:PO-2630
+  Scenario: E2E.04 Header summary requests from an unauthorized user are rejected
+    Given a defendant account with header summary data exists for submitted by "PO2964-AUTH-002" using fixture "draftAccounts/accountJson/adultAccount.json"
+    When the "opal-test-2@dev.platform.hmcts.net" user requests defendant account header summary for the created defendant account
+    Then the response status code is 403
+    And the defendant account header summary error response matches the standard problem detail contract for status 403
+    And the defendant account header summary error title contains "Forbidden"
+    And the defendant account header summary error is non-retriable
+
+  @cleanUpData @JIRA-STORY:PO-2964 @JIRA-EPIC:PO-2630
+  Scenario: E2E.05 Non-existent defendant account returns not found
+    Given I am testing as the "opal-test@dev.platform.hmcts.net" user
+    When I request defendant account header summary for a non-existent defendant account
+    Then the response status code is 404
+    And the defendant account header summary error response matches the standard problem detail contract for status 404
+    And the defendant account header summary error title contains "Entity Not Found"
+    And the defendant account header summary error is non-retriable
+    And the defendant account header summary error response does not leak internal details

--- a/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountHeaderSummary.feature
+++ b/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountHeaderSummary.feature
@@ -1,7 +1,7 @@
 @Opal @JIRA-LABEL:account-enquiry @R1B
 Feature: Defendant Account Header Summary
 
-  @cleanUpData @JIRA-STORY:PO-2964 @JIRA-EPIC:PO-2630
+  @cleanUpData @JIRA-STORY:PO-2969 @JIRA-EPIC:PO-2630
   Scenario: E2E.01 Header summary returns stored values for a live adult defendant account
     Given a defendant account with header summary data exists for submitted by "PO2964-TFO-001" using fixture "draftAccounts/accountJson/adultAccount.json"
     When I request defendant account header summary for the created defendant account
@@ -14,7 +14,7 @@ Feature: Defendant Account Header Summary
     And the defendant account header summary contains the expected live values
       | prosecutor_case_reference | 12345 |
 
-  @cleanUpData @JIRA-STORY:PO-2964 @JIRA-EPIC:PO-2630
+  @cleanUpData @JIRA-STORY:PO-2969 @JIRA-EPIC:PO-2630
   Scenario: E2E.02 Header summary returns stored values for a live parent or guardian defendant account
     Given a defendant account with header summary data exists for submitted by "PO2964-TFO-002" using fixture "draftAccounts/accountJson/parentOrGuardianAccount.json"
     When I request defendant account header summary for the created defendant account
@@ -27,7 +27,7 @@ Feature: Defendant Account Header Summary
     And the defendant account header summary contains the expected live values
       | prosecutor_case_reference | 33333 |
 
-  @cleanUpData @JIRA-STORY:PO-2964 @JIRA-EPIC:PO-2630
+  @cleanUpData @JIRA-STORY:PO-2969 @JIRA-EPIC:PO-2630
   Scenario: E2E.03 Header summary requests without a token are rejected
     Given a defendant account with header summary data exists for submitted by "PO2964-AUTH-001" using fixture "draftAccounts/accountJson/adultAccount.json"
     When I request defendant account header summary for the created defendant account without a token
@@ -36,7 +36,7 @@ Feature: Defendant Account Header Summary
     And the defendant account header summary error title contains "Unauthorized"
     And the defendant account header summary error is non-retriable
 
-  @cleanUpData @JIRA-STORY:PO-2964 @JIRA-EPIC:PO-2630
+  @cleanUpData @JIRA-STORY:PO-2969 @JIRA-EPIC:PO-2630
   Scenario: E2E.04 Header summary requests from an unauthorized user are rejected
     Given a defendant account with header summary data exists for submitted by "PO2964-AUTH-002" using fixture "draftAccounts/accountJson/adultAccount.json"
     When the "opal-test-2@dev.platform.hmcts.net" user requests defendant account header summary for the created defendant account
@@ -45,7 +45,7 @@ Feature: Defendant Account Header Summary
     And the defendant account header summary error title contains "Forbidden"
     And the defendant account header summary error is non-retriable
 
-  @cleanUpData @JIRA-STORY:PO-2964 @JIRA-EPIC:PO-2630
+  @cleanUpData @JIRA-STORY:PO-2969 @JIRA-EPIC:PO-2630
   Scenario: E2E.05 Non-existent defendant account returns not found
     Given I am testing as the "opal-test@dev.platform.hmcts.net" user
     When I request defendant account header summary for a non-existent defendant account

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountSummaryViewIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountSummaryViewIntegrationTest.java
@@ -82,6 +82,68 @@ class DefendantAccountSummaryViewIntegrationTest extends AbstractOpalDefendantsI
     }
 
     @Test
+    @JiraStory("PO-2969")
+    @DisplayName("PO-2969 INT.03 - Get header summary returns TFO originator fields and collection order")
+    void int03_getHeaderSummary_returnsTfoOriginatorFieldsAndCollectionOrder() throws Exception {
+
+        ResultActions resultActions = mockMvc.perform(
+            get("/defendant-accounts/77/header-summary")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+        );
+
+        resultActions.andExpect(status().isOk())
+            .andExpect(content().contentType(APPLICATION_JSON))
+            .andExpect(jsonPath("$.account_number").value("177A"))
+            .andExpect(jsonPath("$.originator_type").value("TFO"))
+            .andExpect(jsonPath("$.originator_name").value("Kingston-upon-Thames Mags Court"))
+            .andExpect(jsonPath("$.collection_order").value(true))
+            .andExpect(jsonPath("$.prosecutor_case_reference").value("090A"))
+            .andExpect(jsonPath("$.payment_state_summary").exists())
+            .andExpect(jsonPath("$.party_details").exists());
+    }
+
+    @Test
+    @JiraStory("PO-2969")
+    @DisplayName("PO-2969 INT.04 - Get header summary returns NEW originator fields and collection order")
+    void int04_getHeaderSummary_returnsNewOriginatorFieldsAndCollectionOrder() throws Exception {
+
+        ResultActions resultActions = mockMvc.perform(
+            get("/defendant-accounts/990001/header-summary")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+        );
+
+        resultActions.andExpect(status().isOk())
+            .andExpect(content().contentType(APPLICATION_JSON))
+            .andExpect(jsonPath("$.defendant_account_id").value("990001"))
+            .andExpect(jsonPath("$.originator_type").value("NEW"))
+            .andExpect(jsonPath("$.originator_name").value("Header Summary New Originator"))
+            .andExpect(jsonPath("$.collection_order").value(false))
+            .andExpect(jsonPath("$.has_consolidated_accounts").value(true));
+    }
+
+    @Test
+    @JiraStory("PO-2969")
+    @DisplayName("PO-2969 INT.05 - Get header summary returns FP originator fields and collection order")
+    void int05_getHeaderSummary_returnsFpOriginatorFieldsAndCollectionOrder() throws Exception {
+
+        ResultActions resultActions = mockMvc.perform(
+            get("/defendant-accounts/10001/header-summary")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+        );
+
+        resultActions.andExpect(status().isOk())
+            .andExpect(content().contentType(APPLICATION_JSON))
+            .andExpect(jsonPath("$.defendant_account_id").value("10001"))
+            .andExpect(jsonPath("$.originator_type").value("FP"))
+            .andExpect(jsonPath("$.originator_name").value("Brentwood Mags Court"))
+            .andExpect(jsonPath("$.collection_order").value(true))
+            .andExpect(jsonPath("$.party_details.organisation_flag").value(true));
+    }
+
+    @Test
     @JiraEpic("PO-2332")
     @JiraStory("PO-2334")
     @DisplayName("PO-2629 INT.08 - Get defendant account header summary returns forbidden response")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountSummaryViewIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DefendantAccountSummaryViewIntegrationTest.java
@@ -82,6 +82,7 @@ class DefendantAccountSummaryViewIntegrationTest extends AbstractOpalDefendantsI
     }
 
     @Test
+    @JiraEpic("PO-2630")
     @JiraStory("PO-2969")
     @DisplayName("PO-2969 INT.03 - Get header summary returns TFO originator fields and collection order")
     void int03_getHeaderSummary_returnsTfoOriginatorFieldsAndCollectionOrder() throws Exception {
@@ -104,6 +105,7 @@ class DefendantAccountSummaryViewIntegrationTest extends AbstractOpalDefendantsI
     }
 
     @Test
+    @JiraEpic("PO-2630")
     @JiraStory("PO-2969")
     @DisplayName("PO-2969 INT.04 - Get header summary returns NEW originator fields and collection order")
     void int04_getHeaderSummary_returnsNewOriginatorFieldsAndCollectionOrder() throws Exception {
@@ -124,6 +126,7 @@ class DefendantAccountSummaryViewIntegrationTest extends AbstractOpalDefendantsI
     }
 
     @Test
+    @JiraEpic("PO-2630")
     @JiraStory("PO-2969")
     @DisplayName("PO-2969 INT.05 - Get header summary returns FP originator fields and collection order")
     void int05_getHeaderSummary_returnsFpOriginatorFieldsAndCollectionOrder() throws Exception {

--- a/src/integrationTest/resources/db/insertData/insert_into_defendant_accounts.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_defendant_accounts.sql
@@ -108,7 +108,7 @@ VALUES ( 0077, 0, 078, '177A'
        , 200.00, 500.58, 'L', NULL
        , 780000000185, 780000000185, '2024-01-04 18:06:11'
        , '2024-01-02 17:08:09', '2024-01-03 12:00:12', '10'
-       , 'Kingston-upon-Thames Mags Court', NULL, NULL
+       , 'Kingston-upon-Thames Mags Court', NULL, 'TFO'
        , 'N', 'N', 14, 21
        , 'FWEC', 780000000021, 240
        , 'GB pound sterling', 700.00, 'Y', '2023-12-18 00:00:00'
@@ -721,7 +721,7 @@ VALUES ( 10001, 078, '10001A'
        , 200.00, 500.58, 'L', NULL
        , 780000000185, 780000000185, '2024-01-04 18:06:11'
        , '2024-01-02 17:08:09', '2024-01-03 12:00:12', 'REM'
-       , 'Brentwood Mags Court', NULL, NULL
+       , 'Brentwood Mags Court', NULL, 'FP'
        , 'N', 'N', 14, 21
        , 'FWEC', 780000000021, 240
        , 'GB pound sterling', 700.00, 'Y', '2023-12-18 00:00:00'
@@ -1321,6 +1321,12 @@ VALUES (990001, 0, 78,
         '990001A','PCR990001',
         100.00,0.00,100.00,
         'L','Fine');
+
+UPDATE defendant_accounts
+SET originator_name = 'Header Summary New Originator',
+    originator_type = 'NEW',
+    collection_order = FALSE
+WHERE defendant_account_id = 990001;
 
 INSERT INTO parties
 ( party_id, organisation, surname, forenames )

--- a/src/main/java/uk/gov/hmcts/opal/entity/defendantaccount/DefendantAccountHeaderViewEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/defendantaccount/DefendantAccountHeaderViewEntity.java
@@ -15,6 +15,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import uk.gov.hmcts.opal.entity.converter.DefendantAccountStatusConverter;
 import uk.gov.hmcts.opal.entity.converter.DefendantAccountTypeConverter;
+import uk.gov.hmcts.opal.entity.converter.OriginatorTypeConverter;
 
 @Entity
 @Table(name = "v_defendant_accounts_header")
@@ -97,6 +98,17 @@ public class DefendantAccountHeaderViewEntity {
 
     @Column(name = "ticket_number")
     private String fixedPenaltyTicketNumber;
+
+    @Column(name = "originator_type")
+    @ColumnTransformer(read = "originator_type::text")
+    @Convert(converter = OriginatorTypeConverter.class)
+    private OriginatorType originatorType;
+
+    @Column(name = "originator_name")
+    private String originatorName;
+
+    @Column(name = "collection_order")
+    private Boolean collectionOrder;
 
     @Column(name = "parent_guardian_account_party_id")
     private Long parentGuardianAccountPartyId;

--- a/src/main/java/uk/gov/hmcts/opal/mapper/DefendantAccountHeaderSummaryMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/mapper/DefendantAccountHeaderSummaryMapper.java
@@ -14,11 +14,13 @@ import uk.gov.hmcts.opal.dto.DefendantAccountHeaderSummary;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountHeaderViewEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountStatus;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountType;
+import uk.gov.hmcts.opal.entity.defendantaccount.OriginatorType;
 import uk.gov.hmcts.opal.generated.model.AccountStatusReferenceCommon;
 import uk.gov.hmcts.opal.generated.model.AccountStatusReferenceCommon.AccountStatusCodeEnum;
 import uk.gov.hmcts.opal.generated.model.BusinessUnitSummaryCommon;
 import uk.gov.hmcts.opal.generated.model.GetDefendantAccountHeaderSummary200Response.AccountTypeEnum;
 import uk.gov.hmcts.opal.generated.model.GetDefendantAccountHeaderSummary200Response.DebtorTypeEnum;
+import uk.gov.hmcts.opal.generated.model.GetDefendantAccountHeaderSummary200Response.OriginatorTypeEnum;
 import uk.gov.hmcts.opal.generated.model.IndividualDetailsCommon;
 import uk.gov.hmcts.opal.generated.model.OrganisationDetailsCommon;
 import uk.gov.hmcts.opal.generated.model.PartyDetailsCommon;
@@ -40,6 +42,9 @@ public interface DefendantAccountHeaderSummaryMapper {
         @Mapping(target = "response.accountType", source = "entity.accountType"),
         @Mapping(target = "response.defendantAccountPartyId", source = "entity.defendantAccountPartyId"),
         @Mapping(target = "response.fixedPenaltyTicketNumber", source = "entity.fixedPenaltyTicketNumber"),
+        @Mapping(target = "response.originatorType", source = "entity.originatorType"),
+        @Mapping(target = "response.originatorName", source = "entity.originatorName"),
+        @Mapping(target = "response.collectionOrder", source = "entity.collectionOrder"),
         @Mapping(target = "response.prosecutorCaseReference", source = "entity.prosecutorCaseReference"),
         @Mapping(target = "response.hasConsolidatedAccounts"),
     })
@@ -115,6 +120,10 @@ public interface DefendantAccountHeaderSummaryMapper {
 
     default AccountTypeEnum toAccountTypeLabel(DefendantAccountType accountType) {
         return accountType == null ? null : AccountTypeEnum.fromValue(accountType.getLabel());
+    }
+
+    default OriginatorTypeEnum toOriginatorTypeLabel(OriginatorType originatorType) {
+        return originatorType == null ? null : OriginatorTypeEnum.fromValue(originatorType.getLabel());
     }
 
     default BigDecimal toZeroIfNull(BigDecimal value) {

--- a/src/test/java/uk/gov/hmcts/opal/mapper/DefendantAccountHeaderSummaryMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/mapper/DefendantAccountHeaderSummaryMapperTest.java
@@ -16,9 +16,11 @@ import uk.gov.hmcts.opal.dto.DefendantAccountHeaderSummary;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountHeaderViewEntity;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountStatus;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountType;
+import uk.gov.hmcts.opal.entity.defendantaccount.OriginatorType;
 import uk.gov.hmcts.opal.generated.model.AccountStatusReferenceCommon.AccountStatusCodeEnum;
 import uk.gov.hmcts.opal.generated.model.GetDefendantAccountHeaderSummary200Response.AccountTypeEnum;
 import uk.gov.hmcts.opal.generated.model.GetDefendantAccountHeaderSummary200Response.DebtorTypeEnum;
+import uk.gov.hmcts.opal.generated.model.GetDefendantAccountHeaderSummary200Response.OriginatorTypeEnum;
 
 class DefendantAccountHeaderSummaryMapperTest {
 
@@ -88,6 +90,9 @@ class DefendantAccountHeaderSummaryMapperTest {
             .parentGuardianAccountPartyId(456L)
             .accountNumber("ACCT100")
             .accountType(DefendantAccountType.FINES)
+            .originatorType(OriginatorType.TRANSFER_IN_ACCOUNT)
+            .originatorName("Originator Name")
+            .collectionOrder(Boolean.TRUE)
             .prosecutorCaseReference("PCR1")
             .fixedPenaltyTicketNumber("FPT1")
             .accountStatus(DefendantAccountStatus.LIVE)
@@ -110,7 +115,46 @@ class DefendantAccountHeaderSummaryMapperTest {
         DefendantAccountHeaderSummary dto = mapper.toDto(entity);
         assertEquals("ACCT100", dto.getResponse().getAccountNumber());
         assertEquals("0046", dto.getResponse().getBusinessUnitSummary().getBusinessUnitCode());
+        assertEquals(OriginatorTypeEnum.TFO, dto.getResponse().getOriginatorType());
+        assertEquals("Originator Name", dto.getResponse().getOriginatorName());
+        assertTrue(dto.getResponse().getCollectionOrder());
         assertNotNull(dto.getResponse().getPartyDetails());
+    }
+
+    @Test
+    void mapToDto_mapsOriginatorTypes() {
+        DefendantAccountHeaderViewEntity newEntity = DefendantAccountHeaderViewEntity.builder()
+            .originatorType(OriginatorType.MAC_NEW_ACCOUNT)
+            .version(1L)
+            .build();
+        DefendantAccountHeaderViewEntity tfoEntity = DefendantAccountHeaderViewEntity.builder()
+            .originatorType(OriginatorType.TRANSFER_IN_ACCOUNT)
+            .version(1L)
+            .build();
+        DefendantAccountHeaderViewEntity fpEntity = DefendantAccountHeaderViewEntity.builder()
+            .originatorType(OriginatorType.FIXED_PENALTY)
+            .version(1L)
+            .build();
+
+        assertEquals(OriginatorTypeEnum.NEW, mapper.toDto(newEntity).getResponse().getOriginatorType());
+        assertEquals(OriginatorTypeEnum.TFO, mapper.toDto(tfoEntity).getResponse().getOriginatorType());
+        assertEquals(OriginatorTypeEnum.FP, mapper.toDto(fpEntity).getResponse().getOriginatorType());
+    }
+
+    @Test
+    void mapToDto_preservesNullOriginatorFieldsAndCollectionOrder() {
+        DefendantAccountHeaderViewEntity entity = DefendantAccountHeaderViewEntity.builder()
+            .originatorType(null)
+            .originatorName(null)
+            .collectionOrder(null)
+            .version(1L)
+            .build();
+
+        DefendantAccountHeaderSummary dto = mapper.toDto(entity);
+
+        assertNull(dto.getResponse().getOriginatorType());
+        assertNull(dto.getResponse().getOriginatorName());
+        assertNull(dto.getResponse().getCollectionOrder());
     }
 
     @Test


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PO-2969

### Change description ###

Implements PO-2969 by updating the existing defendant account header summary backend flow to return the additional Release 1b response fields

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
