### PR TITLE
PO-10339 Add Nested Party ID to Legacy Replace Request

### DIFF
--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyDefendantAccountPartyRequest.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyDefendantAccountPartyRequest.java
@@ -1,0 +1,67 @@
+package uk.gov.hmcts.opal.dto.legacy;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import uk.gov.hmcts.opal.dto.common.AddressDetails;
+import uk.gov.hmcts.opal.dto.common.ContactDetails;
+import uk.gov.hmcts.opal.dto.common.DefendantAccountParty;
+import uk.gov.hmcts.opal.dto.common.EmployerDetails;
+import uk.gov.hmcts.opal.dto.common.LanguagePreferences;
+import uk.gov.hmcts.opal.dto.common.PartyDetails;
+import uk.gov.hmcts.opal.dto.common.VehicleDetails;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LegacyDefendantAccountPartyRequest {
+
+    @JsonProperty("defendant_account_party_id")
+    private String defendantAccountPartyId;
+
+    @JsonProperty("defendant_account_party_type")
+    private String defendantAccountPartyType;
+
+    @JsonProperty("is_debtor")
+    private Boolean isDebtor;
+
+    @JsonProperty("party_details")
+    private PartyDetails partyDetails;
+
+    @JsonProperty("address")
+    private AddressDetails address;
+
+    @JsonProperty("contact_details")
+    private ContactDetails contactDetails;
+
+    @JsonProperty("vehicle_details")
+    private VehicleDetails vehicleDetails;
+
+    @JsonProperty("employer_details")
+    private EmployerDetails employerDetails;
+
+    @JsonProperty("language_preferences")
+    private LanguagePreferences languagePreferences;
+
+    public static LegacyDefendantAccountPartyRequest from(
+        Long defendantAccountPartyId, DefendantAccountParty defendantAccountParty) {
+        if (defendantAccountParty == null) {
+            return null;
+        }
+
+        return LegacyDefendantAccountPartyRequest.builder()
+            .defendantAccountPartyId(String.valueOf(defendantAccountPartyId))
+            .defendantAccountPartyType(defendantAccountParty.getDefendantAccountPartyType())
+            .isDebtor(defendantAccountParty.getIsDebtor())
+            .partyDetails(defendantAccountParty.getPartyDetails())
+            .address(defendantAccountParty.getAddress())
+            .contactDetails(defendantAccountParty.getContactDetails())
+            .vehicleDetails(defendantAccountParty.getVehicleDetails())
+            .employerDetails(defendantAccountParty.getEmployerDetails())
+            .languagePreferences(defendantAccountParty.getLanguagePreferences())
+            .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyReplaceDefendantAccountPartyRequest.java
+++ b/src/main/java/uk/gov/hmcts/opal/dto/legacy/LegacyReplaceDefendantAccountPartyRequest.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.jackson.Jacksonized;
-import uk.gov.hmcts.opal.dto.common.DefendantAccountParty;
 
 @Data
 @Builder
@@ -29,6 +28,6 @@ public class LegacyReplaceDefendantAccountPartyRequest {
     private String businessUnitUserId;
 
     @JsonProperty("defendant_account_party")
-    private DefendantAccountParty defendantAccountParty;
+    private LegacyDefendantAccountPartyRequest defendantAccountParty;
 
 }

--- a/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPartyService.java
+++ b/src/main/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPartyService.java
@@ -29,6 +29,7 @@ import uk.gov.hmcts.opal.dto.legacy.GetDefendantAccountPartyLegacyRequest;
 import uk.gov.hmcts.opal.dto.legacy.GetDefendantAccountPartyLegacyResponse;
 import uk.gov.hmcts.opal.dto.legacy.IndividualDetailsLegacy;
 import uk.gov.hmcts.opal.dto.legacy.LanguagePreferencesLegacy;
+import uk.gov.hmcts.opal.dto.legacy.LegacyDefendantAccountPartyRequest;
 import uk.gov.hmcts.opal.dto.legacy.LegacyReplaceDefendantAccountPartyRequest;
 import uk.gov.hmcts.opal.dto.legacy.LegacyReplaceDefendantAccountPartyResponse;
 import uk.gov.hmcts.opal.dto.legacy.OrganisationDetailsLegacy;
@@ -302,7 +303,8 @@ public class LegacyDefendantAccountPartyService implements DefendantAccountParty
             .defendantAccountId(defendantAccountId)
             .businessUnitId(businessUnitId)
             .businessUnitUserId(businessUnitUserId)
-            .defendantAccountParty(defendantAccountParty)
+            .defendantAccountParty(LegacyDefendantAccountPartyRequest.from(
+                defendantAccountPartyId, defendantAccountParty))
             .build();
 
         Response<LegacyReplaceDefendantAccountPartyResponse> response;

--- a/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPartyServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/opal/service/legacy/LegacyDefendantAccountPartyServiceTest.java
@@ -1272,6 +1272,55 @@ class LegacyDefendantAccountPartyServiceTest extends LegacyTestsBase {
     }
 
     @Test
+    void replaceDefendantAccountParty_buildsLegacyRequestWithNestedPartyId() {
+        DefendantAccountParty request = DefendantAccountParty.builder()
+            .defendantAccountPartyType("Defendant")
+            .isDebtor(true)
+            .build();
+
+        LegacyReplaceDefendantAccountPartyResponse legacyResponse = LegacyReplaceDefendantAccountPartyResponse.builder()
+            .version(BigInteger.valueOf(10))
+            .defendantAccountParty(DefendantAccountPartyLegacy.builder().build())
+            .build();
+
+        GatewayService.Response<LegacyReplaceDefendantAccountPartyResponse> resp =
+            new GatewayService.Response<>(HttpStatus.OK, legacyResponse, null, null);
+
+        Class<LegacyReplaceDefendantAccountPartyResponse> respType = LegacyReplaceDefendantAccountPartyResponse.class;
+
+        doReturn(resp).when(gatewayService).postToGateway(
+            eq(LegacyDefendantAccountPartyService.REPLACE_DEFENDANT_ACCOUNT_PARTY),
+            eq(respType),
+            any(LegacyReplaceDefendantAccountPartyRequest.class),
+            Mockito.nullable(String.class)
+        );
+
+        GetDefendantAccountPartyResponse result = legacyDefendantAccountPartyService.replaceDefendantAccountParty(
+            77L, 20010L, request, "\"10\"", "78", "poster", "Poster Name", "dev_user"
+        );
+
+        ArgumentCaptor<LegacyReplaceDefendantAccountPartyRequest> requestCaptor =
+            ArgumentCaptor.forClass(LegacyReplaceDefendantAccountPartyRequest.class);
+
+        verify(gatewayService).postToGateway(
+            eq(LegacyDefendantAccountPartyService.REPLACE_DEFENDANT_ACCOUNT_PARTY),
+            eq(respType),
+            requestCaptor.capture(),
+            Mockito.nullable(String.class)
+        );
+
+        LegacyReplaceDefendantAccountPartyRequest sentRequest = requestCaptor.getValue();
+        assertThat(result.getVersion()).isEqualTo(extractBigInteger("10"));
+        assertEquals(77L, sentRequest.getDefendantAccountId());
+        assertEquals("78", sentRequest.getBusinessUnitId());
+        assertEquals("dev_user", sentRequest.getBusinessUnitUserId());
+        assertEquals("20010", sentRequest.getDefendantAccountParty().getDefendantAccountPartyId());
+        assertEquals(request.getDefendantAccountPartyType(),
+            sentRequest.getDefendantAccountParty().getDefendantAccountPartyType());
+        assertEquals(request.getIsDebtor(), sentRequest.getDefendantAccountParty().getIsDebtor());
+    }
+
+    @Test
     void replaceDefendantAccountParty_mapsNullNestedObjects_toNulls() {
         // Build a legacy response body where nested objects are null
         LegacyReplaceDefendantAccountPartyResponse legacyBody = LegacyReplaceDefendantAccountPartyResponse.builder()


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PO-10339


### Change description ###

- Add a legacy-specific defendant account party request DTO containing `defendant_account_party_id`
- Populate `defendant_account_party.defendant_account_party_id` from the `defendantAccountPartyId` path parameter
- Keep the public replace defendant account party request contract unchanged


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
