### PR TITLE
Add JSON naming strategy to AddPaymentCardLegacyRequest and update te…

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/LegacyDefendantsPaymentsIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/LegacyDefendantsPaymentsIntegrationTest.java
@@ -1,8 +1,13 @@
 package uk.gov.hmcts.opal.controllers.r1b;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_CLASS;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_CLASS;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -13,6 +18,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.ResultActions;
@@ -28,19 +34,28 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 @Slf4j(topic = "opal.LegacyDefendantsPaymentsIntegrationTest")
 class LegacyDefendantsPaymentsIntegrationTest extends AbstractLegacyDefendantsIntegrationTest {
 
+    private static final String ADD_PAYMENT_CARD_REQUEST = "addDefendantAccountPaymentCard";
+
     @Test
     @DisplayName("LEGACY: Add Payment Card Request – Happy Path [@PO-2088]")
     @JiraStory("PO-2088")
     @JiraEpic("PO-977")
     @JiraTestKey("PO-5941")
     void testAddPaymentCardRequest_Happy() throws Exception {
+        stubAddPaymentCardResponse(200, """
+            <response>
+              <defendant_account_id>901</defendant_account_id>
+              <version>4</version>
+            </response>
+            """, "\"business_unit_user_id\":\"L078JG\"");
+
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(userStateStub.getBearerToken());
         headers.add("Business-Unit-Id", "78");
         headers.add("If-Match", "3");
 
         ResultActions result = mockMvc.perform(
-            post("/defendant-accounts/901/payment-card-request")
+            MockMvcRequestBuilders.post("/defendant-accounts/901/payment-card-request")
                 .with(userStateStub.getAuthenticaitonRequestPostProcessor())
                 .headers(headers)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -60,13 +75,15 @@ class LegacyDefendantsPaymentsIntegrationTest extends AbstractLegacyDefendantsIn
     @JiraEpic("PO-977")
     @JiraTestKey("PO-5938")
     void testAddPaymentCardRequest_500() throws Exception {
+        stubAddPaymentCardResponse(500, "<error><message>Internal Server Error</message></error>");
+
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(userStateStub.getBearerToken());
         headers.add("Business-Unit-Id", "78");
         headers.add("If-Match", "1");
 
         ResultActions result = mockMvc.perform(
-            post("/defendant-accounts/555/payment-card-request")
+            MockMvcRequestBuilders.post("/defendant-accounts/555/payment-card-request")
                 .with(userStateStub.getAuthenticaitonRequestPostProcessor())
                 .headers(headers)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -89,7 +106,7 @@ class LegacyDefendantsPaymentsIntegrationTest extends AbstractLegacyDefendantsIn
         headers.add("Business-Unit-Id", "69");
         headers.add(HttpHeaders.IF_MATCH, "\"1\"");
         var response = mockMvc.perform(
-            post("/defendant-accounts/69/payment-terms")
+            MockMvcRequestBuilders.post("/defendant-accounts/69/payment-terms")
                 .with(userStateStub.getAuthenticaitonRequestPostProcessor())
                 .headers(headers)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -117,7 +134,7 @@ class LegacyDefendantsPaymentsIntegrationTest extends AbstractLegacyDefendantsIn
         headers.add(HttpHeaders.IF_MATCH, "\"1\"");
 
         var response = mockMvc.perform(
-            post("/defendant-accounts/500/payment-terms")
+            MockMvcRequestBuilders.post("/defendant-accounts/500/payment-terms")
                 .with(userStateStub.getAuthenticaitonRequestPostProcessor())
                 .headers(headers)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -130,5 +147,24 @@ class LegacyDefendantsPaymentsIntegrationTest extends AbstractLegacyDefendantsIn
             .andExpect(jsonPath("$.payment_terms.days_in_default").doesNotExist())
             .andExpect(jsonPath("$.payment_card_last_requested").doesNotExist())
             .andExpect(jsonPath("$.last_enforcement").doesNotExist());
+    }
+
+    private void stubAddPaymentCardResponse(int status, String body) {
+        stubFor(post(urlPathEqualTo("/opal"))
+            .withQueryParam("actionType", equalTo(ADD_PAYMENT_CARD_REQUEST))
+            .willReturn(aResponse()
+                .withStatus(status)
+                .withHeader("Content-Type", MediaType.APPLICATION_XML_VALUE)
+                .withBody(body)));
+    }
+
+    private void stubAddPaymentCardResponse(int status, String body, String expectedRequestBody) {
+        stubFor(post(urlPathEqualTo("/opal"))
+            .withQueryParam("actionType", equalTo(ADD_PAYMENT_CARD_REQUEST))
+            .withRequestBody(containing(expectedRequestBody))
+            .willReturn(aResponse()
+                .withStatus(status)
+                .withHeader("Content-Type", MediaType.APPLICATION_XML_VALUE)
+                .withBody(body)));
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/AddPaymentCardLegacyRequest.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/AddPaymentCardLegacyRequest.java
@@ -8,12 +8,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.annotation.JsonNaming;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @XmlAccessorType(XmlAccessType.FIELD)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class AddPaymentCardLegacyRequest {
 
     @XmlElement(name = "defendant_account_id")

--- a/src/test/java/uk/gov/hmcts/opal/dto/legacy/AddPaymentCardLegacyRequestTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/dto/legacy/AddPaymentCardLegacyRequestTest.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.opal.dto.legacy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.math.BigInteger;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+class AddPaymentCardLegacyRequestTest {
+
+    @Test
+    void shouldSerializeUsingSnakeCasePropertyNames() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        AddPaymentCardLegacyRequest request = AddPaymentCardLegacyRequest.builder()
+            .defendantAccountId("770000004141")
+            .businessUnitId("77")
+            .businessUnitUserId("L077JG")
+            .version(new BigInteger("835509468493002959816526022013198014020000027379"))
+            .build();
+
+        String json = objectMapper.writeValueAsString(request);
+        JsonNode payload = objectMapper.readTree(json);
+
+        assertEquals("770000004141", payload.get("defendant_account_id").asString());
+        assertEquals("77", payload.get("business_unit_id").asString());
+        assertEquals("L077JG", payload.get("business_unit_user_id").asString());
+        assertEquals(new BigInteger("835509468493002959816526022013198014020000027379"),
+                     payload.get("version").bigIntegerValue());
+        assertNull(payload.get("businessUnitUserId"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPaymentTermsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPaymentTermsServiceTest.java
@@ -34,6 +34,8 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpServerErrorException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.common.legacy.config.LegacyGatewayProperties;
 import uk.gov.hmcts.opal.common.legacy.service.GatewayService;
@@ -142,6 +144,26 @@ class LegacyDefendantAccountPaymentTermsServiceTest {
         assertEquals("78", sent.getBusinessUnitId());
         assertEquals(BigInteger.valueOf(9), sent.getVersion());
         assertEquals("L080JG", sent.getBusinessUnitUserId());
+    }
+
+    @Test
+    void addPaymentCardRequest_legacyRequestSerializesBusinessUnitUserIdAsSnakeCase() throws Exception {
+        AddPaymentCardLegacyRequest request = AddPaymentCardLegacyRequest.builder()
+            .defendantAccountId("770000004141")
+            .businessUnitId("77")
+            .businessUnitUserId("L077JG")
+            .version(new BigInteger("835509468493002959816526022013198014020000027379"))
+            .build();
+
+        String json = new ObjectMapper().writeValueAsString(request);
+        JsonNode payload = new ObjectMapper().readTree(json);
+
+        assertEquals("770000004141", payload.get("defendant_account_id").asString());
+        assertEquals("77", payload.get("business_unit_id").asString());
+        assertEquals("L077JG", payload.get("business_unit_user_id").asString());
+        assertEquals(new BigInteger("835509468493002959816526022013198014020000027379"),
+                     payload.get("version").bigIntegerValue());
+        assertNull(payload.get("businessUnitUserId"));
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPaymentTermsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPaymentTermsServiceTest.java
@@ -34,8 +34,6 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpServerErrorException;
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
 import uk.gov.hmcts.opal.common.legacy.config.LegacyGatewayProperties;
 import uk.gov.hmcts.opal.common.legacy.service.GatewayService;
@@ -144,26 +142,6 @@ class LegacyDefendantAccountPaymentTermsServiceTest {
         assertEquals("78", sent.getBusinessUnitId());
         assertEquals(BigInteger.valueOf(9), sent.getVersion());
         assertEquals("L080JG", sent.getBusinessUnitUserId());
-    }
-
-    @Test
-    void addPaymentCardRequest_legacyRequestSerializesBusinessUnitUserIdAsSnakeCase() throws Exception {
-        AddPaymentCardLegacyRequest request = AddPaymentCardLegacyRequest.builder()
-            .defendantAccountId("770000004141")
-            .businessUnitId("77")
-            .businessUnitUserId("L077JG")
-            .version(new BigInteger("835509468493002959816526022013198014020000027379"))
-            .build();
-
-        String json = new ObjectMapper().writeValueAsString(request);
-        JsonNode payload = new ObjectMapper().readTree(json);
-
-        assertEquals("770000004141", payload.get("defendant_account_id").asString());
-        assertEquals("77", payload.get("business_unit_id").asString());
-        assertEquals("L077JG", payload.get("business_unit_user_id").asString());
-        assertEquals(new BigInteger("835509468493002959816526022013198014020000027379"),
-                     payload.get("version").bigIntegerValue());
-        assertNull(payload.get("businessUnitUserId"));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-10372


### Change description ###
Added Jackson 3 snake_case serialization to AddPaymentCardLegacyRequest so outbound JSON includes business_unit_user_id
•Added regression coverage proving the legacy payment-card request serializes business_unit_user_id and not camelCase: 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
