### PR TITLE
Refactor addNote method to streamline parameters and improve legacy h…

### DIFF
--- a/bruno/collections/Release 1B/DefendantAccount/Notes/Add Note.bru
+++ b/bruno/collections/Release 1B/DefendantAccount/Notes/Add Note.bru
@@ -1,0 +1,34 @@
+meta {
+  name: Add Note
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseURL}}/notes/add
+  body: json
+  auth: inherit
+}
+
+headers {
+  Content-Type: application/json
+  Accept: application/json
+  Business-Unit-Id: 78
+  If-Match: 1
+}
+
+body:json {
+  {
+    "activity_note": {
+      "record_type": "defendant_accounts",
+      "record_id": "770000004141",
+      "note_text": "PO-10341 manual test note",
+      "note_type": "AA"
+    }
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/bruno/collections/Release 1B/DefendantAccount/Notes/Add Note.bru
+++ b/bruno/collections/Release 1B/DefendantAccount/Notes/Add Note.bru
@@ -13,8 +13,8 @@ post {
 headers {
   Content-Type: application/json
   Accept: application/json
-  Business-Unit-Id: 78
-  If-Match: 1
+  Business-Unit-Id: 77
+  If-Match: "{{legacyOnlyAccountVersion}}"
 }
 
 body:json {

--- a/bruno/collections/Release 1B/DefendantAccount/Notes/folder.bru
+++ b/bruno/collections/Release 1B/DefendantAccount/Notes/folder.bru
@@ -1,0 +1,3 @@
+folder {
+  name: Notes
+}

--- a/bruno/collections/test endpoints/IsLegacyMode.bru
+++ b/bruno/collections/test endpoints/IsLegacyMode.bru
@@ -1,0 +1,17 @@
+meta {
+  name: IsLegacyMode
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseURL}}/testing-support/is-legacy-mode
+  body: none
+  auth: inherit
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+  forwardAuthorizationHeader: false
+}

--- a/bruno/environments/env.template
+++ b/bruno/environments/env.template
@@ -1,2 +1,3 @@
 BEARER_TOKEN=your_bearer_token_here
 BASE_URL=http://localhost:4550
+legacyOnlyAccountVersion=version_from_header_summary_response

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/LegacyNotesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/LegacyNotesIntegrationTest.java
@@ -36,6 +36,13 @@ public class LegacyNotesIntegrationTest extends NotesIntegrationTest {
         super.legacyTestAddNote500Error(log);
     }
 
+    @Test
+    @JiraStory("PO-10341")
+    @JiraEpic("PO-812")
+    void testPostAddNoteForLegacyOnlyAccount() throws Exception {
+        super.legacyOnlyAccountAddNoteSuccess(log);
+    }
+
     @ParameterizedTest(name = "{0}")
     @MethodSource("nonNotesPermissions")
     @JiraStory("PO-1566")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/LegacyNotesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/LegacyNotesIntegrationTest.java
@@ -50,6 +50,13 @@ public class LegacyNotesIntegrationTest extends NotesIntegrationTest {
         super.legacyOnlyAccountAddNoteThenFetchHeaderSummary(log);
     }
 
+    @Test
+    @JiraStory("PO-10341")
+    @JiraEpic("PO-812")
+    void testPostAddNoteThenFetchHistoryForLegacyOnlyAccount() throws Exception {
+        super.legacyOnlyAccountAddNoteThenFetchHistory(log);
+    }
+
     @ParameterizedTest(name = "{0}")
     @MethodSource("nonNotesPermissions")
     @JiraStory("PO-1566")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/LegacyNotesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/LegacyNotesIntegrationTest.java
@@ -43,6 +43,13 @@ public class LegacyNotesIntegrationTest extends NotesIntegrationTest {
         super.legacyOnlyAccountAddNoteSuccess(log);
     }
 
+    @Test
+    @JiraStory("PO-10341")
+    @JiraEpic("PO-812")
+    void testPostAddNoteThenFetchHeaderSummaryForLegacyOnlyAccount() throws Exception {
+        super.legacyOnlyAccountAddNoteThenFetchHeaderSummary(log);
+    }
+
     @ParameterizedTest(name = "{0}")
     @MethodSource("nonNotesPermissions")
     @JiraStory("PO-1566")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/NotesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/NotesIntegrationTest.java
@@ -357,7 +357,7 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
                 .header(HttpHeaders.AUTHORIZATION, userStateStub.getBearerToken())
-                .header(HttpHeaders.IF_MATCH, "1")
+                .header(HttpHeaders.IF_MATCH, "\"1\"")
                 .header("Business-Unit-Id", 78)
                 .with(authentication(allFinesPermissionsToken()))
         );

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/NotesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/NotesIntegrationTest.java
@@ -424,6 +424,43 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
             .withRequestBody(matchingJsonPath("$.defendant_account_id", equalTo("770000004141"))));
     }
 
+    @DisplayName("post notes then fetch history for a legacy-only defendant account [PO-10341]")
+    @JiraStory("PO-10341")
+    void legacyOnlyAccountAddNoteThenFetchHistory(Logger log) throws Exception {
+
+        userStateStub.addPermissions((short) 77, ADD_ACCOUNT_ACTIVITY_NOTES);
+        userStateStub.addPermissions((short) 77, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
+
+        stubFor(WireMock.post(urlPathEqualTo("/opal"))
+            .withQueryParam("actionType", equalTo("getDefendantAccountHistory"))
+            .withRequestBody(matchingJsonPath("$.defendant_account_id", equalTo("770000004141")))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/xml")
+                .withBody(legacyOnlyHistoryXml())));
+
+        legacyOnlyAccountAddNoteSuccess(log);
+
+        ResultActions resultActions = mockMvc.perform(
+            get("/defendant-accounts/770000004141/history")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header(HttpHeaders.AUTHORIZATION, userStateStub.getBearerToken())
+                .accept(MediaType.APPLICATION_JSON)
+        );
+
+        String body = resultActions.andReturn().getResponse().getContentAsString();
+        log.info(":legacyOnlyAccountAddNoteThenFetchHistory: Response body:\n{}", ToJsonString.toPrettyJson(body));
+
+        resultActions.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.historyItems[0].type").value("Note"))
+            .andExpect(jsonPath("$.historyItems[0].details.noteText").value("legacy-only account note"));
+
+        WireMock.verify(1, postRequestedFor(urlPathEqualTo("/opal"))
+            .withQueryParam("actionType", equalTo("getDefendantAccountHistory"))
+            .withRequestBody(matchingJsonPath("$.defendant_account_id", equalTo("770000004141"))));
+    }
+
     private static String legacyOnlyHeaderSummaryXml() {
         return """
             <?xml version="1.0" encoding="UTF-8"?>
@@ -451,6 +488,28 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
                 <account_balance>5000.00</account_balance>
               </payment_state_summary>
               <has_consolidated_accounts>false</has_consolidated_accounts>
+            </response>
+            """;
+    }
+
+    private static String legacyOnlyHistoryXml() {
+        return """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <response>
+              <version>9223372036854775808</version>
+              <history_items>
+                <history_items_element>
+                  <posted_details>
+                    <posted_date>2026-09-03T09:58:34</posted_date>
+                    <posted_by>01000000A</posted_by>
+                    <posted_by_name>Opal Test User</posted_by_name>
+                  </posted_details>
+                  <type>Note</type>
+                  <details>
+                    <note_text>legacy-only account note</note_text>
+                  </details>
+                </history_items_element>
+              </history_items>
             </response>
             """;
     }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/NotesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/NotesIntegrationTest.java
@@ -362,7 +362,7 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
                 .header(HttpHeaders.AUTHORIZATION, userStateStub.getBearerToken())
-                .header(HttpHeaders.IF_MATCH, "\"1\"")
+                .header(HttpHeaders.IF_MATCH, OVER_LONG_VERSION_ETAG)
                 .header("Business-Unit-Id", 77)
                 .with(userStateStub.getAuthenticaitonRequestPostProcessor())
         );

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/NotesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/NotesIntegrationTest.java
@@ -1,9 +1,12 @@
 package uk.gov.hmcts.opal.controllers.shared;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -380,5 +383,75 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
             .withRequestBody(matchingJsonPath("$.activity_note.record_type", equalTo("defendant_accounts")))
             .withRequestBody(matchingJsonPath("$.activity_note.note_text", equalTo("legacy-only account note")))
             .withRequestBody(matchingJsonPath("$.activity_note.note_type", equalTo("AA"))));
+    }
+
+    @DisplayName("post notes then fetch header summary for a legacy-only defendant account [PO-10341]")
+    @JiraStory("PO-10341")
+    void legacyOnlyAccountAddNoteThenFetchHeaderSummary(Logger log) throws Exception {
+
+        userStateStub.addPermissions((short) 77, ADD_ACCOUNT_ACTIVITY_NOTES);
+        userStateStub.addPermissions((short) 77, FinesPermission.SEARCH_AND_VIEW_ACCOUNTS);
+
+        stubFor(WireMock.post(urlPathEqualTo("/opal"))
+            .withQueryParam("actionType", equalTo("getDefendantAccountHeaderSummary"))
+            .withRequestBody(matchingJsonPath("$.defendant_account_id", equalTo("770000004141")))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/xml")
+                .withBody(legacyOnlyHeaderSummaryXml())));
+
+        legacyOnlyAccountAddNoteSuccess(log);
+
+        ResultActions resultActions = mockMvc.perform(
+            get("/defendant-accounts/770000004141/header-summary")
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .header(HttpHeaders.AUTHORIZATION, userStateStub.getBearerToken())
+                .accept(MediaType.APPLICATION_JSON)
+        );
+
+        String body = resultActions.andReturn().getResponse().getContentAsString();
+        log.info(":legacyOnlyAccountAddNoteThenFetchHeaderSummary: Response body:\n{}",
+            ToJsonString.toPrettyJson(body));
+
+        resultActions.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.defendant_account_id").value("770000004141"))
+            .andExpect(jsonPath("$.account_number").value("770000004141A"))
+            .andExpect(jsonPath("$.business_unit_summary.business_unit_id").value(77));
+
+        WireMock.verify(1, postRequestedFor(urlPathEqualTo("/opal"))
+            .withQueryParam("actionType", equalTo("getDefendantAccountHeaderSummary"))
+            .withRequestBody(matchingJsonPath("$.defendant_account_id", equalTo("770000004141"))));
+    }
+
+    private static String legacyOnlyHeaderSummaryXml() {
+        return """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <response>
+              <version>9223372036854775808</version>
+              <defendant_account_id>770000004141</defendant_account_id>
+              <account_number>770000004141A</account_number>
+              <defendant_party_id>7</defendant_party_id>
+              <debtor_type>Defendant</debtor_type>
+              <is_youth>false</is_youth>
+              <account_status_reference>
+                <account_status_code>L</account_status_code>
+              </account_status_reference>
+              <account_type>Fine</account_type>
+              <business_unit_summary>
+                <business_unit_id>77</business_unit_id>
+                <business_unit_name>Legacy Unit</business_unit_name>
+                <business_unit_code>77</business_unit_code>
+                <welsh_speaking>N</welsh_speaking>
+              </business_unit_summary>
+              <payment_state_summary>
+                <imposed_amount>700.58</imposed_amount>
+                <arrears_amount>300.00</arrears_amount>
+                <paid_amount>200.00</paid_amount>
+                <account_balance>5000.00</account_balance>
+              </payment_state_summary>
+              <has_consolidated_accounts>false</has_consolidated_accounts>
+            </response>
+            """;
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/NotesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/NotesIntegrationTest.java
@@ -1,5 +1,9 @@
 package uk.gov.hmcts.opal.controllers.shared;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -10,6 +14,7 @@ import static uk.gov.hmcts.opal.authorisation.model.FinesPermission.ADD_ACCOUNT_
 import static uk.gov.hmcts.opal.controllers.shared.util.UserStateUtil.allFinesPermissionsToken;
 import static uk.gov.hmcts.opal.controllers.shared.util.UserStateUtil.permissionsToken;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -366,5 +371,14 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
         log.info(":legacyOnlyAccountAddNoteSuccess: Response body:\n{}", ToJsonString.toPrettyJson(body));
 
         resultActions.andExpect(status().isCreated());
+
+        WireMock.verify(1, postRequestedFor(urlPathEqualTo("/opal"))
+            .withQueryParam("actionType", equalTo("addNote"))
+            .withRequestBody(matchingJsonPath("$.business_unit_id", equalTo("77")))
+            .withRequestBody(matchingJsonPath("$.business_unit_user_id"))
+            .withRequestBody(matchingJsonPath("$.activity_note.record_id", equalTo("770000004141")))
+            .withRequestBody(matchingJsonPath("$.activity_note.record_type", equalTo("defendant_accounts")))
+            .withRequestBody(matchingJsonPath("$.activity_note.note_text", equalTo("legacy-only account note")))
+            .withRequestBody(matchingJsonPath("$.activity_note.note_type", equalTo("AA"))));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/NotesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/NotesIntegrationTest.java
@@ -336,4 +336,35 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
         resultActions.andExpect(status().is5xxServerError());
 
     }
+
+    @DisplayName("post notes for a legacy-only defendant account [PO-10341]")
+    @JiraStory("PO-10341")
+    void legacyOnlyAccountAddNoteSuccess(Logger log) throws Exception {
+
+        userStateStub.addPermissions((short) 78, ADD_ACCOUNT_ACTIVITY_NOTES);
+
+        Note note = new Note();
+        note.setNoteText("legacy-only account note");
+        note.setRecordId("770000004141");
+        note.setRecordType(RecordType.DEFENDANT_ACCOUNTS);
+        note.setNoteType("AA");
+
+        AddNoteRequest request = new AddNoteRequest();
+        request.setActivityNote(note);
+
+        ResultActions resultActions = mockMvc.perform(
+            post(URL_BASE + "/add")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .header(HttpHeaders.AUTHORIZATION, userStateStub.getBearerToken())
+                .header(HttpHeaders.IF_MATCH, "1")
+                .header("Business-Unit-Id", 78)
+                .with(authentication(allFinesPermissionsToken()))
+        );
+
+        String body = resultActions.andReturn().getResponse().getContentAsString();
+        log.info(":legacyOnlyAccountAddNoteSuccess: Response body:\n{}", ToJsonString.toPrettyJson(body));
+
+        resultActions.andExpect(status().isCreated());
+    }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/NotesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/NotesIntegrationTest.java
@@ -341,7 +341,7 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
     @JiraStory("PO-10341")
     void legacyOnlyAccountAddNoteSuccess(Logger log) throws Exception {
 
-        userStateStub.addPermissions((short) 78, ADD_ACCOUNT_ACTIVITY_NOTES);
+        userStateStub.addPermissions((short) 77, ADD_ACCOUNT_ACTIVITY_NOTES);
 
         Note note = new Note();
         note.setNoteText("legacy-only account note");
@@ -358,8 +358,8 @@ abstract class NotesIntegrationTest extends AbstractIntegrationTest {
                 .content(objectMapper.writeValueAsString(request))
                 .header(HttpHeaders.AUTHORIZATION, userStateStub.getBearerToken())
                 .header(HttpHeaders.IF_MATCH, "\"1\"")
-                .header("Business-Unit-Id", 78)
-                .with(authentication(allFinesPermissionsToken()))
+                .header("Business-Unit-Id", 77)
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
         );
 
         String body = resultActions.andReturn().getResponse().getContentAsString();

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/search/LegacyAddNoteRequest.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/search/LegacyAddNoteRequest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.dto.legacy.search;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -18,19 +19,23 @@ import lombok.Data;
 public class LegacyAddNoteRequest {
 
     @NotBlank
+    @JsonProperty("business_unit_id")
     @XmlElement(name = "business_unit_id", required = true)
-    private Short businessUnitId;
+    private String businessUnitId;
 
     @NotBlank
+    @JsonProperty("business_unit_user_id")
     @XmlElement(name = "business_unit_user_id", required = true)
     private String businessUnitUserId;
 
     @NotNull
+    @JsonProperty("version")
     @XmlElement(name = "version", required = true)
     private BigInteger version;
 
     @NotNull
     @Valid
+    @JsonProperty("activity_note")
     @XmlElement(name = "activity_note", required = true)
     private LegacyNote activityNote;
 }

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/search/LegacyAddNoteRequest.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/search/LegacyAddNoteRequest.java
@@ -23,7 +23,7 @@ public class LegacyAddNoteRequest {
 
     @NotBlank
     @XmlElement(name = "business_unit_user_id", required = true)
-    private Long businessUnitUserId;
+    private String businessUnitUserId;
 
     @NotNull
     @XmlElement(name = "version", required = true)

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/search/LegacyAddNoteResponse.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/search/LegacyAddNoteResponse.java
@@ -12,6 +12,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import uk.gov.hmcts.opal.common.legacy.model.ErrorResponse;
+import uk.gov.hmcts.opal.common.legacy.model.HasErrorResponse;
 import uk.gov.hmcts.opal.dto.ToXmlString;
 
 @NoArgsConstructor
@@ -22,7 +24,7 @@ import uk.gov.hmcts.opal.dto.ToXmlString;
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "response")
 @Builder
-public class LegacyAddNoteResponse implements ToXmlString {
+public class LegacyAddNoteResponse implements ToXmlString, HasErrorResponse {
 
     @NotNull
     @XmlElement(name = "version", required = true)
@@ -30,5 +32,8 @@ public class LegacyAddNoteResponse implements ToXmlString {
 
     @XmlElement(name = "activity_note", required = true)
     private LegacyNote note;
+
+    @XmlElement(name = "error_response")
+    private ErrorResponse errorResponse;
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/search/LegacyNote.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/search/LegacyNote.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.dto.legacy.search;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.xml.bind.annotation.XmlAccessType;
@@ -18,19 +19,23 @@ import uk.gov.hmcts.opal.dto.RecordType;
 @Builder
 public class LegacyNote {
 
+    @JsonProperty("record_type")
     @XmlElement(name = "record_type", required = true)
     private RecordType recordType; // uses your existing enum/type
 
     @NotBlank
+    @JsonProperty("record_id")
     @XmlElement(name = "record_id", required = true)
     private String recordId;
 
     @NotBlank
+    @JsonProperty("note_text")
     @XmlElement(name = "note_text", required = true)
     private String noteText;
 
     @NotBlank
     @Pattern(regexp = "AA", message = "note_type must be 'AA'")
+    @JsonProperty("note_type")
     @XmlElement(name = "note_type", required = true)
     private String noteType; // uses your existing enum/type
 

--- a/src/main/java/uk/gov/hmcts/opal/service/NotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/NotesService.java
@@ -16,19 +16,17 @@ public class NotesService {
 
     private final NotesProxy notesProxy;
     private final UserStateService userStateService;
-    private final AccountNoteContextFactory accountNoteContextFactory;
 
     public String addNote(AddNoteRequest request, String ifMatch, Short businessUnitId) {
         log.debug(":addNote:");
 
         UserState userState = userStateService.getUserStateV1FromSecurityContext();
-        AccountNoteContext target = accountNoteContextFactory.from(request.getActivityNote());
 
         if (!userState.hasBusinessUnitUserWithPermission(
             businessUnitId, FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES)) {
             throw new PermissionNotAllowedException(businessUnitId, FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES);
         }
 
-        return notesProxy.addNote(request, ifMatch, userState, target);
+        return notesProxy.addNote(request, ifMatch, userState, businessUnitId);
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/iface/NotesServiceInterface.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/iface/NotesServiceInterface.java
@@ -2,10 +2,9 @@ package uk.gov.hmcts.opal.service.iface;
 
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
-import uk.gov.hmcts.opal.service.AccountNoteContext;
 
 public interface NotesServiceInterface {
 
-    String addNote(AddNoteRequest request, String ifMatch, UserState user, AccountNoteContext target);
+    String addNote(AddNoteRequest request, String ifMatch, UserState user, Short businessUnitId);
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.opal.service.legacy;
 
-import java.math.BigInteger;
+import static uk.gov.hmcts.opal.util.VersionUtils.extractBigInteger;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -61,6 +62,6 @@ public class LegacyNotesService implements NotesServiceInterface {
             .recordId(request.getActivityNote().getRecordId()).build();
 
         return LegacyAddNoteRequest.builder().businessUnitId(businessUnitId)
-            .businessUnitUserId(user.getUserId()).version(new BigInteger(version)).activityNote(note).build();
+            .businessUnitUserId(user.getUserId()).version(extractBigInteger(version)).activityNote(note).build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.opal.dto.AddNoteRequest;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyAddNoteRequest;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyAddNoteResponse;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyNote;
-import uk.gov.hmcts.opal.service.AccountNoteContext;
 import uk.gov.hmcts.opal.service.iface.NotesServiceInterface;
 
 @Service
@@ -27,10 +26,6 @@ public class LegacyNotesService implements NotesServiceInterface {
     private final GatewayService gatewayService;
 
     @Override
-    public String addNote(AddNoteRequest request, String ifMatch, UserState user, AccountNoteContext target) {
-        return addNote(request, ifMatch, user, target.businessUnitId());
-    }
-
     public String addNote(AddNoteRequest request, String ifMatch, UserState user, Short businessUnitId) {
         log.info(":LegacyAddNote");
         LegacyAddNoteRequest legacyRequest = createRequest(request, ifMatch, user, businessUnitId);

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
@@ -5,7 +5,10 @@ import static uk.gov.hmcts.opal.util.VersionUtils.extractBigInteger;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
+import uk.gov.hmcts.opal.common.legacy.model.ErrorResponse;
 import uk.gov.hmcts.opal.common.legacy.service.GatewayService;
+import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
 import uk.gov.hmcts.opal.common.user.authorisation.model.BusinessUnitUser;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
@@ -30,11 +33,14 @@ public class LegacyNotesService implements NotesServiceInterface {
 
     public String addNote(AddNoteRequest request, String ifMatch, UserState user, Short businessUnitId) {
         log.info(":LegacyAddNote");
+        LegacyAddNoteRequest legacyRequest = createRequest(request, ifMatch, user, businessUnitId);
+        log.debug(":LegacyAddNote: request metadata: businessUnitId={}, businessUnitUserId={}",
+            legacyRequest.getBusinessUnitId(), legacyRequest.getBusinessUnitUserId());
 
         GatewayService.Response<LegacyAddNoteResponse> response = gatewayService.postToGateway(
             ADD_NOTE,
             LegacyAddNoteResponse.class,
-            createRequest(request, ifMatch, user, businessUnitId),
+            legacyRequest,
             null
         );
 
@@ -46,7 +52,7 @@ public class LegacyNotesService implements NotesServiceInterface {
 
         if (response.responseEntity != null && response.responseEntity.getErrorResponse() != null) {
             log.error(":LegacyAddNote: Legacy Gateway error response: {}", response.responseEntity.getErrorResponse());
-            throw new IllegalArgumentException("Legacy gateway returned failure");
+            throw new IllegalArgumentException(legacyFailureMessage(response.responseEntity.getErrorResponse()));
         }
 
         if (response.responseEntity == null || response.responseEntity.getNote() == null) {
@@ -72,11 +78,17 @@ public class LegacyNotesService implements NotesServiceInterface {
         return user.getBusinessUnitUserForBusinessUnit(businessUnitId)
             .map(BusinessUnitUser::getBusinessUnitUserId)
             .filter(id -> !id.isBlank())
-            .orElse(user.getUserName());
+            .orElseThrow(() -> new PermissionNotAllowedException(
+                businessUnitId, FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES));
     }
 
     private void handleGatewayError(GatewayService.Response<LegacyAddNoteResponse> response) {
         log.error(":LegacyAddNote: Legacy Gateway response: HTTP Response Code: {}", response.code);
+
+        if (response.responseEntity != null && response.responseEntity.getErrorResponse() != null) {
+            log.error(":LegacyAddNote: Legacy Gateway error response: {}", response.responseEntity.getErrorResponse());
+            throw new IllegalArgumentException(legacyFailureMessage(response.responseEntity.getErrorResponse()));
+        }
 
         if (response.isException()) {
             log.error(":LegacyAddNote:", response.exception);
@@ -93,5 +105,17 @@ public class LegacyNotesService implements NotesServiceInterface {
         }
 
         throw new IllegalArgumentException("Legacy gateway error: " + response.code);
+    }
+
+    private String legacyFailureMessage(ErrorResponse errorResponse) {
+        String errorCode = errorResponse.getErrorCode();
+        String errorMessage = errorResponse.getErrorMessage();
+        if (errorCode == null || errorCode.isBlank()) {
+            return "Legacy gateway returned failure: " + errorMessage;
+        }
+        if (errorMessage == null || errorMessage.isBlank()) {
+            return "Legacy gateway returned failure: " + errorCode;
+        }
+        return "Legacy gateway returned failure: " + errorCode + " " + errorMessage;
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
@@ -44,20 +44,7 @@ public class LegacyNotesService implements NotesServiceInterface {
             null
         );
 
-        if (response.isError()) {
-            handleGatewayError(response);
-        } else if (response.isSuccessful()) {
-            log.info(":LegacyAddNote: Legacy Gateway response: Success.");
-        }
-
-        if (response.responseEntity != null && response.responseEntity.getErrorResponse() != null) {
-            log.error(":LegacyAddNote: Legacy Gateway error response: {}", response.responseEntity.getErrorResponse());
-            throw new IllegalArgumentException(legacyFailureMessage(response.responseEntity.getErrorResponse()));
-        }
-
-        if (response.responseEntity == null || response.responseEntity.getNote() == null) {
-            throw new IllegalArgumentException("Legacy add note response missing activity note");
-        }
+        validateGatewayResponse(response);
 
         return response.responseEntity.getNote().getRecordId();
     }
@@ -82,13 +69,25 @@ public class LegacyNotesService implements NotesServiceInterface {
                 businessUnitId, FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES));
     }
 
-    private void handleGatewayError(GatewayService.Response<LegacyAddNoteResponse> response) {
-        log.error(":LegacyAddNote: Legacy Gateway response: HTTP Response Code: {}", response.code);
-
+    private void validateGatewayResponse(GatewayService.Response<LegacyAddNoteResponse> response) {
         if (response.responseEntity != null && response.responseEntity.getErrorResponse() != null) {
             log.error(":LegacyAddNote: Legacy Gateway error response: {}", response.responseEntity.getErrorResponse());
             throw new IllegalArgumentException(legacyFailureMessage(response.responseEntity.getErrorResponse()));
         }
+
+        if (response.isError()) {
+            handleGatewayError(response);
+        } else if (response.isSuccessful()) {
+            log.info(":LegacyAddNote: Legacy Gateway response: Success.");
+        }
+
+        if (response.responseEntity == null || response.responseEntity.getNote() == null) {
+            throw new IllegalArgumentException("Legacy add note response missing activity note");
+        }
+    }
+
+    private void handleGatewayError(GatewayService.Response<LegacyAddNoteResponse> response) {
+        log.error(":LegacyAddNote: Legacy Gateway response: HTTP Response Code: {}", response.code);
 
         if (response.isException()) {
             log.error(":LegacyAddNote:", response.exception);

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
@@ -23,12 +23,16 @@ public class LegacyNotesService implements NotesServiceInterface {
 
     @Override
     public String addNote(AddNoteRequest request, String ifMatch, UserState user, AccountNoteContext target) {
+        return addNote(request, ifMatch, user, target.businessUnitId());
+    }
+
+    public String addNote(AddNoteRequest request, String ifMatch, UserState user, Short businessUnitId) {
         log.info(":LegacyAddNote");
 
         GatewayService.Response<LegacyAddNoteResponse> response = gatewayService.postToGateway(
             ADD_NOTE,
             LegacyAddNoteResponse.class,
-            createRequest(request, ifMatch, user, target.businessUnitId()),
+            createRequest(request, ifMatch, user, businessUnitId),
             null
         );
 

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
@@ -56,7 +56,7 @@ public class LegacyNotesService implements NotesServiceInterface {
             .noteType(request.getActivityNote().getNoteType()).recordType(request.getActivityNote().getRecordType())
             .recordId(request.getActivityNote().getRecordId()).build();
 
-        return LegacyAddNoteRequest.builder().businessUnitId(businessUnitId)
+        return LegacyAddNoteRequest.builder().businessUnitId(businessUnitId.toString())
             .businessUnitUserId(getBusinessUnitUserId(user, businessUnitId))
             .version(extractBigInteger(version)).activityNote(note).build();
     }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.opal.common.legacy.service.GatewayService;
+import uk.gov.hmcts.opal.common.user.authorisation.model.BusinessUnitUser;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyAddNoteRequest;
@@ -38,17 +39,18 @@ public class LegacyNotesService implements NotesServiceInterface {
         );
 
         if (response.isError()) {
-            log.error(":LegacyAddNote: Legacy Gateway response: HTTP Response Code: {}", response.code);
-
-            if (response.isException()) {
-                log.error(":LegacyAddNote:", response.exception);
-            } else if (response.isLegacyFailure()) {
-                log.error(":LegacyAddNote: Legacy Gateway: body: \n{}", response.body);
-                LegacyAddNoteResponse responseEntity = response.responseEntity;
-                log.error(":LegacyAddNote: Legacy Gateway: entity: \n{}", responseEntity.toXml());
-            }
+            handleGatewayError(response);
         } else if (response.isSuccessful()) {
             log.info(":LegacyAddNote: Legacy Gateway response: Success.");
+        }
+
+        if (response.responseEntity != null && response.responseEntity.getErrorResponse() != null) {
+            log.error(":LegacyAddNote: Legacy Gateway error response: {}", response.responseEntity.getErrorResponse());
+            throw new IllegalArgumentException("Legacy gateway returned failure");
+        }
+
+        if (response.responseEntity == null || response.responseEntity.getNote() == null) {
+            throw new IllegalArgumentException("Legacy add note response missing activity note");
         }
 
         return response.responseEntity.getNote().getRecordId();
@@ -62,6 +64,34 @@ public class LegacyNotesService implements NotesServiceInterface {
             .recordId(request.getActivityNote().getRecordId()).build();
 
         return LegacyAddNoteRequest.builder().businessUnitId(businessUnitId)
-            .businessUnitUserId(user.getUserId()).version(extractBigInteger(version)).activityNote(note).build();
+            .businessUnitUserId(getBusinessUnitUserId(user, businessUnitId))
+            .version(extractBigInteger(version)).activityNote(note).build();
+    }
+
+    private String getBusinessUnitUserId(UserState user, Short businessUnitId) {
+        return user.getBusinessUnitUserForBusinessUnit(businessUnitId)
+            .map(BusinessUnitUser::getBusinessUnitUserId)
+            .filter(id -> !id.isBlank())
+            .orElse(user.getUserName());
+    }
+
+    private void handleGatewayError(GatewayService.Response<LegacyAddNoteResponse> response) {
+        log.error(":LegacyAddNote: Legacy Gateway response: HTTP Response Code: {}", response.code);
+
+        if (response.isException()) {
+            log.error(":LegacyAddNote:", response.exception);
+            throw new IllegalArgumentException("Legacy gateway exception", response.exception);
+        }
+
+        if (response.isLegacyFailure()) {
+            log.error(":LegacyAddNote: Legacy Gateway: body: \n{}", response.body);
+            LegacyAddNoteResponse responseEntity = response.responseEntity;
+            if (responseEntity != null) {
+                log.error(":LegacyAddNote: Legacy Gateway: entity: \n{}", responseEntity.toXml());
+            }
+            throw new IllegalArgumentException("Legacy gateway returned failure");
+        }
+
+        throw new IllegalArgumentException("Legacy gateway error: " + response.code);
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesService.java
@@ -41,7 +41,7 @@ public class LegacyNotesService implements NotesServiceInterface {
 
         validateGatewayResponse(response);
 
-        return response.responseEntity.getNote().getRecordId();
+        return request.getActivityNote().getRecordId();
     }
 
     private LegacyAddNoteRequest createRequest(AddNoteRequest request, String version, UserState user,
@@ -74,10 +74,8 @@ public class LegacyNotesService implements NotesServiceInterface {
             handleGatewayError(response);
         } else if (response.isSuccessful()) {
             log.info(":LegacyAddNote: Legacy Gateway response: Success.");
-        }
-
-        if (response.responseEntity == null || response.responseEntity.getNote() == null) {
-            throw new IllegalArgumentException("Legacy add note response missing activity note");
+        } else {
+            throw new IllegalArgumentException("Legacy gateway response missing status");
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalNotesService.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.opal.entity.NoteType;
 import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
 import uk.gov.hmcts.opal.repository.NoteRepository;
 import uk.gov.hmcts.opal.service.AccountNoteContext;
+import uk.gov.hmcts.opal.service.AccountNoteContextFactory;
 import uk.gov.hmcts.opal.service.iface.NotesServiceInterface;
 import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
 import uk.gov.hmcts.opal.util.Versioned;
@@ -29,9 +30,16 @@ public class OpalNotesService implements NotesServiceInterface {
     private final NoteRepository repository;
     private final DefendantAccountRepositoryService defendantAccountRepositoryService;
     private final CreditorAccountRepository creditorAccountRepository;
+    private final AccountNoteContextFactory accountNoteContextFactory;
     private final Clock clock;
 
     @Override
+    @Transactional
+    public String addNote(AddNoteRequest req, String ifMatch, UserState user, Short businessUnitId) {
+        AccountNoteContext target = accountNoteContextFactory.from(req.getActivityNote());
+        return addNote(req, ifMatch, user, target);
+    }
+
     @Transactional
     public String addNote(AddNoteRequest req, String ifMatch, UserState user, AccountNoteContext target) {
         log.info(":OpalAddNote");

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/OpalNotesService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/OpalNotesService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
 import uk.gov.hmcts.opal.dto.Note;
+import uk.gov.hmcts.opal.entity.AssociatedRecordType;
 import uk.gov.hmcts.opal.entity.NoteEntity;
 import uk.gov.hmcts.opal.entity.NoteType;
 import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
@@ -44,7 +45,7 @@ public class OpalNotesService implements NotesServiceInterface {
     public String addNote(AddNoteRequest req, String ifMatch, UserState user, AccountNoteContext target) {
         log.info(":OpalAddNote");
 
-        getAccountAndVerifyVersion(target, ifMatch);
+        final Versioned account = getAccountAndVerifyVersion(target, ifMatch);
 
         Note requestNote = req.getActivityNote();
 
@@ -58,8 +59,15 @@ public class OpalNotesService implements NotesServiceInterface {
         note.setPostedByUsername(user.getDisplayName());
 
         NoteEntity entity = repository.save(note);
+        incrementAccountVersion(target, account);
 
         return entity.getNoteId().toString();
+    }
+
+    private void incrementAccountVersion(AccountNoteContext target, Versioned account) {
+        if (target.associatedRecordType() == AssociatedRecordType.DEFENDANT_ACCOUNTS) {
+            defendantAccountRepositoryService.incrementVersionNumber(target.accountId(), account.getVersion());
+        }
     }
 
     private Versioned getAccountAndVerifyVersion(AccountNoteContext target, String ifMatch) {

--- a/src/main/java/uk/gov/hmcts/opal/service/proxy/NotesProxy.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/proxy/NotesProxy.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
 import uk.gov.hmcts.opal.service.AccountNoteContext;
-import uk.gov.hmcts.opal.service.AccountNoteContextFactory;
 import uk.gov.hmcts.opal.service.iface.NotesServiceInterface;
 import uk.gov.hmcts.opal.service.legacy.LegacyNotesService;
 import uk.gov.hmcts.opal.service.opal.DynamicConfigService;
@@ -20,24 +19,18 @@ public class NotesProxy implements NotesServiceInterface, ProxyInterface {
     private final OpalNotesService notesService;
     private final LegacyNotesService legacyNotesService;
     private final DynamicConfigService dynamicConfigService;
-    private final AccountNoteContextFactory accountNoteContextFactory;
 
     private NotesServiceInterface getCurrentModeService() {
         return isLegacyMode(dynamicConfigService) ? legacyNotesService : notesService;
     }
 
-    @Override
     public String addNote(AddNoteRequest request, String ifMatch, UserState user, AccountNoteContext target) {
         return notesService.addNote(request, ifMatch, user, target);
     }
 
+    @Override
     public String addNote(AddNoteRequest request, String ifMatch, UserState user, Short businessUnitId) {
-        if (isLegacyMode(dynamicConfigService)) {
-            return legacyNotesService.addNote(request, ifMatch, user, businessUnitId);
-        }
-
-        AccountNoteContext target = accountNoteContextFactory.from(request.getActivityNote());
-        return notesService.addNote(request, ifMatch, user, target);
+        return getCurrentModeService().addNote(request, ifMatch, user, businessUnitId);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/proxy/NotesProxy.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/proxy/NotesProxy.java
@@ -28,7 +28,7 @@ public class NotesProxy implements NotesServiceInterface, ProxyInterface {
 
     @Override
     public String addNote(AddNoteRequest request, String ifMatch, UserState user, AccountNoteContext target) {
-        return getCurrentModeService().addNote(request, ifMatch, user, target);
+        return notesService.addNote(request, ifMatch, user, target);
     }
 
     public String addNote(AddNoteRequest request, String ifMatch, UserState user, Short businessUnitId) {

--- a/src/main/java/uk/gov/hmcts/opal/service/proxy/NotesProxy.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/proxy/NotesProxy.java
@@ -12,7 +12,7 @@ import uk.gov.hmcts.opal.service.opal.DynamicConfigService;
 import uk.gov.hmcts.opal.service.opal.OpalNotesService;
 
 @Service
-@Slf4j(topic = "opal.DefendantAccountServiceProxy")
+@Slf4j(topic = "opal.NotesProxy")
 @RequiredArgsConstructor
 public class NotesProxy implements NotesServiceInterface, ProxyInterface {
 

--- a/src/main/java/uk/gov/hmcts/opal/service/proxy/NotesProxy.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/proxy/NotesProxy.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
 import uk.gov.hmcts.opal.service.AccountNoteContext;
+import uk.gov.hmcts.opal.service.AccountNoteContextFactory;
 import uk.gov.hmcts.opal.service.iface.NotesServiceInterface;
 import uk.gov.hmcts.opal.service.legacy.LegacyNotesService;
 import uk.gov.hmcts.opal.service.opal.DynamicConfigService;
@@ -19,6 +20,7 @@ public class NotesProxy implements NotesServiceInterface, ProxyInterface {
     private final OpalNotesService notesService;
     private final LegacyNotesService legacyNotesService;
     private final DynamicConfigService dynamicConfigService;
+    private final AccountNoteContextFactory accountNoteContextFactory;
 
     private NotesServiceInterface getCurrentModeService() {
         return isLegacyMode(dynamicConfigService) ? legacyNotesService : notesService;
@@ -27,6 +29,15 @@ public class NotesProxy implements NotesServiceInterface, ProxyInterface {
     @Override
     public String addNote(AddNoteRequest request, String ifMatch, UserState user, AccountNoteContext target) {
         return getCurrentModeService().addNote(request, ifMatch, user, target);
+    }
+
+    public String addNote(AddNoteRequest request, String ifMatch, UserState user, Short businessUnitId) {
+        if (isLegacyMode(dynamicConfigService)) {
+            return legacyNotesService.addNote(request, ifMatch, user, businessUnitId);
+        }
+
+        AccountNoteContext target = accountNoteContextFactory.from(request.getActivityNote());
+        return notesService.addNote(request, ifMatch, user, target);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/NotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/NotesServiceTest.java
@@ -17,8 +17,6 @@ import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
 import uk.gov.hmcts.opal.dto.Note;
 import uk.gov.hmcts.opal.dto.RecordType;
-import uk.gov.hmcts.opal.entity.AssociatedRecordType;
-import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.service.proxy.NotesProxy;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,30 +28,21 @@ class NotesServiceTest {
 
     @Mock private NotesProxy notesProxy;
     @Mock private UserStateService userStateService;
-    @Mock private AccountNoteContextFactory accountNoteContextFactory;
     @Mock private UserState userState;
 
     @InjectMocks
     private NotesService notesService;
 
     private AddNoteRequest request;
-    private AccountNoteContext target;
 
     @BeforeEach
     void setUp() {
         request = addNoteRequest();
-        target = new AccountNoteContext(
-            DefendantAccountEntity.class,
-            DEFENDANT_ACCOUNT_ID,
-            BUSINESS_UNIT_ID,
-            AssociatedRecordType.DEFENDANT_ACCOUNTS
-        );
     }
 
     @Test
     void addNote_shouldThrowPermissionNotAllowedException_whenUserLacksPermission() {
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(accountNoteContextFactory.from(request.getActivityNote())).thenReturn(target);
         when(userState.hasBusinessUnitUserWithPermission(
             BUSINESS_UNIT_ID, FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES)).thenReturn(false);
 
@@ -68,15 +57,14 @@ class NotesServiceTest {
         String expectedResponse = "note-id-456";
 
         when(userStateService.getUserStateV1FromSecurityContext()).thenReturn(userState);
-        when(accountNoteContextFactory.from(request.getActivityNote())).thenReturn(target);
         when(userState.hasBusinessUnitUserWithPermission(
             BUSINESS_UNIT_ID, FinesPermission.ADD_ACCOUNT_ACTIVITY_NOTES)).thenReturn(true);
-        when(notesProxy.addNote(request, IF_MATCH, userState, target)).thenReturn(expectedResponse);
+        when(notesProxy.addNote(request, IF_MATCH, userState, BUSINESS_UNIT_ID)).thenReturn(expectedResponse);
 
         String actualResponse = notesService.addNote(request, IF_MATCH, BUSINESS_UNIT_ID);
 
         assertEquals(expectedResponse, actualResponse);
-        verify(notesProxy).addNote(request, IF_MATCH, userState, target);
+        verify(notesProxy).addNote(request, IF_MATCH, userState, BUSINESS_UNIT_ID);
     }
 
     private static AddNoteRequest addNoteRequest() {

--- a/src/test/java/uk/gov/hmcts/opal/service/NotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/NotesServiceTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.opal.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -50,6 +51,7 @@ class NotesServiceTest {
             PermissionNotAllowedException.class,
             () -> notesService.addNote(request, IF_MATCH, BUSINESS_UNIT_ID)
         );
+        verifyNoInteractions(notesProxy);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.opal.service.legacy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.math.BigInteger;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -20,7 +22,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import uk.gov.hmcts.opal.common.legacy.model.ErrorResponse;
 import uk.gov.hmcts.opal.common.legacy.service.GatewayService;
+import uk.gov.hmcts.opal.common.user.authorisation.model.BusinessUnitUser;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
 import uk.gov.hmcts.opal.dto.Note;
@@ -64,14 +68,14 @@ class LegacyNotesServiceTest {
         )).thenReturn(resp);
 
         AddNoteRequest req = addReq("77", "hello");
-        when(user.getUserId()).thenReturn(999L);
+        givenBusinessUnitUser((short) 1, "L001JG");
 
         String id = service.addNote(req, "1", user, targetWithBu((short) 1));
         assertEquals("77", id);
 
         LegacyAddNoteRequest sent = reqCap.getValue();
         assertEquals((short) 1, sent.getBusinessUnitId());
-        assertEquals(999, sent.getBusinessUnitUserId());
+        assertEquals("L001JG", sent.getBusinessUnitUserId());
         assertEquals(BigInteger.valueOf(1L), sent.getVersion());
 
         LegacyNote sentNote = sent.getActivityNote();
@@ -110,16 +114,17 @@ class LegacyNotesServiceTest {
         )).thenReturn(resp);
 
         AddNoteRequest req = addReq("770000004141", "hello");
-        when(user.getUserId()).thenReturn(999L);
+        givenBusinessUnitUser((short) 77, "L077JG");
 
         String id = service.addNote(req, '"' + LEGACY_VERSION + '"', user, targetWithBu((short) 77));
 
         assertEquals("770000004141", id);
         assertEquals(new BigInteger(LEGACY_VERSION), reqCap.getValue().getVersion());
+        assertEquals("L077JG", reqCap.getValue().getBusinessUnitUserId());
     }
 
     @Test
-    void addNote_errorWithException_stillReturnsRecordId() {
+    void addNote_errorWithException_throwsLegacyGatewayException() {
 
         LegacyAddNoteResponse entity = legacyRespWithNote("77", "boom");
 
@@ -138,10 +143,13 @@ class LegacyNotesServiceTest {
         )).thenReturn(resp);
 
         AddNoteRequest req = addReq("77", "boom");
-        when(user.getUserId()).thenReturn(1L);
+        givenBusinessUnitUser((short) 5, "L005JG");
 
-        String id = service.addNote(req, "1", user, targetWithBu((short) 5));
-        assertEquals("77", id);
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> service.addNote(req, "1", user, targetWithBu((short) 5))
+        );
+        assertEquals("Legacy gateway exception", exception.getMessage());
 
         verify(gatewayService).postToGateway(
             anyString(),
@@ -153,7 +161,7 @@ class LegacyNotesServiceTest {
     }
 
     @Test
-    void addNote_errorLegacyFailure_stillReturnsRecordId() {
+    void addNote_errorLegacyFailure_throwsLegacyGatewayFailure() {
 
         LegacyAddNoteResponse entity = legacyRespWithNote("77", "world");
 
@@ -173,10 +181,13 @@ class LegacyNotesServiceTest {
         )).thenReturn(resp);
 
         AddNoteRequest req = addReq("77", "world");
-        when(user.getUserId()).thenReturn(42L);
+        givenBusinessUnitUser((short) 9, "L009JG");
 
-        String id = service.addNote(req, "1", user, targetWithBu((short) 9));
-        assertEquals("77", id);
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> service.addNote(req, "1", user, targetWithBu((short) 9))
+        );
+        assertEquals("Legacy gateway returned failure", exception.getMessage());
 
         verify(gatewayService).postToGateway(
             anyString(),
@@ -188,7 +199,7 @@ class LegacyNotesServiceTest {
     }
 
     @Test
-    void addNote_errorGeneric_stillReturnsRecordId() {
+    void addNote_errorGeneric_throwsLegacyGatewayError() {
 
         LegacyAddNoteResponse entity = legacyRespWithNote("77", "meh");
 
@@ -208,10 +219,13 @@ class LegacyNotesServiceTest {
         )).thenReturn(resp);
 
         AddNoteRequest req = addReq("77", "meh");
-        when(user.getUserId()).thenReturn(5L);
+        givenBusinessUnitUser((short) 3, "L003JG");
 
-        String id = service.addNote(req, "7", user, targetWithBu((short) 3));
-        assertEquals("77", id);
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> service.addNote(req, "7", user, targetWithBu((short) 3))
+        );
+        assertEquals("Legacy gateway error: null", exception.getMessage());
 
         verify(gatewayService).postToGateway(
             anyString(),
@@ -220,6 +234,39 @@ class LegacyNotesServiceTest {
             isNull(String.class)
         );
         verifyNoMoreInteractions(gatewayService);
+    }
+
+    @Test
+    void addNote_successWithErrorResponse_throwsLegacyGatewayFailure() {
+
+        LegacyAddNoteResponse entity = LegacyAddNoteResponse.builder()
+            .errorResponse(ErrorResponse.builder()
+                .errorCode("-20001")
+                .errorMessage("User not found")
+                .build())
+            .build();
+
+        @SuppressWarnings("unchecked")
+        GatewayService.Response<LegacyAddNoteResponse> resp = mock(GatewayService.Response.class);
+        ReflectionTestUtils.setField(resp, "responseEntity", entity);
+        when(resp.isSuccessful()).thenReturn(true);
+
+        when(gatewayService.<LegacyAddNoteResponse>postToGateway(
+            anyString(),
+            eq(LegacyAddNoteResponse.class),
+            any(LegacyAddNoteRequest.class),
+            isNull(String.class)
+        )).thenReturn(resp);
+
+        AddNoteRequest req = addReq("770000004141", "test");
+        givenBusinessUnitUser((short) 77, "L077JG");
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> service.addNote(req, '"' + LEGACY_VERSION + '"', user, targetWithBu((short) 77))
+        );
+
+        assertEquals("Legacy gateway returned failure", exception.getMessage());
     }
 
     // ---------- helpers ----------
@@ -231,6 +278,13 @@ class LegacyNotesServiceTest {
             buId,
             AssociatedRecordType.DEFENDANT_ACCOUNTS
         );
+    }
+
+    private void givenBusinessUnitUser(short businessUnitId, String businessUnitUserId) {
+        BusinessUnitUser businessUnitUser = BusinessUnitUser.builder()
+            .businessUnitUserId(businessUnitUserId)
+            .build();
+        when(user.getBusinessUnitUserForBusinessUnit(businessUnitId)).thenReturn(Optional.of(businessUnitUser));
     }
 
     private static AddNoteRequest addReq(String recordId, String text) {

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
@@ -251,7 +251,6 @@ class LegacyNotesServiceTest {
         @SuppressWarnings("unchecked")
         GatewayService.Response<LegacyAddNoteResponse> resp = mock(GatewayService.Response.class);
         ReflectionTestUtils.setField(resp, "responseEntity", entity);
-        when(resp.isSuccessful()).thenReturn(true);
 
         when(gatewayService.<LegacyAddNoteResponse>postToGateway(
             anyString(),
@@ -284,7 +283,6 @@ class LegacyNotesServiceTest {
         @SuppressWarnings("unchecked")
         GatewayService.Response<LegacyAddNoteResponse> resp = mock(GatewayService.Response.class);
         ReflectionTestUtils.setField(resp, "responseEntity", entity);
-        when(resp.isError()).thenReturn(true);
 
         when(gatewayService.<LegacyAddNoteResponse>postToGateway(
             anyString(),

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.opal.service.legacy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -15,6 +16,7 @@ import static org.mockito.Mockito.when;
 
 import java.math.BigInteger;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -31,12 +33,14 @@ import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
 import uk.gov.hmcts.opal.dto.Note;
 import uk.gov.hmcts.opal.dto.RecordType;
+import uk.gov.hmcts.opal.dto.ToJsonString;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyAddNoteRequest;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyAddNoteResponse;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyNote;
 import uk.gov.hmcts.opal.entity.AssociatedRecordType;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.service.AccountNoteContext;
+import uk.gov.hmcts.opal.service.opal.JsonSchemaValidationService;
 
 @ExtendWith(MockitoExtension.class)
 class LegacyNotesServiceTest {
@@ -76,7 +80,7 @@ class LegacyNotesServiceTest {
         assertEquals("77", id);
 
         LegacyAddNoteRequest sent = reqCap.getValue();
-        assertEquals((short) 1, sent.getBusinessUnitId());
+        assertEquals("1", sent.getBusinessUnitId());
         assertEquals("L001JG", sent.getBusinessUnitUserId());
         assertEquals(BigInteger.valueOf(1L), sent.getVersion());
 
@@ -122,7 +126,43 @@ class LegacyNotesServiceTest {
 
         assertEquals("770000004141", id);
         assertEquals(new BigInteger(LEGACY_VERSION), reqCap.getValue().getVersion());
+        assertEquals("77", reqCap.getValue().getBusinessUnitId());
         assertEquals("L077JG", reqCap.getValue().getBusinessUnitUserId());
+    }
+
+    @Test
+    void addNote_success_buildsLegacySchemaCompliantJson() throws Exception {
+
+        LegacyAddNoteResponse entity = legacyRespWithNote("770000004141", "hello");
+
+        @SuppressWarnings("unchecked")
+        GatewayService.Response<LegacyAddNoteResponse> resp = mock(GatewayService.Response.class);
+        ReflectionTestUtils.setField(resp, "responseEntity", entity);
+        when(resp.isSuccessful()).thenReturn(true);
+
+        ArgumentCaptor<LegacyAddNoteRequest> reqCap = ArgumentCaptor.forClass(LegacyAddNoteRequest.class);
+
+        when(gatewayService.<LegacyAddNoteResponse>postToGateway(
+            eq("addNote"),
+            eq(LegacyAddNoteResponse.class),
+            reqCap.capture(),
+            isNull(String.class)
+        )).thenReturn(resp);
+
+        AddNoteRequest req = addReq("770000004141", "hello");
+        givenBusinessUnitUser((short) 77, "L077JG");
+
+        service.addNote(req, '"' + LEGACY_VERSION + '"', user, targetWithBu((short) 77));
+
+        String json = ToJsonString.getObjectMapper().writeValueAsString(reqCap.getValue());
+
+        assertFalse(json.contains("businessUnitId"));
+        assertFalse(json.contains("businessUnitUserId"));
+        assertFalse(json.contains("activityNote"));
+        assertEquals(
+            Set.of(),
+            new JsonSchemaValidationService().validate(json, "legacy/addNoteLegacyRequest.json")
+        );
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
@@ -128,6 +128,55 @@ class LegacyNotesServiceTest {
     }
 
     @Test
+    void addNote_successWithoutFetchedNote_returnsRequestRecordId() {
+
+        LegacyAddNoteResponse entity = LegacyAddNoteResponse.builder()
+            .version(BigInteger.valueOf(1L))
+            .build();
+
+        @SuppressWarnings("unchecked")
+        GatewayService.Response<LegacyAddNoteResponse> resp = mock(GatewayService.Response.class);
+        ReflectionTestUtils.setField(resp, "responseEntity", entity);
+        when(resp.isSuccessful()).thenReturn(true);
+
+        when(gatewayService.<LegacyAddNoteResponse>postToGateway(
+            anyString(),
+            eq(LegacyAddNoteResponse.class),
+            any(LegacyAddNoteRequest.class),
+            isNull(String.class)
+        )).thenReturn(resp);
+
+        AddNoteRequest req = addReq("770000004141", "hello");
+        givenBusinessUnitUser((short) 77, "L077JG");
+
+        String id = service.addNote(req, '"' + LEGACY_VERSION + '"', user, (short) 77);
+
+        assertEquals("770000004141", id);
+    }
+
+    @Test
+    void addNote_successWithoutResponseEntity_returnsRequestRecordId() {
+
+        @SuppressWarnings("unchecked")
+        GatewayService.Response<LegacyAddNoteResponse> resp = mock(GatewayService.Response.class);
+        when(resp.isSuccessful()).thenReturn(true);
+
+        when(gatewayService.<LegacyAddNoteResponse>postToGateway(
+            anyString(),
+            eq(LegacyAddNoteResponse.class),
+            any(LegacyAddNoteRequest.class),
+            isNull(String.class)
+        )).thenReturn(resp);
+
+        AddNoteRequest req = addReq("770000004141", "hello");
+        givenBusinessUnitUser((short) 77, "L077JG");
+
+        String id = service.addNote(req, '"' + LEGACY_VERSION + '"', user, (short) 77);
+
+        assertEquals("770000004141", id);
+    }
+
+    @Test
     void addNote_success_buildsLegacySchemaCompliantJson() throws Exception {
 
         LegacyAddNoteResponse entity = legacyRespWithNote("770000004141", "hello");

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
@@ -35,6 +35,8 @@ import uk.gov.hmcts.opal.service.AccountNoteContext;
 @ExtendWith(MockitoExtension.class)
 class LegacyNotesServiceTest {
 
+    private static final String LEGACY_VERSION = "835509468493002959816526022013198014020000027379";
+
     @Mock private GatewayService gatewayService;
     @Mock private UserState user;
 
@@ -86,6 +88,34 @@ class LegacyNotesServiceTest {
             isNull(String.class)
         );
         verifyNoMoreInteractions(gatewayService);
+    }
+
+    @Test
+    void addNote_success_acceptsQuotedLegacyETag() {
+
+        LegacyAddNoteResponse entity = legacyRespWithNote("770000004141", "hello");
+
+        @SuppressWarnings("unchecked")
+        GatewayService.Response<LegacyAddNoteResponse> resp = mock(GatewayService.Response.class);
+        ReflectionTestUtils.setField(resp, "responseEntity", entity);
+        when(resp.isSuccessful()).thenReturn(true);
+
+        ArgumentCaptor<LegacyAddNoteRequest> reqCap = ArgumentCaptor.forClass(LegacyAddNoteRequest.class);
+
+        when(gatewayService.<LegacyAddNoteResponse>postToGateway(
+            eq("addNote"),
+            eq(LegacyAddNoteResponse.class),
+            reqCap.capture(),
+            isNull(String.class)
+        )).thenReturn(resp);
+
+        AddNoteRequest req = addReq("770000004141", "hello");
+        when(user.getUserId()).thenReturn(999L);
+
+        String id = service.addNote(req, '"' + LEGACY_VERSION + '"', user, targetWithBu((short) 77));
+
+        assertEquals("770000004141", id);
+        assertEquals(new BigInteger(LEGACY_VERSION), reqCap.getValue().getVersion());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -24,6 +25,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import uk.gov.hmcts.opal.common.legacy.model.ErrorResponse;
 import uk.gov.hmcts.opal.common.legacy.service.GatewayService;
+import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
 import uk.gov.hmcts.opal.common.user.authorisation.model.BusinessUnitUser;
 import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
 import uk.gov.hmcts.opal.dto.AddNoteRequest;
@@ -266,7 +268,68 @@ class LegacyNotesServiceTest {
             () -> service.addNote(req, '"' + LEGACY_VERSION + '"', user, targetWithBu((short) 77))
         );
 
-        assertEquals("Legacy gateway returned failure", exception.getMessage());
+        assertEquals("Legacy gateway returned failure: -20001 User not found", exception.getMessage());
+    }
+
+    @Test
+    void addNote_errorResponseOnErrorPath_includesLegacyErrorDetails() {
+
+        LegacyAddNoteResponse entity = LegacyAddNoteResponse.builder()
+            .errorResponse(ErrorResponse.builder()
+                .errorCode("-20001")
+                .errorMessage("User not found")
+                .build())
+            .build();
+
+        @SuppressWarnings("unchecked")
+        GatewayService.Response<LegacyAddNoteResponse> resp = mock(GatewayService.Response.class);
+        ReflectionTestUtils.setField(resp, "responseEntity", entity);
+        when(resp.isError()).thenReturn(true);
+
+        when(gatewayService.<LegacyAddNoteResponse>postToGateway(
+            anyString(),
+            eq(LegacyAddNoteResponse.class),
+            any(LegacyAddNoteRequest.class),
+            isNull(String.class)
+        )).thenReturn(resp);
+
+        AddNoteRequest req = addReq("770000004141", "test");
+        givenBusinessUnitUser((short) 77, "L077JG");
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> service.addNote(req, '"' + LEGACY_VERSION + '"', user, targetWithBu((short) 77))
+        );
+
+        assertEquals("Legacy gateway returned failure: -20001 User not found", exception.getMessage());
+    }
+
+    @Test
+    void addNote_missingBusinessUnitUserId_throwsForbiddenBeforeGateway() {
+
+        AddNoteRequest req = addReq("770000004141", "test");
+        when(user.getBusinessUnitUserForBusinessUnit((short) 77)).thenReturn(Optional.empty());
+
+        assertThrows(
+            PermissionNotAllowedException.class,
+            () -> service.addNote(req, '"' + LEGACY_VERSION + '"', user, targetWithBu((short) 77))
+        );
+
+        verifyNoInteractions(gatewayService);
+    }
+
+    @Test
+    void addNote_blankBusinessUnitUserId_throwsForbiddenBeforeGateway() {
+
+        AddNoteRequest req = addReq("770000004141", "test");
+        givenBusinessUnitUser((short) 77, " ");
+
+        assertThrows(
+            PermissionNotAllowedException.class,
+            () -> service.addNote(req, '"' + LEGACY_VERSION + '"', user, targetWithBu((short) 77))
+        );
+
+        verifyNoInteractions(gatewayService);
     }
 
     // ---------- helpers ----------

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyNotesServiceTest.java
@@ -37,9 +37,6 @@ import uk.gov.hmcts.opal.dto.ToJsonString;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyAddNoteRequest;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyAddNoteResponse;
 import uk.gov.hmcts.opal.dto.legacy.search.LegacyNote;
-import uk.gov.hmcts.opal.entity.AssociatedRecordType;
-import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
-import uk.gov.hmcts.opal.service.AccountNoteContext;
 import uk.gov.hmcts.opal.service.opal.JsonSchemaValidationService;
 
 @ExtendWith(MockitoExtension.class)
@@ -76,7 +73,7 @@ class LegacyNotesServiceTest {
         AddNoteRequest req = addReq("77", "hello");
         givenBusinessUnitUser((short) 1, "L001JG");
 
-        String id = service.addNote(req, "1", user, targetWithBu((short) 1));
+        String id = service.addNote(req, "1", user, (short) 1);
         assertEquals("77", id);
 
         LegacyAddNoteRequest sent = reqCap.getValue();
@@ -122,7 +119,7 @@ class LegacyNotesServiceTest {
         AddNoteRequest req = addReq("770000004141", "hello");
         givenBusinessUnitUser((short) 77, "L077JG");
 
-        String id = service.addNote(req, '"' + LEGACY_VERSION + '"', user, targetWithBu((short) 77));
+        String id = service.addNote(req, '"' + LEGACY_VERSION + '"', user, (short) 77);
 
         assertEquals("770000004141", id);
         assertEquals(new BigInteger(LEGACY_VERSION), reqCap.getValue().getVersion());
@@ -152,7 +149,7 @@ class LegacyNotesServiceTest {
         AddNoteRequest req = addReq("770000004141", "hello");
         givenBusinessUnitUser((short) 77, "L077JG");
 
-        service.addNote(req, '"' + LEGACY_VERSION + '"', user, targetWithBu((short) 77));
+        service.addNote(req, '"' + LEGACY_VERSION + '"', user, (short) 77);
 
         String json = ToJsonString.getObjectMapper().writeValueAsString(reqCap.getValue());
 
@@ -189,7 +186,7 @@ class LegacyNotesServiceTest {
 
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            () -> service.addNote(req, "1", user, targetWithBu((short) 5))
+            () -> service.addNote(req, "1", user, (short) 5)
         );
         assertEquals("Legacy gateway exception", exception.getMessage());
 
@@ -227,7 +224,7 @@ class LegacyNotesServiceTest {
 
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            () -> service.addNote(req, "1", user, targetWithBu((short) 9))
+            () -> service.addNote(req, "1", user, (short) 9)
         );
         assertEquals("Legacy gateway returned failure", exception.getMessage());
 
@@ -265,7 +262,7 @@ class LegacyNotesServiceTest {
 
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            () -> service.addNote(req, "7", user, targetWithBu((short) 3))
+            () -> service.addNote(req, "7", user, (short) 3)
         );
         assertEquals("Legacy gateway error: null", exception.getMessage());
 
@@ -304,7 +301,7 @@ class LegacyNotesServiceTest {
 
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            () -> service.addNote(req, '"' + LEGACY_VERSION + '"', user, targetWithBu((short) 77))
+            () -> service.addNote(req, '"' + LEGACY_VERSION + '"', user, (short) 77)
         );
 
         assertEquals("Legacy gateway returned failure: -20001 User not found", exception.getMessage());
@@ -336,7 +333,7 @@ class LegacyNotesServiceTest {
 
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            () -> service.addNote(req, '"' + LEGACY_VERSION + '"', user, targetWithBu((short) 77))
+            () -> service.addNote(req, '"' + LEGACY_VERSION + '"', user, (short) 77)
         );
 
         assertEquals("Legacy gateway returned failure: -20001 User not found", exception.getMessage());
@@ -350,7 +347,7 @@ class LegacyNotesServiceTest {
 
         assertThrows(
             PermissionNotAllowedException.class,
-            () -> service.addNote(req, '"' + LEGACY_VERSION + '"', user, targetWithBu((short) 77))
+            () -> service.addNote(req, '"' + LEGACY_VERSION + '"', user, (short) 77)
         );
 
         verifyNoInteractions(gatewayService);
@@ -364,22 +361,13 @@ class LegacyNotesServiceTest {
 
         assertThrows(
             PermissionNotAllowedException.class,
-            () -> service.addNote(req, '"' + LEGACY_VERSION + '"', user, targetWithBu((short) 77))
+            () -> service.addNote(req, '"' + LEGACY_VERSION + '"', user, (short) 77)
         );
 
         verifyNoInteractions(gatewayService);
     }
 
     // ---------- helpers ----------
-
-    private static AccountNoteContext targetWithBu(short buId) {
-        return new AccountNoteContext(
-            DefendantAccountEntity.class,
-            77L,
-            buId,
-            AssociatedRecordType.DEFENDANT_ACCOUNTS
-        );
-    }
 
     private void givenBusinessUnitUser(short businessUnitId, String businessUnitUserId) {
         BusinessUnitUser businessUnitUser = BusinessUnitUser.builder()

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalNotesServiceTest.java
@@ -30,6 +30,7 @@ import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.repository.CreditorAccountRepository;
 import uk.gov.hmcts.opal.repository.NoteRepository;
 import uk.gov.hmcts.opal.service.AccountNoteContext;
+import uk.gov.hmcts.opal.service.AccountNoteContextFactory;
 import uk.gov.hmcts.opal.service.persistence.DefendantAccountRepositoryService;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,6 +39,7 @@ class OpalNotesServiceTest {
     @Mock private NoteRepository repository;
     @Mock private DefendantAccountRepositoryService defendantAccountRepositoryService;
     @Mock private CreditorAccountRepository creditorAccountRepository;
+    @Mock private AccountNoteContextFactory accountNoteContextFactory;
     @Mock private Clock clock;
     @Mock private UserState user;
 
@@ -104,6 +106,32 @@ class OpalNotesServiceTest {
         assertThat(entity.getBusinessUnitUserId()).isEqualTo("78");
         assertThat(entity.getPostedByUsername()).isEqualTo("Creditor User");
         verify(creditorAccountRepository).findByCreditorAccountIdForUpdate(104L);
+    }
+
+    @Test
+    void addNote_shouldResolveAccountContextForOpalRoute() {
+        when(clock.instant()).thenReturn(Instant.parse("2026-07-03T10:15:30Z"));
+        when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+        DefendantAccountEntity managed = new DefendantAccountEntity();
+        managed.setVersionNumber(12L);
+        BusinessUnitEntity businessUnit = new BusinessUnitEntity();
+        businessUnit.setBusinessUnitId((short) 78);
+        managed.setBusinessUnit(businessUnit);
+        NoteEntity saved = new NoteEntity();
+        saved.setNoteId(999L);
+        AddNoteRequest req = buildRequest("77", RecordType.DEFENDANT_ACCOUNTS);
+        AccountNoteContext target = defendantTarget();
+        when(accountNoteContextFactory.from(req.getActivityNote())).thenReturn(target);
+        when(defendantAccountRepositoryService.getDefendantAccountByIdForUpdate(77L))
+            .thenReturn(managed);
+        when(user.getDisplayName()).thenReturn("Test User");
+        when(repository.save(any(NoteEntity.class))).thenReturn(saved);
+
+        String result = service.addNote(req, "\"12\"", user, (short) 78);
+
+        assertThat(result).isEqualTo("999");
+        verify(accountNoteContextFactory).from(req.getActivityNote());
+        verify(defendantAccountRepositoryService).getDefendantAccountByIdForUpdate(77L);
     }
 
     private static AddNoteRequest buildRequest(String recordId, RecordType recordType) {

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/OpalNotesServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/OpalNotesServiceTest.java
@@ -79,6 +79,7 @@ class OpalNotesServiceTest {
             LocalDateTime.ofInstant(Instant.parse("2026-07-03T10:15:30Z"), ZoneOffset.UTC));
         assertThat(entity.getPostedByUsername()).isEqualTo("Test User");
         verify(defendantAccountRepositoryService).getDefendantAccountByIdForUpdate(77L);
+        verify(defendantAccountRepositoryService).incrementVersionNumber(77L, managed.getVersion());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/proxy/NotesProxyTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/proxy/NotesProxyTest.java
@@ -1,0 +1,86 @@
+package uk.gov.hmcts.opal.service.proxy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.opal.common.user.authorisation.model.UserState;
+import uk.gov.hmcts.opal.dto.AddNoteRequest;
+import uk.gov.hmcts.opal.dto.Note;
+import uk.gov.hmcts.opal.dto.RecordType;
+import uk.gov.hmcts.opal.entity.AssociatedRecordType;
+import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
+import uk.gov.hmcts.opal.service.AccountNoteContext;
+import uk.gov.hmcts.opal.service.AccountNoteContextFactory;
+import uk.gov.hmcts.opal.service.legacy.LegacyNotesService;
+import uk.gov.hmcts.opal.service.opal.OpalNotesService;
+
+@ExtendWith(MockitoExtension.class)
+class NotesProxyTest extends ProxyTestsBase {
+
+    private static final String IF_MATCH = "1";
+    private static final Short BUSINESS_UNIT_ID = 78;
+    private static final Long DEFENDANT_ACCOUNT_ID = 770000004141L;
+
+    @Mock private OpalNotesService notesService;
+    @Mock private LegacyNotesService legacyNotesService;
+    @Mock private AccountNoteContextFactory accountNoteContextFactory;
+    @Mock private UserState userState;
+
+    @InjectMocks
+    private NotesProxy notesProxy;
+
+    @Test
+    void addNote_shouldRouteToLegacyWithoutResolvingLocalAccountContext_whenInLegacyMode() {
+        setLegacyMode(true);
+        AddNoteRequest request = addNoteRequest();
+        String expectedResponse = "legacy-note-id";
+
+        when(legacyNotesService.addNote(request, IF_MATCH, userState, BUSINESS_UNIT_ID)).thenReturn(expectedResponse);
+
+        String actualResponse = notesProxy.addNote(request, IF_MATCH, userState, BUSINESS_UNIT_ID);
+
+        assertEquals(expectedResponse, actualResponse);
+        verify(legacyNotesService).addNote(request, IF_MATCH, userState, BUSINESS_UNIT_ID);
+        verifyNoInteractions(accountNoteContextFactory, notesService);
+    }
+
+    @Test
+    void addNote_shouldResolveLocalAccountContextAndRouteToOpal_whenInOpalMode() {
+        setLegacyMode(false);
+        AddNoteRequest request = addNoteRequest();
+        AccountNoteContext target = new AccountNoteContext(
+            DefendantAccountEntity.class,
+            DEFENDANT_ACCOUNT_ID,
+            BUSINESS_UNIT_ID,
+            AssociatedRecordType.DEFENDANT_ACCOUNTS
+        );
+        String expectedResponse = "opal-note-id";
+
+        when(accountNoteContextFactory.from(request.getActivityNote())).thenReturn(target);
+        when(notesService.addNote(request, IF_MATCH, userState, target)).thenReturn(expectedResponse);
+
+        String actualResponse = notesProxy.addNote(request, IF_MATCH, userState, BUSINESS_UNIT_ID);
+
+        assertEquals(expectedResponse, actualResponse);
+        verify(accountNoteContextFactory).from(request.getActivityNote());
+        verify(notesService).addNote(request, IF_MATCH, userState, target);
+        verifyNoInteractions(legacyNotesService);
+    }
+
+    private static AddNoteRequest addNoteRequest() {
+        Note note = Note.builder()
+            .recordType(RecordType.DEFENDANT_ACCOUNTS)
+            .recordId(DEFENDANT_ACCOUNT_ID.toString())
+            .noteText("test")
+            .noteType("AA")
+            .build();
+        return new AddNoteRequest(note);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/proxy/NotesProxyTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/proxy/NotesProxyTest.java
@@ -17,7 +17,6 @@ import uk.gov.hmcts.opal.dto.RecordType;
 import uk.gov.hmcts.opal.entity.AssociatedRecordType;
 import uk.gov.hmcts.opal.entity.defendantaccount.DefendantAccountEntity;
 import uk.gov.hmcts.opal.service.AccountNoteContext;
-import uk.gov.hmcts.opal.service.AccountNoteContextFactory;
 import uk.gov.hmcts.opal.service.legacy.LegacyNotesService;
 import uk.gov.hmcts.opal.service.opal.OpalNotesService;
 
@@ -30,7 +29,6 @@ class NotesProxyTest extends ProxyTestsBase {
 
     @Mock private OpalNotesService notesService;
     @Mock private LegacyNotesService legacyNotesService;
-    @Mock private AccountNoteContextFactory accountNoteContextFactory;
     @Mock private UserState userState;
 
     @InjectMocks
@@ -48,29 +46,21 @@ class NotesProxyTest extends ProxyTestsBase {
 
         assertEquals(expectedResponse, actualResponse);
         verify(legacyNotesService).addNote(request, IF_MATCH, userState, BUSINESS_UNIT_ID);
-        verifyNoInteractions(accountNoteContextFactory, notesService);
+        verifyNoInteractions(notesService);
     }
 
     @Test
-    void addNote_shouldResolveLocalAccountContextAndRouteToOpal_whenInOpalMode() {
+    void addNote_shouldRouteToOpalWithoutResolvingLocalAccountContext_whenInOpalMode() {
         setLegacyMode(false);
         AddNoteRequest request = addNoteRequest();
-        AccountNoteContext target = new AccountNoteContext(
-            DefendantAccountEntity.class,
-            DEFENDANT_ACCOUNT_ID,
-            BUSINESS_UNIT_ID,
-            AssociatedRecordType.DEFENDANT_ACCOUNTS
-        );
         String expectedResponse = "opal-note-id";
 
-        when(accountNoteContextFactory.from(request.getActivityNote())).thenReturn(target);
-        when(notesService.addNote(request, IF_MATCH, userState, target)).thenReturn(expectedResponse);
+        when(notesService.addNote(request, IF_MATCH, userState, BUSINESS_UNIT_ID)).thenReturn(expectedResponse);
 
         String actualResponse = notesProxy.addNote(request, IF_MATCH, userState, BUSINESS_UNIT_ID);
 
         assertEquals(expectedResponse, actualResponse);
-        verify(accountNoteContextFactory).from(request.getActivityNote());
-        verify(notesService).addNote(request, IF_MATCH, userState, target);
+        verify(notesService).addNote(request, IF_MATCH, userState, BUSINESS_UNIT_ID);
         verifyNoInteractions(legacyNotesService);
     }
 
@@ -91,7 +81,7 @@ class NotesProxyTest extends ProxyTestsBase {
 
         assertEquals(expectedResponse, actualResponse);
         verify(notesService).addNote(request, IF_MATCH, userState, target);
-        verifyNoInteractions(accountNoteContextFactory, legacyNotesService);
+        verifyNoInteractions(legacyNotesService);
     }
 
     private static AddNoteRequest addNoteRequest() {

--- a/src/test/java/uk/gov/hmcts/opal/service/proxy/NotesProxyTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/proxy/NotesProxyTest.java
@@ -50,7 +50,7 @@ class NotesProxyTest extends ProxyTestsBase {
     }
 
     @Test
-    void addNote_shouldRouteToOpalWithoutResolvingLocalAccountContext_whenInOpalMode() {
+    void addNote_shouldRouteToOpalService_whenInOpalMode() {
         setLegacyMode(false);
         AddNoteRequest request = addNoteRequest();
         String expectedResponse = "opal-note-id";

--- a/src/test/java/uk/gov/hmcts/opal/service/proxy/NotesProxyTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/proxy/NotesProxyTest.java
@@ -74,6 +74,26 @@ class NotesProxyTest extends ProxyTestsBase {
         verifyNoInteractions(legacyNotesService);
     }
 
+    @Test
+    void addNote_shouldRouteExistingAccountContextToOpal() {
+        AddNoteRequest request = addNoteRequest();
+        AccountNoteContext target = new AccountNoteContext(
+            DefendantAccountEntity.class,
+            DEFENDANT_ACCOUNT_ID,
+            BUSINESS_UNIT_ID,
+            AssociatedRecordType.DEFENDANT_ACCOUNTS
+        );
+        String expectedResponse = "opal-note-id";
+
+        when(notesService.addNote(request, IF_MATCH, userState, target)).thenReturn(expectedResponse);
+
+        String actualResponse = notesProxy.addNote(request, IF_MATCH, userState, target);
+
+        assertEquals(expectedResponse, actualResponse);
+        verify(notesService).addNote(request, IF_MATCH, userState, target);
+        verifyNoInteractions(accountNoteContextFactory, legacyNotesService);
+    }
+
     private static AddNoteRequest addNoteRequest() {
         Note note = Note.builder()
             .recordType(RecordType.DEFENDANT_ACCOUNTS)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-10341


### Change description ###
When legacy mode is enabled, route the request to LegacyNotesService without requiring the account to exist in the local Opal database.

The local account lookup should remain for the Opal persistence route.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
