### PR TITLE
PO-10472 repayment flag missing from minor creditor header summary api

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/LegacyMinorCreditorIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/LegacyMinorCreditorIntegrationTest.java
@@ -65,6 +65,22 @@ public class LegacyMinorCreditorIntegrationTest extends MinorCreditorControllerI
     }
 
     @Test
+    @Sql(
+        statements = "UPDATE public.creditor_accounts SET repayment = true WHERE creditor_account_id = 99000000000802",
+        executionPhase = BEFORE_TEST_METHOD
+    )
+    @Sql(
+        statements = "UPDATE public.creditor_accounts SET repayment = false WHERE creditor_account_id = 99000000000802",
+        executionPhase = AFTER_TEST_METHOD
+    )
+    @JiraStory("PO-9786")
+    @JiraEpic("PO-2630")
+    @JiraTestKey("PO-9786")
+    void getHeaderSummary_repayment_returnsRepaymentTrue() throws Exception {
+        super.getHeaderSummary_repaymentTrue(log);
+    }
+
+    @Test
     @JiraStory("PO-1912")
     @JiraEpic("PO-2234")
     @JiraTestKey("PO-5946")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/MinorCreditorControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/MinorCreditorControllerIntegrationTest.java
@@ -1298,6 +1298,7 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
             .andExpect(jsonPath("$.party.organisation_details.organisation_aliases")
                 .value(nullValue()))
 
+            .andExpect(jsonPath("$.repayment").value(false))
             .andExpect(jsonPath("$.financials.awarded").value(0))
             .andExpect(jsonPath("$.financials.paid_out").value(0))
             .andExpect(jsonPath("$.financials.awaiting_payout").value(0))
@@ -1338,6 +1339,23 @@ abstract class MinorCreditorControllerIntegrationTest extends AbstractIntegratio
         log.info(":testGetMinorCreditorHeaderSummary_NotFound: Response body:\n" + ToJsonString.toPrettyJson(body));
 
         resultActions.andExpect(status().isNotFound());
+    }
+
+    void getHeaderSummary_repaymentTrue(Logger logger) throws Exception {
+        ResultActions result = mockMvc.perform(get(URL_BASE + "/{id}/header-summary",
+            repaymentMinorCreditorAccountId())
+            .accept(MediaType.APPLICATION_JSON)
+            .with(userStateStub.getAuthenticaitonRequestPostProcessor())
+            .header("authorization", userStateStub.getBearerToken()));
+
+        String body = result.andReturn().getResponse().getContentAsString();
+        logger.info(":getHeaderSummary_repaymentTrue: Response body:\n{}", ToJsonString.toPrettyJson(body));
+
+        result.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(header().string("ETag", minorCreditorVersionEtag()))
+            .andExpect(jsonPath("$.creditor.account_id").value(repaymentMinorCreditorAccountId()))
+            .andExpect(jsonPath("$.repayment").value(true));
     }
 
     void getHeaderSummary_missingAuthHeader_returns403() throws Exception {

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/OpalMinorCreditorIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/OpalMinorCreditorIntegrationTest.java
@@ -289,6 +289,13 @@ public class OpalMinorCreditorIntegrationTest extends MinorCreditorControllerInt
     }
 
     @Test
+    @JiraEpic("PO-2630")
+    @JiraStory("PO-10472")
+    void getHeaderSummary_repayment_returnsRepaymentTrue() throws Exception {
+        super.getHeaderSummary_repaymentTrue(log);
+    }
+
+    @Test
     @JiraStory("PO-1915")
     @JiraEpic("PO-812")
     @JiraTestKey("PO-6200")

--- a/src/main/java/uk/gov/hmcts/opal/dto/GetMinorCreditorAccountHeaderSummaryResponse.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/GetMinorCreditorAccountHeaderSummaryResponse.java
@@ -33,6 +33,9 @@ public class GetMinorCreditorAccountHeaderSummaryResponse implements ToJsonStrin
     @JsonProperty("creditor")
     private CreditorHeader creditor;
 
+    @JsonProperty("repayment")
+    private Boolean repayment;
+
     @JsonProperty("financials")
     private Financials financials;
 

--- a/src/main/java/uk/gov/hmcts/opal/entity/minorcreditor/MinorCreditorAccountHeaderEntity.java
+++ b/src/main/java/uk/gov/hmcts/opal/entity/minorcreditor/MinorCreditorAccountHeaderEntity.java
@@ -83,4 +83,7 @@ public class MinorCreditorAccountHeaderEntity {
 
     @Column(name = "outstanding")
     private BigDecimal outstanding;
+
+    @Column(name = "repayment")
+    private boolean repayment;
 }

--- a/src/main/java/uk/gov/hmcts/opal/mapper/MinorCreditorAccountHeaderEntityMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/mapper/MinorCreditorAccountHeaderEntityMapper.java
@@ -22,7 +22,6 @@ public interface MinorCreditorAccountHeaderEntityMapper {
     @Mapping(target = "creditor.accountType", source = "entity.creditorAccountType")
     @Mapping(target = "creditor.hasAssociatedDefendant", source = "entity.hasAssociatedDefendant")
     @Mapping(target = "version", source = "entity.versionNumber")
-    @Mapping(target = "repayment", source = "entity.repayment")
     @Mapping(target = "financials.awarded", source = "entity.awarded")
     @Mapping(target = "financials.paidOut", source = "entity.paidOut")
     @Mapping(target = "financials.awaitingPayout", source = "entity.awaitingPayment")

--- a/src/main/java/uk/gov/hmcts/opal/mapper/MinorCreditorAccountHeaderEntityMapper.java
+++ b/src/main/java/uk/gov/hmcts/opal/mapper/MinorCreditorAccountHeaderEntityMapper.java
@@ -22,6 +22,7 @@ public interface MinorCreditorAccountHeaderEntityMapper {
     @Mapping(target = "creditor.accountType", source = "entity.creditorAccountType")
     @Mapping(target = "creditor.hasAssociatedDefendant", source = "entity.hasAssociatedDefendant")
     @Mapping(target = "version", source = "entity.versionNumber")
+    @Mapping(target = "repayment", source = "entity.repayment")
     @Mapping(target = "financials.awarded", source = "entity.awarded")
     @Mapping(target = "financials.paidOut", source = "entity.paidOut")
     @Mapping(target = "financials.awaitingPayout", source = "entity.awaitingPayment")

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorService.java
@@ -119,7 +119,6 @@ public class LegacyMinorCreditorService implements MinorCreditorServiceInterface
         mapped.setRepayment(creditorAccount.map(CreditorAccountEntity::isRepayment)
             .orElse(false));
 
-
         CreditorHeaderLegacy creditor = response.responseEntity.getCreditor();
         mapped.setVersion(creditor.getAccountVersion());
         applyResolvedBusinessUnitCode(mapped, response.responseEntity.getBusinessUnit());

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorService.java
@@ -114,12 +114,10 @@ public class LegacyMinorCreditorService implements MinorCreditorServiceInterface
         GetMinorCreditorAccountHeaderSummaryResponse mapped = headerSummaryResponseMapper
             .toOpal(response.responseEntity);
 
-        if (mapped != null) {
-            Optional<CreditorAccountEntity> creditorAccount = creditorAccountRepository
-                .findById(minorCreditorAccountId);
-            mapped.setRepayment(creditorAccount.map(CreditorAccountEntity::isRepayment)
-                .orElse(false));
-        }
+        Optional<CreditorAccountEntity> creditorAccount = creditorAccountRepository
+            .findById(minorCreditorAccountId);
+        mapped.setRepayment(creditorAccount.map(CreditorAccountEntity::isRepayment)
+            .orElse(false));
 
 
         CreditorHeaderLegacy creditor = response.responseEntity.getCreditor();

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorService.java
@@ -114,6 +114,14 @@ public class LegacyMinorCreditorService implements MinorCreditorServiceInterface
         GetMinorCreditorAccountHeaderSummaryResponse mapped = headerSummaryResponseMapper
             .toOpal(response.responseEntity);
 
+        if (mapped != null) {
+            Optional<CreditorAccountEntity> creditorAccount = creditorAccountRepository
+                .findById(minorCreditorAccountId);
+            mapped.setRepayment(creditorAccount.map(CreditorAccountEntity::isRepayment)
+                .orElse(false));
+        }
+
+
         CreditorHeaderLegacy creditor = response.responseEntity.getCreditor();
         mapped.setVersion(creditor.getAccountVersion());
         applyResolvedBusinessUnitCode(mapped, response.responseEntity.getBusinessUnit());

--- a/src/test/java/uk/gov/hmcts/opal/mapper/MinorCreditorAccountHeaderEntityMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/mapper/MinorCreditorAccountHeaderEntityMapperTest.java
@@ -92,7 +92,7 @@ class MinorCreditorAccountHeaderEntityMapperTest extends AbstractMapperTest {
         assertEquals(new BigDecimal("2.00"), mapped.getFinancials().getPaidOut());
         assertEquals(new BigDecimal("1.00"), mapped.getFinancials().getAwaitingPayout());
         assertEquals(BigDecimal.ZERO, mapped.getFinancials().getOutstanding());
-        assertEquals(mapped.getRepayment(), repayment);
+        assertEquals(repayment, mapped.getRepayment());
 
 
         verify(partyMapper).toDto(party);

--- a/src/test/java/uk/gov/hmcts/opal/mapper/MinorCreditorAccountHeaderEntityMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/mapper/MinorCreditorAccountHeaderEntityMapperTest.java
@@ -8,8 +8,9 @@ import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.hmcts.opal.dto.common.BusinessUnitSummary;
@@ -47,8 +48,9 @@ class MinorCreditorAccountHeaderEntityMapperTest extends AbstractMapperTest {
     private DebtorDetailRepositoryService debtorService;
 
 
-    @Test
-    void givenFullEntity_whenToResponse_thenMapsExpectedFieldsAndCallsSubmappers() {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void givenFullEntity_whenToResponse_thenMapsExpectedFieldsAndCallsSubmappers(boolean repayment) {
         // Arrange
         MinorCreditorAccountHeaderEntity entity = MinorCreditorAccountHeaderEntity.builder()
             .creditorAccountId(101L)
@@ -65,6 +67,7 @@ class MinorCreditorAccountHeaderEntityMapperTest extends AbstractMapperTest {
             .awaitingPayment(new BigDecimal("1.00"))
             .outstanding(BigDecimal.ZERO)
             .hasAssociatedDefendant(true)
+            .repayment(repayment)
             .build();
 
         PartyEntity party = PartyEntity.builder()
@@ -89,6 +92,7 @@ class MinorCreditorAccountHeaderEntityMapperTest extends AbstractMapperTest {
         assertEquals(new BigDecimal("2.00"), mapped.getFinancials().getPaidOut());
         assertEquals(new BigDecimal("1.00"), mapped.getFinancials().getAwaitingPayout());
         assertEquals(BigDecimal.ZERO, mapped.getFinancials().getOutstanding());
+        assertEquals(mapped.getRepayment(), repayment);
 
 
         verify(partyMapper).toDto(party);

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyMinorCreditorServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -506,11 +507,17 @@ class LegacyMinorCreditorServiceTest {
                 .build();
 
         when(headerSummaryResponseMapper.toOpal(legacyResponse)).thenReturn(mapperResponse);
+        when(creditorAccountRepository.findById(101L)).thenReturn(
+            Optional.of(CreditorAccountEntity.builder()
+                .businessUnitId((short) 80)
+                .repayment(true)
+                .build()));
 
         GetMinorCreditorAccountHeaderSummaryResponse result = legacyMinorCreditorService.getHeaderSummary(101L);
 
         assertEquals("101", result.getCreditor().getAccountId());
         assertEquals(BigInteger.ONE, result.getVersion());
+        assertTrue(result.getRepayment());
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-10472


### Change description ###
- Adds ``repayment`` flag to minor creditor account header summary responses.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
