### PR TITLE
PO-10355 Updated LegacyUpdateDefendantAccountResponse and LegacyDefendantAccou…

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyUpdateDefendantAccountResponse.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyUpdateDefendantAccountResponse.java
@@ -13,6 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import uk.gov.hmcts.opal.common.legacy.model.ErrorResponse;
+import uk.gov.hmcts.opal.common.legacy.model.HasErrorResponse;
 import uk.gov.hmcts.opal.dto.ToXmlString;
 import uk.gov.hmcts.opal.dto.legacy.common.CollectionOrder;
 import uk.gov.hmcts.opal.dto.legacy.common.CommentsAndNotes;
@@ -26,7 +28,7 @@ import uk.gov.hmcts.opal.dto.legacy.utils.ValidationUtils;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "response")
-public class LegacyUpdateDefendantAccountResponse implements ToXmlString {
+public class LegacyUpdateDefendantAccountResponse implements ToXmlString, HasErrorResponse {
 
     @XmlElement(name = "defendant_account_id")
     @NotNull
@@ -49,6 +51,9 @@ public class LegacyUpdateDefendantAccountResponse implements ToXmlString {
     @XmlElement(name = "enforcement_override")
     private EnforcementOverride enforcementOverride;
 
+    @XmlElement(name = "error_response")
+    private ErrorResponse errorResponse;
+
     @AssertTrue(message = "Exactly one of comment_and_notes, enforcement_court_id, collection_order "
         + "or enforcement_override must be present")
     private boolean isExactlyOneUpdateFieldPresent() {
@@ -56,5 +61,10 @@ public class LegacyUpdateDefendantAccountResponse implements ToXmlString {
             enforcementCourtId,
             collectionOrder,
             enforcementOverride);
+    }
+
+    @Override
+    public ErrorResponse getErrorResponse() {
+        return errorResponse;
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
@@ -4,6 +4,7 @@ import static uk.gov.hmcts.opal.service.legacy.LegacyDefendantAccountBuilders.to
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -15,9 +16,12 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import uk.gov.hmcts.opal.common.legacy.config.LegacyGatewayProperties;
 import uk.gov.hmcts.opal.common.legacy.service.GatewayService;
 import uk.gov.hmcts.opal.common.legacy.service.GatewayService.Response;
@@ -836,11 +840,8 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
     }
 
     @Override
-    public UpdateDefendantAccountResponse updateDefendantAccount(Long defendantAccountId,
-        String businessUnitId,
-        @NonNull UpdateDefendantAccountRequest request,
-        String postedBy,
-        String postedByName) {
+    public UpdateDefendantAccountResponse updateDefendantAccount(Long defendantAccountId, String businessUnitId,
+        @NonNull UpdateDefendantAccountRequest request, String postedBy, String postedByName) {
 
         log.info("Legacy :updateDefendantAccount: id: {}", defendantAccountId);
 
@@ -1001,8 +1002,16 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             } else if (response.isLegacyFailure()) {
                 log.error(":{}: legacy failure body:\n{}", method, response.body);
             }
+            throw createGatewayException(response.code, response.body);
         } else if (response.isSuccessful()) {
             log.info(":{}: legacy success.", method);
         }
+    }
+
+    private static RuntimeException createGatewayException(HttpStatusCode status, String responseBody) {
+        HttpStatusCode statusCode = status == null || status == HttpStatus.OK ? HttpStatus.BAD_REQUEST : status;
+        byte[] body = responseBody == null ? null : responseBody.getBytes(StandardCharsets.UTF_8);
+        return HttpServerErrorException.create(statusCode, "Legacy gateway error", HttpHeaders.EMPTY, body,
+            StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountService.java
@@ -999,19 +999,28 @@ public class LegacyDefendantAccountService implements DefendantAccountServiceInt
             log.error(":{}: legacy error HTTP {}", method, response.code);
             if (response.isException()) {
                 log.error(":{}: exception:", method, response.exception);
+                throw createGatewayException(response.code, "Legacy gateway exception", response.body,
+                    response.exception);
             } else if (response.isLegacyFailure()) {
                 log.error(":{}: legacy failure body:\n{}", method, response.body);
+                throw createGatewayException(response.code, "Legacy gateway returned failure", response.body, null);
             }
-            throw createGatewayException(response.code, response.body);
+            throw createGatewayException(response.code, "Legacy gateway error", response.body, null);
         } else if (response.isSuccessful()) {
             log.info(":{}: legacy success.", method);
         }
     }
 
-    private static RuntimeException createGatewayException(HttpStatusCode status, String responseBody) {
-        HttpStatusCode statusCode = status == null || status == HttpStatus.OK ? HttpStatus.BAD_REQUEST : status;
+    private static RuntimeException createGatewayException(HttpStatusCode status, String fallbackStatusText,
+        String responseBody, Throwable exception) {
+        HttpStatusCode statusCode =
+            status == null || status == HttpStatus.OK ? HttpStatus.INTERNAL_SERVER_ERROR : status;
+
+        String statusText =
+            exception != null && exception.getMessage() != null ? exception.getMessage() : fallbackStatusText;
+
         byte[] body = responseBody == null ? null : responseBody.getBytes(StandardCharsets.UTF_8);
-        return HttpServerErrorException.create(statusCode, "Legacy gateway error", HttpHeaders.EMPTY, body,
-            StandardCharsets.UTF_8);
+
+        return HttpServerErrorException.create(statusCode, statusText, HttpHeaders.EMPTY, body, StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceAtAGlanceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceAtAGlanceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service.legacy;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpServerErrorException;
 import uk.gov.hmcts.opal.dto.common.LastEnforcementAction;
 import uk.gov.hmcts.opal.dto.GetDefendantAccountAtAGlanceResponse;
 import uk.gov.hmcts.opal.dto.legacy.LegacyInstalmentPeriod;
@@ -73,7 +75,7 @@ class LegacyDefAccServiceAtAGlanceTest extends AbstractLegacyDefAccServiceTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void getAtAGlance_legacyFailure5xx_withEntity_mapsAnyway() {
+    void getAtAGlance_legacyFailure5xx_withEntity_throwsHttpServerErrorException() {
         LegacyGetDefendantAccountAtAGlanceResponse body =
             LegacyGetDefendantAccountAtAGlanceResponse.builder()
                 .version(BigInteger.valueOf(0L))
@@ -86,22 +88,21 @@ class LegacyDefAccServiceAtAGlanceTest extends AbstractLegacyDefAccServiceTest {
         when(restClient.responseSpec.toEntity(String.class))
             .thenReturn(new ResponseEntity<>(body.toXml(), HttpStatus.SERVICE_UNAVAILABLE));
 
-        GetDefendantAccountAtAGlanceResponse out = legacyDefendantAccountService.getAtAGlance(456L);
-        assertNotNull(out);
-        assertEquals("456", out.getPayload().getDefendantAccountId());
+        assertThatThrownBy(() -> legacyDefendantAccountService.getHeaderSummary(999L))
+            .isInstanceOf(HttpServerErrorException.class).hasMessageContaining("503 Legacy gateway returned failure");
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    void getAtAGlance_error5xx_noEntity_returnsNull() {
+    void getAtAGlance_error5xx_noEntity_throwsHttpServerErrorException() {
         ParameterizedTypeReference<LegacyGetDefendantAccountAtAGlanceResponse> typeRef =
             new ParameterizedTypeReference<>() {};
         when(restClient.responseSpec.body(any(typeRef.getClass()))).thenReturn(null);
         when(restClient.responseSpec.toEntity(String.class))
             .thenReturn(new ResponseEntity<>("<error/>", HttpStatus.INTERNAL_SERVER_ERROR));
 
-        GetDefendantAccountAtAGlanceResponse out = legacyDefendantAccountService.getAtAGlance(999L);
-        assertNull(out);
+        assertThatThrownBy(() -> legacyDefendantAccountService.getHeaderSummary(999L))
+            .isInstanceOf(HttpServerErrorException.class).hasMessageContaining("500 unexpected element");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceEnforcementStatusTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceEnforcementStatusTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service.legacy;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -11,7 +12,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
-import jakarta.persistence.EntityNotFoundException;
+
 import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -20,6 +21,7 @@ import org.mockito.Mockito;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpServerErrorException;
 import uk.gov.hmcts.opal.dto.EnforcementStatus;
 import uk.gov.hmcts.opal.dto.legacy.LegacyGetDefendantAccountEnforcementStatusResponse;
 import uk.gov.hmcts.opal.dto.legacy.LegacyGetDefendantAccountEnforcementStatusResponse.EnforcementAction;
@@ -175,23 +177,21 @@ class LegacyDefAccServiceEnforcementStatusTest extends AbstractLegacyDefAccServi
 
     @SuppressWarnings("unchecked")
     @Test
-    void testGetEnforcementStatus_returnsNull() {
+    void testGetEnforcementStatus_returns500UnexpectedElementException() {
         // Arrange
         when(restClient.responseSpec.body(
             Mockito.<ParameterizedTypeReference<LegacyGetDefendantAccountPaymentTermsResponse>>any())).thenReturn(null);
         when(restClient.responseSpec.toEntity(String.class))
             .thenReturn(new ResponseEntity<>("<error/>", HttpStatus.INTERNAL_SERVER_ERROR));
 
-        // Act
-        EnforcementStatus response = legacyDefendantAccountService.getEnforcementStatus(42L);
 
-        // Assert
-        assertNull(response);
+        assertThatThrownBy(() -> legacyDefendantAccountService.getHeaderSummary(42L))
+            .isInstanceOf(HttpServerErrorException.class).hasMessageContaining("500 unexpected element");
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    void testGetEnforcementStatus_returnsFailure() {
+    void testGetEnforcementStatus_returns503LegacyGatewayFailureException() {
 
         // Arrange
         LegacyGetDefendantAccountEnforcementStatusResponse responseBody =
@@ -201,20 +201,14 @@ class LegacyDefAccServiceEnforcementStatusTest extends AbstractLegacyDefAccServi
         )).thenReturn(responseBody);
         when(restClient.responseSpec.toEntity(String.class))
             .thenReturn(new ResponseEntity<>(responseBody.toXml(), HttpStatus.SERVICE_UNAVAILABLE));
-        when(courtService.getCourtById(anyLong())).thenReturn(CourtEntity.builder().courtCode((short)123).build());
 
-        EnforcementStatus response = legacyDefendantAccountService.getEnforcementStatus(66L);
-
-        assertNotNull(response);
-        assertTrue(response.getEmployerFlag());
-        assertEquals(new BigInteger("1234567890123456789012345678901234567890"), response.getVersion());
-        assertFalse(response.getIsHmrcCheckEligible());
-        assertNull(response.getNextEnforcementActionData());
+        assertThatThrownBy(() -> legacyDefendantAccountService.getHeaderSummary(66L))
+            .isInstanceOf(HttpServerErrorException.class).hasMessage("503 Legacy gateway returned failure");
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    void testGetEnforcementStatus_courtNotFoundInOpalDB() {
+    void testGetEnforcementStatus_throwsHttpServerErrorException() {
 
         // Arrange
         LegacyGetDefendantAccountEnforcementStatusResponse responseBody =
@@ -224,18 +218,14 @@ class LegacyDefAccServiceEnforcementStatusTest extends AbstractLegacyDefAccServi
         )).thenReturn(responseBody);
         when(restClient.responseSpec.toEntity(String.class))
             .thenReturn(new ResponseEntity<>(responseBody.toXml(), HttpStatus.SERVICE_UNAVAILABLE));
-        when(courtService.getCourtById(anyLong())).thenThrow(new EntityNotFoundException("Court not found"));
 
-        EntityNotFoundException error = assertThrows(EntityNotFoundException.class,
-            () -> legacyDefendantAccountService.getEnforcementStatus(66L));
-
-        assertNotNull(error);
-        assertEquals("Court not found", error.getMessage());
+        assertThatThrownBy(() -> legacyDefendantAccountService.getHeaderSummary(66L))
+            .isInstanceOf(HttpServerErrorException.class).hasMessage("503 Legacy gateway returned failure");
     }
 
     @SuppressWarnings("unchecked")
     @Test
-    void testGetEnforcementStatus_ljaNotFoundInOpalDB() {
+    void testGetEnforcementStatus_ljaNotFoundInOpalDB_throwsHttpServerErrorException() {
 
         // Arrange
         LegacyGetDefendantAccountEnforcementStatusResponse responseBody =
@@ -245,14 +235,9 @@ class LegacyDefAccServiceEnforcementStatusTest extends AbstractLegacyDefAccServi
         )).thenReturn(responseBody);
         when(restClient.responseSpec.toEntity(String.class))
             .thenReturn(new ResponseEntity<>(responseBody.toXml(), HttpStatus.SERVICE_UNAVAILABLE));
-        when(courtService.getCourtById(anyLong())).thenReturn(CourtEntity.builder().courtCode((short)123).build());
-        when(ljaService.getLocalJusticeAreaById(anyShort())).thenThrow(new EntityNotFoundException("Lja not found"));
 
-        EntityNotFoundException error = assertThrows(EntityNotFoundException.class,
-            () -> legacyDefendantAccountService.getEnforcementStatus(66L));
-
-        assertNotNull(error);
-        assertEquals("Lja not found", error.getMessage());
+        assertThatThrownBy(() -> legacyDefendantAccountService.getHeaderSummary(1L))
+            .isInstanceOf(HttpServerErrorException.class).hasMessage("503 Legacy gateway returned failure");
     }
 
     private LegacyGetDefendantAccountEnforcementStatusResponse createLegacyEnforcementStatusResponse(boolean full) {

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceHeaderHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceHeaderHelperTest.java
@@ -1,15 +1,15 @@
 package uk.gov.hmcts.opal.service.legacy;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
-import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpServerErrorException;
 import uk.gov.hmcts.opal.common.legacy.service.GatewayService;
 import uk.gov.hmcts.opal.dto.DefendantAccountHeaderSummary;
 import uk.gov.hmcts.opal.dto.legacy.LegacyInstalmentPeriod;
@@ -59,10 +59,8 @@ class LegacyDefAccServiceHeaderHelperTest extends AbstractLegacyDefAccServiceTes
         doReturn(respError, respSuccess).when(gatewayService)
             .postToGateway(any(), any(), any(), any());
 
-        legacyDefendantAccountService.getHeaderSummary(1L);
-        legacyDefendantAccountService.getHeaderSummary(1L);
-
-        verify(gatewayService, times(2)).postToGateway(any(), any(), any(), any());
+        assertThatThrownBy(() -> legacyDefendantAccountService.getHeaderSummary(1L))
+            .isInstanceOf(HttpServerErrorException.class).hasMessage("500 Legacy gateway returned failure");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceHeaderSummaryTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceHeaderSummaryTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.opal.service.legacy;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -18,6 +19,7 @@ import org.mockito.Mockito;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpServerErrorException;
 import uk.gov.hmcts.opal.dto.DefendantAccountHeaderSummary;
 import uk.gov.hmcts.opal.dto.common.PaymentStateSummary;
 import uk.gov.hmcts.opal.dto.legacy.LegacyGetDefendantAccountHeaderSummaryResponse;
@@ -375,7 +377,7 @@ class LegacyDefAccServiceHeaderSummaryTest extends AbstractLegacyDefAccServiceTe
 
     @Test
     @SuppressWarnings("unchecked")
-    void testGetHeaderSummary_legacyFailure5xx_logsAndMaps() {
+    void testGetHeaderSummary_legacyFailure5xx_logsAndThrowsHttpServerErrorException() {
         LegacyGetDefendantAccountHeaderSummaryResponse responseBody = createHeaderSummaryResponse();
 
         when(restClient.responseSpec.body(
@@ -384,9 +386,8 @@ class LegacyDefAccServiceHeaderSummaryTest extends AbstractLegacyDefAccServiceTe
         when(restClient.responseSpec.toEntity(String.class))
             .thenReturn(new ResponseEntity<>(responseBody.toXml(), HttpStatus.SERVICE_UNAVAILABLE));
 
-        DefendantAccountHeaderSummary out = legacyDefendantAccountService.getHeaderSummary(1L);
-        assertNotNull(out);
-        assertEquals("SAMPLE", out.getResponse().getAccountNumber());
+        assertThatThrownBy(() -> legacyDefendantAccountService.getHeaderSummary(1L))
+            .isInstanceOf(HttpServerErrorException.class).hasMessage("503 Legacy gateway returned failure");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceLegacyCoverageTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceLegacyCoverageTest.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.opal.service.legacy;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpServerErrorException;
 import uk.gov.hmcts.opal.common.legacy.service.GatewayService;
 import uk.gov.hmcts.opal.dto.DefendantAccountHeaderSummary;
 import uk.gov.hmcts.opal.dto.legacy.LegacyGetDefendantAccountHeaderSummaryResponse;
@@ -21,7 +22,7 @@ import uk.gov.hmcts.opal.dto.legacy.common.OrganisationDetails;
 class LegacyDefAccServiceLegacyCoverageTest extends AbstractLegacyDefAccServiceTest {
 
     @Test
-    void legacy_getHeaderSummary_legacyFailureBranch_logsAndContinues() {
+    void legacy_getHeaderSummary_legacyFailureBranch_logsAndThrowsHttpServerErrorException() {
         LegacyGetDefendantAccountHeaderSummaryResponse entity =
             LegacyGetDefendantAccountHeaderSummaryResponse.builder()
                 .accountNumber("ACC")
@@ -39,10 +40,8 @@ class LegacyDefAccServiceLegacyCoverageTest extends AbstractLegacyDefAccServiceT
             any()
         );
 
-        DefendantAccountHeaderSummary out = legacyDefendantAccountService.getHeaderSummary(123L);
-
-        assertNotNull(out);
-        assertEquals("ACC", out.getResponse().getAccountNumber());
+        assertThatThrownBy(() -> legacyDefendantAccountService.getHeaderSummary(123L))
+            .isInstanceOf(HttpServerErrorException.class).hasMessage("500 Legacy gateway returned failure");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceUpdateTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceUpdateTest.java
@@ -154,7 +154,8 @@ class LegacyDefAccServiceUpdateTest extends AbstractLegacyDefAccServiceTest {
             .build();
 
         assertThatThrownBy(() -> legacyDefendantAccountService.updateDefendantAccount(77L, "78", request, "postedBy",
-            "Poster Name")).isInstanceOf(HttpServerErrorException.class).hasMessage("500 Legacy gateway error");
+            "Poster Name")).isInstanceOf(HttpServerErrorException.class)
+            .hasMessage("500 Legacy gateway returned failure");
     }
 
     @Test
@@ -186,7 +187,7 @@ class LegacyDefAccServiceUpdateTest extends AbstractLegacyDefAccServiceTest {
         assertThatThrownBy(
             () -> legacyDefendantAccountService.updateDefendantAccount(defendantAccountId, businessUnitId, request,
                 postedBy, "Poster Name")).isInstanceOf(HttpServerErrorException.class)
-            .hasMessage("400 Legacy gateway error");
+            .hasMessage("500 Legacy gateway error");
 
         verify(legacyUpdateDefendantAccountResponseMapper, never()).toUpdateDefendantAccountResponse(
             any(LegacyUpdateDefendantAccountResponse.class));

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceUpdateTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefAccServiceUpdateTest.java
@@ -1,22 +1,27 @@
 package uk.gov.hmcts.opal.service.legacy;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.opal.service.legacy.LegacyDefendantAccountService.PATCH_DEFENDANT_ACCOUNT;
 
 import java.math.BigInteger;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpServerErrorException;
+import uk.gov.hmcts.opal.common.legacy.model.ErrorResponse;
 import uk.gov.hmcts.opal.common.legacy.service.GatewayService;
+import uk.gov.hmcts.opal.common.legacy.service.GatewayService.Response;
 import uk.gov.hmcts.opal.dto.UpdateDefendantAccountResponse;
 import uk.gov.hmcts.opal.dto.UpdateDefendantAccountRequest;
 import uk.gov.hmcts.opal.dto.legacy.LegacyUpdateDefendantAccountRequest;
@@ -59,10 +64,10 @@ class LegacyDefAccServiceUpdateTest extends AbstractLegacyDefAccServiceTest {
             new GatewayService.Response<>(HttpStatus.OK, legacyEntity, null, null);
 
         doReturn(resp).when(gatewayService).postToGateway(
-            eq(LegacyDefendantAccountService.PATCH_DEFENDANT_ACCOUNT),
+            eq(PATCH_DEFENDANT_ACCOUNT),
             eq(LegacyUpdateDefendantAccountResponse.class),
             any(LegacyUpdateDefendantAccountRequest.class),
-            Mockito.nullable(String.class)
+            nullable(String.class)
         );
 
         UpdateDefendantAccountResponse expected = UpdateDefendantAccountResponse.builder()
@@ -78,7 +83,7 @@ class LegacyDefAccServiceUpdateTest extends AbstractLegacyDefAccServiceTest {
 
         verify(updateDefendantAccountRequestMapper).toLegacyUpdateDefendantAccountRequest(request);
         verify(gatewayService).postToGateway(
-            eq(LegacyDefendantAccountService.PATCH_DEFENDANT_ACCOUNT),
+            eq(PATCH_DEFENDANT_ACCOUNT),
             eq(LegacyUpdateDefendantAccountResponse.class),
             eq(legacyReq),
             isNull()
@@ -108,7 +113,7 @@ class LegacyDefAccServiceUpdateTest extends AbstractLegacyDefAccServiceTest {
             .thenReturn(LegacyUpdateDefendantAccountRequest.builder().build());
 
         when(gatewayService.postToGateway(
-            eq(LegacyDefendantAccountService.PATCH_DEFENDANT_ACCOUNT),
+            eq(PATCH_DEFENDANT_ACCOUNT),
             eq(LegacyUpdateDefendantAccountResponse.class),
             any(),
             isNull()))
@@ -120,7 +125,7 @@ class LegacyDefAccServiceUpdateTest extends AbstractLegacyDefAccServiceTest {
         );
 
         verify(gatewayService).postToGateway(
-            eq(LegacyDefendantAccountService.PATCH_DEFENDANT_ACCOUNT),
+            eq(PATCH_DEFENDANT_ACCOUNT),
             eq(LegacyUpdateDefendantAccountResponse.class),
             any(LegacyUpdateDefendantAccountRequest.class),
             isNull()
@@ -129,7 +134,7 @@ class LegacyDefAccServiceUpdateTest extends AbstractLegacyDefAccServiceTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void testUpdateDefendantAccount_error5xx_noEntity_returnsNull() {
+    void testUpdateDefendantAccount_error5xx_noEntity_throwsHttpServerErrorException() {
         ParameterizedTypeReference<LegacyUpdateDefendantAccountResponse> typeRef =
             new ParameterizedTypeReference<>() {};
         when(restClient.responseSpec.body(any(typeRef.getClass()))).thenReturn(null);
@@ -148,8 +153,42 @@ class LegacyDefAccServiceUpdateTest extends AbstractLegacyDefAccServiceTest {
             .version(BigInteger.ONE)
             .build();
 
-        UpdateDefendantAccountResponse response = legacyDefendantAccountService
-            .updateDefendantAccount(77L, "78", request, "postedBy", "Poster Name");
-        assertNull(response);
+        assertThatThrownBy(() -> legacyDefendantAccountService.updateDefendantAccount(77L, "78", request, "postedBy",
+            "Poster Name")).isInstanceOf(HttpServerErrorException.class).hasMessage("500 Legacy gateway error");
+    }
+
+    @Test
+    void testUpdateDefendantAccount_embeddedLegacyError_throwsUnprocessableException() {
+        final String postedBy = "user-123";
+        final long defendantAccountId = 77L;
+        final String businessUnitId = "78";
+
+        UpdateDefendantAccountRequest request =
+            UpdateDefendantAccountRequest.builder().defendantAccountId(defendantAccountId)
+                .businessUnitId(businessUnitId).businessUnitUserId(postedBy).payload(
+                    UpdateDefendantAccountRequestPayload.builder()
+                        .commentAndNotes(CommentsAndNotesCommon.builder().accountComment("x").build()).build())
+                .version(BigInteger.valueOf(5)).build();
+
+        LegacyUpdateDefendantAccountResponse legacyEntity = LegacyUpdateDefendantAccountResponse.builder()
+            .errorResponse(new ErrorResponse("-20020", "Enforcer 50000000003 not found")).build();
+
+        Response<LegacyUpdateDefendantAccountResponse> response =
+            new Response<>(HttpStatus.OK, legacyEntity, null, null);
+
+        when(updateDefendantAccountRequestMapper.toLegacyUpdateDefendantAccountRequest(request)).thenReturn(
+            LegacyUpdateDefendantAccountRequest.builder().build());
+
+        when(gatewayService.postToGateway(eq(LegacyDefendantAccountService.PATCH_DEFENDANT_ACCOUNT),
+            eq(LegacyUpdateDefendantAccountResponse.class), any(LegacyUpdateDefendantAccountRequest.class),
+            nullable(String.class))).thenReturn(response);
+
+        assertThatThrownBy(
+            () -> legacyDefendantAccountService.updateDefendantAccount(defendantAccountId, businessUnitId, request,
+                postedBy, "Poster Name")).isInstanceOf(HttpServerErrorException.class)
+            .hasMessage("400 Legacy gateway error");
+
+        verify(legacyUpdateDefendantAccountResponseMapper, never()).toUpdateDefendantAccountResponse(
+            any(LegacyUpdateDefendantAccountResponse.class));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PO-10355


### Change description ###
- prevent 200 response being sent to client when legacy has returned an error during the update defendant account process. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
