### PR TITLE
PO-2461 Refactor DraftAccountTestData to remove unused fields 'submitted_by',…

### DIFF
--- a/src/functionalTest/resources/features/opalMode/draftAccounts/replace/ReplaceDraftAccountAuthorisation.feature
+++ b/src/functionalTest/resources/features/opalMode/draftAccounts/replace/ReplaceDraftAccountAuthorisation.feature
@@ -159,11 +159,9 @@ Feature: Replace Draft Account Authorisation
       | account           | draftAccounts/accountJson/adultAccount.json |
       | account_type      | Fine                                        |
       | account_status    | Submitted                                   |
-      | submitted_by      |                                             |
-      | submitted_by_name | Laura Clerk                                 |
       | If-Match          | 0                                           |
 
-    Then the request is rejected as bad request and the created draft account remains with the following data
+    Then the request is rejected as conflict and the created draft account remains with the following data
       | business_unit_id                    | 73          |
       | account_type                        | Fine        |
       | account_status                      | Submitted   |

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CommonDraftAccountControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/CommonDraftAccountControllerIntegrationTest.java
@@ -72,8 +72,6 @@ class CommonDraftAccountControllerIntegrationTest extends AbstractIntegrationTes
         return """
             {
               "account_status": "%2$s",
-              "validated_by": "BUUID1%3$s",
-              "validated_by_name": "%3$s",
               "business_unit_id": %1$s,
               "reason_text": "Reason %3$s",
               "version": 0

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerIntegrationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.controllers;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -69,11 +70,42 @@ class DraftAccountControllerIntegrationTest extends CommonDraftAccountController
             .andExpect(status().isBadRequest());
     }
 
+    @ParameterizedTest(name = "Token-derived request fields return 400 [{index}]")
+    @MethodSource("endpointsWithTokenDerivedFieldsProvider")
+    @JiraStory("PO-2461")
+    @JiraEpic("PO-2219")
+    void methodsShouldReturn400_whenTokenDerivedFieldsAreSupplied(
+        MockHttpServletRequestBuilder requestBuilder, String requestBody, String prohibitedField) throws Exception {
+
+        mockMvc.perform(requestBuilder
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header("authorization", userStateStub.getBearerToken())
+                .header("Accept", "application/json")
+                .header("If-Match", "0")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.detail", containsString("not allowed in draft account requests")))
+            .andExpect(jsonPath("$.detail", containsString(prohibitedField)));
+    }
+
     private static Stream<Arguments> endpointsWithInvalidBodiesProvider() {
         return Stream.of(Arguments.of(post(URL_BASE), invalidCreateRequestBody()),
             Arguments.of(put(URL_BASE + "/1"), invalidCreateRequestBody()),
             Arguments.of(patch(URL_BASE + "/1"), invalidCreateRequestBody())
         );
+    }
+
+    private static Stream<Arguments> endpointsWithTokenDerivedFieldsProvider() {
+        return Stream.of("submitted_by", "submitted_by_name", "validated_by", "validated_by_name")
+            .flatMap(prohibitedField -> Stream.of(
+                Arguments.of(post(URL_BASE), requestBodyWithTokenDerivedField(prohibitedField), prohibitedField),
+                Arguments.of(put(URL_BASE + "/1"), requestBodyWithTokenDerivedField(prohibitedField),
+                             prohibitedField),
+                Arguments.of(patch(URL_BASE + "/1"), updateRequestBodyWithTokenDerivedField(prohibitedField),
+                             prohibitedField)
+            ));
     }
 
     //CEP3 - Not Authorised to perform the requested action (403)
@@ -172,12 +204,29 @@ class DraftAccountControllerIntegrationTest extends CommonDraftAccountController
         );
     }
 
+    private static String requestBodyWithTokenDerivedField(String fieldName) {
+        return """
+            {
+              "business_unit_id": 78,
+              "%s": "client-supplied",
+              "account": {},
+              "account_type": "Fine"
+            }""".formatted(fieldName);
+    }
+
+    private static String updateRequestBodyWithTokenDerivedField(String fieldName) {
+        return """
+            {
+              "business_unit_id": 78,
+              "account_status": "Publishing Pending",
+              "%s": "client-supplied"
+            }""".formatted(fieldName);
+    }
+
     private static String validCreateRequestBody() {
         return """
             {
               "business_unit_id": 78,
-              "submitted_by": "BUUID1",
-              "submitted_by_name": "John",
               "account": {
                 "account_type": "Fine",
                 "defendant_type": "Adult",

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPatchIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPatchIntegrationTest.java
@@ -129,7 +129,6 @@ class DraftAccountControllerPatchIntegrationTest extends CommonDraftAccountContr
             .content("""
                 {
                   "account_status": "Rejected",
-                  "validated_by": "BUUID1A",
                   "reason_text": "Reason for rejection",
                   "business_unit_id": 78,
                   "version": 0
@@ -151,7 +150,7 @@ class DraftAccountControllerPatchIntegrationTest extends CommonDraftAccountContr
             .andExpect(jsonPath("$.timeline_data[0].username").value("opal-test"))
             .andExpect(jsonPath("$.timeline_data[0].reason_text").doesNotExist())
             .andExpect(jsonPath("$.timeline_data[1].status").value("Rejected"))
-            .andExpect(jsonPath("$.timeline_data[1].username").value("BUUID1A"))
+            .andExpect(jsonPath("$.timeline_data[1].username").value("L078JG"))
             .andExpect(jsonPath("$.timeline_data[1].reason_text").value("Reason for rejection"));
     }
 
@@ -301,8 +300,6 @@ class DraftAccountControllerPatchIntegrationTest extends CommonDraftAccountContr
         Long draftAccountId = 241L;
         String requestBody = "            {\n"
             + "                \"account_status\": \"Publishing Pending\",\n"
-            + "                \"validated_by\": \"BUUID1\",\n"
-            + "                \"validated_by_name\": \"No Permission\",\n"
             + "                \"business_unit_id\": 5,\n"
             + "                \"version\": 0\n"
             + "            }";

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPostIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPostIntegrationTest.java
@@ -40,8 +40,6 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
     private String validRawJsonCreateRequestBody() {
         AddDraftAccountRequestDto dto = AddDraftAccountRequestDto.builder()
             .businessUnitId((short) 78)
-            .submittedBy("BUUID1")
-            .submittedByName("John")
             .account(validAccountJsonString())
             .accountType(DraftAccountType.FINE)
             .build();
@@ -56,8 +54,6 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
     private String invalidLanguageRawJsonCreateRequestBody(String languageField) {
         AddDraftAccountRequestDto dto = AddDraftAccountRequestDto.builder()
             .businessUnitId((short) 78)
-            .submittedBy("BUUID1")
-            .submittedByName("John")
             .account(validAccountJsonStringWithDebtorLanguages()
                 .replace("\"%s\": \"EN\"".formatted(languageField), "\"%s\": \"English\"".formatted(languageField)))
             .accountType(DraftAccountType.FINE)
@@ -254,9 +250,8 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
     void shouldReturn400WhenTimelineDataIsSupplied() throws Exception {
         String request = validCreateRequestBody()
             .replace(
-                "\"submitted_by\": \"BUUID1\",",
-                "\"timeline_data\": " + validTimelineDataString().trim()
-                    + ",\n              \"submitted_by\": \"BUUID1\","
+                "\"business_unit_id\": 78,",
+                "\"business_unit_id\": 78,\n              \"timeline_data\": " + validTimelineDataString().trim() + ","
             );
 
         mockMvc.perform(post(URL_BASE)
@@ -608,8 +603,6 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
         return """
             {
               "business_unit_id": 78,
-              "submitted_by": "BUUID1",
-              "submitted_by_name": "John",
               "account": {
                 "account_type": "Fine",
                 "defendant_type": "Adult",
@@ -733,7 +726,6 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
               "draft_account_id": 5,
               "created_at": "2025-11-01T10:30:00+00:00",
               "business_unit_id": 78,
-              "validated_by": null,
               "account": {
                 "account_type": "Fine",
                 "defendant_type": "adultOrYouthOnly",
@@ -833,9 +825,7 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
                 "account_notes": null
               },
               "account_snapshot": null,
-              "account_type": "Fine",
-              "submitted_by": "BUUID1",
-              "submitted_by_name": "Business User 1"
+              "account_type": "Fine"
             }
 
             """;
@@ -849,8 +839,6 @@ class DraftAccountControllerPostIntegrationTest extends CommonDraftAccountContro
                "account_snapshot":null,
                "account_status_date":null,
                "business_unit_id":77,
-               "submitted_by":"L077JG",
-               "submitted_by_name":"opal-test",
                "account":{
                   "account_type":"Fixed Penalty",
                   "defendant_type":"adultOrYouthOnly",

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPutIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerPutIntegrationTest.java
@@ -518,8 +518,6 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
         return """
             {
               "business_unit_id": 78,
-              "submitted_by": "BUUID1",
-              "submitted_by_name": "John",
               "account": {
                 "account_type": "Fine",
                 "defendant_type": "Adult",
@@ -600,8 +598,6 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
         return """
             {
               "business_unit_id": 78,
-              "submitted_by": "BUUID1",
-              "submitted_by_name": "John",
               "account": {
                 "account_type": "Fine",
                 "defendant_type": "adultOrYouthOnly",
@@ -705,8 +701,6 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
         return """
             {
               "business_unit_id": 78,
-              "submitted_by": "BUUID1",
-              "submitted_by_name": "John",
               "account": {
                 "account_type": "Fine",
                 "defendant_type": "pgToPay",
@@ -778,8 +772,6 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
         return """
             {
               "business_unit_id": 78,
-              "submitted_by": "BUUID1",
-              "submitted_by_name": "John",
               "account": {
                 "account_type": "Fine",
                 "defendant_type": "adultOrYouthOnly",
@@ -836,8 +828,6 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
         return """
             {
               "business_unit_id": 78,
-              "submitted_by": "BUUID1",
-              "submitted_by_name": "John",
               "account": {
                 "account_type": "Fine",
                 "defendant_type": "pgToPay",
@@ -902,8 +892,6 @@ class DraftAccountControllerPutIntegrationTest extends CommonDraftAccountControl
         return """
             {
               "business_unit_id": 78,
-              "submitted_by": "BUUID1",
-              "submitted_by_name": "John",
               "account": {
                 "account_type": "Fine",
                 "defendant_type": "adultOrYouthOnly",

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerTransientErrorsIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerTransientErrorsIntegrationTest.java
@@ -244,8 +244,6 @@ class DraftAccountControllerTransientErrorsIntegrationTest extends AbstractInteg
         return """
             {
               "business_unit_id": 77,
-              "submitted_by": "BUUID1",
-              "submitted_by_name": "John",
               "account": {
               "account_type": "Fine",
               "defendant_type": "Adult",
@@ -325,7 +323,6 @@ class DraftAccountControllerTransientErrorsIntegrationTest extends AbstractInteg
     private static String validUpdateRequestBody() {
         return "{\n"
             + "    \"account_status\": \"Publishing Pending\",\n"
-            + "    \"validated_by\": \"BUUID1\",\n"
             + "    \"business_unit_id\": 5\n"
             + "}";
     }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountPublishTransactionIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/DraftAccountPublishTransactionIntegrationTest.java
@@ -124,8 +124,6 @@ class DraftAccountPublishTransactionIntegrationTest extends AbstractIntegrationT
         return """
             {
               "account_status": "Publishing Pending",
-              "validated_by": "ignored-by-service",
-              "validated_by_name": "ignored-by-service",
               "business_unit_id": 77,
               "reason_text": "Approve for publish",
               "version": %d

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/util/DraftAccountTestData.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/util/DraftAccountTestData.java
@@ -55,12 +55,6 @@ public final class DraftAccountTestData {
         @JsonProperty("business_unit_id")
         int businessUnitId,
 
-        @JsonProperty("submitted_by")
-        String submittedBy,
-
-        @JsonProperty("submitted_by_name")
-        String submittedByName,
-
         @JsonProperty("account_type")
         String accountType,
 
@@ -76,8 +70,6 @@ public final class DraftAccountTestData {
         public static Post defaultData() {
             return new Post(
                 77,
-                "L077JG",
-                "opal-test-post",
                 "Fine",
                 "Submitted",
                 MINIMAL_ACCOUNT_JSON
@@ -94,12 +86,6 @@ public final class DraftAccountTestData {
         @JsonProperty("business_unit_id")
         int businessUnitId,
 
-        @JsonProperty("submitted_by")
-        String submittedBy,
-
-        @JsonProperty("submitted_by_name")
-        String submittedByName,
-
         @JsonProperty("account_type")
         String accountType,
 
@@ -115,8 +101,6 @@ public final class DraftAccountTestData {
         public static Put defaultData() {
             return new Put(
                 77,
-                "L077JG",
-                "opal-test-put",
                 "Fine",
                 "Resubmitted",
                 MINIMAL_ACCOUNT_JSON
@@ -136,12 +120,6 @@ public final class DraftAccountTestData {
         @JsonProperty("account_status")
         String accountStatus,
 
-        @JsonProperty("validated_by")
-        String validatedBy,
-
-        @JsonProperty("validated_by_name")
-        String validatedByName,
-
         @JsonProperty("reason_text")
         String reasonText
 
@@ -151,8 +129,6 @@ public final class DraftAccountTestData {
             return new Patch(
                 77,
                 "Rejected",
-                "L077JG",
-                "opal-test-patch",
                 "Feature toggle test"
             );
         }

--- a/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandler.java
@@ -26,6 +26,7 @@ import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowe
 import uk.gov.hmcts.opal.exception.DefendantAccountNotFoundException;
 import uk.gov.hmcts.opal.exception.InvalidReferenceValidationException;
 import uk.gov.hmcts.opal.exception.JsonSchemaValidationException;
+import uk.gov.hmcts.opal.exception.ProhibitedDraftAccountRequestFieldException;
 import uk.gov.hmcts.opal.exception.MissingMappingTypeException;
 import uk.gov.hmcts.opal.exception.MissingReportServiceException;
 import uk.gov.hmcts.opal.exception.MissingStoredReportContentException;
@@ -240,10 +241,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(JsonSchemaValidationException.class)
     public ResponseEntity<ProblemDetail> handleJsonSchemaValidationException(JsonSchemaValidationException ex) {
+        String detail = ex instanceof ProhibitedDraftAccountRequestFieldException
+            ? ex.getMessage()
+            : "The request does not conform to the required JSON schema";
         ProblemDetail problemDetail = createProblemDetail(
             HttpStatus.BAD_REQUEST,
             "Bad Request",
-            "The request does not conform to the required JSON schema",
+            detail,
             "json-schema-validation",
             false,
             ex

--- a/src/main/java/uk/gov/hmcts/opal/controllers/advice/JsonSchemaValidationAdvice.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/advice/JsonSchemaValidationAdvice.java
@@ -5,10 +5,14 @@ import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.converter.HttpMessageConverter;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdviceAdapter;
 import uk.gov.hmcts.opal.annotation.JsonSchemaValidated;
 import uk.gov.hmcts.opal.exception.JsonSchemaValidationException;
+import uk.gov.hmcts.opal.exception.ProhibitedDraftAccountRequestFieldException;
+import uk.gov.hmcts.opal.common.dto.ToJsonString;
 import uk.gov.hmcts.opal.service.opal.JsonSchemaValidationService;
 
 import java.io.ByteArrayInputStream;
@@ -16,12 +20,27 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @ControllerAdvice
 @AllArgsConstructor
 public class JsonSchemaValidationAdvice extends RequestBodyAdviceAdapter {
 
     private final JsonSchemaValidationService jsonSchemaValidationService;
+    private static final Set<String> DRAFT_ACCOUNT_REQUEST_SCHEMAS = Set.of(
+        "addDraftAccountRequest",
+        "replaceDraftAccountRequest",
+        "updateDraftAccountRequest"
+    );
+    // The request schemas deliberately omit these token-derived fields. This explicit check gives clients the
+    // PO-2461/AC2 error message instead of a generic schema-validation response or permissive unknown-field handling.
+    private static final Set<String> TOKEN_DERIVED_DRAFT_ACCOUNT_FIELDS = Set.of(
+        "submitted_by",
+        "submitted_by_name",
+        "validated_by",
+        "validated_by_name"
+    );
 
     @Override
     public boolean supports(MethodParameter methodParameter, Type targetType,
@@ -41,6 +60,7 @@ public class JsonSchemaValidationAdvice extends RequestBodyAdviceAdapter {
         if (annotation != null) {
             String schemaPath = annotation.schemaPath();
             rejectTimelineDataForDraftAccountRequests(body, schemaPath);
+            rejectTokenDerivedFieldsForDraftAccountRequests(body, schemaPath);
             jsonSchemaValidationService.validateOrError(body, schemaPath);
         }
 
@@ -59,11 +79,35 @@ public class JsonSchemaValidationAdvice extends RequestBodyAdviceAdapter {
 
     private static void rejectTimelineDataForDraftAccountRequests(String body, String schemaPath) {
         if (schemaPath.contains("draft-account")
-            && (schemaPath.contains("addDraftAccountRequest")
-            || schemaPath.contains("replaceDraftAccountRequest")
-            || schemaPath.contains("updateDraftAccountRequest"))
+            && DRAFT_ACCOUNT_REQUEST_SCHEMAS.stream().anyMatch(schemaPath::contains)
             && body.contains("\"timeline_data\"")) {
             throw new JsonSchemaValidationException("timeline_data is not allowed in draft account requests");
+        }
+    }
+
+    private static void rejectTokenDerivedFieldsForDraftAccountRequests(String body, String schemaPath) {
+        if (schemaPath.contains("draft-account")
+            && DRAFT_ACCOUNT_REQUEST_SCHEMAS.stream().anyMatch(schemaPath::contains)) {
+            Set<String> prohibitedFields = getTokenDerivedTopLevelFields(body);
+            if (!prohibitedFields.isEmpty()) {
+                throw new ProhibitedDraftAccountRequestFieldException(
+                    String.join(", ", prohibitedFields) + " are not allowed in draft account requests"
+                );
+            }
+        }
+    }
+
+    private static Set<String> getTokenDerivedTopLevelFields(String body) {
+        try {
+            JsonNode root = ToJsonString.getObjectMapper().readTree(body);
+            if (!root.isObject()) {
+                return Set.of();
+            }
+            return TOKEN_DERIVED_DRAFT_ACCOUNT_FIELDS.stream()
+                .filter(root::has)
+                .collect(Collectors.toSet());
+        } catch (JacksonException ex) {
+            return Set.of();
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/dto/AddDraftAccountRequestDto.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/AddDraftAccountRequestDto.java
@@ -36,9 +36,6 @@ public class AddDraftAccountRequestDto implements ToJsonString, DraftAccountRequ
     @NonNull
     private Short businessUnitId;
 
-    @JsonProperty("validated_by")
-    private String validatedBy;
-
     @JsonProperty(value = "account", required = true)
     @JsonDeserialize(using = KeepAsJsonDeserializer.class)
     @JsonRawValue
@@ -62,9 +59,4 @@ public class AddDraftAccountRequestDto implements ToJsonString, DraftAccountRequ
     @JsonProperty("timeline_data")
     private Object timelineData;
 
-    @JsonProperty("submitted_by")
-    private String submittedBy;
-
-    @JsonProperty("submitted_by_name")
-    private String submittedByName;
 }

--- a/src/main/java/uk/gov/hmcts/opal/dto/DraftAccountRequestDto.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/DraftAccountRequestDto.java
@@ -6,9 +6,5 @@ public interface DraftAccountRequestDto {
 
     String getAccount();
 
-    String getSubmittedBy();
-
-    String getSubmittedByName();
-
     DraftAccountType getAccountType();
 }

--- a/src/main/java/uk/gov/hmcts/opal/dto/ReplaceDraftAccountRequestDto.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/ReplaceDraftAccountRequestDto.java
@@ -28,12 +28,6 @@ public class ReplaceDraftAccountRequestDto implements ToJsonString, DraftAccount
     @JsonProperty(value = "business_unit_id", required = true)
     private Short businessUnitId;
 
-    @JsonProperty("submitted_by")
-    private String submittedBy;
-
-    @JsonProperty("submitted_by_name")
-    private String submittedByName;
-
     @NotBlank
     @JsonProperty(value = "account", required = true)
     @JsonDeserialize(using = KeepAsJsonDeserializer.class)

--- a/src/main/java/uk/gov/hmcts/opal/dto/UpdateDraftAccountRequestDto.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/UpdateDraftAccountRequestDto.java
@@ -15,12 +15,6 @@ import uk.gov.hmcts.opal.entity.draft.DraftAccountStatus;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class UpdateDraftAccountRequestDto implements ToJsonString {
 
-    @JsonProperty("validated_by")
-    private String validatedBy;
-
-    @JsonProperty("validated_by_name")
-    private String validatedByName;
-
     @JsonProperty("business_unit_id")
     private Short businessUnitId;
 

--- a/src/main/java/uk/gov/hmcts/opal/exception/ProhibitedDraftAccountRequestFieldException.java
+++ b/src/main/java/uk/gov/hmcts/opal/exception/ProhibitedDraftAccountRequestFieldException.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.opal.exception;
+
+public class ProhibitedDraftAccountRequestFieldException extends JsonSchemaValidationException {
+
+    public ProhibitedDraftAccountRequestFieldException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/DraftAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/DraftAccountService.java
@@ -175,11 +175,12 @@ public class DraftAccountService {
                                                         FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS)) {
 
             BusinessUnitUser unitUser = getBusinessUnitUserOrThrow(userState, dto.getBusinessUnitId());
-            applySubmittedBy(dto, userState, unitUser);
+            String submittedBy = unitUser.getBusinessUnitUserId();
+            String submittedByName = userState.getDisplayName();
 
             jsonSchemaValidationService.validateOrError(dto.toJson(), ADD_DRAFT_ACCOUNT_REQUEST_JSON);
             referenceValidationService.validateReferences(dto.getAccount());
-            DraftAccountEntity entity = draftAccountTransactional.submitDraftAccount(dto);
+            DraftAccountEntity entity = draftAccountTransactional.submitDraftAccount(dto, submittedBy, submittedByName);
             log.debug(":submitDraftAccount: created in DB: {}", entity);
 
             loggingService.pdplForDraftAccount(entity, Action.SUBMIT, userState);
@@ -203,11 +204,13 @@ public class DraftAccountService {
         if (userState.hasBusinessUnitUserWithPermission(dto.getBusinessUnitId(),
                                                         FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS)) {
             BusinessUnitUser unitUser = getBusinessUnitUserOrThrow(userState, dto.getBusinessUnitId());
-            applySubmittedBy(dto, userState, unitUser);
+            String submittedBy = unitUser.getBusinessUnitUserId();
+            String submittedByName = userState.getDisplayName();
             jsonSchemaValidationService.validateOrError(dto.toJson(), REPLACE_DRAFT_ACCOUNT_REQUEST_JSON);
             referenceValidationService.validateReferences(dto.getAccount());
             DraftAccountEntity replacedEntity = draftAccountTransactional
-                .replaceDraftAccount(draftAccountId, dto, draftAccountTransactional, ifMatch);
+                .replaceDraftAccount(draftAccountId, dto, draftAccountTransactional, ifMatch, submittedBy,
+                                     submittedByName);
             verifyUpdated(replacedEntity, dto, draftAccountId, "replaceDraftAccount");
             log.debug(":replaceDraftAccount: replaced with version: {}", replacedEntity.getVersion());
 
@@ -229,13 +232,13 @@ public class DraftAccountService {
         Optional<BusinessUnitUser> unitUser = userState.getBusinessUnitUserForBusinessUnit(dto.getBusinessUnitId());
         log.info(":updateDraftAccount: unit user: {}", unitUser);
         if (UserState.userHasPermission(unitUser, FinesPermission.CHECK_VALIDATE_DRAFT_ACCOUNTS)) {
-            if (DraftAccountStatus.PUBLISHING_PENDING.equals(dto.getAccountStatus())) {
-                applyValidatedBy(dto, userState, unitUser.orElseThrow());
-            }
+            BusinessUnitUser businessUnitUser = unitUser.orElseThrow();
+            String statusUpdatedBy = businessUnitUser.getBusinessUnitUserId();
+            String statusUpdatedByName = userState.getDisplayName();
             jsonSchemaValidationService.validateOrError(dto.toJson(), UPDATE_DRAFT_ACCOUNT_REQUEST_JSON);
             BigInteger updateVersion = extractBigInteger(ifMatch);
             DraftAccountEntity updatedEntity = draftAccountTransactional.updateDraftAccount(draftAccountId, dto,
-                draftAccountTransactional, updateVersion, userState);
+                draftAccountTransactional, updateVersion, userState, statusUpdatedBy, statusUpdatedByName);
             verifyUpdated(updatedEntity, updateVersion, draftAccountId, "updateDraftAccount");
 
             loggingService.pdplForDraftAccount(updatedEntity, Action.RESUBMIT, userState);
@@ -277,19 +280,4 @@ public class DraftAccountService {
                                                                 FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS));
     }
 
-    private void applySubmittedBy(AddDraftAccountRequestDto dto, UserState userState, BusinessUnitUser unitUser) {
-        dto.setSubmittedBy(unitUser.getBusinessUnitUserId());
-        dto.setSubmittedByName(userState.getDisplayName());
-        dto.setValidatedBy(null);
-    }
-
-    private void applySubmittedBy(ReplaceDraftAccountRequestDto dto, UserState userState, BusinessUnitUser unitUser) {
-        dto.setSubmittedBy(unitUser.getBusinessUnitUserId());
-        dto.setSubmittedByName(userState.getDisplayName());
-    }
-
-    private void applyValidatedBy(UpdateDraftAccountRequestDto dto, UserState userState, BusinessUnitUser unitUser) {
-        dto.setValidatedBy(unitUser.getBusinessUnitUserId());
-        dto.setValidatedByName(userState.getDisplayName());
-    }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactional.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactional.java
@@ -114,21 +114,23 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
     }
 
     @Transactional
-    public DraftAccountEntity submitDraftAccount(AddDraftAccountRequestDto dto) {
+    public DraftAccountEntity submitDraftAccount(AddDraftAccountRequestDto dto, String submittedBy,
+                                                 String submittedByName) {
         LocalDateTime created = LocalDateTime.now(clock);
         BusinessUnitEntity businessUnit = businessUnitRepository.getReferenceById(
             dto.getBusinessUnitId());
-        String snapshot = createInitialSnapshot(dto, created, businessUnit);
+        String snapshot = createInitialSnapshot(dto, created, businessUnit, submittedBy, submittedByName);
         log.debug(":submitDraftAccount: dto: \n{}", dto.toPrettyJson());
 
         return draftAccountRepository.save(
-            toEntity(dto, created, businessUnit, snapshot));
+            toEntity(dto, created, businessUnit, snapshot, submittedBy, submittedByName));
 
     }
 
     @Transactional
     public DraftAccountEntity replaceDraftAccount(Long draftAccountId, ReplaceDraftAccountRequestDto dto,
-                                                  DraftAccountTransactionalProxy proxy, String ifMatch) {
+                                                  DraftAccountTransactionalProxy proxy, String ifMatch,
+                                                  String submittedBy, String submittedByName) {
         DraftAccountEntity existingAccount = proxy.getDraftAccount(draftAccountId);
         verifyIfMatch(existingAccount, ifMatch, draftAccountId, "replaceDraftAccount");
 
@@ -144,9 +146,10 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
             );
         }
 
-        String newSnapshot = createUpdateSnapshot(dto, existingAccount.getCreatedDate(), businessUnit);
-        existingAccount.setSubmittedBy(dto.getSubmittedBy());
-        existingAccount.setSubmittedByName(dto.getSubmittedByName());
+        String newSnapshot = createUpdateSnapshot(dto, existingAccount.getCreatedDate(), businessUnit, submittedBy,
+                                                  submittedByName);
+        existingAccount.setSubmittedBy(submittedBy);
+        existingAccount.setSubmittedByName(submittedByName);
         existingAccount.setAccount(dto.getAccount());
         existingAccount.setAccountSnapshot(newSnapshot);
         existingAccount.setAccountType(dto.getAccountType());
@@ -155,7 +158,7 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
         existingAccount.setTimelineData(
             appendTimelineEntry(
                 existingAccount.getTimelineData(),
-                dto.getSubmittedBy(),
+                submittedBy,
                 DraftAccountStatus.RESUBMITTED,
                 null
             )
@@ -170,7 +173,8 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
     @Transactional
     public DraftAccountEntity updateDraftAccount(Long draftAccountId, UpdateDraftAccountRequestDto dto,
                                                  DraftAccountTransactionalProxy proxy, BigInteger updateVersion,
-                                                 UserState userState) {
+                                                 UserState userState, String statusUpdatedBy,
+                                                 String statusUpdatedByName) {
         DraftAccountEntity existingAccount = proxy.getDraftAccount(draftAccountId);
         verifyIfMatch(existingAccount, updateVersion, draftAccountId, "updateDraftAccount");
 
@@ -196,11 +200,11 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
 
         if (newStatus.isPublishingPending()) {
             LocalDateTime validationTimestamp = LocalDateTime.now(clock);
-            checkValidatorIsNotSubmitter(existingAccount.getSubmittedBy(), dto.getValidatedBy(), draftAccountId,
+            checkValidatorIsNotSubmitter(existingAccount.getSubmittedBy(), statusUpdatedBy, draftAccountId,
                 userState, dto.getBusinessUnitId());
             existingAccount.setValidatedDate(validationTimestamp);
-            existingAccount.setValidatedBy(dto.getValidatedBy());
-            existingAccount.setValidatedByName(dto.getValidatedByName());
+            existingAccount.setValidatedBy(statusUpdatedBy);
+            existingAccount.setValidatedByName(statusUpdatedByName);
             existingAccount.setAccountSnapshot(addSnapshotApprovedDate(existingAccount));
             existingAccount.setAccountStatusDate(validationTimestamp);
         }
@@ -212,7 +216,7 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
         }
 
         existingAccount.setTimelineData(
-            appendTimelineEntry(existingAccount.getTimelineData(), dto.getValidatedBy(), newStatus, dto.getReasonText())
+            appendTimelineEntry(existingAccount.getTimelineData(), statusUpdatedBy, newStatus, dto.getReasonText())
         );
 
         log.info(":updateDraftAccount: Updating draft account with ID: {} and status: {}",
@@ -299,14 +303,14 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
     }
 
     private String createInitialSnapshot(AddDraftAccountRequestDto dto, LocalDateTime created,
-                                         BusinessUnitEntity businessUnit) {
-        return buildSnapshot(dto.getAccount(), created, businessUnit, dto.getSubmittedBy(), dto.getSubmittedByName(),
+                                         BusinessUnitEntity businessUnit, String submittedBy, String submittedByName) {
+        return buildSnapshot(dto.getAccount(), created, businessUnit, submittedBy, submittedByName,
                              "AddDraftAccountRequestDto.account").toPrettyJson();
     }
 
     private String createUpdateSnapshot(ReplaceDraftAccountRequestDto dto, LocalDateTime created,
-                                         BusinessUnitEntity businessUnit) {
-        return buildSnapshot(dto.getAccount(), created, businessUnit, dto.getSubmittedBy(), dto.getSubmittedByName(),
+                                        BusinessUnitEntity businessUnit, String submittedBy, String submittedByName) {
+        return buildSnapshot(dto.getAccount(), created, businessUnit, submittedBy, submittedByName,
                              "ReplaceDraftAccountRequestDto.account").toPrettyJson();
     }
 
@@ -342,19 +346,20 @@ public class DraftAccountTransactional implements DraftAccountTransactionalProxy
     }
 
     DraftAccountEntity toEntity(AddDraftAccountRequestDto dto, LocalDateTime created,
-                                BusinessUnitEntity businessUnit, String snapshot) {
+                                BusinessUnitEntity businessUnit, String snapshot, String submittedBy,
+                                String submittedByName) {
         return DraftAccountEntity.builder()
             .businessUnit(businessUnit)
             .createdDate(created)
-            .submittedBy(dto.getSubmittedBy())
-            .submittedByName(dto.getSubmittedByName())
+            .submittedBy(submittedBy)
+            .submittedByName(submittedByName)
             .account(dto.getAccount())
             .accountSnapshot(snapshot)
             .accountType(dto.getAccountType())
             .accountStatus(DraftAccountStatus.SUBMITTED)
             .accountStatusDate(created)
             .statusMessage(dto.getStatusMessage())
-            .timelineData(createTimelineData(dto.getSubmittedBy(), DraftAccountStatus.SUBMITTED, null))
+            .timelineData(createTimelineData(submittedBy, DraftAccountStatus.SUBMITTED, null))
             .draftAccountId(null)
             .build();
     }

--- a/src/main/resources/jsonSchemas/opal/draft-account/addDraftAccountRequest.json
+++ b/src/main/resources/jsonSchemas/opal/draft-account/addDraftAccountRequest.json
@@ -7,14 +7,6 @@
       "format": "int32",
       "description": "ID of the Business Unit the Draft Account belongs to"
     },
-    "submitted_by": {
-      "type": "string",
-      "description": "ID of the User that last submitted the Draft Account for checking"
-    },
-    "submitted_by_name": {
-      "type": "string",
-      "description": "Value of the name claim in the AAD Acces Token"
-    },
     "account": {
       "$ref": "resource:/jsonSchemas/opal/defendant-account/account.json",
       "description": "The structured Account data (JSON)"

--- a/src/main/resources/jsonSchemas/opal/draft-account/replaceDraftAccountRequest.json
+++ b/src/main/resources/jsonSchemas/opal/draft-account/replaceDraftAccountRequest.json
@@ -8,18 +8,6 @@
       "format": "int32",
       "description": "ID of the Business Unit the Draft Account belongs to"
     },
-    "submitted_by": {
-      "type": "string",
-      "description": "ID of the User that last submitted the Draft Account for checking"
-    },
-    "submitted_by_name": {
-      "type": "string",
-      "description": "Value of the name claim in the AAD Acces Token"
-    },
-    "validated_by": {
-      "type": ["string", "null"],
-      "description": "ID of the User that validated the Draft Account for checking"
-    },
     "account": {
       "$ref": "resource:/jsonSchemas/opal/defendant-account/account.json",
       "description": "The structured Account data (JSON)"

--- a/src/main/resources/jsonSchemas/opal/draft-account/updateDraftAccountRequest.json
+++ b/src/main/resources/jsonSchemas/opal/draft-account/updateDraftAccountRequest.json
@@ -3,14 +3,6 @@
   "$id": "https://opal-fines-service/updateDraftAccountRequest.json",
   "type": ["object", "null"],
   "properties": {
-    "validated_by": {
-      "type": ["string", "null"],
-      "description": "ID of the User that validated the Draft Account for checking"
-    },
-    "validated_by_name": {
-      "type": ["string", "null"],
-      "description": "Value of the name claim in the AAD Acces Token"
-    },
     "business_unit_id": {
       "type": "integer",
       "format": "int32",

--- a/src/test/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/DraftAccountControllerTest.java
@@ -108,8 +108,6 @@ class DraftAccountControllerTest {
             .accountType(DraftAccountType.FINE)
             .account(getAccountJson())
             .businessUnitId((short)1)
-            .submittedBy("USER_ID")
-            .submittedByName("USER_NAME")
             .build();
 
         when(draftAccountService.submitDraftAccount(any())).thenReturn(toGetDto(entity));

--- a/src/test/java/uk/gov/hmcts/opal/controllers/DraftAccountRequestSchemaTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/DraftAccountRequestSchemaTest.java
@@ -1,0 +1,50 @@
+package uk.gov.hmcts.opal.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.InputStream;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+class DraftAccountRequestSchemaTest {
+
+    private static final Set<String> TOKEN_DERIVED_FIELDS = Set.of(
+        "submitted_by",
+        "submitted_by_name",
+        "validated_by",
+        "validated_by_name"
+    );
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @ParameterizedTest
+    @MethodSource("draftAccountRequestSchemas")
+    void draftAccountRequestSchemas_doNotExposeTokenDerivedFields(String schemaPath) throws Exception {
+        JsonNode properties = readSchema(schemaPath).get("properties");
+
+        assertNotNull(properties);
+        assertAll(TOKEN_DERIVED_FIELDS.stream()
+            .map(field -> () -> assertFalse(properties.has(field), schemaPath + " must not expose " + field)));
+    }
+
+    private static Stream<String> draftAccountRequestSchemas() {
+        return Stream.of(
+            "jsonSchemas/opal/draft-account/addDraftAccountRequest.json",
+            "jsonSchemas/opal/draft-account/replaceDraftAccountRequest.json",
+            "jsonSchemas/opal/draft-account/updateDraftAccountRequest.json"
+        );
+    }
+
+    private static JsonNode readSchema(String schemaPath) throws Exception {
+        try (InputStream inputStream = DraftAccountRequestSchemaTest.class.getClassLoader()
+            .getResourceAsStream(schemaPath)) {
+            assertNotNull(inputStream, schemaPath + " must exist");
+            return OBJECT_MAPPER.readTree(inputStream);
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/advice/GlobalExceptionHandlerTest.java
@@ -41,6 +41,7 @@ import uk.gov.hmcts.opal.exception.JsonSchemaValidationException;
 import uk.gov.hmcts.opal.exception.MissingMappingTypeException;
 import uk.gov.hmcts.opal.exception.MissingReportServiceException;
 import uk.gov.hmcts.opal.exception.MissingStoredReportContentException;
+import uk.gov.hmcts.opal.exception.ProhibitedDraftAccountRequestFieldException;
 import uk.gov.hmcts.opal.exception.RequiredPermissionException;
 import uk.gov.hmcts.opal.exception.ResourceConflictException;
 import uk.gov.hmcts.opal.exception.SchemaConfigurationException;
@@ -225,6 +226,17 @@ class GlobalExceptionHandlerTest {
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertEquals("Bad Request", response.getBody().getTitle());
         assertEquals("The request does not conform to the required JSON schema", response.getBody().getDetail());
+    }
+
+    @Test
+    void handleJsonSchemaValidation_exposesProhibitedDraftAccountFieldProblem() {
+        ResponseEntity<ProblemDetail> response = globalExceptionHandler.handleJsonSchemaValidationException(
+            new ProhibitedDraftAccountRequestFieldException("submitted_by is not allowed in draft account requests")
+        );
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Bad Request", response.getBody().getTitle());
+        assertEquals("submitted_by is not allowed in draft account requests", response.getBody().getDetail());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/controllers/advice/JsonSchemaValidationAdviceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/advice/JsonSchemaValidationAdviceTest.java
@@ -1,0 +1,93 @@
+package uk.gov.hmcts.opal.controllers.advice;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.converter.HttpMessageConverter;
+import uk.gov.hmcts.opal.annotation.JsonSchemaValidated;
+import uk.gov.hmcts.opal.exception.ProhibitedDraftAccountRequestFieldException;
+import uk.gov.hmcts.opal.service.opal.JsonSchemaValidationService;
+
+class JsonSchemaValidationAdviceTest {
+
+    private static final String DRAFT_ACCOUNT_SCHEMA = "opal/draft-account/addDraftAccountRequest.json";
+
+    private final JsonSchemaValidationService jsonSchemaValidationService = mock(JsonSchemaValidationService.class);
+    private final JsonSchemaValidationAdvice advice = new JsonSchemaValidationAdvice(jsonSchemaValidationService);
+
+    @Test
+    void beforeBodyRead_rejectsTopLevelTokenDerivedField() {
+        assertThrows(
+            ProhibitedDraftAccountRequestFieldException.class,
+            () -> advice.beforeBodyRead(inputMessage("""
+                {
+                  "business_unit_id": 78,
+                  "submitted_by": "client-user",
+                  "account": {}
+                }"""), methodParameter(), targetType(), converterType())
+        );
+    }
+
+    @Test
+    void beforeBodyRead_allowsTokenDerivedFieldNameInsideNestedValue() {
+        String body = """
+            {
+              "business_unit_id": 78,
+              "account": {
+                "note": "submitted_by"
+              }
+            }""";
+
+        assertDoesNotThrow(() -> advice.beforeBodyRead(
+            inputMessage(body),
+            methodParameter(),
+            targetType(),
+            converterType()
+        ));
+
+        verify(jsonSchemaValidationService).validateOrError(body, DRAFT_ACCOUNT_SCHEMA);
+    }
+
+    private MethodParameter methodParameter() {
+        JsonSchemaValidated annotation = mock(JsonSchemaValidated.class);
+        when(annotation.schemaPath()).thenReturn(DRAFT_ACCOUNT_SCHEMA);
+
+        MethodParameter methodParameter = mock(MethodParameter.class);
+        when(methodParameter.getParameterAnnotation(JsonSchemaValidated.class)).thenReturn(annotation);
+        return methodParameter;
+    }
+
+    private HttpInputMessage inputMessage(String body) {
+        return new HttpInputMessage() {
+            @Override
+            public InputStream getBody() {
+                return new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8));
+            }
+
+            @Override
+            public HttpHeaders getHeaders() {
+                return HttpHeaders.EMPTY;
+            }
+        };
+    }
+
+    private Type targetType() {
+        return Object.class;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Class<? extends HttpMessageConverter<?>> converterType() {
+        return (Class<? extends HttpMessageConverter<?>>) (Class<?>) HttpMessageConverter.class;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/DraftAccountServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -173,13 +174,11 @@ class DraftAccountServiceTest {
         DraftAccountEntity draftAccountEntity = DraftAccountEntity.builder().build();
         when(draftAccountMapper.toResponseDto(draftAccountEntity))
             .thenReturn(DraftAccountResponseDto.builder().build());
-        when(draftAccountTransactional.submitDraftAccount(any())).thenReturn(draftAccountEntity);
+        when(draftAccountTransactional.submitDraftAccount(any(), any(), any())).thenReturn(draftAccountEntity);
         var userState = UserStateUtil.permissionUser((short) 2, FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS);
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         AddDraftAccountRequestDto addDraftAccountDto = AddDraftAccountRequestDto.builder()
             .businessUnitId((short) 2)
-            .submittedBy("SpoofedUser")
-            .submittedByName("Spoofed Name")
             .account(createAccountString())
             .accountType(DraftAccountType.FINE)
             .build();
@@ -191,10 +190,8 @@ class DraftAccountServiceTest {
         assertEquals(draftAccountEntity.getAccount(), result.getAccount());
         verify(referenceValidationService).validateReferences(addDraftAccountDto.getAccount());
         ArgumentCaptor<AddDraftAccountRequestDto> captor = ArgumentCaptor.forClass(AddDraftAccountRequestDto.class);
-        verify(draftAccountTransactional, times(1)).submitDraftAccount(captor.capture());
-        assertEquals("USER01", captor.getValue().getSubmittedBy());
-        assertEquals("Normal User", captor.getValue().getSubmittedByName());
-        assertEquals(null, captor.getValue().getValidatedBy());
+        verify(draftAccountTransactional, times(1))
+            .submitDraftAccount(captor.capture(), eq("USER01"), eq("Normal User"));
         verify(pdplLoggingService).pdplForDraftAccount(draftAccountEntity, Action.SUBMIT, userState);
     }
 
@@ -206,8 +203,6 @@ class DraftAccountServiceTest {
             .businessUnitId(businessUnitId)
             .accountType(DraftAccountType.FINE)
             .account(createAccountString())
-            .submittedBy("TestUser")
-            .submittedByName("Test User")
             .build();
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(UserStateUtil.noPermissionsUser());
 
@@ -225,8 +220,6 @@ class DraftAccountServiceTest {
     void testSubmitDraftAccounts_invalidHearingLanguage_rejectedBySchema() {
         AddDraftAccountRequestDto addDraftAccountDto = AddDraftAccountRequestDto.builder()
             .businessUnitId((short) 2)
-            .submittedBy("SpoofedUser")
-            .submittedByName("Spoofed Name")
             .account(createAccountString().replace("\"hearing_language\": \"EN\"", "\"hearing_language\": \"English\""))
             .accountType(DraftAccountType.FINE)
             .build();
@@ -241,7 +234,7 @@ class DraftAccountServiceTest {
         );
 
         assertTrue(ex.getMessage().contains("hearing_language"));
-        verify(draftAccountTransactional, never()).submitDraftAccount(any());
+        verify(draftAccountTransactional, never()).submitDraftAccount(any(), any(), any());
     }
 
     @Test
@@ -293,13 +286,12 @@ class DraftAccountServiceTest {
                 .timelineData(createTimelineDataString())
                 .build()
         );
-        when(draftAccountTransactional.replaceDraftAccount(any(), any(), any(), any())).thenReturn(updatedAccount);
+        when(draftAccountTransactional.replaceDraftAccount(any(), any(), any(), any(), any(), any()))
+            .thenReturn(updatedAccount);
         var userState = UserStateUtil.permissionUser((short) 2, FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS);
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         ReplaceDraftAccountRequestDto replaceDto = ReplaceDraftAccountRequestDto.builder()
             .businessUnitId((short) 2)
-            .submittedBy("SpoofedUser")
-            .submittedByName("Spoofed Name")
             .account(createAccountString())
             .accountType(DraftAccountType.FINE)
             .version(BigInteger.valueOf(0L))
@@ -321,9 +313,8 @@ class DraftAccountServiceTest {
 
         ArgumentCaptor<ReplaceDraftAccountRequestDto> captor =
             ArgumentCaptor.forClass(ReplaceDraftAccountRequestDto.class);
-        verify(draftAccountTransactional).replaceDraftAccount(any(), captor.capture(), any(), any());
-        assertEquals("USER01", captor.getValue().getSubmittedBy());
-        assertEquals("Normal User", captor.getValue().getSubmittedByName());
+        verify(draftAccountTransactional)
+            .replaceDraftAccount(any(), captor.capture(), any(), any(), eq("USER01"), eq("Normal User"));
 
         verify(jsonSchemaValidationService).validateOrError(any(), any());
         verify(pdplLoggingService).pdplForDraftAccount(updatedAccount, Action.REPLACE, userState);
@@ -337,11 +328,9 @@ class DraftAccountServiceTest {
             .businessUnitId((short)1)
             .accountType(DraftAccountType.FINE)
             .account(createAccountString())
-            .submittedBy("SpoofedUser")
-            .submittedByName("Spoofed Name")
             .version(BigInteger.valueOf(0L))
             .build();
-        when(draftAccountTransactional.replaceDraftAccount(any(), any(), any(), any())).thenThrow(
+        when(draftAccountTransactional.replaceDraftAccount(any(), any(), any(), any(), any(), any())).thenThrow(
             new EntityNotFoundException("Draft Account not found with id: " + draftAccountId));
         when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(UserStateUtil.permissionUser((short) 1, FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS));
@@ -365,11 +354,10 @@ class DraftAccountServiceTest {
             .businessUnitId((short) 2)
             .accountType(DraftAccountType.FINE)
             .account(createAccountString())
-            .submittedBy("SpoofedUser")
-            .submittedByName("Spoofed Name")
             .version(BigInteger.valueOf(0L))
             .build();
-        when(draftAccountTransactional.replaceDraftAccount(any(), any(), any(), any())).thenReturn(existingAccount);
+        when(draftAccountTransactional.replaceDraftAccount(any(), any(), any(), any(), any(), any()))
+            .thenReturn(existingAccount);
         when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(UserStateUtil.permissionUser((short) 2, FinesPermission.CREATE_MANAGE_DRAFT_ACCOUNTS));
 
@@ -392,7 +380,7 @@ class DraftAccountServiceTest {
             .businessUnit(BusinessUnitEntity.builder().businessUnitId((short) 3).build())
             .versionNumber(0L)
             .build();
-        when(draftAccountTransactional.updateDraftAccount(any(), any(), any(), any(), any()))
+        when(draftAccountTransactional.updateDraftAccount(any(), any(), any(), any(), any(), any(), any()))
             .thenReturn(existingAccount);
         when(userStateService.getUserStateV1FromSecurityContext())
             .thenReturn(UserStateUtil.permissionUser((short) 2, FinesPermission.CHECK_VALIDATE_DRAFT_ACCOUNTS));
@@ -411,8 +399,6 @@ class DraftAccountServiceTest {
         Long draftAccountId = 1L;
         final UpdateDraftAccountRequestDto updateDto = UpdateDraftAccountRequestDto.builder()
             .accountStatus(DraftAccountStatus.PUBLISHING_PENDING)
-            .validatedBy("SpoofedUser")
-            .validatedByName("Spoofed Name")
             .businessUnitId((short) 2)
             .build();
         final DraftAccountEntity updatedAccount = DraftAccountEntity.builder()
@@ -426,7 +412,7 @@ class DraftAccountServiceTest {
             .timelineData(createTimelineDataString())
             .versionNumber(1L)
             .build();
-        when(draftAccountTransactional.updateDraftAccount(any(), any(), any(), any(), any()))
+        when(draftAccountTransactional.updateDraftAccount(any(), any(), any(), any(), any(), any(), any()))
             .thenReturn(updatedAccount);
         var userState = UserStateUtil.permissionUser((short) 2, FinesPermission.CHECK_VALIDATE_DRAFT_ACCOUNTS);
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
@@ -436,9 +422,8 @@ class DraftAccountServiceTest {
         // More Assert
         ArgumentCaptor<UpdateDraftAccountRequestDto> captor =
             ArgumentCaptor.forClass(UpdateDraftAccountRequestDto.class);
-        verify(draftAccountTransactional).updateDraftAccount(any(), captor.capture(), any(), any(), any());
-        assertEquals("USER01", captor.getValue().getValidatedBy());
-        assertEquals("Normal User", captor.getValue().getValidatedByName());
+        verify(draftAccountTransactional)
+            .updateDraftAccount(any(), captor.capture(), any(), any(), any(), eq("USER01"), eq("Normal User"));
 
         verify(jsonSchemaValidationService).validateOrError(any(), any());
         verify(securityEventLoggingService, times(1)).logEvent(
@@ -463,8 +448,6 @@ class DraftAccountServiceTest {
         Long draftAccountId = 1L;
         UpdateDraftAccountRequestDto updateDto = UpdateDraftAccountRequestDto.builder()
             .accountStatus(DraftAccountStatus.REJECTED)
-            .validatedBy("PATCH002_REVIEWER")
-            .validatedByName("Laura Reviewer")
             .businessUnitId((short) 2)
             .build();
         DraftAccountEntity updatedAccount = DraftAccountEntity.builder()
@@ -477,7 +460,7 @@ class DraftAccountServiceTest {
             .build();
         var userState = UserStateUtil.permissionUser((short) 2, FinesPermission.CHECK_VALIDATE_DRAFT_ACCOUNTS);
 
-        when(draftAccountTransactional.updateDraftAccount(any(), any(), any(), any(), any()))
+        when(draftAccountTransactional.updateDraftAccount(any(), any(), any(), any(), any(), any(), any()))
             .thenReturn(updatedAccount);
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
         when(draftAccountMapper.toResponseDto(updatedAccount)).thenReturn(
@@ -499,10 +482,47 @@ class DraftAccountServiceTest {
 
         ArgumentCaptor<UpdateDraftAccountRequestDto> captor =
             ArgumentCaptor.forClass(UpdateDraftAccountRequestDto.class);
-        verify(draftAccountTransactional).updateDraftAccount(any(), captor.capture(), any(), any(), any());
-        assertEquals("PATCH002_REVIEWER", captor.getValue().getValidatedBy());
-        assertEquals("Laura Reviewer", captor.getValue().getValidatedByName());
+        verify(draftAccountTransactional)
+            .updateDraftAccount(any(), captor.capture(), any(), any(), any(), eq("USER01"), eq("Normal User"));
 
+        verify(draftAccountPublishProxy, never()).publishDefendantAccount(any(), any());
+        verify(pdplLoggingService).pdplForDraftAccount(updatedAccount, Action.RESUBMIT, userState);
+        verify(jsonSchemaValidationService).validateOrError(any(), any());
+    }
+
+    @Test
+    void testUpdateDraftAccount_deletedPassesAuthenticatedUserForTimelineActor() {
+        Long draftAccountId = 1L;
+        UpdateDraftAccountRequestDto updateDto = UpdateDraftAccountRequestDto.builder()
+            .accountStatus(DraftAccountStatus.DELETED)
+            .businessUnitId((short) 2)
+            .build();
+        DraftAccountEntity updatedAccount = DraftAccountEntity.builder()
+            .draftAccountId(draftAccountId)
+            .accountStatus(DraftAccountStatus.DELETED)
+            .timelineData(createTimelineDataString())
+            .versionNumber(1L)
+            .build();
+        var userState = UserStateUtil.permissionUser((short) 2, FinesPermission.CHECK_VALIDATE_DRAFT_ACCOUNTS);
+
+        when(draftAccountTransactional.updateDraftAccount(any(), any(), any(), any(), any(), any(), any()))
+            .thenReturn(updatedAccount);
+        when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
+        when(draftAccountMapper.toResponseDto(updatedAccount)).thenReturn(
+            DraftAccountResponseDto.builder()
+                .draftAccountId(draftAccountId)
+                .accountStatus(DraftAccountStatus.DELETED)
+                .timelineData(updatedAccount.getTimelineData())
+                .build()
+        );
+
+        DraftAccountResponseDto result = draftAccountService
+            .updateDraftAccount(draftAccountId, updateDto, "0");
+
+        assertNotNull(result);
+        assertEquals(DraftAccountStatus.DELETED, result.getAccountStatus());
+        verify(draftAccountTransactional)
+            .updateDraftAccount(any(), any(), any(), any(), any(), eq("USER01"), eq("Normal User"));
         verify(draftAccountPublishProxy, never()).publishDefendantAccount(any(), any());
         verify(pdplLoggingService).pdplForDraftAccount(updatedAccount, Action.RESUBMIT, userState);
         verify(jsonSchemaValidationService).validateOrError(any(), any());

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/jpa/DraftAccountTransactionalTest.java
@@ -143,8 +143,6 @@ class DraftAccountTransactionalTest {
 
         AddDraftAccountRequestDto dto = AddDraftAccountRequestDto.builder()
             .businessUnitId((short) 2)
-            .submittedBy("TestUser")
-            .submittedByName("Test User")
             .account(minimalAccountJson)
             .accountType(DraftAccountType.FINE)
             .build();
@@ -156,7 +154,7 @@ class DraftAccountTransactionalTest {
         when(businessUnitRepository.getReferenceById(any())).thenReturn(businessUnit);
         when(draftAccountRepository.save(any(DraftAccountEntity.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        DraftAccountEntity result = draftAccountTransactional.submitDraftAccount(dto);
+        DraftAccountEntity result = draftAccountTransactional.submitDraftAccount(dto, "TestUser", "Test User");
 
         assertEquals(minimalAccountJson, result.getAccount());
         assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), result.getCreatedDate());
@@ -205,8 +203,6 @@ class DraftAccountTransactionalTest {
         Long draftAccountId = 1L;
         ReplaceDraftAccountRequestDto replaceDto = ReplaceDraftAccountRequestDto.builder()
             .businessUnitId((short) 2)
-            .submittedBy("TestUser")
-            .submittedByName("Test User")
             .account(createAccountString())
             .accountType(DraftAccountType.FINE)
             .version(BigInteger.valueOf(0L))
@@ -230,7 +226,7 @@ class DraftAccountTransactionalTest {
 
         // Act
         DraftAccountEntity result = draftAccountTransactional
-            .replaceDraftAccount(draftAccountId, replaceDto, draftAccountTransactional, "0");
+            .replaceDraftAccount(draftAccountId, replaceDto, draftAccountTransactional, "0", "TestUser", "Test User");
 
         // Assert
         assertNotNull(result);
@@ -259,8 +255,6 @@ class DraftAccountTransactionalTest {
         String existingTimeline = singleTimelineDataString("original-user", "Submitted");
         ReplaceDraftAccountRequestDto replaceDto = ReplaceDraftAccountRequestDto.builder()
             .businessUnitId((short) 2)
-            .submittedBy("TestUser")
-            .submittedByName("Test User")
             .account(createAccountString())
             .accountType(DraftAccountType.FINE)
             .version(BigInteger.valueOf(0L))
@@ -285,7 +279,7 @@ class DraftAccountTransactionalTest {
             .getArgument(0));
 
         DraftAccountEntity result = draftAccountTransactional
-            .replaceDraftAccount(draftAccountId, replaceDto, draftAccountTransactional, "0");
+            .replaceDraftAccount(draftAccountId, replaceDto, draftAccountTransactional, "0", "TestUser", "Test User");
 
         assertThat(result.getTimelineData()).contains("original-user", "TestUser");
         assertThat(result.getTimelineData().indexOf("original-user"))
@@ -300,8 +294,6 @@ class DraftAccountTransactionalTest {
             .businessUnitId((short) 1)
             .accountType(DraftAccountType.FINE)
             .account(createAccountString())
-            .submittedBy("TestUser")
-            .submittedByName("Test User")
             .version(BigInteger.valueOf(0L))
             .build();
 
@@ -309,7 +301,8 @@ class DraftAccountTransactionalTest {
 
         // Act & Assert
         RuntimeException exception = assertThrows(RuntimeException.class, () ->
-            draftAccountTransactional.replaceDraftAccount(draftAccountId, replaceDto, draftAccountTransactional, "")
+            draftAccountTransactional.replaceDraftAccount(
+                draftAccountId, replaceDto, draftAccountTransactional, "", "TestUser", "Test User")
         );
         assertEquals("Draft Account not found with id: 1", exception.getMessage());
     }
@@ -322,8 +315,6 @@ class DraftAccountTransactionalTest {
             .businessUnitId((short) 2)
             .accountType(DraftAccountType.FINE)
             .account(createAccountString())
-            .submittedBy("TestUser")
-            .submittedByName("Test User")
             .version(BigInteger.valueOf(0L))
             .build();
 
@@ -334,7 +325,8 @@ class DraftAccountTransactionalTest {
 
         // Act & Assert
         RuntimeException exception = assertThrows(RuntimeException.class, () ->
-            draftAccountTransactional.replaceDraftAccount(draftAccountId, replaceDto, draftAccountTransactional, "0")
+            draftAccountTransactional.replaceDraftAccount(
+                draftAccountId, replaceDto, draftAccountTransactional, "0", "TestUser", "Test User")
         );
         assertEquals("Business Unit not found with id: 2", exception.getMessage());
     }
@@ -357,8 +349,6 @@ class DraftAccountTransactionalTest {
             .businessUnitId((short) 2)
             .accountType(DraftAccountType.FINE)
             .account(createAccountString())
-            .submittedBy("TestUser")
-            .submittedByName("Test User")
             .version(BigInteger.valueOf(0L))
             .build();
 
@@ -367,7 +357,8 @@ class DraftAccountTransactionalTest {
 
         // Act & Assert
         assertThrows(ResourceConflictException.class, () ->
-            draftAccountTransactional.replaceDraftAccount(draftAccountId, dto, draftAccountTransactional, "0")
+            draftAccountTransactional.replaceDraftAccount(
+                draftAccountId, dto, draftAccountTransactional, "0", "TestUser", "Test User")
         );
     }
 
@@ -391,7 +382,7 @@ class DraftAccountTransactionalTest {
         // Act & Assert
         assertThrows(ResourceConflictException.class, () ->
             draftAccountTransactional.updateDraftAccount(draftAccountId, updateDto, draftAccountTransactional,
-                BigInteger.ZERO, userState)
+                BigInteger.ZERO, userState, null, null)
         );
     }
 
@@ -401,7 +392,6 @@ class DraftAccountTransactionalTest {
         Long draftAccountId = 1L;
         UpdateDraftAccountRequestDto updateDto = UpdateDraftAccountRequestDto.builder()
             .accountStatus(DraftAccountStatus.PUBLISHING_PENDING)
-            .validatedBy("TestValidator")
             .businessUnitId((short) 2)
             .build();
 
@@ -421,7 +411,8 @@ class DraftAccountTransactionalTest {
 
         // Act
         DraftAccountEntity result = draftAccountTransactional
-            .updateDraftAccount(draftAccountId, updateDto, draftAccountTransactional, BigInteger.ZERO, userState);
+            .updateDraftAccount(draftAccountId, updateDto, draftAccountTransactional, BigInteger.ZERO, userState,
+                                "TestValidator", null);
 
         // Assert
         assertNotNull(result);
@@ -449,7 +440,6 @@ class DraftAccountTransactionalTest {
         Long draftAccountId = 1L;
         UpdateDraftAccountRequestDto updateDto = UpdateDraftAccountRequestDto.builder()
             .accountStatus(DraftAccountStatus.PUBLISHING_PENDING)
-            .validatedBy("TestValidator")
             .businessUnitId((short) 2)
             .build();
 
@@ -469,7 +459,7 @@ class DraftAccountTransactionalTest {
 
         RuntimeException exception = assertThrows(RuntimeException.class, () ->
             draftAccountTransactional.updateDraftAccount(draftAccountId, updateDto, draftAccountTransactional,
-                BigInteger.ZERO, userState)
+                BigInteger.ZERO, userState, "TestValidator", null)
         );
 
         assertEquals("Error processing JSON in addSnapshotApprovedDate", exception.getMessage());
@@ -482,7 +472,6 @@ class DraftAccountTransactionalTest {
         String existingTimeline = singleTimelineDataString("original-user", "Submitted");
         UpdateDraftAccountRequestDto updateDto = UpdateDraftAccountRequestDto.builder()
             .accountStatus(DraftAccountStatus.REJECTED)
-            .validatedBy("normal@users.com")
             .businessUnitId((short) 2)
             .build();
 
@@ -501,7 +490,8 @@ class DraftAccountTransactionalTest {
         UserState userState = UserState.builder().userName("USER_NAME_1").build();
 
         DraftAccountEntity result = draftAccountTransactional
-            .updateDraftAccount(draftAccountId, updateDto, draftAccountTransactional, BigInteger.ZERO, userState);
+            .updateDraftAccount(draftAccountId, updateDto, draftAccountTransactional, BigInteger.ZERO, userState,
+                                "normal@users.com", null);
 
         assertThat(result.getTimelineData()).contains("original-user", "normal@users.com");
         assertThat(result.getTimelineData().indexOf("original-user"))
@@ -515,8 +505,6 @@ class DraftAccountTransactionalTest {
         Long draftAccountId = 1L;
         UpdateDraftAccountRequestDto updateDto = UpdateDraftAccountRequestDto.builder()
             .accountStatus(DraftAccountStatus.PUBLISHING_PENDING)
-            .validatedBy("BUUID1")
-            .validatedByName("User One")
             .businessUnitId((short) 2)
             .build();
 
@@ -536,7 +524,7 @@ class DraftAccountTransactionalTest {
         // Act & Assert
         SubmitterDeniedException ex = assertThrows(SubmitterDeniedException.class, () -> {
             draftAccountTransactional.updateDraftAccount(draftAccountId, updateDto, draftAccountTransactional,
-                BigInteger.ZERO, userState);
+                BigInteger.ZERO, userState, "BUUID1", "User One");
         });
         assertThat(ex.getUpdateType()).isEqualTo("validate");
         assertThat(ex.getSubmitterUsername()).isEqualTo("BUUID1");
@@ -562,8 +550,6 @@ class DraftAccountTransactionalTest {
         Long draftAccountId = 1L;
         UpdateDraftAccountRequestDto updateDto = UpdateDraftAccountRequestDto.builder()
             .accountStatus(DraftAccountStatus.DELETED)
-            .validatedBy("BUUID1")
-            .validatedByName("User One")
             .businessUnitId((short) 2)
             .build();
 
@@ -583,7 +569,7 @@ class DraftAccountTransactionalTest {
         // Act & Assert
         SubmitterDeniedException ex = assertThrows(SubmitterDeniedException.class, () -> {
             draftAccountTransactional.updateDraftAccount(draftAccountId, updateDto, draftAccountTransactional,
-                BigInteger.ZERO, userState);
+                BigInteger.ZERO, userState, null, null);
         });
         assertThat(ex.getUpdateType()).isEqualTo("delete");
         assertThat(ex.getSubmitterUsername()).isEqualTo("BUUID1");
@@ -608,7 +594,6 @@ class DraftAccountTransactionalTest {
         Long draftAccountId = 1L;
         UpdateDraftAccountRequestDto updateDto = UpdateDraftAccountRequestDto.builder()
             .accountStatus(DraftAccountStatus.DELETED)
-            .validatedBy("Validator")
             .businessUnitId((short) 2)
             .build();
 
@@ -627,7 +612,7 @@ class DraftAccountTransactionalTest {
         UserState userState = UserState.builder().userName("DifferentUser").build();
 
         DraftAccountEntity result = draftAccountTransactional.updateDraftAccount(
-            draftAccountId, updateDto, draftAccountTransactional, BigInteger.ZERO, userState);
+            draftAccountId, updateDto, draftAccountTransactional, BigInteger.ZERO, userState, null, null);
 
         assertEquals(DraftAccountStatus.DELETED, result.getAccountStatus());
         assertEquals(LocalDateTime.of(2026, 5, 7, 10, 15), result.getAccountStatusDate());
@@ -658,7 +643,7 @@ class DraftAccountTransactionalTest {
         // Act & Assert
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
             draftAccountTransactional.updateDraftAccount(draftAccountId, updateDto, draftAccountTransactional,
-                BigInteger.ZERO, userState)
+                BigInteger.ZERO, userState, null, null)
         );
         assertEquals("Invalid account status for update: SUBMITTED", exception.getMessage());
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PO-2461

### Change description ###
Remove the following fields from add/update/replace draft-accounts request payloads and related DTOs / JSON schemas:

submitted_by
submitted_by_name
validated_by
validated_by_name
These values must be derived server-side from the authenticated access token and the User Service. Client requests must not send these fields.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
