### PR TITLE
PO-10354 legacy get enforcement status fails if legacy response contains enforcement override

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountBuilders.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountBuilders.java
@@ -66,6 +66,9 @@ public class LegacyDefendantAccountBuilders {
     }
 
     static LjaReferenceCommon buildLja(LjaReference lja) {
+        if (lja == null) {
+            return null;
+        }
         return LjaReferenceCommon.builder()
             .ljaId(lja.getLjaId())
             .ljaCode(lja.getLjaCode())

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountEnforcementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountEnforcementServiceTest.java
@@ -374,6 +374,7 @@ class LegacyDefendantAccountEnforcementServiceTest {
         assertEquals("Arthur", override.getEnforcer().getEnforcerName());
         assertNotNull(override.getLja());
         assertEquals((short) 1, override.getLja().getLjaId());
+        assertEquals("50", override.getLja().getLjaCode());
         assertEquals("England", override.getLja().getLjaName());
 
         EnforcementActionDefendantAccount action = response.getLastEnforcementAction();
@@ -531,6 +532,79 @@ class LegacyDefendantAccountEnforcementServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void testGetEnforcementStatus_successNullLja() {
+        // Arrange
+        LegacyGetDefendantAccountEnforcementStatusResponse responseBody =
+            createLegacyEnforcementStatusResponse(true);
+        responseBody.getEnforcementOverride().setLja(null);
+
+        when(restClient.responseSpec.body(
+            Mockito.<ParameterizedTypeReference<LegacyGetDefendantAccountEnforcementStatusResponse>>any()
+        )).thenReturn(responseBody);
+
+        ResponseEntity<String> serverSuccessResponse = new ResponseEntity<>(responseBody.toXml(), HttpStatus.OK);
+        when(restClient.responseSpec.toEntity(String.class)).thenReturn(serverSuccessResponse);
+        when(courtService.getCourtById(anyLong())).thenReturn(CourtEntity.builder().courtCode((short) 123).build());
+
+        // Act
+        EnforcementStatus response = legacyDefendantAccountEnforcementService
+            .getEnforcementStatus(72L);
+
+        // Assert
+        assertNotNull(response);
+        assertTrue(response.getEmployerFlag());
+        assertEquals(new BigInteger("1234567890123456789012345678901234567890"), response.getVersion());
+        assertFalse(response.getIsHmrcCheckEligible());
+        assertNull(response.getNextEnforcementActionData());
+        assertNotNull(response.getEnforcementOverride());
+        assertNotNull(response.getLastEnforcementAction());
+        assertNotNull(response.getEnforcementOverview());
+        assertNotNull(response.getAccountStatusReference());
+
+        EnforcementOverrideCommon override = response.getEnforcementOverride();
+        assertNotNull(override.getEnforcementOverrideResult());
+        assertEquals("AAB", override.getEnforcementOverrideResult().getEnforcementOverrideResultId());
+        assertEquals("AaAaBb", override.getEnforcementOverrideResult().getEnforcementOverrideResultName());
+        assertNotNull(override.getEnforcer());
+        assertEquals(2L, override.getEnforcer().getEnforcerId());
+        assertEquals("Arthur", override.getEnforcer().getEnforcerName());
+        assertNull(override.getLja());
+
+        EnforcementActionDefendantAccount action = response.getLastEnforcementAction();
+        assertEquals("late", action.getReason());
+        assertEquals("123", action.getWarrantNumber());
+        assertEquals(LocalDateTime.of(2024, 1, 1, 10, 0), action.getDateAdded());
+        assertNotNull(action.getEnforcer());
+        assertEquals(4L, action.getEnforcer().getEnforcerId());
+        assertEquals("Merlin", action.getEnforcer().getEnforcerName());
+        assertNotNull(action.getEnforcementAction());
+        assertEquals("FEE", action.getEnforcementAction().getResultId());
+        assertEquals("Result Ref", action.getEnforcementAction().getResultTitle());
+        assertNotNull(action.getResultResponses());
+        assertNotNull(action.getResultResponses().getFirst());
+        assertEquals("Param Name", action.getResultResponses().getFirst().getParameterName());
+        assertEquals("A response", action.getResultResponses().getFirst().getResponse());
+
+        EnforcementOverviewDefendantAccount overview = response.getEnforcementOverview();
+        assertEquals(6, overview.getDaysInDefault());
+        assertNotNull(overview.getCollectionOrder());
+        assertEquals(true, overview.getCollectionOrder().getCollectionOrderFlag());
+        assertEquals(
+            LocalDate.of(2024, 3, 4),
+            overview.getCollectionOrder().getCollectionOrderDate()
+        );
+        assertNotNull(overview.getEnforcementCourt());
+        assertEquals(3, overview.getEnforcementCourt().getCourtId());
+        assertEquals((short) 123, overview.getEnforcementCourt().getCourtCode());
+        assertEquals("Bath", overview.getEnforcementCourt().getCourtName());
+
+        AccountStatusReferenceCommon statusRef = response.getAccountStatusReference();
+        assertEquals(AccountStatusCodeEnum.L, statusRef.getAccountStatusCode());
+        assertEquals("Alive", statusRef.getAccountStatusDisplayName());
+    }
+
+    @Test
     void testGetEnforcementStatus_throwsRuntimeException() {
         // Arrange
         doThrow(new RuntimeException("boom"))
@@ -617,7 +691,10 @@ class LegacyDefendantAccountEnforcementServiceTest {
                     .build())
             .enforcementOverride(full ? EnforcementOverride.builder()  // Optional
                 .lja(LjaReference.builder()
-                    .ljaId((short) 1).ljaName("England").build())
+                    .ljaId((short) 1)
+                     .ljaCode("50")
+                     .ljaName("England")
+                     .build())
                 .enforcer(EnforcerReference.builder()
                     .enforcerId(2L).enforcerName("Arthur").build())
                 .enforcementOverrideResult(EnforcementOverrideResultReference.builder()


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-10354


### Change description ###
Added null check to ``buildLja`` method in ``LegacyDefendantAccountBuilders.java`` to prevent the getEnforcementStatus endpoint from failing in legacy mode when enforcement override is present.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
