### PR TITLE
PO-2576: Add GET Interface Jobs Processed File Summary API

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/opal/steps/interfacejobs/InterfaceJobsProcessedFileSummaryStepDef.java
+++ b/src/functionalTest/java/uk/gov/hmcts/opal/steps/interfacejobs/InterfaceJobsProcessedFileSummaryStepDef.java
@@ -1,0 +1,284 @@
+package uk.gov.hmcts.opal.steps.interfacejobs;
+
+import static net.serenitybdd.rest.SerenityRest.then;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.cucumber.java.After;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.Response;
+import java.time.Duration;
+import java.util.List;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import uk.gov.hmcts.opal.steps.BaseStepDef;
+import uk.gov.hmcts.opal.steps.BearerTokenStepDef;
+import uk.gov.hmcts.opal.utils.TestHttpClient;
+import uk.gov.hmcts.opal.utils.TestHttpClient.TestHttpResponse;
+
+/**
+ * Defines functional-test steps for the processed interface-job file summary endpoint.
+ */
+public class InterfaceJobsProcessedFileSummaryStepDef extends BaseStepDef {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final short BUSINESS_UNIT_ID = 78;
+    private static final String INTERFACE_NAME = "E2E Processed File Summary";
+    private static final String INTERFACE_JOBS_PATH = "/interface-jobs";
+    private static final String PROCESS_PATH = "/interface-jobs/process";
+    private static final String SUMMARY_PATH = "/interface-jobs/summary";
+    private static final String TESTING_SUPPORT_PATH = "/testing-support/interface-jobs";
+    private static final Duration COMPLETION_TIMEOUT = Duration.ofSeconds(60);
+    private static final Duration POLL_INTERVAL = Duration.ofSeconds(2);
+    private static final Set<String> SUMMARY_FIELDS = Set.of(
+        "file_name", "source", "business_unit_name", "total_amount", "total_records", "total_errors",
+        "interface_messages"
+    );
+    private static final Set<String> MESSAGE_GROUP_FIELDS = Set.of("message_text", "messages");
+    private static final Set<String> MESSAGE_FIELDS = Set.of("interface_messages_id", "message_data", "message_type");
+
+    private Long createdInterfaceJobId;
+    private String createdByToken;
+
+    /**
+     * Creates an interface job and remembers its generated ID for the current scenario.
+     */
+    @Given("I create an interface job for processed file summary")
+    public void createInterfaceJobForProcessedFileSummary() {
+        createdByToken = BearerTokenStepDef.getToken();
+        Response response = authorisedJsonRequest()
+            .body(createRequestBody())
+            .when()
+            .post(getTestUrl() + INTERFACE_JOBS_PATH);
+
+        assertEquals(200, response.statusCode(), "Expected interface job creation to succeed");
+        createdInterfaceJobId = JsonPath.from(response.asString()).getLong("interface_jobs[0].interface_job_id");
+    }
+
+    /**
+     * Submits the created interface job to the existing interface-job processor.
+     */
+    @When("I submit the interface job for processing")
+    public void submitInterfaceJobForProcessing() {
+        long interfaceJobId = createdInterfaceJobIdOrFail();
+        authorisedJsonRequest()
+            .body(processRequestBody(interfaceJobId))
+            .when()
+            .post(getTestUrl() + PROCESS_PATH);
+
+        then().log().ifValidationFails().statusCode(200);
+    }
+
+    /**
+     * Polls the interface-job summary until the asynchronous processor marks the job completed.
+     */
+    @When("I wait for the interface job to complete")
+    public void waitForInterfaceJobToComplete() {
+        long interfaceJobId = createdInterfaceJobIdOrFail();
+        long deadline = System.nanoTime() + COMPLETION_TIMEOUT.toNanos();
+        String lastStatus = "unknown";
+
+        while (System.nanoTime() < deadline) {
+            TestHttpResponse response = TestHttpClient.request(
+                "GET",
+                getTestUrl() + SUMMARY_PATH + "?business_unit_ids=" + BUSINESS_UNIT_ID
+                    + "&interface_name=" + INTERFACE_NAME.replace(" ", "%20"),
+                authorisedHeaders(),
+                null);
+            assertEquals(200, response.statusCode(), "Expected interface-job summary request to succeed");
+
+            List<Map<String, Object>> jobs = JsonPath.from(response.body()).getList("interface_jobs");
+            Map<String, Object> job = jobs.stream()
+                .filter(item -> ((Number) item.get("interface_job_id")).longValue() == interfaceJobId)
+                .findFirst()
+                .orElse(null);
+
+            if (job != null) {
+                lastStatus = String.valueOf(job.get("status"));
+                if ("COMPLETED".equals(lastStatus)) {
+                    return;
+                }
+                if ("FAILED".equals(lastStatus)) {
+                    throw new AssertionError("Interface job failed during processing: " + interfaceJobId);
+                }
+            }
+
+            sleepBeforeNextPoll();
+        }
+
+        throw new AssertionError("Timed out waiting for interface job " + interfaceJobId
+            + " to complete; last status was " + lastStatus);
+    }
+
+    /**
+     * Requests the summary using the ID generated during the scenario.
+     */
+    @When("I request the processed file summary for the completed interface job")
+    public void requestProcessedFileSummaryForCompletedInterfaceJob() {
+        authorisedJsonRequest()
+            .accept("application/json")
+            .when()
+            .get(getTestUrl() + "/interface-jobs/" + createdInterfaceJobIdOrFail()
+                + "/processed-file-summary");
+    }
+
+    /**
+     * Removes any interface job created by this feature scenario.
+     */
+    @After(order = Integer.MAX_VALUE)
+    public void cleanUpCreatedInterfaceJob() {
+        if (createdInterfaceJobId == null) {
+            return;
+        }
+
+        TestHttpClient.request(
+            "DELETE",
+            getTestUrl() + TESTING_SUPPORT_PATH + "?ids=" + createdInterfaceJobId,
+            authorisedHeaders(createdByToken),
+            null);
+        createdInterfaceJobId = null;
+        createdByToken = null;
+    }
+
+    /**
+     * Requests the supplied processed-file-summary endpoint using the current scenario user.
+     *
+     * @param path endpoint path to request.
+     */
+    @When("I request GET {string}")
+    public void requestGet(String path) {
+        authorisedJsonRequest()
+            .accept("application/json")
+            .when()
+            .get(getTestUrl() + path);
+    }
+
+    /**
+     * Checks the documented top-level and nested response structure and field types.
+     */
+    @Then("the response matches the processed file summary schema")
+    public void responseMatchesProcessedFileSummarySchema() {
+        JsonNode response = readResponse();
+
+        assertFieldNames(response, SUMMARY_FIELDS, "processed file summary");
+        assertTrue(response.path("file_name").isTextual(), "file_name must be a string");
+        assertTrue(response.path("source").isTextual(), "source must be a string");
+        assertTrue(response.path("business_unit_name").isTextual(), "business_unit_name must be a string");
+        assertTrue(response.path("total_amount").isNumber(), "total_amount must be numeric");
+        assertTrue(response.path("total_records").isIntegralNumber(), "total_records must be an integer");
+        assertTrue(response.path("total_errors").isIntegralNumber(), "total_errors must be an integer");
+        assertTrue(response.path("interface_messages").isArray(), "interface_messages must be an array");
+
+        for (JsonNode group : response.path("interface_messages")) {
+            assertFieldNames(group, MESSAGE_GROUP_FIELDS, "message group");
+            assertTrue(group.path("message_text").isTextual(), "message_text must be a string");
+            assertTrue(group.path("messages").isArray(), "messages must be an array");
+
+            for (JsonNode message : group.path("messages")) {
+                assertFieldNames(message, MESSAGE_FIELDS, "interface message");
+                assertTrue(message.path("interface_messages_id").isIntegralNumber(),
+                    "interface_messages_id must be an integer");
+                assertTrue(message.path("message_data").isObject(), "message_data must be an object");
+                assertTrue(message.path("message_type").isTextual(), "message_type must be a string");
+            }
+        }
+    }
+
+    /**
+     * Confirms that the response contains one group per message text and that each group
+     * contains a messages array.
+     */
+    @Then("interface messages are grouped by message text")
+    public void interfaceMessagesAreGroupedByMessageText() {
+        JsonNode response = readResponse();
+        Set<String> messageTexts = new HashSet<>();
+
+        for (JsonNode group : response.path("interface_messages")) {
+            String messageText = group.path("message_text").asText();
+
+            assertTrue(messageTexts.add(messageText),
+                "Duplicate message group found: " + messageText);
+            assertTrue(group.path("messages").isArray(),
+                "Each message group must contain a messages array");
+        }
+    }
+
+    private JsonNode readResponse() {
+        try {
+            return OBJECT_MAPPER.readTree(then().extract().asString());
+        } catch (JacksonException e) {
+            throw new AssertionError("Processed file summary response was not valid JSON", e);
+        }
+    }
+
+    private void assertFieldNames(JsonNode node, Set<String> expectedFields, String objectName) {
+        Set<String> actualFields = new HashSet<>();
+        node.properties().forEach(property -> actualFields.add(property.getKey()));
+        assertEquals(expectedFields, actualFields, "Unexpected fields in " + objectName);
+    }
+
+    private String createRequestBody() {
+        return """
+            {
+              "interface_jobs": [
+                {
+                  "file_name": "e2e-processed-file-summary.dat",
+                  "source": "NATWEST",
+                  "records": "[{\\\"receiving_sort_code\\\":\\\"123456\\\",\\\"receiving_bank_account_number\\\":\\\"01234567\\\",\\\"receiving_account_type\\\":\\\"5\\\",\\\"transaction_code\\\":\\\"68\\\",\\\"originator_sort_code\\\":\\\"654321\\\",\\\"originator_bank_account_number\\\":\\\"98765432\\\",\\\"amount_pence\\\":\\\"12345\\\",\\\"originator_name\\\":\\\"Test Payer\\\",\\\"originator_reference\\\":\\\"99000001A\\\",\\\"originator_beneficiary_name\\\":\\\"Test Court\\\"}]",
+                  "business_unit_id": %d,
+                  "interface_name": "%s",
+                  "created_datetime": "2026-07-14T10:00:00"
+                }
+              ]
+            }
+            """.formatted(BUSINESS_UNIT_ID, INTERFACE_NAME);
+    }
+
+    private String processRequestBody(long interfaceJobId) {
+        return """
+            {
+              "interface_jobs": [
+                {
+                  "interface_job_id": %d,
+                  "business_unit_id": %d,
+                  "override_inhibits": false
+                }
+              ]
+            }
+            """.formatted(interfaceJobId, BUSINESS_UNIT_ID);
+    }
+
+    private Map<String, String> authorisedHeaders() {
+        return authorisedHeaders(BearerTokenStepDef.getToken());
+    }
+
+    private Map<String, String> authorisedHeaders(String token) {
+        return Map.of(
+            "Accept", "*/*",
+            "Content-Type", "application/json",
+            "Authorization", "Bearer " + token);
+    }
+
+    private long createdInterfaceJobIdOrFail() {
+        if (createdInterfaceJobId == null) {
+            throw new IllegalStateException("No interface job has been created for this scenario");
+        }
+        return createdInterfaceJobId;
+    }
+
+    private void sleepBeforeNextPoll() {
+        try {
+            Thread.sleep(POLL_INTERVAL.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Interrupted while waiting for interface job completion", e);
+        }
+    }
+}

--- a/src/functionalTest/resources/features/opalMode/interfaceJobs/InterfaceJobsProcessedFileSummary.feature
+++ b/src/functionalTest/resources/features/opalMode/interfaceJobs/InterfaceJobsProcessedFileSummary.feature
@@ -1,0 +1,39 @@
+@Opal @R1CPayment @JIRA-LABEL:interface-jobs @JIRA-EPIC:PO-2468
+Feature: Get processed file summary
+
+  @JIRA-STORY:PO-2576
+  Scenario: Reject request without an access token
+    When I call GET "/interface-jobs/999999999/processed-file-summary" without a token
+    Then the request is rejected as unauthorized
+
+  @JIRA-STORY:PO-2576
+  Scenario: Reject request with an invalid access token
+    When I call GET "/interface-jobs/999999999/processed-file-summary" with an invalid token
+    Then the request is rejected as unauthorized
+
+  @JIRA-STORY:PO-2576
+  Scenario: Permitted user retrieves a processed file summary
+    Given I am testing as the "opal-test@dev.platform.hmcts.net" user
+    And I create an interface job for processed file summary
+    And I submit the interface job for processing
+    And I wait for the interface job to complete
+    When I request the processed file summary for the completed interface job
+    Then the response status code is 200
+    And the response matches the processed file summary schema
+    And interface messages are grouped by message text
+
+  @JIRA-STORY:PO-2576
+  Scenario: Unknown interface job returns not found
+    Given I am testing as the "opal-test@dev.platform.hmcts.net" user
+    When I request GET "/interface-jobs/999999999/processed-file-summary"
+    Then the request is rejected as not found
+
+  @JIRA-STORY:PO-2576
+  Scenario: User without payment processing permission is forbidden
+    Given I am testing as the "opal-test@dev.platform.hmcts.net" user
+    And I create an interface job for processed file summary
+    And I submit the interface job for processing
+    And I wait for the interface job to complete
+    When I am testing as the "opal-test-2@dev.platform.hmcts.net" user
+    And I request the processed file summary for the completed interface job
+    Then the request is rejected as forbidden

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/InterfaceJobProcessedFileSummaryErrorIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/InterfaceJobProcessedFileSummaryErrorIT.java
@@ -1,0 +1,81 @@
+package uk.gov.hmcts.opal.controllers;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+import jakarta.persistence.QueryTimeoutException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.hmcts.opal.AbstractIntegrationTest;
+import uk.gov.hmcts.opal.repository.InterfaceJobsProcessedFileSummaryRepository;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
+
+@TestPropertySource(properties = {
+    "launchdarkly.default-flag-values.release-1c-payment=true"
+})
+@DisplayName("Interface Job Processed File Summary Error Integration Tests")
+class InterfaceJobProcessedFileSummaryErrorIT extends AbstractIntegrationTest {
+
+    private static final long INTERFACE_JOB_ID = 123L;
+    private static final String URL = "/interface-jobs/" + INTERFACE_JOB_ID + "/processed-file-summary";
+
+    @MockitoBean
+    private InterfaceJobsProcessedFileSummaryRepository summaryViewRepository;
+
+    @Test
+    @DisplayName("PO-2576 INT.10 - maps a query timeout to 408")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void mapsQueryTimeoutToRequestTimeout() throws Exception {
+        when(summaryViewRepository.findAllByInterfaceJobIdOrderByInterfaceFileIdAsc(INTERFACE_JOB_ID))
+            .thenThrow(new QueryTimeoutException("timeout", null, null));
+
+        mockMvc.perform(get(URL).accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isRequestTimeout())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(header().exists("operation_id"))
+            .andExpect(jsonPath("$.status").value(408));
+    }
+
+    @Test
+    @DisplayName("PO-2576 INT.10 - maps database availability failure to 503")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void mapsDatabaseAvailabilityFailureToServiceUnavailable() throws Exception {
+        when(summaryViewRepository.findAllByInterfaceJobIdOrderByInterfaceFileIdAsc(INTERFACE_JOB_ID))
+            .thenThrow(new DataAccessResourceFailureException("database unavailable"));
+
+        mockMvc.perform(get(URL).accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isServiceUnavailable())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(header().exists("operation_id"))
+            .andExpect(jsonPath("$.status").value(503));
+    }
+
+    @Test
+    @DisplayName("PO-2576 INT.10 - maps unexpected failures to 500")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void mapsUnexpectedFailureToInternalServerError() throws Exception {
+        when(summaryViewRepository.findAllByInterfaceJobIdOrderByInterfaceFileIdAsc(INTERFACE_JOB_ID))
+            .thenThrow(new ResponseStatusException(INTERNAL_SERVER_ERROR, "unexpected failure"));
+
+        mockMvc.perform(get(URL).accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isInternalServerError())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(header().exists("operation_id"))
+            .andExpect(jsonPath("$.status").value(500));
+    }
+
+}

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/InterfaceJobProcessedFileSummaryIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/InterfaceJobProcessedFileSummaryIT.java
@@ -1,0 +1,297 @@
+package uk.gov.hmcts.opal.controllers;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+import uk.gov.hmcts.opal.AbstractIntegrationTest;
+import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
+import uk.gov.hmcts.opal.common.logging.LogUtil;
+import uk.gov.hmcts.opal.common.user.authorisation.model.UserStateV2;
+import uk.gov.hmcts.opal.logging.integration.service.LoggingService;
+import uk.gov.hmcts.opal.logging.integration.dto.PersonalDataProcessingLogDetails;
+import uk.gov.hmcts.opal.service.UserStateService;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
+
+@ActiveProfiles({"integration"})
+@TestPropertySource(properties = {
+    "launchdarkly.default-flag-values.release-1c-payment=true"
+})
+@DisplayName("Interface Job Processed File Summary Controller Integration Tests")
+@Sql(scripts = "classpath:db/insertData/insert_into_interface_job_processed_file_summary.sql",
+     executionPhase = BEFORE_TEST_METHOD)
+@Sql(scripts = "classpath:db/deleteData/delete_from_interface_job_processed_file_summary.sql",
+     executionPhase = AFTER_TEST_METHOD)
+class InterfaceJobProcessedFileSummaryIT extends AbstractIntegrationTest {
+
+    private static final Long INTERFACE_JOB_ID = 257601L;
+    private static final Long IGNORED_INTERFACE_JOB_ID = 257602L;
+    private static final Long SUMMARY_MISSING_INTERFACE_JOB_ID = 257603L;
+    private static final long UNKNOWN_INTERFACE_JOB_ID = 257699L;
+    private static final Short BUSINESS_UNIT_ID = 2576;
+    private static final String URL = "/interface-jobs/" + INTERFACE_JOB_ID + "/processed-file-summary";
+    private static final String IGNORED_URL = "/interface-jobs/" + IGNORED_INTERFACE_JOB_ID
+        + "/processed-file-summary";
+    private static final int SUMMARY_RESPONSE_FIELD_COUNT = 7;
+    private static final int MESSAGE_GROUP_RESPONSE_FIELD_COUNT = 2;
+    private static final int MESSAGE_RESPONSE_FIELD_COUNT = 3;
+    private static final Instant PDPO_LOGGED_AT = Instant.parse("2026-08-26T12:00:00Z");
+    private static final String REQUEST_IP_ADDRESS = "192.0.2.10";
+
+    @MockitoBean
+    private UserStateService userStateService;
+
+    @MockitoBean
+    private LoggingService loggingService;
+
+    @MockitoBean
+    private Clock clock;
+
+    @BeforeEach
+    void setUpTestDoubles() {
+        when(loggingService.personalDataAccessLogAsync(any())).thenReturn(true);
+        when(clock.instant()).thenReturn(PDPO_LOGGED_AT);
+        when(clock.getZone()).thenReturn(ZoneOffset.UTC);
+    }
+
+    @Test
+    @DisplayName("PO-2576 INT.01/INT.04/INT.06 - returns the permitted processed file summary")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void returnsPermittedProcessedFileSummary() throws Exception {
+
+        // Arrange
+        stubPermittedOpalUser();
+
+        // Act & Assert
+        mockMvc.perform(get(URL).accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$", aMapWithSize(SUMMARY_RESPONSE_FIELD_COUNT)))
+            .andExpect(jsonPath("$.file_name").value("processed-summary.dat"))
+            .andExpect(jsonPath("$.source").value("NATWEST"))
+            .andExpect(jsonPath("$.business_unit_name").value("Processed Summary BU"))
+            .andExpect(jsonPath("$.total_amount").value(123.45))
+            .andExpect(jsonPath("$.total_records").value(3))
+            .andExpect(jsonPath("$.total_errors").value(1))
+            .andExpect(jsonPath("$.interface_messages", hasSize(2)))
+            .andExpect(jsonPath("$.interface_messages[0].message_text").value("records_read"))
+            .andExpect(jsonPath("$.interface_messages[0]", aMapWithSize(MESSAGE_GROUP_RESPONSE_FIELD_COUNT)))
+            .andExpect(jsonPath("$.interface_messages[0].messages", hasSize(2)))
+            .andExpect(jsonPath("$.interface_messages[0].messages[0]", aMapWithSize(MESSAGE_RESPONSE_FIELD_COUNT)))
+            .andExpect(jsonPath("$.interface_messages[0].messages[0].interface_messages_id").value(257631))
+            .andExpect(jsonPath("$.interface_messages[0].messages[0].message_data.count").value(3))
+            .andExpect(jsonPath("$.interface_messages[0].messages[1].interface_messages_id").value(257633))
+            .andExpect(jsonPath("$.interface_messages[0].messages[1].message_data.count").value(4))
+            .andExpect(jsonPath("$.interface_messages[1].message_text").value("records_rejected"))
+            .andExpect(jsonPath("$.interface_messages[1].messages", hasSize(1)));
+    }
+
+    @Test
+    @DisplayName("PO-2576 PDPO INT.01/INT.02 - logs the payer consultation with mapped details")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void logsPayerConsultationWithMappedDetails() throws Exception {
+
+        // Arrange
+        stubPermittedOpalUser();
+        try (MockedStatic<LogUtil> logUtil = Mockito.mockStatic(LogUtil.class)) {
+            logUtil.when(LogUtil::getIpAddress).thenReturn(REQUEST_IP_ADDRESS);
+
+            // Act & Assert
+            mockMvc.perform(get(URL).accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+        }
+
+        // Assert
+        ArgumentCaptor<PersonalDataProcessingLogDetails> captor =
+            ArgumentCaptor.forClass(PersonalDataProcessingLogDetails.class);
+        verify(loggingService).personalDataAccessLogAsync(captor.capture());
+        PersonalDataProcessingLogDetails details = captor.getValue();
+
+        assertEquals("View File Processing Summary", details.getBusinessIdentifier());
+        assertEquals("Consultation", details.getCategory().getJsonValue());
+        assertEquals("1", details.getCreatedBy().getIdentifier());
+        assertEquals("OPAL_USER_ID", details.getCreatedBy().getType().getType());
+        assertEquals("PAYER", details.getIndividuals().getFirst().getType().getType());
+        assertNull(details.getRecipient());
+        assertEquals(REQUEST_IP_ADDRESS, details.getIpAddress());
+        assertEquals(PDPO_LOGGED_AT.atOffset(ZoneOffset.UTC), details.getCreatedAt());
+    }
+
+    @Test
+    @DisplayName("PO-2576 INT.02 - rejects a user without business-unit permission")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void rejectsUserWithoutBusinessUnitPermission() throws Exception {
+
+        when(userStateService.getPermittedBusinessUnitIds(
+            List.of(BUSINESS_UNIT_ID), FinesPermission.PROCESS_AND_ALLOCATE_PAYMENTS)).thenReturn(List.of());
+
+        mockMvc.perform(get(URL).accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON));
+    }
+
+    @Test
+    @DisplayName("PO-2576 INT.03 - returns not found for an unknown interface job")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void returnsNotFoundForUnknownInterfaceJob() throws Exception {
+
+        assertNotFound("/interface-jobs/" + UNKNOWN_INTERFACE_JOB_ID + "/processed-file-summary");
+    }
+
+    @Test
+    @DisplayName("PO-2576 INT.03 - returns not found when an interface job has no processed file summary")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void returnsNotFoundWhenInterfaceJobHasNoProcessedFileSummary() throws Exception {
+
+        assertNotFound("/interface-jobs/" + SUMMARY_MISSING_INTERFACE_JOB_ID + "/processed-file-summary");
+    }
+
+    @Test
+    @DisplayName("PO-2576 PDPO INT.03 - rejects a caller without an OPAL user identity")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void rejectsCallerWithoutOpalUserIdentity() throws Exception {
+
+        when(userStateService.getPermittedBusinessUnitIds(
+            List.of(BUSINESS_UNIT_ID), FinesPermission.PROCESS_AND_ALLOCATE_PAYMENTS))
+            .thenReturn(List.of(BUSINESS_UNIT_ID));
+        when(userStateService.getUserStateFromSecurityContext())
+            .thenThrow(new AccessDeniedException("Unexpected token type"));
+
+        mockMvc.perform(get(URL).accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON));
+
+        verify(loggingService, never()).personalDataAccessLogAsync(any());
+    }
+
+    @Test
+    @DisplayName("PO-2576 INT.08; PDPO INT.04 - repeated requests return the same summary and log independently")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void repeatedRequestsAreIdempotentAndLoggedIndependently() throws Exception {
+
+        stubPermittedOpalUser();
+
+        MvcResult firstResult = mockMvc.perform(get(URL).accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        MvcResult secondResult = mockMvc.perform(get(URL).accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        assertEquals(firstResult.getResponse().getContentAsString(), secondResult.getResponse().getContentAsString());
+        verify(loggingService, times(2)).personalDataAccessLogAsync(any());
+    }
+
+    @Test
+    @DisplayName("PO-2576 PDPO INT.05 - logging failure does not change the successful response")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void loggingFailureDoesNotChangeSuccessfulResponse() throws Exception {
+
+        stubPermittedOpalUser();
+        when(loggingService.personalDataAccessLogAsync(any())).thenThrow(new RuntimeException("logging unavailable"));
+
+        mockMvc.perform(get(URL).accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.file_name").value("processed-summary.dat"));
+
+        verify(loggingService, times(1)).personalDataAccessLogAsync(any());
+    }
+
+    @Test
+    @DisplayName("PO-2576 INT.01 - returns a permitted ignored file summary without a till")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void returnsPermittedIgnoredFileSummaryWithoutTill() throws Exception {
+
+        stubPermittedOpalUser();
+
+        mockMvc.perform(get(IGNORED_URL).accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.file_name").value("ignored-summary.dat"))
+            .andExpect(jsonPath("$.business_unit_name").value("Processed Summary BU"))
+            .andExpect(jsonPath("$.total_amount").value(50.00))
+            .andExpect(jsonPath("$.total_records").value(2))
+            .andExpect(jsonPath("$.total_errors").value(1))
+            .andExpect(jsonPath("$.interface_messages[0].message_text").value("records_ignored"));
+
+        verify(loggingService, times(1)).personalDataAccessLogAsync(any());
+    }
+
+    @Test
+    @DisplayName("PO-2576 INT.02 - rejects an ignored file when its interface job BU is not permitted")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void rejectsIgnoredFileWithoutInterfaceJobBusinessUnitPermission() throws Exception {
+
+        when(userStateService.getPermittedBusinessUnitIds(
+            List.of(BUSINESS_UNIT_ID), FinesPermission.PROCESS_AND_ALLOCATE_PAYMENTS)).thenReturn(List.of());
+
+        mockMvc.perform(get(IGNORED_URL).accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON));
+
+        verify(loggingService, never()).personalDataAccessLogAsync(any());
+    }
+
+    private void stubPermittedOpalUser() {
+        when(userStateService.getPermittedBusinessUnitIds(
+            List.of(BUSINESS_UNIT_ID), FinesPermission.PROCESS_AND_ALLOCATE_PAYMENTS))
+            .thenReturn(List.of(BUSINESS_UNIT_ID));
+        when(userStateService.getUserStateFromSecurityContext()).thenReturn(UserStateV2.builder()
+            .userId(1L)
+            .username("test-user")
+            .name("Test User")
+            .build());
+    }
+
+    private void assertNotFound(String url) throws Exception {
+        mockMvc.perform(get(url).accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(header().exists("operation_id"))
+            .andExpect(jsonPath("$.status").value(404))
+            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/entity-not-found"));
+
+        verify(loggingService, never()).personalDataAccessLogAsync(any());
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/InterfaceJobProcessedFileSummarySecurityIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/InterfaceJobProcessedFileSummarySecurityIT.java
@@ -1,0 +1,98 @@
+package uk.gov.hmcts.opal.controllers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.BEFORE_TEST_METHOD;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+import uk.gov.hmcts.opal.AbstractIntegrationWithSecurityTest;
+import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
+import uk.gov.hmcts.opal.logging.integration.service.LoggingService;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
+
+@TestPropertySource(properties = {
+    "launchdarkly.default-flag-values.release-1c-payment=true",
+    "launchdarkly.default-flag-values.is-legacy-mode=false"
+})
+@DisplayName("Interface Job Processed File Summary Security Integration Tests")
+@Sql(scripts = "classpath:db/insertData/insert_into_interface_job_processed_file_summary.sql",
+     executionPhase = BEFORE_TEST_METHOD)
+@Sql(scripts = "classpath:db/deleteData/delete_from_interface_job_processed_file_summary.sql",
+     executionPhase = AFTER_TEST_METHOD)
+class InterfaceJobProcessedFileSummarySecurityIT extends AbstractIntegrationWithSecurityTest {
+
+    private static final String URL = "/interface-jobs/257601/processed-file-summary";
+    private static final short BUSINESS_UNIT_ID = 2576;
+
+    @MockitoBean
+    private LoggingService loggingService;
+
+    @Test
+    @DisplayName("PO-2576 INT.07 - rejects a request without an access token")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void rejectsRequestWithoutAccessToken() throws Exception {
+        mockMvc.perform(get(URL).accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnauthorized())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.status").value(401));
+    }
+
+    @Test
+    @DisplayName("PO-2576 INT.07 - rejects a request with an invalid access token")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void rejectsRequestWithInvalidAccessToken() throws Exception {
+        mockMvc.perform(get(URL)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer invalid-token")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnauthorized())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.status").value(401));
+    }
+
+    @Test
+    @DisplayName("PO-2576 INT.07 - rejects a valid caller without BU permission")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void rejectsValidCallerWithoutBusinessUnitPermission() throws Exception {
+        userStateStub.setupWithNoPermissions();
+
+        mockMvc.perform(get(URL)
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.status").value(403));
+    }
+
+    @Test
+    @DisplayName("PO-2576 INT.07 - permits a valid caller with BU permission")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void permitsValidCallerWithBusinessUnitPermission() throws Exception {
+        userStateStub.addPermissions(BUSINESS_UNIT_ID,
+            FinesPermission.PROCESS_AND_ALLOCATE_PAYMENTS);
+        when(loggingService.personalDataAccessLogAsync(any())).thenReturn(true);
+
+        mockMvc.perform(get(URL)
+                .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.file_name").value("processed-summary.dat"));
+    }
+
+}

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/InterfaceJobsProcessedFileSummaryFeatureToggleIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/InterfaceJobsProcessedFileSummaryFeatureToggleIT.java
@@ -1,0 +1,113 @@
+package uk.gov.hmcts.opal.controllers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.opal.util.FeatureFlags.RELEASE_1C_PAYMENT;
+
+import com.launchdarkly.sdk.LDContext;
+import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import uk.gov.hmcts.opal.AbstractIntegrationTest;
+import uk.gov.hmcts.opal.service.opal.DynamicConfigService;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
+import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
+
+@ActiveProfiles({"integration", "opal"})
+@TestPropertySource(properties = {
+    "launchdarkly.enabled=true",
+    "launchdarkly.sdk-key=test-sdk-key",
+    "launchdarkly.default-flag-values.release-1c-payment=false"
+})
+@DisplayName("Interface Jobs Processed File Summary Feature Toggle Integration Tests")
+class InterfaceJobsProcessedFileSummaryFeatureToggleIT extends AbstractIntegrationTest {
+
+    private static final long INTERFACE_JOB_ID = 123L;
+    private static final String URL = "/interface-jobs/" + INTERFACE_JOB_ID + "/processed-file-summary";
+
+    @MockitoBean
+    private LDClientInterface ldClient;
+
+    @MockitoBean
+    private DynamicConfigService dynamicConfigService;
+
+    @Test
+    @DisplayName("PO-2576 AC Feature Flags - returns feature disabled response when release-1c-payment is disabled")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void returnsFeatureDisabledWhenRelease1cPaymentIsDisabled() throws Exception {
+        when(ldClient.boolVariation(eq(RELEASE_1C_PAYMENT), any(LDContext.class), anyBoolean()))
+            .thenReturn(false);
+
+        mockMvc.perform(get(URL)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/feature-disabled"))
+            .andExpect(jsonPath("$.title").value("Feature Disabled"))
+            .andExpect(jsonPath("$.detail").value("The requested feature is not currently available"))
+            .andExpect(jsonPath("$.status").value(404))
+            .andExpect(jsonPath("$.retriable").value(false));
+
+        verify(ldClient, times(1)).boolVariation(eq(RELEASE_1C_PAYMENT), any(LDContext.class), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("PO-2576 AC Feature Flags - allows endpoint logic when release-1c-payment is enabled")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void allowsEndpointLogicWhenRelease1cPaymentIsEnabled() throws Exception {
+        when(ldClient.boolVariation(eq(RELEASE_1C_PAYMENT), any(LDContext.class), anyBoolean()))
+            .thenReturn(true);
+
+        mockMvc.perform(get(URL)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/entity-not-found"));
+
+        verify(ldClient, times(1)).boolVariation(eq(RELEASE_1C_PAYMENT), any(LDContext.class), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("PO-2576 INT.05 - rejects unsupported Accept header")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void rejectsUnsupportedAcceptHeader() throws Exception {
+        when(ldClient.boolVariation(eq(RELEASE_1C_PAYMENT), any(LDContext.class), anyBoolean()))
+            .thenReturn(true);
+
+        mockMvc.perform(get(URL)
+                .accept(MediaType.APPLICATION_XML))
+            .andExpect(status().isNotAcceptable());
+
+        verify(ldClient, times(0)).boolVariation(eq(RELEASE_1C_PAYMENT), any(LDContext.class), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("PO-2576 INT.09 - returns feature disabled response outside OPAL mode")
+    @JiraStory("PO-2576")
+    @JiraEpic("PO-2468")
+    void returnsFeatureDisabledResponseOutsideOpalMode() throws Exception {
+        when(ldClient.boolVariation(eq(RELEASE_1C_PAYMENT), any(LDContext.class), anyBoolean()))
+            .thenReturn(true);
+        when(dynamicConfigService.isLegacyMode()).thenReturn(true);
+
+        mockMvc.perform(get(URL).accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.type").value("https://hmcts.gov.uk/problems/feature-disabled"));
+    }
+}

--- a/src/integrationTest/resources/db/deleteData/delete_from_interface_job_processed_file_summary.sql
+++ b/src/integrationTest/resources/db/deleteData/delete_from_interface_job_processed_file_summary.sql
@@ -1,0 +1,5 @@
+DELETE FROM interface_messages WHERE interface_message_id IN (257631, 257632, 257633, 257634);
+DELETE FROM tills WHERE till_id = 257621;
+DELETE FROM interface_files WHERE interface_file_id IN (257611, 257612);
+DELETE FROM interface_jobs WHERE interface_job_id IN (257601, 257602, 257603);
+DELETE FROM business_units WHERE business_unit_id = 2576;

--- a/src/integrationTest/resources/db/insertData/insert_into_interface_job_processed_file_summary.sql
+++ b/src/integrationTest/resources/db/insertData/insert_into_interface_job_processed_file_summary.sql
@@ -1,0 +1,104 @@
+INSERT INTO business_units (
+    business_unit_id,
+    business_unit_name,
+    business_unit_code,
+    business_unit_type,
+    account_number_prefix,
+    opal_domain,
+    welsh_language
+) VALUES (
+    2576, 'Processed Summary BU', 'PSBU', 'Area', 'PS', 'Fines', true
+);
+
+INSERT INTO interface_jobs (
+    interface_job_id,
+    business_unit_id,
+    interface_name,
+    status,
+    created_datetime,
+    completed_datetime
+) VALUES (
+    257601, 2576, 'Auto Payments In', 'COMPLETED',
+    '2026-07-01 10:00:00', '2026-07-01 10:30:00'
+);
+
+INSERT INTO interface_jobs (
+    interface_job_id,
+    business_unit_id,
+    interface_name,
+    status,
+    created_datetime,
+    completed_datetime
+) VALUES (
+    257602, 2576, 'Auto Payments In', 'COMPLETED',
+    '2026-07-01 11:00:00', '2026-07-01 11:30:00'
+);
+
+INSERT INTO interface_jobs (
+    interface_job_id,
+    business_unit_id,
+    interface_name,
+    status,
+    created_datetime,
+    completed_datetime
+) VALUES (
+    257603, 2576, 'Auto Payments In', 'COMPLETED',
+    '2026-07-01 12:00:00', '2026-07-01 12:30:00'
+);
+
+INSERT INTO interface_files (
+    interface_file_id,
+    interface_job_id,
+    file_name,
+    created_datetime,
+    source,
+    record_count,
+    total_amount
+) VALUES (
+    257611, 257601, 'processed-summary.dat', '2026-07-01 10:01:00',
+    'NATWEST'::t_interface_file_source_enum, 3, 123.45
+);
+
+INSERT INTO interface_files (
+    interface_file_id,
+    interface_job_id,
+    file_name,
+    created_datetime,
+    source,
+    record_count,
+    total_amount
+) VALUES (
+    257612, 257602, 'ignored-summary.dat', '2026-07-01 11:01:00',
+    'NATWEST'::t_interface_file_source_enum, 2, 50.00
+);
+
+INSERT INTO tills (
+    till_id,
+    business_unit_id,
+    till_number,
+    owned_by,
+    interface_file_id,
+    source,
+    total_amount,
+    payments_count,
+    owned_by_name,
+    auto_payment,
+    created_date
+) VALUES (
+    257621, 2576, 901, 'test-user', 257611,
+    'NATWEST'::t_interface_file_source_enum, 123.45, 3, 'Test User', true,
+    '2026-07-01 10:30:00'
+);
+
+INSERT INTO interface_messages (
+    interface_message_id,
+    interface_job_id,
+    interface_file_id,
+    message_type,
+    message_text,
+    message_data
+) VALUES
+    (257631, 257601, 257611, 'Info', 'records_read', '{"count": 3}'),
+    (257632, 257601, 257611, 'Warning', 'records_rejected', '{"count": 1}'),
+    (257633, 257601, 257611, 'Info', 'records_read', '{"count": 4}'),
+    (257634, 257602, 257612, 'Exception', 'records_ignored', '{"count": 2}');

--- a/src/main/java/uk/gov/hmcts/opal/controllers/InterfaceJobsApiController.java
+++ b/src/main/java/uk/gov/hmcts/opal/controllers/InterfaceJobsApiController.java
@@ -6,7 +6,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.opal.common.launchdarkly.FeatureDisabledException;
 import uk.gov.hmcts.opal.common.launchdarkly.FeatureToggle;
@@ -14,9 +16,11 @@ import uk.gov.hmcts.opal.generated.http.api.InterfaceJobsApi;
 import uk.gov.hmcts.opal.generated.model.InterfaceJobsCreateRequest;
 import uk.gov.hmcts.opal.generated.model.InterfaceJobsCreateResponse;
 import uk.gov.hmcts.opal.generated.model.InterfaceJobsProcessRequest;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsProcessedFileSummaryResponse;
 import uk.gov.hmcts.opal.generated.model.InterfaceJobsSummaryResponse;
 import uk.gov.hmcts.opal.service.opal.DynamicConfigService;
 import uk.gov.hmcts.opal.service.opal.InterfaceJobService;
+import uk.gov.hmcts.opal.service.opal.InterfaceJobProcessedFileSummaryService;
 import uk.gov.hmcts.opal.service.opal.InterfaceJobService.InterfaceJobSearchCriteria;
 import uk.gov.hmcts.opal.util.FeatureFlags;
 
@@ -27,6 +31,8 @@ public class InterfaceJobsApiController implements InterfaceJobsApi {
 
     private final DynamicConfigService dynamicConfigService;
     private final InterfaceJobService interfaceJobService;
+
+    private final InterfaceJobProcessedFileSummaryService processedFileSummaryService;
 
     @Override
     @FeatureToggle(feature = FeatureFlags.RELEASE_1C_PAYMENT,
@@ -68,6 +74,25 @@ public class InterfaceJobsApiController implements InterfaceJobsApi {
         log.debug(":GET:getInterfaceJobsSummary: searchCriteria: {}", searchCriteria);
 
         return buildResponse(interfaceJobService.getSummary(searchCriteria));
+    }
+
+    @Override
+    @FeatureToggle(feature = FeatureFlags.RELEASE_1C_PAYMENT,
+        defaultValueProperty = FeatureFlags.RELEASE_1C_PAYMENT_ENABLED_PROPERTY)
+    public ResponseEntity<InterfaceJobsProcessedFileSummaryResponse> getInterfaceJobProcessedFileSummary(Long id) {
+
+        log.debug(":GET:getInterfaceJobProcessedFileSummary: id={}", id);
+
+        if (dynamicConfigService.isLegacyMode()) {
+            log.debug(":GET:getInterfaceJobProcessedFileSummary: rejecting request as service is in legacy mode");
+            throw new FeatureDisabledException("Processed file summary is only available in OPAL mode");
+        }
+        try {
+            return buildResponse(processedFileSummaryService.getProcessedFileSummary(id));
+        } catch (IllegalStateException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                "Unable to retrieve processed file summary", e);
+        }
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/dto/PdplIdentifierType.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/PdplIdentifierType.java
@@ -9,6 +9,7 @@ public enum PdplIdentifierType implements IdentifierType {
     DEBTOR_ACCOUNT,
     PARENT_GUARDIAN,
     DRAFT_ACCOUNT,
+    PAYER,
     OPAL_USER_ID,
     EXTERNAL_SYSTEM;
 

--- a/src/main/java/uk/gov/hmcts/opal/entity/InterfaceJobProcessedFileSummaryEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/InterfaceJobProcessedFileSummaryEntity.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.opal.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.Getter;
+import org.hibernate.annotations.Immutable;
+
+@Entity
+@Immutable
+@Getter
+@Table(name = "v_interface_jobs_processed_file_summary")
+public class InterfaceJobProcessedFileSummaryEntity {
+
+    @Id
+    @Column(name = "interface_file_id")
+    private Long interfaceFileId;
+
+    @Column(name = "interface_job_id")
+    private Long interfaceJobId;
+
+    @Column(name = "interface_file_name")
+    private String interfaceFileName;
+
+    @Column(name = "source")
+    private String source;
+
+    @Column(name = "business_unit_name")
+    private String businessUnitName;
+
+    @Column(name = "total_amount")
+    private BigDecimal totalAmount;
+
+    @Column(name = "total_records")
+    private Short totalRecords;
+
+    @Column(name = "total_errors")
+    private Long totalErrors;
+}

--- a/src/main/java/uk/gov/hmcts/opal/mapper/InterfaceJobProcessedFileSummaryMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/mapper/InterfaceJobProcessedFileSummaryMapper.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.opal.mapper;
+
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import uk.gov.hmcts.opal.entity.InterfaceJobProcessedFileSummaryEntity;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsMessageGroup;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsProcessedFileSummaryResponse;
+
+@Mapper(componentModel = "spring")
+public interface InterfaceJobProcessedFileSummaryMapper {
+
+    @Mapping(target = "fileName", source = "summary.interfaceFileName")
+    @Mapping(target = "businessUnitName", source = "businessUnitName")
+    @Mapping(target = "interfaceMessages", source = "messages")
+    InterfaceJobsProcessedFileSummaryResponse toResponse(
+        InterfaceJobProcessedFileSummaryEntity summary,
+        String businessUnitName,
+        List<InterfaceJobsMessageGroup> messages);
+}

--- a/src/main/java/uk/gov/hmcts/opal/mapper/InterfaceMessageMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/mapper/InterfaceMessageMapper.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.opal.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import uk.gov.hmcts.opal.entity.InterfaceMessageEntity;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsMessage;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsMessageType;
+import uk.gov.hmcts.opal.mapper.helper.JsonMapperHelper;
+
+@Mapper(componentModel = "spring", uses = JsonMapperHelper.class)
+public interface InterfaceMessageMapper {
+
+    @Mapping(target = "interfaceMessagesId", source = "interfaceMessageId")
+    @Mapping(target = "messageData", source = "messageData", qualifiedByName = "parseJsonToMap")
+    @Mapping(target = "messageType", source = "messageType", qualifiedByName = "toMessageType")
+    InterfaceJobsMessage toMessage(InterfaceMessageEntity message);
+
+    @Named("toMessageType")
+    default InterfaceJobsMessageType toMessageType(String messageType) {
+        return messageType == null ? null : InterfaceJobsMessageType.fromValue(messageType);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/repository/InterfaceJobsProcessedFileSummaryRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/InterfaceJobsProcessedFileSummaryRepository.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.opal.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.hmcts.opal.entity.InterfaceJobProcessedFileSummaryEntity;
+
+@Repository
+public interface InterfaceJobsProcessedFileSummaryRepository
+    extends JpaRepository<InterfaceJobProcessedFileSummaryEntity, Long> {
+
+    List<InterfaceJobProcessedFileSummaryEntity> findAllByInterfaceJobIdOrderByInterfaceFileIdAsc(Long interfaceJobId);
+}

--- a/src/main/java/uk/gov/hmcts/opal/repository/InterfaceMessageRepository.java
+++ b/src/main/java/uk/gov/hmcts/opal/repository/InterfaceMessageRepository.java
@@ -7,7 +7,7 @@ import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredPr
 import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.MESSAGE_TYPE;
 import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.RECORD_DETAIL;
 import static uk.gov.hmcts.opal.entity.interfacemessage.InterfaceMessageStoredProcedureNames.RECORD_INDEX;
-
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -38,4 +38,7 @@ public interface InterfaceMessageRepository extends JpaRepository<InterfaceMessa
                                 @Param(RECORD_INDEX) Long recordIndex,
                                 @Param(RECORD_DETAIL) String recordDetail,
                                 @Param(MESSAGE_DATA) String messageData);
+
+    List<InterfaceMessageEntity> findAllByInterfaceFile_InterfaceFileIdOrderByMessageTextAscInterfaceMessageIdAsc(
+        Long interfaceFileId);
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/AbstractPdplLoggingService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/AbstractPdplLoggingService.java
@@ -25,10 +25,19 @@ public abstract class AbstractPdplLoggingService {
         ParticipantIdentifier recipient,
         UserState userState) {
 
+        logPdpl(businessIdentifier, category, individuals, recipient, userState.getUserId());
+    }
+
+    protected boolean logPdpl(String businessIdentifier,
+        PersonalDataProcessingCategory category,
+        List<ParticipantIdentifier> individuals,
+        ParticipantIdentifier recipient,
+        Long userId) {
+
 
         // attempt to resolve createdBy from Spring Security
         ParticipantIdentifier createdBy = ParticipantIdentifier.builder()
-            .identifier(userState.getUserId().toString())
+            .identifier(userId.toString())
             .type(PdplIdentifierType.OPAL_USER_ID)
             .build();
 
@@ -42,6 +51,6 @@ public abstract class AbstractPdplLoggingService {
             .individuals(individuals)
             .build();
 
-        loggingService.personalDataAccessLogAsync(logDetails);
+        return loggingService.personalDataAccessLogAsync(logDetails);
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/InterfaceJobProcessedFileSummaryPdplLoggingService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/InterfaceJobProcessedFileSummaryPdplLoggingService.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.opal.service.opal;
+
+import java.time.Clock;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.opal.common.user.authorisation.model.UserStateV2;
+import uk.gov.hmcts.opal.dto.PdplIdentifierType;
+import uk.gov.hmcts.opal.logging.integration.dto.ParticipantIdentifier;
+import uk.gov.hmcts.opal.logging.integration.dto.PersonalDataProcessingCategory;
+import uk.gov.hmcts.opal.logging.integration.service.LoggingService;
+
+@Service
+@Slf4j(topic = "opal.pdplLoggingService")
+public class InterfaceJobProcessedFileSummaryPdplLoggingService extends AbstractPdplLoggingService {
+
+    private static final String BUSINESS_IDENTIFIER = "View File Processing Summary";
+
+    public InterfaceJobProcessedFileSummaryPdplLoggingService(LoggingService loggingService, Clock clock) {
+        super(loggingService, clock);
+    }
+
+    public void logView(UserStateV2 userState) {
+        ParticipantIdentifier payer = ParticipantIdentifier.builder()
+            .type(PdplIdentifierType.PAYER)
+            .build();
+
+        try {
+            // No recipient is involved when viewing a file processing summary.
+            boolean sent = logPdpl(BUSINESS_IDENTIFIER, PersonalDataProcessingCategory.CONSULTATION,
+                List.of(payer), null, userState.getUserId());
+            if (!sent) {
+                log.error("Unable to submit PDPO log for {}", BUSINESS_IDENTIFIER);
+            }
+        } catch (RuntimeException e) {
+            log.error("Unable to submit PDPO log for {}", BUSINESS_IDENTIFIER, e);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/service/opal/InterfaceJobProcessedFileSummaryService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/opal/InterfaceJobProcessedFileSummaryService.java
@@ -1,0 +1,123 @@
+package uk.gov.hmcts.opal.service.opal;
+
+import jakarta.persistence.EntityNotFoundException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
+import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
+import uk.gov.hmcts.opal.common.user.authorisation.model.UserStateV2;
+import uk.gov.hmcts.opal.entity.InterfaceJobEntity;
+import uk.gov.hmcts.opal.entity.InterfaceJobProcessedFileSummaryEntity;
+import uk.gov.hmcts.opal.entity.InterfaceMessageEntity;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsMessage;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsMessageGroup;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsProcessedFileSummaryResponse;
+import uk.gov.hmcts.opal.mapper.InterfaceJobProcessedFileSummaryMapper;
+import uk.gov.hmcts.opal.mapper.InterfaceMessageMapper;
+import uk.gov.hmcts.opal.repository.InterfaceJobRepository;
+import uk.gov.hmcts.opal.repository.InterfaceJobsProcessedFileSummaryRepository;
+import uk.gov.hmcts.opal.repository.InterfaceMessageRepository;
+import uk.gov.hmcts.opal.service.UserStateService;
+
+@Service
+@RequiredArgsConstructor
+public class InterfaceJobProcessedFileSummaryService {
+
+    private final InterfaceJobRepository interfaceJobRepository;
+
+    private final InterfaceJobsProcessedFileSummaryRepository summaryViewRepository;
+
+    private final InterfaceMessageRepository interfaceMessageRepository;
+
+    private final InterfaceJobProcessedFileSummaryMapper processedFileSummaryMapper;
+
+    private final InterfaceMessageMapper interfaceMessageMapper;
+
+    private final UserStateService userStateService;
+
+    private final InterfaceJobProcessedFileSummaryPdplLoggingService pdplLoggingService;
+
+    @Transactional(readOnly = true)
+    public InterfaceJobsProcessedFileSummaryResponse getProcessedFileSummary(Long interfaceJobId) {
+
+        InterfaceJobProcessedFileSummaryEntity summary = findProcessedFileSummary(interfaceJobId);
+        InterfaceJobEntity interfaceJob = findInterfaceJob(summary);
+        checkPermission(getBusinessUnitId(interfaceJob));
+        UserStateV2 userState = userStateService.getUserStateFromSecurityContext();
+        List<InterfaceJobsMessageGroup> messageGroups = getMessageGroups(summary.getInterfaceFileId());
+        InterfaceJobsProcessedFileSummaryResponse response = processedFileSummaryMapper.toResponse(summary,
+            resolveBusinessUnitName(summary, interfaceJob), messageGroups);
+        pdplLoggingService.logView(userState);
+
+        return response;
+    }
+
+    private InterfaceJobProcessedFileSummaryEntity findProcessedFileSummary(Long interfaceJobId) {
+
+        List<InterfaceJobProcessedFileSummaryEntity> rows = summaryViewRepository
+            .findAllByInterfaceJobIdOrderByInterfaceFileIdAsc(interfaceJobId);
+
+        if (rows.isEmpty()) {
+            throw new EntityNotFoundException("Processed file summary not found for interface job id: "
+                + interfaceJobId);
+        }
+        // An OPAL interface job represents one interface file. Multiple summary rows indicate
+        // inconsistent data, so fail rather than return an arbitrary file summary.
+        if (rows.size() > 1) {
+            throw new IllegalStateException("Multiple processed file summaries found for interface job id: "
+                + interfaceJobId);
+        }
+        return rows.getFirst();
+    }
+
+    private InterfaceJobEntity findInterfaceJob(InterfaceJobProcessedFileSummaryEntity summary) {
+        return interfaceJobRepository.findById(summary.getInterfaceJobId())
+            .orElseThrow(() -> new EntityNotFoundException(
+                "Interface job not found for processed file summary: " + summary.getInterfaceJobId()));
+    }
+
+    private void checkPermission(Short businessUnitId) {
+        if (!userStateService.getPermittedBusinessUnitIds(
+            List.of(businessUnitId), FinesPermission.PROCESS_AND_ALLOCATE_PAYMENTS).contains(businessUnitId)) {
+            throw new PermissionNotAllowedException(businessUnitId, FinesPermission.PROCESS_AND_ALLOCATE_PAYMENTS);
+        }
+    }
+
+    private Short getBusinessUnitId(InterfaceJobEntity interfaceJob) {
+        if (interfaceJob.getBusinessUnit() == null) {
+            throw new PermissionNotAllowedException(FinesPermission.PROCESS_AND_ALLOCATE_PAYMENTS);
+        }
+
+        return interfaceJob.getBusinessUnit().getBusinessUnitId();
+    }
+
+    private String resolveBusinessUnitName(InterfaceJobProcessedFileSummaryEntity summary,
+        InterfaceJobEntity interfaceJob) {
+
+        if (summary.getBusinessUnitName() != null) {
+            return summary.getBusinessUnitName();
+        }
+
+        return interfaceJob.getBusinessUnit() == null ? null : interfaceJob.getBusinessUnit().getBusinessUnitName();
+    }
+
+    private List<InterfaceJobsMessageGroup> getMessageGroups(Long interfaceFileId) {
+
+        Map<String, List<InterfaceJobsMessage>> messagesByText = interfaceMessageRepository
+            .findAllByInterfaceFile_InterfaceFileIdOrderByMessageTextAscInterfaceMessageIdAsc(interfaceFileId)
+            .stream()
+            .collect(Collectors.groupingBy(InterfaceMessageEntity::getMessageText, LinkedHashMap::new,
+                Collectors.mapping(interfaceMessageMapper::toMessage, Collectors.toList())));
+
+        return messagesByText.entrySet().stream()
+            .map(entry -> new InterfaceJobsMessageGroup()
+                .messageText(entry.getKey())
+                .messages(entry.getValue()))
+            .toList();
+    }
+}

--- a/src/main/resources/openapi/InterfaceJobs.yaml
+++ b/src/main/resources/openapi/InterfaceJobs.yaml
@@ -231,6 +231,7 @@ paths:
         Get processed file summary information for the supplied interface job ID.
         Results require the Process and Allocate Payments permission in the business unit
         associated with the supplied interface job ID.
+      operationId: get_interface_job_processed_file_summary
       parameters:
         - name: id
           in: path
@@ -265,6 +266,12 @@ paths:
                 $ref: './common.yaml#/components/schemas/ProblemDetail'
         "404":
           description: Not found
+          content:
+            application/json+problem:
+              schema:
+                $ref: './common.yaml#/components/schemas/ProblemDetail'
+        "408":
+          description: Request timeout
           content:
             application/json+problem:
               schema:
@@ -414,9 +421,25 @@ components:
           description: DB Mapping - v_interface_jobs_processed_file_summary.total_records
         total_errors:
           type: integer
+          format: int64
           minimum: 0
           description: DB Mapping - v_interface_jobs_processed_file_summary.total_errors
         interface_messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/InterfaceJobsMessageGroup'
+
+    InterfaceJobsMessageGroup:
+      type: object
+      additionalProperties: false
+      required:
+        - message_text
+        - messages
+      properties:
+        message_text:
+          type: string
+          description: Grouping key from interface_messages.message_text
+        messages:
           type: array
           items:
             $ref: '#/components/schemas/InterfaceJobsMessage'
@@ -428,7 +451,6 @@ components:
         - interface_messages_id
         - message_data
         - message_type
-        - message_text
       properties:
         interface_messages_id:
           $ref: './types.yaml#/components/schemas/BigInt'
@@ -440,9 +462,6 @@ components:
         message_type:
           $ref: '#/components/schemas/InterfaceJobsMessageType'
           description: DB Mapping - interface_messages.message_type
-        message_text:
-          type: string
-          description: DB Mapping - interface_messages.message_text
 
     InterfaceJobsSummaryResponse:
       type: object

--- a/src/test/java/uk/gov/hmcts/opal/controllers/InterfaceJobsProcessedFileSummaryResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/controllers/InterfaceJobsProcessedFileSummaryResponseTest.java
@@ -1,0 +1,63 @@
+package uk.gov.hmcts.opal.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsMessage;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsMessageGroup;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsMessageType;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsProcessedFileSummaryResponse;
+
+class InterfaceJobsProcessedFileSummaryResponseTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void serializesExpectedResponseFields() {
+        // Arrange
+        InterfaceJobsMessage message = new InterfaceJobsMessage()
+            .interfaceMessagesId(1L)
+            .messageData(Map.of("number", 1))
+            .messageType(InterfaceJobsMessageType.ERROR);
+
+        InterfaceJobsMessageGroup messageGroup = new InterfaceJobsMessageGroup()
+            .messageText("records_rejected")
+            .messages(List.of(message));
+
+        InterfaceJobsProcessedFileSummaryResponse response = InterfaceJobsProcessedFileSummaryResponse.builder()
+            .fileName("auto-payments-in.dat")
+            .source("NATWEST")
+            .businessUnitName("Luton")
+            .totalAmount(new BigDecimal("12.34"))
+            .totalRecords((short) 2)
+            .totalErrors(1L)
+            .interfaceMessages(List.of(messageGroup))
+            .build();
+
+        // Act
+        JsonNode json = objectMapper.readTree(objectMapper.writeValueAsString(response));
+
+        // Assert
+        assertEquals(Set.of("file_name", "source", "business_unit_name", "total_amount", "total_records",
+            "total_errors", "interface_messages"), fieldNames(json));
+        assertEquals(Set.of("message_text", "messages"), fieldNames(json.get("interface_messages").get(0)));
+        assertEquals(Set.of("interface_messages_id", "message_data", "message_type"),
+            fieldNames(json.get("interface_messages").get(0).get("messages").get(0)));
+        assertEquals("Error", json.get("interface_messages").get(0).get("messages").get(0)
+            .get("message_type").asString());
+        assertEquals("12.34", json.get("total_amount").asString());
+    }
+
+    private Set<String> fieldNames(JsonNode node) {
+        return node.properties().stream()
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/mapper/InterfaceJobProcessedFileSummaryMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/mapper/InterfaceJobProcessedFileSummaryMapperTest.java
@@ -1,0 +1,57 @@
+package uk.gov.hmcts.opal.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import uk.gov.hmcts.opal.entity.InterfaceJobProcessedFileSummaryEntity;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsMessage;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsMessageGroup;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsMessageType;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsProcessedFileSummaryResponse;
+
+class InterfaceJobProcessedFileSummaryMapperTest {
+
+    private static final long INTERFACE_MESSAGE_ID = 11L;
+
+    private final InterfaceJobProcessedFileSummaryMapper mapper =
+        Mappers.getMapper(InterfaceJobProcessedFileSummaryMapper.class);
+
+    @Test
+    void toResponseMapsSummaryAndMessages() {
+        // Arrange
+        InterfaceJobProcessedFileSummaryEntity summary = mock(InterfaceJobProcessedFileSummaryEntity.class);
+        when(summary.getInterfaceFileName()).thenReturn("payments.dat");
+        when(summary.getSource()).thenReturn("NATWEST");
+        when(summary.getTotalAmount()).thenReturn(new BigDecimal("10.00"));
+        when(summary.getTotalRecords()).thenReturn((short) 2);
+        when(summary.getTotalErrors()).thenReturn(1L);
+
+        InterfaceJobsMessage message = new InterfaceJobsMessage()
+            .interfaceMessagesId(INTERFACE_MESSAGE_ID)
+            .messageData(Map.of("record", 3))
+            .messageType(InterfaceJobsMessageType.ERROR);
+
+        InterfaceJobsMessageGroup messageGroup = new InterfaceJobsMessageGroup()
+            .messageText("bad record")
+            .messages(List.of(message));
+
+        // Act
+        InterfaceJobsProcessedFileSummaryResponse response = mapper.toResponse(
+            summary, "Luton", List.of(messageGroup));
+
+        // Assert
+        assertEquals("payments.dat", response.getFileName());
+        assertEquals("NATWEST", response.getSource());
+        assertEquals("Luton", response.getBusinessUnitName());
+        assertEquals(new BigDecimal("10.00"), response.getTotalAmount());
+        assertEquals((short) 2, response.getTotalRecords());
+        assertEquals(1L, response.getTotalErrors());
+        assertEquals(List.of(messageGroup), response.getInterfaceMessages());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/mapper/InterfaceMessageMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/mapper/InterfaceMessageMapperTest.java
@@ -1,0 +1,54 @@
+package uk.gov.hmcts.opal.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import uk.gov.hmcts.opal.config.JacksonCompatibilityConfiguration;
+import uk.gov.hmcts.opal.entity.InterfaceMessageEntity;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsMessage;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsMessageType;
+import uk.gov.hmcts.opal.mapper.helper.JsonMapperHelper;
+
+@SpringJUnitConfig(classes = {JacksonCompatibilityConfiguration.class, InterfaceMessageMapperImpl.class,
+    JsonMapperHelper.class})
+class InterfaceMessageMapperTest {
+
+    private static final long INTERFACE_MESSAGE_ID = 11L;
+
+    @Autowired
+    private InterfaceMessageMapper mapper;
+
+    @Test
+    void toMessageMapsFieldsAndJson() {
+        // Arrange
+        InterfaceMessageEntity message = InterfaceMessageEntity.builder()
+            .interfaceMessageId(INTERFACE_MESSAGE_ID)
+            .messageType("Error")
+            .messageText("bad record")
+            .messageData("{\"record\":3}")
+            .build();
+
+        // Act
+        InterfaceJobsMessage result = mapper.toMessage(message);
+
+        // Assert
+        assertEquals(INTERFACE_MESSAGE_ID, result.getInterfaceMessagesId());
+        assertEquals(InterfaceJobsMessageType.ERROR, result.getMessageType());
+        assertEquals(Map.of("record", 3), result.getMessageData());
+    }
+
+    @Test
+    void toMessageRejectsInvalidMessageType() {
+        InterfaceMessageEntity message = InterfaceMessageEntity.builder()
+            .messageType("Invalid")
+            .messageText("invalid type")
+            .messageData("{}")
+            .build();
+
+        assertThrows(IllegalArgumentException.class, () -> mapper.toMessage(message));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/InterfaceJobProcessedFileSummaryPdplLoggingServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/InterfaceJobProcessedFileSummaryPdplLoggingServiceTest.java
@@ -1,0 +1,108 @@
+package uk.gov.hmcts.opal.service.opal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.opal.common.logging.LogUtil;
+import uk.gov.hmcts.opal.common.user.authorisation.model.UserStateV2;
+import uk.gov.hmcts.opal.dto.PdplIdentifierType;
+import uk.gov.hmcts.opal.logging.integration.dto.ParticipantIdentifier;
+import uk.gov.hmcts.opal.logging.integration.dto.PersonalDataProcessingCategory;
+import uk.gov.hmcts.opal.logging.integration.dto.PersonalDataProcessingLogDetails;
+import uk.gov.hmcts.opal.logging.integration.service.LoggingService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PO-2576 PDPO logging tests")
+class InterfaceJobProcessedFileSummaryPdplLoggingServiceTest {
+
+    @Mock
+    private LoggingService loggingService;
+    @Mock
+    private UserStateV2 userState;
+    private static final Long USER_ID = 42L;
+
+    @Test
+    @DisplayName("PO-2576 - maps the payer consultation log")
+    void logsConsultationWithPayerAndUserDetails() {
+        // Arrange
+        OffsetDateTime now = OffsetDateTime.parse("2026-08-24T10:15:30Z");
+        when(loggingService.personalDataAccessLogAsync(any())).thenReturn(true);
+        when(userState.getUserId()).thenReturn(USER_ID);
+
+        InterfaceJobProcessedFileSummaryPdplLoggingService service =
+            new InterfaceJobProcessedFileSummaryPdplLoggingService(
+                loggingService, Clock.fixed(now.toInstant(), ZoneOffset.UTC));
+
+        try (MockedStatic<LogUtil> logUtil = Mockito.mockStatic(LogUtil.class)) {
+            logUtil.when(LogUtil::getIpAddress).thenReturn("192.0.2.10");
+
+            // Act
+            service.logView(userState);
+        }
+
+        // Assert
+        ArgumentCaptor<PersonalDataProcessingLogDetails> captor =
+            ArgumentCaptor.forClass(PersonalDataProcessingLogDetails.class);
+        verify(loggingService).personalDataAccessLogAsync(captor.capture());
+        PersonalDataProcessingLogDetails details = captor.getValue();
+
+        assertEquals("View File Processing Summary", details.getBusinessIdentifier());
+        assertEquals(PersonalDataProcessingCategory.CONSULTATION, details.getCategory());
+        assertEquals("192.0.2.10", details.getIpAddress());
+        assertEquals(now, details.getCreatedAt());
+        assertEquals("42", details.getCreatedBy().getIdentifier());
+        assertEquals(PdplIdentifierType.OPAL_USER_ID, details.getCreatedBy().getType());
+        ParticipantIdentifier payer = details.getIndividuals().getFirst();
+        assertEquals(PdplIdentifierType.PAYER, payer.getType());
+        assertNull(payer.getIdentifier());
+        assertNull(details.getRecipient());
+    }
+
+    @Test
+    @DisplayName("PO-2576 - isolates logging integration failures")
+    void containsLoggingIntegrationFailures() {
+        // Arrange
+        when(userState.getUserId()).thenReturn(USER_ID);
+        doThrow(new RuntimeException("logging unavailable"))
+            .when(loggingService).personalDataAccessLogAsync(any());
+        InterfaceJobProcessedFileSummaryPdplLoggingService service =
+            new InterfaceJobProcessedFileSummaryPdplLoggingService(loggingService, Clock.systemUTC());
+
+        // Act
+        service.logView(userState);
+
+        // Assert
+        verify(loggingService).personalDataAccessLogAsync(any());
+    }
+
+    @Test
+    @DisplayName("PO-2576 - handles a library retry exhaustion result")
+    void containsLoggingRetryExhaustion() {
+        // Arrange
+        when(userState.getUserId()).thenReturn(USER_ID);
+        when(loggingService.personalDataAccessLogAsync(any())).thenReturn(false);
+        InterfaceJobProcessedFileSummaryPdplLoggingService service =
+            new InterfaceJobProcessedFileSummaryPdplLoggingService(loggingService, Clock.systemUTC());
+
+        // Act
+        service.logView(userState);
+
+        // Assert
+        verify(loggingService).personalDataAccessLogAsync(any());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/opal/service/opal/InterfaceJobProcessedFileSummaryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/opal/InterfaceJobProcessedFileSummaryServiceTest.java
@@ -1,0 +1,237 @@
+package uk.gov.hmcts.opal.service.opal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.opal.authorisation.model.FinesPermission;
+import uk.gov.hmcts.opal.common.user.authorisation.model.UserStateV2;
+import uk.gov.hmcts.opal.common.user.authorisation.exception.PermissionNotAllowedException;
+import uk.gov.hmcts.opal.entity.InterfaceJobProcessedFileSummaryEntity;
+import uk.gov.hmcts.opal.entity.InterfaceJobEntity;
+import uk.gov.hmcts.opal.entity.InterfaceMessageEntity;
+import uk.gov.hmcts.opal.entity.businessunit.BusinessUnitEntity;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsMessage;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsMessageGroup;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsMessageType;
+import uk.gov.hmcts.opal.generated.model.InterfaceJobsProcessedFileSummaryResponse;
+import uk.gov.hmcts.opal.mapper.InterfaceJobProcessedFileSummaryMapper;
+import uk.gov.hmcts.opal.mapper.InterfaceMessageMapper;
+import uk.gov.hmcts.opal.repository.InterfaceJobRepository;
+import uk.gov.hmcts.opal.repository.InterfaceJobsProcessedFileSummaryRepository;
+import uk.gov.hmcts.opal.repository.InterfaceMessageRepository;
+import uk.gov.hmcts.opal.service.UserStateService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Interface Job Processed File Summary Service Tests")
+class InterfaceJobProcessedFileSummaryServiceTest {
+
+    private static final Long JOB_ID = 257701L;
+    private static final Long FILE_ID = 25770101L;
+    private static final Short BUSINESS_UNIT_ID = 2577;
+
+    @Mock
+    private InterfaceJobRepository interfaceJobRepository;
+    @Mock
+    private InterfaceJobProcessedFileSummaryMapper processedFileSummaryMapper;
+    @Mock
+    private InterfaceMessageMapper interfaceMessageMapper;
+    @Mock
+    private UserStateService userStateService;
+    @Mock
+    private InterfaceJobsProcessedFileSummaryRepository viewRepository;
+    @Mock
+    private InterfaceMessageRepository messageRepository;
+    @Mock
+    private InterfaceJobProcessedFileSummaryPdplLoggingService pdplLoggingService;
+    @Mock
+    private UserStateV2 userState;
+    @Captor
+    private ArgumentCaptor<List<InterfaceJobsMessageGroup>> messageGroupsCaptor;
+
+    private InterfaceJobProcessedFileSummaryService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new InterfaceJobProcessedFileSummaryService(interfaceJobRepository, viewRepository,
+            messageRepository, processedFileSummaryMapper, interfaceMessageMapper, userStateService,
+            pdplLoggingService);
+    }
+
+    @Test
+    @DisplayName("PO-2576 returns a mapped processed-file summary and logs the view")
+    void returnsMappedSummaryAndLogsView() {
+
+        // Arrange
+        final InterfaceJobProcessedFileSummaryEntity interfaceJobProcessedFileSummary = stubSummaryViewWithDetails();
+        stubInterfaceJobWithBusinessUnit();
+        stubUserWithPermission();
+
+        when(messageRepository
+            .findAllByInterfaceFile_InterfaceFileIdOrderByMessageTextAscInterfaceMessageIdAsc(FILE_ID))
+            .thenReturn(List.of());
+
+        InterfaceJobsProcessedFileSummaryResponse mappedResponse = new InterfaceJobsProcessedFileSummaryResponse();
+        when(processedFileSummaryMapper.toResponse(eq(interfaceJobProcessedFileSummary),
+            eq("Luton"), any())).thenReturn(mappedResponse);
+
+        // Act
+        InterfaceJobsProcessedFileSummaryResponse response = service.getProcessedFileSummary(JOB_ID);
+
+        // Assert
+        assertSame(mappedResponse, response);
+        verify(pdplLoggingService).logView(userState);
+    }
+
+    @Test
+    @DisplayName("PO-2576 groups messages by text while retaining every source row")
+    void groupsMessagesByText() {
+
+        // Arrange
+        final InterfaceJobProcessedFileSummaryEntity summary = stubSummaryViewWithDetails();
+        stubInterfaceJobWithBusinessUnit();
+        stubUserWithPermission();
+
+        InterfaceMessageEntity firstRead = mock(InterfaceMessageEntity.class);
+        InterfaceMessageEntity secondRead = mock(InterfaceMessageEntity.class);
+        InterfaceMessageEntity rejected = mock(InterfaceMessageEntity.class);
+
+        when(firstRead.getMessageText()).thenReturn("records_read");
+        when(secondRead.getMessageText()).thenReturn("records_read");
+        when(rejected.getMessageText()).thenReturn("records_rejected");
+        when(messageRepository
+            .findAllByInterfaceFile_InterfaceFileIdOrderByMessageTextAscInterfaceMessageIdAsc(FILE_ID))
+            .thenReturn(List.of(firstRead, secondRead, rejected));
+        when(interfaceMessageMapper.toMessage(firstRead)).thenReturn(message(1L));
+        when(interfaceMessageMapper.toMessage(secondRead)).thenReturn(message(2L));
+        when(interfaceMessageMapper.toMessage(rejected)).thenReturn(message(3L));
+
+        // Act
+        service.getProcessedFileSummary(JOB_ID);
+
+        // Assert
+        verify(processedFileSummaryMapper).toResponse(eq(summary), eq("Luton"), messageGroupsCaptor.capture());
+
+        List<InterfaceJobsMessageGroup> groups = messageGroupsCaptor.getValue();
+
+        assertEquals(2, groups.size());
+        assertEquals("records_read", groups.getFirst().getMessageText());
+        assertEquals(List.of(1L, 2L), messageIds(groups.getFirst()));
+        assertEquals("records_rejected", groups.get(1).getMessageText());
+        assertEquals(List.of(3L), messageIds(groups.get(1)));
+    }
+
+    @Test
+    @DisplayName("PO-2576 rejects multiple summaries for one interface job")
+    void rejectsMultipleSummariesForOneInterfaceJob() {
+
+        // Arrange
+        InterfaceJobProcessedFileSummaryEntity firstView = mock(
+            InterfaceJobProcessedFileSummaryEntity.class);
+        InterfaceJobProcessedFileSummaryEntity secondView = mock(
+            InterfaceJobProcessedFileSummaryEntity.class);
+
+        when(viewRepository.findAllByInterfaceJobIdOrderByInterfaceFileIdAsc(JOB_ID))
+            .thenReturn(List.of(firstView, secondView));
+
+        // Act & Assert
+        assertThrows(IllegalStateException.class, () -> service.getProcessedFileSummary(JOB_ID));
+
+        verifyNoInteractions(messageRepository, pdplLoggingService);
+    }
+
+    @Test
+    @DisplayName("PO-2576 returns not found when no summary exists")
+    void missingViewThrowsNotFoundWithoutPermissionOrPdpo() {
+
+        // Arrange
+        when(viewRepository.findAllByInterfaceJobIdOrderByInterfaceFileIdAsc(JOB_ID)).thenReturn(List.of());
+
+        // Act & Assert
+        assertThrows(EntityNotFoundException.class, () -> service.getProcessedFileSummary(JOB_ID));
+
+        verifyNoInteractions(userStateService, pdplLoggingService, messageRepository);
+    }
+
+    @Test
+    @DisplayName("PO-2576 rejects users without permission before reading messages")
+    void userWithoutBusinessUnitPermissionIsRejectedBeforeMessagesOrPdpo() {
+
+        // Arrange
+        stubSummaryView();
+        stubInterfaceJobWithBusinessUnit();
+
+        when(userStateService.getPermittedBusinessUnitIds(List.of(BUSINESS_UNIT_ID),
+            FinesPermission.PROCESS_AND_ALLOCATE_PAYMENTS)).thenReturn(List.of());
+
+        // Act & Assert
+        assertThrows(PermissionNotAllowedException.class, () -> service.getProcessedFileSummary(JOB_ID));
+
+        verifyNoInteractions(messageRepository, pdplLoggingService);
+    }
+
+    private void stubInterfaceJobWithBusinessUnit() {
+
+        when(interfaceJobRepository.findById(JOB_ID)).thenReturn(Optional.of(InterfaceJobEntity.builder()
+            .interfaceJobId(JOB_ID)
+            .businessUnit(BusinessUnitEntity.builder()
+                .businessUnitId(BUSINESS_UNIT_ID)
+                .businessUnitName("Luton")
+                .build())
+            .build()));
+    }
+
+    private void stubUserWithPermission() {
+
+        when(userStateService.getPermittedBusinessUnitIds(List.of(BUSINESS_UNIT_ID),
+            FinesPermission.PROCESS_AND_ALLOCATE_PAYMENTS)).thenReturn(List.of(BUSINESS_UNIT_ID));
+        when(userStateService.getUserStateFromSecurityContext()).thenReturn(userState);
+    }
+
+    private InterfaceJobProcessedFileSummaryEntity stubSummaryView() {
+
+        InterfaceJobProcessedFileSummaryEntity view = mock(
+            InterfaceJobProcessedFileSummaryEntity.class);
+        when(viewRepository.findAllByInterfaceJobIdOrderByInterfaceFileIdAsc(JOB_ID)).thenReturn(List.of(view));
+        when(view.getInterfaceJobId()).thenReturn(JOB_ID);
+        return view;
+    }
+
+    private InterfaceJobProcessedFileSummaryEntity stubSummaryViewWithDetails() {
+
+        InterfaceJobProcessedFileSummaryEntity interfaceJobProcessedFileSummary = stubSummaryView();
+        when(interfaceJobProcessedFileSummary.getInterfaceFileId()).thenReturn(FILE_ID);
+        when(interfaceJobProcessedFileSummary.getBusinessUnitName()).thenReturn("Luton");
+        return interfaceJobProcessedFileSummary;
+    }
+
+    private InterfaceJobsMessage message(Long messageId) {
+        return new InterfaceJobsMessage()
+            .interfaceMessagesId(messageId)
+            .messageType(InterfaceJobsMessageType.INFO);
+    }
+
+    private List<Long> messageIds(InterfaceJobsMessageGroup group) {
+        return group.getMessages().stream()
+            .map(InterfaceJobsMessage::getInterfaceMessagesId)
+            .toList();
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-2576


### Change description ###

- Adds  OPAL only `GET /interface-jobs/{id}/processed-file-summary` endpoint behind the `release-1c-payment` feature flag.
- Retrieves processed-file summary data from `v_interface_jobs_processed_file_summary` and groups interface messages by message text.
- Enforces access-token and Process and Allocate Payments business-unit permissions.
- Adds asynchronous PDPO logging for Payer consultations.
- Fails safely when inconsistent data produces multiple processed-file summaries for one interface job, rather than returning an arbitrary result.
- Adds unit and integration coverage for response mapping, permissions, feature flags, PDPO logging, error handling, and response schema.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
