### PR TITLE
Introduce 'core' and 'extended' tests to help improve build times.

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -7,6 +7,14 @@ def type = "java"
 def product = "opal"
 def component = "fines-service"
 
+def enableExtendedTestsForLabel() {
+  def githubApi = new GithubAPI(this)
+  if (githubApi.getLabels(env.BRANCH_NAME).any { it.equalsIgnoreCase("ExtendedTests") }) {
+    env.EXTENDED_TESTS = "true"
+    echo "PR label 'ExtendedTests' found; extended test lane enabled for Gradle test tasks"
+  }
+}
+
 def determineDevEnvironmentDeployment() {
   env.TEST_URL = "https://opal-fines-service-pr-${env.CHANGE_ID}.dev.platform.hmcts.net"
 
@@ -31,6 +39,7 @@ def determineDevEnvironmentDeployment() {
   if (githubApi.checkForLabel(env.BRANCH_NAME, "legacy_mode")) {
     env.IS_LEGACY_MODE = "true"
   }
+
   //Enable logging service and service bus by default to allow for functional tests to run with azure service bus connectivity
   env.DEV_ENABLE_OPAL_LOGGING_SERVICE = true
   env.DEV_ENABLE_OPAL_SERVICE_BUS = true
@@ -178,6 +187,7 @@ def publishSmokeResults(String reportNameSuffix = '') {
 
 withPipeline(type, product, component) {
   env.FAIL_FAST = false
+  env.EXTENDED_TESTS = "false"
   env.STAGING_DB_SCHEMA = 'public'
   env.OPAL_LEGACY_GATEWAY_URL = 'https://opal-legacy-db-stub-staging.platform.hmcts.net/opal'
   env.OPAL_LEGACY_STUB_IMAGE = 'hmctsprod.azurecr.io/opal/legacy-db-stub:latest'
@@ -199,6 +209,10 @@ withPipeline(type, product, component) {
   }
 
   before('test') {
+    onPR {
+      enableExtendedTestsForLabel()
+    }
+
     steps.sh './gradlew checkTestJiraAnnotations'
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,39 @@ ext {
 def defaultLegacyStubImage = 'hmctsprod.azurecr.io/opal/legacy-db-stub:latest'
 def legacyStubImage = System.getenv('OPAL_LEGACY_STUB_IMAGE') ?: defaultLegacyStubImage
 def legacyStubPort = 4553
+def extendedTestTag = 'ExtendedTest'
+def extendedCucumberTag = "@${extendedTestTag}"
+def extendedTests = providers.gradleProperty('extendedTests')
+  .orElse(providers.environmentVariable('EXTENDED_TESTS'))
+  .map { it.toBoolean() }
+  .orElse(true)
 def ciEnvironmentVariables = ['CI', 'GITHUB_ACTIONS', 'JENKINS_HOME', 'BUILD_ID']
+
+def requestedGradleTasks = gradle.startParameter.taskNames ?: ['build']
+def coreTestsCommand = "./gradlew -PextendedTests=false ${requestedGradleTasks.join(' ')}"
+
+def printTestLaneBanner = { boolean includeExtendedTests ->
+  def lines = includeExtendedTests ? [
+    'Running core and extended tests.',
+    "Tests tagged '${extendedTestTag}' are included.",
+    "Run core tests only with: ${coreTestsCommand}"
+  ] : [
+    "Running core tests only for quicker build times.",
+    "Tests tagged '${extendedTestTag}' are excluded unless specific tests are selected.",
+    "This run has opted out of the default extended-test lane."
+  ]
+
+  def width = lines.collect { it.length() }.max() + 4
+  logger.lifecycle('')
+  logger.lifecycle('#' * width)
+  lines.each { logger.lifecycle("# ${it.padRight(width - 4)} #") }
+  logger.lifecycle('#' * width)
+  logger.lifecycle('')
+}
+
+def cucumberTagsForTestSelection = { String tags ->
+  extendedTests.get() || tags.contains(extendedCucumberTag) ? tags : "(${tags}) and not ${extendedCucumberTag}"
+}
 
 def isLocalIntegrationEnvironment = {
   ciEnvironmentVariables.every { !System.getenv(it) }
@@ -346,8 +378,22 @@ tasks.named('sonarResolver') {
   dependsOn(processResources)
 }
 
+gradle.taskGraph.whenReady { graph ->
+  if (graph.allTasks.any { it instanceof Test }) {
+    printTestLaneBanner(extendedTests.get())
+  }
+}
+
 tasks.withType(Test).configureEach {
   useJUnitPlatform()
+
+  doFirst {
+    if (!extendedTests.get() && filter.commandLineIncludePatterns.empty) {
+      useJUnitPlatform {
+        excludeTags extendedTestTag
+      }
+    }
+  }
 
   systemProperty 'spring.test.context.cache.maxSize', 4
 
@@ -430,6 +476,19 @@ tasks.register('functionalOpal', Test) {
     "net.serenitybdd.cucumber.core.plugin.SerenityReporterParallel,pretty,json:${rootDir}/target/zephyr-reports/cucumber-opal.json,timeline:${rootDir}/target/test-results/timeline"
   include '**/OpalTestRunner.class'
 
+  doFirst {
+    systemProperty 'cucumber.filter.tags', cucumberTagsForTestSelection(
+      '@Opal and not @Smoke and not @Ignore and not '
+        + '(@R1AOff or @R1BOff or @R1COff or @R1CWriteOffOff or '
+        + '@R1CEnforcementOperationalReportingOff or @R1CAdministrationOff or @R1CFinancialMovementsOff or '
+        + '@R1CAutoEnforcementOff or @R1CDataRetentionOff or @R1CAutoEnforcementConfigOff or '
+        + '@R1CRmFinancialMovementsOff or @R1CRmFinancialChecksOff or '
+        + '@R1CRmSuspenseOff or @R1CRmPaymentOff or @R1CRmAdminReportsOff or @R1CRmAccountActionsOff or '
+        + '@R1CChecksOff or @R1CSuspenseOff or @R1CPaymentOff or @R1CR1ATidyUpOff or @R1CReferenceDataOff or '
+        + '@R1CBankingInterfacesOff or @R1CCppEnforcementOff or @R1CCppOff or @R1CPrintingOff)'
+    )
+  }
+
   finalizedBy 'copyOpalCucumberJson', 'mergeFunctionalResults', 'aggregate', 'copyFunctionalReport'
 }
 
@@ -464,7 +523,7 @@ tasks.register('functionalOpalTags', Test) {
       )
     }
 
-    systemProperty 'cucumber.filter.tags', cucumberTags.toString()
+    systemProperty 'cucumber.filter.tags', cucumberTagsForTestSelection(cucumberTags.toString())
   }
 
   finalizedBy 'copyOpalTagsCucumberJson', 'mergeFunctionalOpalTagsResults', 'aggregate', 'copyDemoFunctionalReport',

--- a/src/functionalTest/resources/features/opalMode/referenceData/ReferenceDataSmoke.feature
+++ b/src/functionalTest/resources/features/opalMode/referenceData/ReferenceDataSmoke.feature
@@ -25,7 +25,7 @@ Feature: Reference Data Smoke Checks
     When I make a request to the LJA ref data api with
     Then the LJA ref data matching to result
 
-  @JIRA-STORY:PO-316 @JIRA-EPIC:PO-304 @JIRA-TEST-KEY:PO-5737
+  @ExtendedTest @JIRA-STORY:PO-316 @JIRA-EPIC:PO-304 @JIRA-TEST-KEY:PO-5737
   Scenario: Enforcer reference data is available
     When I make a request to enforcer ref data api filtering by name "Alder"
     Then the enforcer ref data matching to result

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1a/Release1AFeatureToggleIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1a/Release1AFeatureToggleIntegrationTest.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.opal.controllers.r1a;
 
-import uk.gov.hmcts.opal.controllers.shared.AbstractFeatureToggleIntegrationTest;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -11,12 +9,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import uk.gov.hmcts.opal.controllers.shared.AbstractFeatureToggleIntegrationTest;
 import uk.gov.hmcts.opal.controllers.shared.util.DraftAccountTestData;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
@@ -29,6 +29,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 @ActiveProfiles({"integration"})
 @Slf4j(topic = "opal.Release1AFeatureToggleIntegrationTest")
 @DisplayName("Release 1A - returns 404 when release-1a flag is disabled")
+@Tag("ExtendedTest")
 @TestPropertySource(properties = {
     "launchdarkly.enabled=false",
     "launchdarkly.default-flag-values.release-1a=false"

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1a/ResultR1aDisabledTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1a/ResultR1aDisabledTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -22,6 +23,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
     "launchdarkly.enabled=false"
 })
 @DisplayName("ResultController release-1a disabled Integration Test")
+@Tag("ExtendedTest")
 class ResultR1aDisabledTest extends AbstractIntegrationTest {
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/DefAccHistoryFlagTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/DefAccHistoryFlagTest.java
@@ -1,18 +1,18 @@
 package uk.gov.hmcts.opal.controllers.r1b;
 
-import uk.gov.hmcts.opal.controllers.shared.AbstractFeatureToggleIntegrationTest;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.ResultActions;
+import uk.gov.hmcts.opal.controllers.shared.AbstractFeatureToggleIntegrationTest;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
@@ -23,6 +23,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
     "launchdarkly.default-flag-values.release-1b=false"
 })
 @DisplayName("Defendant Account History Feature Flag Integration Test")
+@Tag("ExtendedTest")
 class DefAccHistoryFlagTest extends AbstractFeatureToggleIntegrationTest {
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/DefendantSearchR1bDisabledTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/DefendantSearchR1bDisabledTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -25,6 +26,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
     "launchdarkly.default-flag-values.release-1c-write-off=true"
 })
 @DisplayName("Defendant account search release-1b disabled Integration Test")
+@Tag("ExtendedTest")
 class DefendantSearchR1bDisabledTest extends AbstractIntegrationTest {
 
     private static final String DEFENDANTS_SEARCH_URL = "/defendant-accounts/search";

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/EnforcementReportingFlagTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/EnforcementReportingFlagTest.java
@@ -1,7 +1,5 @@
 package uk.gov.hmcts.opal.controllers.r1b;
 
-import uk.gov.hmcts.opal.controllers.shared.AbstractFeatureToggleIntegrationTest;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -9,12 +7,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import uk.gov.hmcts.opal.controllers.shared.AbstractFeatureToggleIntegrationTest;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraEpic;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
@@ -26,6 +26,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 @ActiveProfiles({"integration"})
 @Slf4j(topic = "opal.EnforcementReportingFlagTest")
 @DisplayName("Release 1C Enforcement Operational Reporting - returns 404 when flag is disabled")
+@Tag("ExtendedTest")
 @TestPropertySource(properties = {
     "launchdarkly.enabled=false",
     "launchdarkly.default-flag-values.release-1c-enforcement-operational-reporting=false"

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/MajorCreditorHeaderFlagIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/MajorCreditorHeaderFlagIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -25,6 +26,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
     "launchdarkly.default-flag-values.release-1b=false"
 })
 @DisplayName("Major Creditor Account Header Summary Feature Flag Integration Tests")
+@Tag("ExtendedTest")
 class MajorCreditorHeaderFlagIntegrationTest extends AbstractIntegrationTest {
 
     @MockitoBean

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/R1bFlagDisabledTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/R1bFlagDisabledTest.java
@@ -4,6 +4,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.MediaType;
@@ -20,6 +21,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
     "launchdarkly.enabled=false",
     "launchdarkly.default-flag-values.release-1b=false"
 })
+@Tag("ExtendedTest")
 class R1bFlagDisabledTest extends AbstractIntegrationTest {
 
     @ParameterizedTest(name = "{0}")

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/Release1bLaunchDarklyFalseIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/Release1bLaunchDarklyFalseIntegrationTest.java
@@ -13,6 +13,7 @@ import static uk.gov.hmcts.opal.util.FeatureFlags.RELEASE_1B;
 
 import com.launchdarkly.sdk.LDContext;
 import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.MediaType;
@@ -31,6 +32,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
     "launchdarkly.sdk-key=test-sdk-key",
     "launchdarkly.default-flag-values.release-1b=true"
 })
+@Tag("ExtendedTest")
 class Release1bLaunchDarklyFalseIntegrationTest extends AbstractIntegrationTest {
 
     @MockitoBean

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/Release1bLaunchDarklyTrueIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/Release1bLaunchDarklyTrueIntegrationTest.java
@@ -11,6 +11,7 @@ import static uk.gov.hmcts.opal.util.FeatureFlags.RELEASE_1B;
 
 import com.launchdarkly.sdk.LDContext;
 import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpStatus;
@@ -29,6 +30,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
     "launchdarkly.sdk-key=test-sdk-key",
     "launchdarkly.default-flag-values.release-1b=false"
 })
+@Tag("ExtendedTest")
 class Release1bLaunchDarklyTrueIntegrationTest extends AbstractIntegrationTest {
 
     @MockitoBean

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/ResultR1bDisabledTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1b/ResultR1bDisabledTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -24,6 +25,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
     "launchdarkly.enabled=false"
 })
 @DisplayName("ResultController release-1b disabled Integration Test")
+@Tag("ExtendedTest")
 class ResultR1bDisabledTest extends AbstractIntegrationTest {
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1c/CentralFundFlagTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1c/CentralFundFlagTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -24,6 +25,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
 })
 @Slf4j(topic = "opal.CentralFundFlagTest")
 @DisplayName("Central Fund Controller Feature Flag Integration Tests")
+@Tag("ExtendedTest")
 class CentralFundFlagTest extends AbstractIntegrationTest {
 
     private static final String AUTH_HEADER = "Bearer test-token";

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1c/DefendantSearchR1cDisabledTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1c/DefendantSearchR1cDisabledTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -32,6 +33,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
     "launchdarkly.default-flag-values.release-1c-write-off=false"
 })
 @DisplayName("Defendant account search release-1c-write-off disabled Integration Test")
+@Tag("ExtendedTest")
 class DefendantSearchR1cDisabledTest extends AbstractIntegrationTest {
 
     private static final String DEFENDANTS_SEARCH_URL = "/defendant-accounts/search";

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1c/Release1CPaymentFeatureToggleIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/r1c/Release1CPaymentFeatureToggleIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -24,6 +25,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 @ActiveProfiles({"integration"})
 @Slf4j(topic = "opal.Release1CPaymentFeatureToggleIntegrationTest")
 @DisplayName("Release 1C Payment - returns 404 when flag is disabled")
+@Tag("ExtendedTest")
 @TestPropertySource(properties = {
     "launchdarkly.enabled=false",
     "launchdarkly.default-flag-values.release-1c-payment=false"

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/DeleteInterfaceJobsDisabledIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/DeleteInterfaceJobsDisabledIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -15,6 +16,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 @ActiveProfiles({"integration", "opal"})
 @TestPropertySource(properties = {"opal.testing-support-endpoints.enabled=false"})
 @DisplayName("Testing Support Interface Jobs Delete Disabled Controller Integration Tests")
+@Tag("ExtendedTest")
 public class DeleteInterfaceJobsDisabledIntegrationTest extends AbstractIntegrationTest {
     private static final String URL = "/testing-support/interface-jobs";
 

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/InterfaceJobsCreateFeatureToggleDisabledIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/InterfaceJobsCreateFeatureToggleDisabledIT.java
@@ -15,6 +15,7 @@ import static uk.gov.hmcts.opal.util.FeatureFlags.RELEASE_1C_PAYMENT;
 import com.launchdarkly.sdk.LDContext;
 import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -33,6 +34,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
     "launchdarkly.default-flag-values.release-1c-payment=false"
 })
 @DisplayName("Interface Jobs Create Feature Toggle Integration Tests")
+@Tag("ExtendedTest")
 class InterfaceJobsCreateFeatureToggleDisabledIT extends AbstractIntegrationTest {
 
     private static final String URL = "/interface-jobs";

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/InterfaceJobsSummaryFlagIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/InterfaceJobsSummaryFlagIT.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -20,6 +21,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraTestKey;
     "launchdarkly.default-flag-values.release-1c-payment=false"
 })
 @DisplayName("Interface Jobs Summary Flag Integration Tests")
+@Tag("ExtendedTest")
 class InterfaceJobsSummaryFlagIT extends AbstractIntegrationTest {
 
     private static final String URL = "/interface-jobs/summary";

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/ProcessInterfaceJobsFlagOffTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/ProcessInterfaceJobsFlagOffTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -25,6 +26,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
     "launchdarkly.default-flag-values.release-1c-payment=false"
 })
 @DisplayName("Interface Jobs Process Feature Toggle Disabled Integration Tests")
+@Tag("ExtendedTest")
 class ProcessInterfaceJobsFlagOffTest extends AbstractIntegrationTest {
 
     private static final String URL = "/interface-jobs/process";

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/ProcessInterfaceJobsFlagOnTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/ProcessInterfaceJobsFlagOnTest.java
@@ -16,6 +16,7 @@ import static uk.gov.hmcts.opal.util.FeatureFlags.RELEASE_1C_PAYMENT;
 import com.launchdarkly.sdk.LDContext;
 import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
@@ -32,6 +33,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
     "launchdarkly.default-flag-values.release-1c-payment=false"
 })
 @DisplayName("Interface Jobs Process Feature Toggle Enabled Integration Tests")
+@Tag("ExtendedTest")
 class ProcessInterfaceJobsFlagOnTest extends AbstractIntegrationTest {
 
     private static final String URL = "/interface-jobs/process";

--- a/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/TestingSupportEndpointToggleIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/opal/controllers/shared/TestingSupportEndpointToggleIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -18,6 +19,7 @@ import uk.hmcts.zephyr.automation.junit5.annotations.JiraStory;
 
 @ActiveProfiles({"integration", "opal"})
 @TestPropertySource(properties = {"opal.testing-support-endpoints.enabled=false"})
+@Tag("ExtendedTest")
 public class TestingSupportEndpointToggleIntegrationTest extends AbstractFeatureToggleIntegrationTest {
     static Stream<Arguments> testingSupportEndpoints() {
         return Stream.of(


### PR DESCRIPTION
`./gradlew build` runs everything locally by default.

`./gradlew -PextendedTests=false build` gives a quicker local/core-only run.

 CNP PR builds default to core-only via `EXTENDED_TESTS=false.`
 Adding PR label `ExtendedTests` opts that PR back into the full set.

 Nightly builds run the full set because that is the Gradle default.


Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
