### PR TITLE
Add serialization tests for LegacyPaymentTerms and update naming stra…

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyInstalmentPeriod.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyInstalmentPeriod.java
@@ -7,10 +7,13 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.annotation.JsonNaming;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @XmlRootElement(name = "installment_period")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class LegacyInstalmentPeriod {

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyPaymentTerms.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyPaymentTerms.java
@@ -12,6 +12,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.jackson.Jacksonized;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.annotation.JsonNaming;
 import uk.gov.hmcts.opal.util.LocalDateAdapter;
 
 @Data
@@ -19,6 +21,7 @@ import uk.gov.hmcts.opal.util.LocalDateAdapter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Jacksonized
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @XmlRootElement(name = "payment_terms")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class LegacyPaymentTerms {

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyPaymentTermsType.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyPaymentTermsType.java
@@ -7,10 +7,13 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.annotation.JsonNaming;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @XmlRootElement(name = "payment_terms_type")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class LegacyPaymentTermsType {

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyPostedDetails.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyPostedDetails.java
@@ -9,11 +9,14 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.annotation.JsonNaming;
 import uk.gov.hmcts.opal.util.LocalDateTimeAdapter;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @XmlRootElement(name = "posted_details")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class LegacyPostedDetails {

--- a/src/test/java/uk/gov/hmcts/opal/dto/legacy/LegacyPaymentTermsTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/dto/legacy/LegacyPaymentTermsTest.java
@@ -21,6 +21,7 @@ class LegacyPaymentTermsTest {
             .reasonForExtension("reason")
             .paymentTermsType(new LegacyPaymentTermsType(LegacyPaymentTermsType.PaymentTermsTypeCode.B))
             .effectiveDate(LocalDate.parse("2026-08-09"))
+            .instalmentPeriod(new LegacyInstalmentPeriod(LegacyInstalmentPeriod.InstalmentPeriodCode.W))
             .lumpSumAmount(new BigDecimal("100.00"))
             .instalmentAmount(new BigDecimal("25.00"))
             .postedDetails(new LegacyPostedDetails(
@@ -36,6 +37,7 @@ class LegacyPaymentTermsTest {
         assertEquals("reason", json.get("reason_for_extension").asText());
         assertEquals("B", json.get("payment_terms_type").get("payment_terms_type_code").asText());
         assertEquals("2026-08-09", json.get("effective_date").asText());
+        assertEquals("W", json.get("instalment_period").get("instalment_period_code").asText());
         assertEquals(100.00, json.get("lump_sum_amount").asDouble());
         assertEquals(25.00, json.get("instalment_amount").asDouble());
         assertEquals("L077JG", json.get("posted_details").get("posted_by").asText());
@@ -46,10 +48,12 @@ class LegacyPaymentTermsTest {
         assertFalse(json.has("reasonForExtension"));
         assertFalse(json.has("paymentTermsType"));
         assertFalse(json.has("effectiveDate"));
+        assertFalse(json.has("instalmentPeriod"));
         assertFalse(json.has("lumpSumAmount"));
         assertFalse(json.has("instalmentAmount"));
         assertFalse(json.has("postedDetails"));
         assertFalse(json.get("payment_terms_type").has("paymentTermsTypeCode"));
+        assertFalse(json.get("instalment_period").has("instalmentPeriodCode"));
         assertFalse(json.get("posted_details").has("postedBy"));
         assertFalse(json.get("posted_details").has("postedByName"));
     }

--- a/src/test/java/uk/gov/hmcts/opal/dto/legacy/LegacyPaymentTermsTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/dto/legacy/LegacyPaymentTermsTest.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.opal.dto.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import uk.gov.hmcts.opal.dto.ToJsonString;
+
+class LegacyPaymentTermsTest {
+
+    @Test
+    void toJsonString_serializesNestedFieldsInSnakeCase() throws Exception {
+        LegacyPaymentTerms paymentTerms = LegacyPaymentTerms.builder()
+            .daysInDefault(5)
+            .dateDaysInDefaultImposed(LocalDate.parse("2026-08-01"))
+            .extension(true)
+            .reasonForExtension("reason")
+            .paymentTermsType(new LegacyPaymentTermsType(LegacyPaymentTermsType.PaymentTermsTypeCode.B))
+            .effectiveDate(LocalDate.parse("2026-08-09"))
+            .lumpSumAmount(new BigDecimal("100.00"))
+            .instalmentAmount(new BigDecimal("25.00"))
+            .postedDetails(new LegacyPostedDetails(
+                LocalDateTime.parse("2026-08-10T09:15:30"), "L077JG", "opal-test"))
+            .build();
+
+        JsonNode json = ToJsonString.getObjectMapper().readTree(
+            ToJsonString.getObjectMapper().writeValueAsString(paymentTerms)
+        );
+
+        assertEquals(5, json.get("days_in_default").asInt());
+        assertEquals("2026-08-01", json.get("date_days_in_default_imposed").asText());
+        assertEquals("reason", json.get("reason_for_extension").asText());
+        assertEquals("B", json.get("payment_terms_type").get("payment_terms_type_code").asText());
+        assertEquals("2026-08-09", json.get("effective_date").asText());
+        assertEquals(100.00, json.get("lump_sum_amount").asDouble());
+        assertEquals(25.00, json.get("instalment_amount").asDouble());
+        assertEquals("L077JG", json.get("posted_details").get("posted_by").asText());
+        assertEquals("opal-test", json.get("posted_details").get("posted_by_name").asText());
+
+        assertFalse(json.has("daysInDefault"));
+        assertFalse(json.has("dateDaysInDefaultImposed"));
+        assertFalse(json.has("reasonForExtension"));
+        assertFalse(json.has("paymentTermsType"));
+        assertFalse(json.has("effectiveDate"));
+        assertFalse(json.has("lumpSumAmount"));
+        assertFalse(json.has("instalmentAmount"));
+        assertFalse(json.has("postedDetails"));
+        assertFalse(json.get("payment_terms_type").has("paymentTermsTypeCode"));
+        assertFalse(json.get("posted_details").has("postedBy"));
+        assertFalse(json.get("posted_details").has("postedByName"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPaymentTermsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPaymentTermsServiceTest.java
@@ -18,6 +18,7 @@ import static uk.gov.hmcts.opal.util.VersionUtils.extractBigInteger;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -34,6 +35,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpServerErrorException;
+import tools.jackson.databind.JsonNode;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.common.legacy.config.LegacyGatewayProperties;
 import uk.gov.hmcts.opal.common.legacy.service.GatewayService;
@@ -43,6 +45,8 @@ import uk.gov.hmcts.opal.dto.AddPaymentCardRequestResponse;
 import uk.gov.hmcts.opal.dto.GetDefendantAccountPaymentTermsResponse;
 import uk.gov.hmcts.opal.dto.PaymentTerms;
 import uk.gov.hmcts.opal.dto.PostedDetails;
+import uk.gov.hmcts.opal.dto.ToJsonString;
+import uk.gov.hmcts.opal.dto.common.PaymentTermsType;
 import uk.gov.hmcts.opal.dto.legacy.AddPaymentCardLegacyRequest;
 import uk.gov.hmcts.opal.dto.legacy.AddPaymentCardLegacyResponse;
 import uk.gov.hmcts.opal.dto.legacy.AddPaymentTermsLegacyRequest;
@@ -50,6 +54,7 @@ import uk.gov.hmcts.opal.dto.legacy.AddPaymentTermsLegacyResponse;
 import uk.gov.hmcts.opal.dto.legacy.LegacyGetDefendantAccountPaymentTermsResponse;
 import uk.gov.hmcts.opal.dto.legacy.LegacyPaymentTerms;
 import uk.gov.hmcts.opal.dto.legacy.LegacyPostedDetails;
+import uk.gov.hmcts.opal.dto.request.AddDefendantAccountPaymentTermsRequest;
 import uk.gov.hmcts.opal.service.opal.CourtService;
 
 @ExtendWith(MockitoExtension.class)
@@ -406,6 +411,67 @@ class LegacyDefendantAccountPaymentTermsServiceTest {
             businessUnitUserId, ifMatch
         );
         assertGetDefendantAccountPaymentTermsResponse(actualResponse, legacyResponse);
+    }
+
+    @Test
+    void addPaymentTerms_serializesNestedLegacyPayloadInSnakeCase() throws Exception {
+        // Given
+        long defendantAccountId = 770000004141L;
+        String businessUnitId = "77";
+        String businessUnitUserId = "L077JG";
+        String ifMatch = "\"835509468493002959816526022013198014020000027212\"";
+        var legacyResponse = createAddPaymentTermsLegacyResponse(defendantAccountId, ifMatch);
+        var gateWayResponse = new GatewayService.Response<>(HttpStatus.OK, legacyResponse, null, null);
+        var addPaymentTermsRequest = AddDefendantAccountPaymentTermsRequest.builder()
+            .paymentTerms(PaymentTerms.builder()
+                .extension(true)
+                .reasonForExtension("dmweoapde")
+                .paymentTermsType(new PaymentTermsType(PaymentTermsType.PaymentTermsTypeCode.B))
+                .effectiveDate(LocalDate.parse("2026-08-09"))
+                .lumpSumAmount(new BigDecimal("100.00"))
+                .postedDetails(new PostedDetails(null, "frontend-user", "Frontend User"))
+                .build())
+            .build();
+
+        doReturn(gateWayResponse).when(gatewayService).postToGateway(any(), any(), any(), any());
+
+        // When
+        legacyDefendantAccountPaymentTermsService.addPaymentTerms(
+            defendantAccountId, businessUnitId, businessUnitUserId, "opal-test", ifMatch, addPaymentTermsRequest
+        );
+
+        // Then
+        var requestCaptor = ArgumentCaptor.forClass(AddPaymentTermsLegacyRequest.class);
+
+        verify(gatewayService, times(1))
+            .postToGateway(
+                eq(LegacyDefendantAccountPaymentTermsService.ADD_PAYMENT_TERMS),
+                eq(AddPaymentTermsLegacyResponse.class),
+                requestCaptor.capture(),
+                isNull()
+            );
+
+        JsonNode json = ToJsonString.getObjectMapper().readTree(
+            ToJsonString.getObjectMapper().writeValueAsString(requestCaptor.getValue())
+        );
+        JsonNode paymentTerms = json.get("payment_terms");
+
+        assertThat(json.has("defendant_account_id")).isTrue();
+        assertThat(json.has("business_unit_id")).isTrue();
+        assertThat(json.has("business_unit_user_id")).isTrue();
+        assertThat(paymentTerms.get("effective_date").asText()).isEqualTo("2026-08-09");
+        assertThat(paymentTerms.get("reason_for_extension").asText()).isEqualTo("dmweoapde");
+        assertThat(paymentTerms.get("payment_terms_type").get("payment_terms_type_code").asText()).isEqualTo("B");
+        assertThat(paymentTerms.get("posted_details").get("posted_by").asText()).isEqualTo("frontend-user");
+        assertThat(paymentTerms.get("posted_details").get("posted_by_name").asText()).isEqualTo("Frontend User");
+
+        assertThat(paymentTerms.has("effectiveDate")).isFalse();
+        assertThat(paymentTerms.has("reasonForExtension")).isFalse();
+        assertThat(paymentTerms.has("paymentTermsType")).isFalse();
+        assertThat(paymentTerms.has("postedDetails")).isFalse();
+        assertThat(paymentTerms.get("payment_terms_type").has("paymentTermsTypeCode")).isFalse();
+        assertThat(paymentTerms.get("posted_details").has("postedBy")).isFalse();
+        assertThat(paymentTerms.get("posted_details").has("postedByName")).isFalse();
     }
 
     private static AddPaymentTermsLegacyResponse createAddPaymentTermsLegacyResponse(long defendantAccountId,

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPaymentTermsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPaymentTermsServiceTest.java
@@ -46,6 +46,7 @@ import uk.gov.hmcts.opal.dto.GetDefendantAccountPaymentTermsResponse;
 import uk.gov.hmcts.opal.dto.PaymentTerms;
 import uk.gov.hmcts.opal.dto.PostedDetails;
 import uk.gov.hmcts.opal.dto.ToJsonString;
+import uk.gov.hmcts.opal.dto.common.InstalmentPeriod;
 import uk.gov.hmcts.opal.dto.common.PaymentTermsType;
 import uk.gov.hmcts.opal.dto.legacy.AddPaymentCardLegacyRequest;
 import uk.gov.hmcts.opal.dto.legacy.AddPaymentCardLegacyResponse;
@@ -428,8 +429,9 @@ class LegacyDefendantAccountPaymentTermsServiceTest {
                 .reasonForExtension("dmweoapde")
                 .paymentTermsType(new PaymentTermsType(PaymentTermsType.PaymentTermsTypeCode.B))
                 .effectiveDate(LocalDate.parse("2026-08-09"))
+                .instalmentPeriod(new InstalmentPeriod(InstalmentPeriod.InstalmentPeriodCode.W))
                 .lumpSumAmount(new BigDecimal("100.00"))
-                .postedDetails(new PostedDetails(null, "frontend-user", "Frontend User"))
+                .postedDetails(new PostedDetails(null, businessUnitUserId, "opal-test"))
                 .build())
             .build();
 
@@ -462,14 +464,17 @@ class LegacyDefendantAccountPaymentTermsServiceTest {
         assertThat(paymentTerms.get("effective_date").asText()).isEqualTo("2026-08-09");
         assertThat(paymentTerms.get("reason_for_extension").asText()).isEqualTo("dmweoapde");
         assertThat(paymentTerms.get("payment_terms_type").get("payment_terms_type_code").asText()).isEqualTo("B");
-        assertThat(paymentTerms.get("posted_details").get("posted_by").asText()).isEqualTo("frontend-user");
-        assertThat(paymentTerms.get("posted_details").get("posted_by_name").asText()).isEqualTo("Frontend User");
+        assertThat(paymentTerms.get("instalment_period").get("instalment_period_code").asText()).isEqualTo("W");
+        assertThat(paymentTerms.get("posted_details").get("posted_by").asText()).isEqualTo(businessUnitUserId);
+        assertThat(paymentTerms.get("posted_details").get("posted_by_name").asText()).isEqualTo("opal-test");
 
         assertThat(paymentTerms.has("effectiveDate")).isFalse();
         assertThat(paymentTerms.has("reasonForExtension")).isFalse();
         assertThat(paymentTerms.has("paymentTermsType")).isFalse();
+        assertThat(paymentTerms.has("instalmentPeriod")).isFalse();
         assertThat(paymentTerms.has("postedDetails")).isFalse();
         assertThat(paymentTerms.get("payment_terms_type").has("paymentTermsTypeCode")).isFalse();
+        assertThat(paymentTerms.get("instalment_period").has("instalmentPeriodCode")).isFalse();
         assertThat(paymentTerms.get("posted_details").has("postedBy")).isFalse();
         assertThat(paymentTerms.get("posted_details").has("postedByName")).isFalse();
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-10340


### Change description ###
he frontend sends payment terms using snake_case JSON fields. The fines service deserializes this into the modern PaymentTerms DTO and then maps it to LegacyPaymentTerms.

The legacy DTOs only define JAXB @XmlElement annotations. The legacy gateway sends the DTO as application/json, and Jackson does not use the JAXB field names during JSON serialization. As a result, the nested payment_terms fields are sent
using camelCase.

The legacy integration expects snake_case field names and therefore does not recognise fields such as effectiveDate, paymentTermsType, and postedDetails.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
