### PR TITLE
Split Feature files So R1B Tests are now either in R1B Drop 1 or R1BDrop2

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -7,7 +7,7 @@ properties([
     booleanParam(name: 'Integration', defaultValue: true, description: 'Run integration tests'),
     booleanParam(name: 'Functional', defaultValue: true, description: 'Run functional tests'),
     booleanParam(name: 'Smoke', defaultValue: true, description: 'Run smoke tests'),
-    choice(name: 'DemoTaggedFunctionalMode', choices: ['RunR1AOnly', 'RunR1AAndR1BOnly', 'RunAllFlagsOff'], description: 'Select which demo tagged functional stage to run'),
+    choice(name: 'DemoTaggedFunctionalMode', choices: ['RunR1AOnly', 'RunR1AAndR1BDrop1Only', 'RunR1AAndR1BDropsOnly', 'RunR1BOffOnly', 'RunAllFlagsOff'], description: 'Select which demo tagged functional stage to run'),
     booleanParam(name: 'ZephyrExecution', defaultValue: false, description: 'Create Zephyr Execution'),
   ])
 ])
@@ -423,18 +423,46 @@ withNightlyPipeline(type, product, component) {
           'runR1AOnly'
         )
         break
-      case 'RunR1AAndR1BOnly':
+      case 'RunR1AAndR1BDrop1Only':
         runNamedTaggedFunctionalStage(
           true,
-          'Demo R1A and R1B Functional Tests',
+          'Demo R1A and R1B Drop 1 Functional Tests',
+          shouldRunWithZephyr,
+          'functionalOpalTagsR1AAndR1BDrop1Only',
+          'functional-output-r1a-r1b-drop1-only-demo',
+          ' (Demo R1A and R1B Drop 1)',
+          ['functional-output-r1a-r1b-drop1-only-demo/report', 'build/reports/tests/functionalOpalTagsR1AAndR1BDrop1Only'],
+          'build/test-results/functional/opal-tags-r1a-r1b-drop1-only/*.xml',
+          'build/reports/tests/functionalOpalTagsR1AAndR1BDrop1Only',
+          'runR1AAndR1BDrop1Only'
+        )
+        break
+      case 'RunR1AAndR1BDropsOnly':
+        runNamedTaggedFunctionalStage(
+          true,
+          'Demo R1A and R1B Drop Functional Tests',
           shouldRunWithZephyr,
           'functionalOpalTagsR1AAndR1BOnly',
           'functional-output-r1a-r1b-only-demo',
-          ' (Demo R1A and R1B)',
+          ' (Demo R1A and R1B Drops)',
           ['functional-output-r1a-r1b-only-demo/report', 'build/reports/tests/functionalOpalTagsR1AAndR1BOnly'],
           'build/test-results/functional/opal-tags-r1a-r1b-only/*.xml',
           'build/reports/tests/functionalOpalTagsR1AAndR1BOnly',
           'runR1AAndR1BOnly'
+        )
+        break
+      case 'RunR1BOffOnly':
+        runNamedTaggedFunctionalStage(
+          true,
+          'Demo R1B Off Functional Tests',
+          shouldRunWithZephyr,
+          'functionalOpalTagsR1BOffOnly',
+          'functional-output-r1b-off-only-demo',
+          ' (Demo R1B Off)',
+          ['functional-output-r1b-off-only-demo/report', 'build/reports/tests/functionalOpalTagsR1BOffOnly'],
+          'build/test-results/functional/opal-tags-r1b-off-only/*.xml',
+          'build/reports/tests/functionalOpalTagsR1BOffOnly',
+          'runR1BOffOnly'
         )
         break
       case 'RunAllFlagsOff':

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ feature-flag or business-area configuration:
 You can also pass the tags as a Gradle property instead of an environment variable:
 
 ```bash / zsh
-  ./gradlew functionalOpalTags -Ptags='@R1B and @R1C and not @Ignore'
+  ./gradlew functionalOpalTags -Ptags='@R1BDrop1 and @R1C and not @Ignore'
 ```
 
 Use the combined tagged wrapper when you want the default Opal suite and the tagged Opal
@@ -246,10 +246,13 @@ Common examples:
 
 ```bash / zsh
   ./gradlew functionalOpalTagsR1AOnly
+  ./gradlew functionalOpalTagsR1AAndR1BDrop1Only
+  ./gradlew functionalOpalTagsR1AAndR1BOnly
+  ./gradlew functionalOpalTagsR1BOffOnly
   ./gradlew functionalOpalTagsAllFlagsOff
   TAGS='(@R1AOff or @R1BOff or @R1CWriteOffOff or @R1CEnforcementOperationalReportingOff or @R1CAdministrationOff or @R1CFinancialMovementsOff) and not @Ignore' ./gradlew functionalOpalTags
   TAGS='@R1BOff and not @Ignore' ./gradlew functionalOpalTags
-  TAGS='@R1B and @R1C and not @Ignore' ./gradlew functionalWithTags
+  TAGS='@R1BDrop1 and @R1C and not @Ignore' ./gradlew functionalWithTags
   TAGS='@JIRA-LABEL:manual-account-creation and not @Ignore' ./gradlew functionalOpalTags
 ```
 
@@ -266,7 +269,7 @@ Nightly parameters:
 | `Integration` | `true` | Runs the staging integration-test stage. |
 | `Functional` | `true` | Runs the staging functional-test stage. |
 | `Smoke` | `true` | Runs the staging smoke-test stage. |
-| `DemoTaggedFunctionalMode` | `RunR1AOnly` | Selects exactly one demo tagged functional stage: `RunR1AOnly`, `RunR1AAndR1BOnly`, or `RunAllFlagsOff`. |
+| `DemoTaggedFunctionalMode` | `RunR1AOnly` | Selects exactly one demo tagged functional stage: `RunR1AOnly`, `RunR1AAndR1BDrop1Only`, `RunR1AAndR1BDropsOnly`, `RunR1BOffOnly`, or `RunAllFlagsOff`. |
 | `ZephyrExecution` | `false` | Creates Zephyr executions; this also runs automatically on Fridays. |
 
 Nightly environments:
@@ -284,11 +287,15 @@ Nightly stages:
 | `Functional Tests` | `staging` | `Functional` | `clearReports functionalOpal`, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=functional` if Zephyr is enabled |
 | `Smoke Tests` | `staging` | `Smoke` | `clearReports smokeOpal`, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=smoke` if Zephyr is enabled |
 | `Demo R1A Functional Tests` | `demo` | `DemoTaggedFunctionalMode=RunR1AOnly` | `clearReports functionalOpalTagsR1AOnly`, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=runR1AOnly` if Zephyr is enabled |
-| `Demo R1A and R1B Functional Tests` | `demo` | `DemoTaggedFunctionalMode=RunR1AAndR1BOnly` | `clearReports functionalOpalTagsR1AAndR1BOnly`, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=runR1AAndR1BOnly` if Zephyr is enabled |
+| `Demo R1A and R1B Drop 1 Functional Tests` | `demo` | `DemoTaggedFunctionalMode=RunR1AAndR1BDrop1Only` | `clearReports functionalOpalTagsR1AAndR1BDrop1Only`, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=runR1AAndR1BDrop1Only` if Zephyr is enabled |
+| `Demo R1A and R1B Drop Functional Tests` | `demo` | `DemoTaggedFunctionalMode=RunR1AAndR1BDropsOnly` | `clearReports functionalOpalTagsR1AAndR1BOnly`, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=runR1AAndR1BOnly` if Zephyr is enabled |
+| `Demo R1B Off Functional Tests` | `demo` | `DemoTaggedFunctionalMode=RunR1BOffOnly` | `clearReports functionalOpalTagsR1BOffOnly`, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=runR1BOffOnly` if Zephyr is enabled |
 | `All Flags Off Demo Functional Tests` | `demo` | `DemoTaggedFunctionalMode=RunAllFlagsOff` | `clearReports functionalOpalTagsAllFlagsOff`, then `createJiraExecutionFromFunctionalReport -PzephyrFunctionalStage=runAllFlagsOff` if Zephyr is enabled |
 
-The demo R1A stage is intentionally limited to `@R1A` scenarios. It does not run the
-full backend functional suite.
+The demo tagged stages are intentionally limited to their selected tags. They do not run the
+full backend functional suite. `RunR1AAndR1BDrop1Only` runs `@R1A` and `@R1BDrop1`;
+`RunR1AAndR1BDropsOnly` runs `@R1A`, `@R1BDrop1`, and `@R1BDrop2`; `RunR1BOffOnly`
+runs only `@R1BOff`.
 
 Nightly reports and artifacts:
 
@@ -296,14 +303,20 @@ Nightly reports and artifacts:
 - Staging functional publishes `Serenity Functional Test Report`.
 - Staging smoke publishes `Serenity Smoke Test Report`.
 - Demo R1A publishes `Serenity Functional Test Report (Demo R1AOn Only)`.
-- Demo R1A and R1B publishes `Serenity Functional Test Report (Demo R1A and R1B)`.
+- Demo R1A and R1B Drop 1 publishes `Serenity Functional Test Report (Demo R1A and R1B Drop 1)`.
+- Demo R1A and R1B Drops publishes `Serenity Functional Test Report (Demo R1A and R1B Drops)`.
+- Demo R1B Off publishes `Serenity Functional Test Report (Demo R1B Off)`.
 - Demo all-flags-off publishes `Serenity Functional Test Report (Demo All Flags Off)`.
 - Generic local tagged demo Gradle runs package to `functional-output-demo`; the generic local demo Serenity HTML report is under `functional-output-demo/report`.
 - Local `functionalOpalTagsR1AOnly` packages to `functional-output-r1a-only-demo`; the local demo Serenity HTML report is under `functional-output-r1a-only-demo/report`.
+- Local `functionalOpalTagsR1AAndR1BDrop1Only` packages to `functional-output-r1a-r1b-drop1-only-demo`; the local demo Serenity HTML report is under `functional-output-r1a-r1b-drop1-only-demo/report`.
 - Local `functionalOpalTagsR1AAndR1BOnly` packages to `functional-output-r1a-r1b-only-demo`; the local demo Serenity HTML report is under `functional-output-r1a-r1b-only-demo/report`.
+- Local `functionalOpalTagsR1BOffOnly` packages to `functional-output-r1b-off-only-demo`; the local demo Serenity HTML report is under `functional-output-r1b-off-only-demo/report`.
 - Local `functionalOpalTagsAllFlagsOff` packages to `functional-output-all-flags-off-demo`; the local demo Serenity HTML report is under `functional-output-all-flags-off-demo/report`.
 - Nightly `DemoTaggedFunctionalMode=RunR1AOnly` archives to `functional-output-r1a-only-demo`; the nightly demo Serenity HTML report is under `functional-output-r1a-only-demo/report`.
-- Nightly `DemoTaggedFunctionalMode=RunR1AAndR1BOnly` archives to `functional-output-r1a-r1b-only-demo`; the nightly demo Serenity HTML report is under `functional-output-r1a-r1b-only-demo/report`.
+- Nightly `DemoTaggedFunctionalMode=RunR1AAndR1BDrop1Only` archives to `functional-output-r1a-r1b-drop1-only-demo`; the nightly demo Serenity HTML report is under `functional-output-r1a-r1b-drop1-only-demo/report`.
+- Nightly `DemoTaggedFunctionalMode=RunR1AAndR1BDropsOnly` archives to `functional-output-r1a-r1b-only-demo`; the nightly demo Serenity HTML report is under `functional-output-r1a-r1b-only-demo/report`.
+- Nightly `DemoTaggedFunctionalMode=RunR1BOffOnly` archives to `functional-output-r1b-off-only-demo`; the nightly demo Serenity HTML report is under `functional-output-r1b-off-only-demo/report`.
 - Nightly `DemoTaggedFunctionalMode=RunAllFlagsOff` archives to `functional-output-all-flags-off-demo`; the nightly demo Serenity HTML report is under `functional-output-all-flags-off-demo/report`.
 - Staging functional archives to `functional-output`, integration to `integration-output`, and smoke to `smoke-output`.
 - Functional and smoke outputs are published from `*/report` with Zephyr payloads under `*/zephyr`. Integration publishes `integration-output/report` and archives `integration-output/zephyr` when the integration Zephyr JSON is generated.
@@ -312,8 +325,8 @@ Nightly reports and artifacts:
 Failure handling:
 
 - A Gradle stage failure marks the nightly build `FAILURE`.
-- JUnit-reported test failures for integration, functional, smoke, demo R1A, demo R1A-and-R1B, and demo all-flags-off are promoted from `UNSTABLE` to `FAILURE`.
-- The demo R1A, demo R1A-and-R1B, and all-flags-off stages publish to separate artifact directories so later demo-tagged runs cannot overwrite earlier ones.
+- JUnit-reported test failures for integration, functional, smoke, demo R1A, demo R1A-and-R1B-drop-1, demo R1A-and-R1B-drops, demo R1B-off, and demo all-flags-off are promoted from `UNSTABLE` to `FAILURE`.
+- The demo R1A, demo R1A-and-R1B-drop-1, demo R1A-and-R1B-drops, R1B-off, and all-flags-off stages publish to separate artifact directories so later demo-tagged runs cannot overwrite earlier ones.
 
 ### CNP Jenkins pipeline
 
@@ -358,7 +371,9 @@ Local report paths:
 | `functional` | `-PzephyrFunctionalStage=functional createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal.json` | `functional-output/zephyr/cucumber-opal.json` |
 | `smoke` | `-PzephyrFunctionalStage=smoke createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-smoke.json` | `smoke-output/zephyr/cucumber-smoke.json` |
 | `runR1AOnly` | `./gradlew functionalOpalTagsR1AOnly` then `-PzephyrFunctionalStage=runR1AOnly createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal-tags.json` | `functional-output-r1a-only-demo/zephyr/cucumber-opal-tags.json` |
+| `runR1AAndR1BDrop1Only` | `./gradlew functionalOpalTagsR1AAndR1BDrop1Only` then `-PzephyrFunctionalStage=runR1AAndR1BDrop1Only createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal-tags.json` | `functional-output-r1a-r1b-drop1-only-demo/zephyr/cucumber-opal-tags.json` |
 | `runR1AAndR1BOnly` | `./gradlew functionalOpalTagsR1AAndR1BOnly` then `-PzephyrFunctionalStage=runR1AAndR1BOnly createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal-tags.json` | `functional-output-r1a-r1b-only-demo/zephyr/cucumber-opal-tags.json` |
+| `runR1BOffOnly` | `./gradlew functionalOpalTagsR1BOffOnly` then `-PzephyrFunctionalStage=runR1BOffOnly createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal-tags.json` | `functional-output-r1b-off-only-demo/zephyr/cucumber-opal-tags.json` |
 | `runAllFlagsOff` | `./gradlew functionalOpalTagsAllFlagsOff` then `-PzephyrFunctionalStage=runAllFlagsOff createJiraExecutionFromFunctionalReport` | `target/zephyr-reports/cucumber-opal-tags.json` | `functional-output-all-flags-off-demo/zephyr/cucumber-opal-tags.json` |
 
 Examples:
@@ -407,10 +422,20 @@ export OPAL_LOGGING_SERVICE_API_URL=https://opal-logging-service.demo.platform.h
 ./gradlew functionalOpalTagsR1AOnly
 ./gradlew -PzephyrFunctionalStage=runR1AOnly createJiraExecutionFromFunctionalReport
 
+./gradlew functionalOpalTagsR1AAndR1BDrop1Only
+./gradlew -PzephyrFunctionalStage=runR1AAndR1BDrop1Only createJiraTicketsFromFunctionalReport
+./gradlew -PzephyrFunctionalStage=runR1AAndR1BDrop1Only updateJiraTicketsFromFunctionalReport
+./gradlew -PzephyrFunctionalStage=runR1AAndR1BDrop1Only createJiraExecutionFromFunctionalReport
+
 ./gradlew functionalOpalTagsR1AAndR1BOnly
 ./gradlew -PzephyrFunctionalStage=runR1AAndR1BOnly createJiraTicketsFromFunctionalReport
 ./gradlew -PzephyrFunctionalStage=runR1AAndR1BOnly updateJiraTicketsFromFunctionalReport
 ./gradlew -PzephyrFunctionalStage=runR1AAndR1BOnly createJiraExecutionFromFunctionalReport
+
+./gradlew functionalOpalTagsR1BOffOnly
+./gradlew -PzephyrFunctionalStage=runR1BOffOnly createJiraTicketsFromFunctionalReport
+./gradlew -PzephyrFunctionalStage=runR1BOffOnly updateJiraTicketsFromFunctionalReport
+./gradlew -PzephyrFunctionalStage=runR1BOffOnly createJiraExecutionFromFunctionalReport
 
 ./gradlew functionalOpalTagsAllFlagsOff
 ./gradlew -PzephyrFunctionalStage=runAllFlagsOff createJiraTicketsFromFunctionalReport
@@ -424,9 +449,9 @@ Use the task that matches the populated raw JSON source above.
 
 | Task | Purpose |
 | --- | --- |
-| `createJiraTicketsFromFunctionalReport` | Creates and links Jira test tickets from the selected functional-family Zephyr report. Requires `-PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AAndR1BOnly|runAllFlagsOff`. |
-| `updateJiraTicketsFromFunctionalReport` | Updates Jira test tickets from the selected functional-family Zephyr report. Requires `-PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AAndR1BOnly|runAllFlagsOff`. |
-| `createJiraExecutionFromFunctionalReport` | Creates a Zephyr execution from the selected functional-family Zephyr report. Requires `-PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AAndR1BOnly|runAllFlagsOff`. |
+| `createJiraTicketsFromFunctionalReport` | Creates and links Jira test tickets from the selected functional-family Zephyr report. Requires `-PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AAndR1BDrop1Only|runR1AAndR1BOnly|runR1BOffOnly|runAllFlagsOff`. |
+| `updateJiraTicketsFromFunctionalReport` | Updates Jira test tickets from the selected functional-family Zephyr report. Requires `-PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AAndR1BDrop1Only|runR1AAndR1BOnly|runR1BOffOnly|runAllFlagsOff`. |
+| `createJiraExecutionFromFunctionalReport` | Creates a Zephyr execution from the selected functional-family Zephyr report. Requires `-PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AAndR1BDrop1Only|runR1AAndR1BOnly|runR1BOffOnly|runAllFlagsOff`. |
 | `createJiraTicketsFromIntegrationReport` | Creates and links Jira test tickets from `integration-output/zephyr/Junit5Report-IntegrationTest.json`. |
 | `updateJiraTicketsFromIntegrationReport` | Updates Jira test tickets from `integration-output/zephyr/Junit5Report-IntegrationTest.json`. |
 | `createJiraExecutionFromIntegrationReport` | Creates a Zephyr execution from `integration-output/zephyr/Junit5Report-IntegrationTest.json`. |

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import org.flywaydb.gradle.task.FlywayMigrateTask
+import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 import java.util.concurrent.TimeUnit
 import groovy.io.FileType
 
@@ -314,7 +315,7 @@ dir.eachFileRecurse(FileType.FILES) { file ->
 }
 feignClientList.each {
   def apiName = it.getName().replace(".yaml", "")
-  tasks.register('openApiGenerateFeignClients'+apiName, org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {
+  tasks.register("openApiGenerateFeignClients${apiName}".toString(), GenerateTask) {
     generatorName = 'spring'
     library = 'spring-cloud'
     inputSpec = "$rootDir/src/main/resources/openapi/hmrc/".toString() + "${apiName}.yaml"
@@ -551,8 +552,30 @@ tasks.register('functionalOpalTagsR1AOnly', Test) {
   finalizedBy 'copyR1AOnlyDemoCucumberJson', 'mergeFunctionalOpalTagsR1AOnlyResults', 'aggregate', 'copyR1AOnlyDemoFunctionalReport'
 }
 
+tasks.register('functionalOpalTagsR1AAndR1BDrop1Only', Test) {
+  description = "Runs the demo R1A-and-R1B-drop-1-only tagged Opal functional tests"
+  group = "Verification"
+  testClassesDirs = sourceSets.functionalTest.output.classesDirs
+  classpath = sourceSets.functionalTest.runtimeClasspath
+  outputs.upToDateWhen { false }
+  reports.junitXml.getOutputLocation().set(layout.buildDirectory.dir("test-results/functional/opal-tags-r1a-r1b-drop1-only"))
+  testLogging.showStandardStreams = true
+  environment("IS_LEGACY_MODE", "false")
+  systemProperty 'cucumber.plugin',
+    "net.serenitybdd.cucumber.core.plugin.SerenityReporterParallel,pretty,json:${rootDir}/target/zephyr-reports/cucumber-opal-tags.json,timeline:${rootDir}/target/test-results/timeline"
+
+  include '**/OpalTaggedTestRunner.class'
+
+  doFirst {
+    systemProperty 'cucumber.filter.tags', '(@R1A or @R1BDrop1) and not @Ignore'
+  }
+
+  finalizedBy 'copyR1AAndR1BDrop1DemoCucumberJson', 'mergeFunctionalOpalTagsR1AAndR1BDrop1OnlyResults',
+    'aggregate', 'copyR1AAndR1BDrop1DemoFunctionalReport'
+}
+
 tasks.register('functionalOpalTagsR1AAndR1BOnly', Test) {
-  description = "Runs the demo R1A-and-R1B-only tagged Opal functional tests"
+  description = "Runs the demo R1A-and-R1B-drop-only tagged Opal functional tests"
   group = "Verification"
   testClassesDirs = sourceSets.functionalTest.output.classesDirs
   classpath = sourceSets.functionalTest.runtimeClasspath
@@ -566,10 +589,32 @@ tasks.register('functionalOpalTagsR1AAndR1BOnly', Test) {
   include '**/OpalTaggedTestRunner.class'
 
   doFirst {
-    systemProperty 'cucumber.filter.tags', '(@R1A or @R1B) and not @Ignore'
+    systemProperty 'cucumber.filter.tags', '(@R1A or @R1BDrop1 or @R1BDrop2) and not @Ignore'
   }
 
   finalizedBy 'copyR1AAndR1BDemoCucumberJson', 'mergeFunctionalOpalTagsR1AAndR1BOnlyResults', 'aggregate', 'copyR1AAndR1BDemoFunctionalReport'
+}
+
+tasks.register('functionalOpalTagsR1BOffOnly', Test) {
+  description = "Runs the demo R1B-off-only tagged Opal functional tests"
+  group = "Verification"
+  testClassesDirs = sourceSets.functionalTest.output.classesDirs
+  classpath = sourceSets.functionalTest.runtimeClasspath
+  outputs.upToDateWhen { false }
+  reports.junitXml.getOutputLocation().set(layout.buildDirectory.dir("test-results/functional/opal-tags-r1b-off-only"))
+  testLogging.showStandardStreams = true
+  environment("IS_LEGACY_MODE", "false")
+  systemProperty 'cucumber.plugin',
+    "net.serenitybdd.cucumber.core.plugin.SerenityReporterParallel,pretty,json:${rootDir}/target/zephyr-reports/cucumber-opal-tags.json,timeline:${rootDir}/target/test-results/timeline"
+
+  include '**/OpalTaggedTestRunner.class'
+
+  doFirst {
+    systemProperty 'cucumber.filter.tags', '@R1BOff and not @Ignore'
+  }
+
+  finalizedBy 'copyR1BOffDemoCucumberJson', 'mergeFunctionalOpalTagsR1BOffOnlyResults',
+    'aggregate', 'copyR1BOffDemoFunctionalReport'
 }
 
 tasks.register('functionalOpalTagsAllFlagsOff', Test) {
@@ -606,9 +651,21 @@ tasks.register('copyR1AOnlyDemoCucumberJson', Copy) {
   outputs.upToDateWhen { false }
 }
 
+tasks.register('copyR1AAndR1BDrop1DemoCucumberJson', Copy) {
+  from("${rootDir}/target/zephyr-reports/cucumber-opal-tags.json")
+  into("${rootDir}/functional-output-r1a-r1b-drop1-only-demo/zephyr")
+  outputs.upToDateWhen { false }
+}
+
 tasks.register('copyR1AAndR1BDemoCucumberJson', Copy) {
   from("${rootDir}/target/zephyr-reports/cucumber-opal-tags.json")
   into("${rootDir}/functional-output-r1a-r1b-only-demo/zephyr")
+  outputs.upToDateWhen { false }
+}
+
+tasks.register('copyR1BOffDemoCucumberJson', Copy) {
+  from("${rootDir}/target/zephyr-reports/cucumber-opal-tags.json")
+  into("${rootDir}/functional-output-r1b-off-only-demo/zephyr")
   outputs.upToDateWhen { false }
 }
 
@@ -666,12 +723,33 @@ tasks.register('copyR1AOnlyDemoFunctionalReport', Copy) {
   }
 }
 
+tasks.register('copyR1AAndR1BDrop1DemoFunctionalReport', Copy) {
+  dependsOn 'aggregate'
+  from("${rootDir}/target/site/serenity")
+  into("${rootDir}/functional-output-r1a-r1b-drop1-only-demo/report")
+  doLast {
+    logPublishedHtmlReport(
+      "Demo R1A and R1B Drop 1 Functional Test Report",
+      "${rootDir}/functional-output-r1a-r1b-drop1-only-demo/report"
+    )
+  }
+}
+
 tasks.register('copyR1AAndR1BDemoFunctionalReport', Copy) {
   dependsOn 'aggregate'
   from("${rootDir}/target/site/serenity")
   into("${rootDir}/functional-output-r1a-r1b-only-demo/report")
   doLast {
-    logPublishedHtmlReport("Demo R1A and R1B Functional Test Report", "${rootDir}/functional-output-r1a-r1b-only-demo/report")
+    logPublishedHtmlReport("Demo R1A and R1B Drops Functional Test Report", "${rootDir}/functional-output-r1a-r1b-only-demo/report")
+  }
+}
+
+tasks.register('copyR1BOffDemoFunctionalReport', Copy) {
+  dependsOn 'aggregate'
+  from("${rootDir}/target/site/serenity")
+  into("${rootDir}/functional-output-r1b-off-only-demo/report")
+  doLast {
+    logPublishedHtmlReport("Demo R1B Off Functional Test Report", "${rootDir}/functional-output-r1b-off-only-demo/report")
   }
 }
 
@@ -716,12 +794,32 @@ tasks.register('syncR1AOnlyTaggedFunctionalArtifactsFromExistingResults') {
     )
   }
 }
+tasks.register('syncR1AAndR1BDrop1TaggedFunctionalArtifactsFromExistingResults') {
+  doLast {
+    syncFunctionalArtifacts(
+      'Demo R1A and R1B Drop 1 Functional Test Report',
+      "${rootDir}/functional-output-r1a-r1b-drop1-only-demo/report",
+      "${rootDir}/functional-output-r1a-r1b-drop1-only-demo",
+      'cucumber-opal-tags.json'
+    )
+  }
+}
 tasks.register('syncR1AAndR1BTaggedFunctionalArtifactsFromExistingResults') {
   doLast {
     syncFunctionalArtifacts(
-      'Demo R1A and R1B Functional Test Report',
+      'Demo R1A and R1B Drops Functional Test Report',
       "${rootDir}/functional-output-r1a-r1b-only-demo/report",
       "${rootDir}/functional-output-r1a-r1b-only-demo",
+      'cucumber-opal-tags.json'
+    )
+  }
+}
+tasks.register('syncR1BOffTaggedFunctionalArtifactsFromExistingResults') {
+  doLast {
+    syncFunctionalArtifacts(
+      'Demo R1B Off Functional Test Report',
+      "${rootDir}/functional-output-r1b-off-only-demo/report",
+      "${rootDir}/functional-output-r1b-off-only-demo",
       'cucumber-opal-tags.json'
     )
   }
@@ -779,8 +877,18 @@ tasks.register('mergeFunctionalOpalTagsR1AOnlyResults', Copy) {
   into layout.buildDirectory.dir("test-results/functional")
   include '*.xml'
 }
+tasks.register('mergeFunctionalOpalTagsR1AAndR1BDrop1OnlyResults', Copy) {
+  from layout.buildDirectory.dir("test-results/functional/opal-tags-r1a-r1b-drop1-only")
+  into layout.buildDirectory.dir("test-results/functional")
+  include '*.xml'
+}
 tasks.register('mergeFunctionalOpalTagsR1AAndR1BOnlyResults', Copy) {
   from layout.buildDirectory.dir("test-results/functional/opal-tags-r1a-r1b-only")
+  into layout.buildDirectory.dir("test-results/functional")
+  include '*.xml'
+}
+tasks.register('mergeFunctionalOpalTagsR1BOffOnlyResults', Copy) {
+  from layout.buildDirectory.dir("test-results/functional/opal-tags-r1b-off-only")
   into layout.buildDirectory.dir("test-results/functional")
   include '*.xml'
 }
@@ -876,21 +984,27 @@ tasks.named('aggregate') {
     tasks.named('functionalLegacy'),
     tasks.named('functionalOpalTags'),
     tasks.named('functionalOpalTagsR1AOnly'),
+    tasks.named('functionalOpalTagsR1AAndR1BDrop1Only'),
     tasks.named('functionalOpalTagsR1AAndR1BOnly'),
+    tasks.named('functionalOpalTagsR1BOffOnly'),
     tasks.named('functionalOpalTagsAllFlagsOff'),
     tasks.named('smokeOpal'),
     tasks.named('mergeFunctionalResults'),
     tasks.named('mergeFunctionalWithTagsResults'),
     tasks.named('mergeFunctionalOpalTagsResults'),
     tasks.named('mergeFunctionalOpalTagsR1AOnlyResults'),
+    tasks.named('mergeFunctionalOpalTagsR1AAndR1BDrop1OnlyResults'),
     tasks.named('mergeFunctionalOpalTagsR1AAndR1BOnlyResults'),
+    tasks.named('mergeFunctionalOpalTagsR1BOffOnlyResults'),
     tasks.named('mergeFunctionalOpalTagsAllFlagsOffResults')
   )
 }
 
 tasks.configureEach {
   if (name in ['copyFunctionalReport', 'copyDemoFunctionalReport', 'copyR1AOnlyDemoFunctionalReport',
+               'copyR1AAndR1BDrop1DemoFunctionalReport',
                'copyR1AAndR1BDemoFunctionalReport',
+               'copyR1BOffDemoFunctionalReport',
                'copyAllFlagsOffDemoFunctionalReport', 'copySmokeReport']) {
     mustRunAfter tasks.named('aggregate')
   } else if (name == 'copyOpalCucumberJson') {
@@ -899,8 +1013,12 @@ tasks.configureEach {
     mustRunAfter tasks.named('functionalOpalTags')
   } else if (name == 'copyR1AOnlyDemoCucumberJson') {
     mustRunAfter tasks.named('functionalOpalTagsR1AOnly')
+  } else if (name == 'copyR1AAndR1BDrop1DemoCucumberJson') {
+    mustRunAfter tasks.named('functionalOpalTagsR1AAndR1BDrop1Only')
   } else if (name == 'copyR1AAndR1BDemoCucumberJson') {
     mustRunAfter tasks.named('functionalOpalTagsR1AAndR1BOnly')
+  } else if (name == 'copyR1BOffDemoCucumberJson') {
+    mustRunAfter tasks.named('functionalOpalTagsR1BOffOnly')
   } else if (name == 'copyAllFlagsOffDemoCucumberJson') {
     mustRunAfter tasks.named('functionalOpalTagsAllFlagsOff')
   } else if (name == 'copyLegacyCucumberJson') {
@@ -1200,7 +1318,7 @@ checkstyle {
 tasks.register('migratePostgresDatabase', FlywayMigrateTask) {
   baselineOnMigrate = true
   def taskUrl = providers.gradleProperty("dburl")
-      .map { dbUrl -> "jdbc:postgresql://${dbUrl}" }
+      .map { dbUrl -> "jdbc:postgresql://${dbUrl}".toString() }
       .orElse(providers.environmentVariable("FLYWAY_URL"))
       .orNull
   if (taskUrl) {

--- a/gradle/zephyr.gradle
+++ b/gradle/zephyr.gradle
@@ -42,10 +42,20 @@ Map<String, Map<String, Object>> functionalZephyrTargets = [
                 testFolder: "functionalTest/resources",
                 syncTask  : "syncR1AOnlyTaggedFunctionalArtifactsFromExistingResults",
         ],
+        runR1AAndR1BDrop1Only: [
+                reportPath: "functional-output-r1a-r1b-drop1-only-demo/zephyr/cucumber-opal-tags.json",
+                testFolder: "functionalTest/resources",
+                syncTask  : "syncR1AAndR1BDrop1TaggedFunctionalArtifactsFromExistingResults",
+        ],
         runR1AAndR1BOnly: [
                 reportPath: "functional-output-r1a-r1b-only-demo/zephyr/cucumber-opal-tags.json",
                 testFolder: "functionalTest/resources",
                 syncTask  : "syncR1AAndR1BTaggedFunctionalArtifactsFromExistingResults",
+        ],
+        runR1BOffOnly: [
+                reportPath: "functional-output-r1b-off-only-demo/zephyr/cucumber-opal-tags.json",
+                testFolder: "functionalTest/resources",
+                syncTask  : "syncR1BOffTaggedFunctionalArtifactsFromExistingResults",
         ],
         runAllFlagsOff: [
                 reportPath: "functional-output-all-flags-off-demo/zephyr/cucumber-opal-tags.json",
@@ -161,17 +171,17 @@ void configureReleaseIntegrationZephyrTask(JavaExec task, String release, String
 
 tasks.register('createJiraTicketsFromFunctionalReport', JavaExec) { JavaExec task ->
     configureFunctionalZephyrTask(task, "CREATE_TICKETS",
-            "Creates and links Jira tickets from the selected functional-family Zephyr report. Requires -PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AAndR1BOnly|runAllFlagsOff")
+            "Creates and links Jira tickets from the selected functional-family Zephyr report. Requires -PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AAndR1BDrop1Only|runR1AAndR1BOnly|runR1BOffOnly|runAllFlagsOff")
 }
 
 tasks.register('updateJiraTicketsFromFunctionalReport', JavaExec) { JavaExec task ->
     configureFunctionalZephyrTask(task, "UPDATE_TICKETS",
-            "Updates Jira tickets from the selected functional-family Zephyr report. Requires -PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AAndR1BOnly|runAllFlagsOff")
+            "Updates Jira tickets from the selected functional-family Zephyr report. Requires -PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AAndR1BDrop1Only|runR1AAndR1BOnly|runR1BOffOnly|runAllFlagsOff")
 }
 
 tasks.register('createJiraExecutionFromFunctionalReport', JavaExec) { JavaExec task ->
     configureFunctionalZephyrTask(task, "CREATE_EXECUTION",
-            "Creates a Zephyr execution from the selected functional-family Zephyr report. Requires -PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AAndR1BOnly|runAllFlagsOff")
+            "Creates a Zephyr execution from the selected functional-family Zephyr report. Requires -PzephyrFunctionalStage=functional|smoke|runR1AOnly|runR1AAndR1BDrop1Only|runR1AAndR1BOnly|runR1BOffOnly|runAllFlagsOff")
 }
 
 tasks.register('createJiraTicketsFromIntegrationReport', JavaExec) { JavaExec task ->

--- a/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountConsolidatedAccounts.feature
+++ b/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountConsolidatedAccounts.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:account-enquiry @R1B
+@Opal @JIRA-LABEL:account-enquiry @R1BDrop1
 Feature: Defendant Account Consolidated Accounts
 
   # NOTE: Blocked until Consolidation 2 can create or seed real consolidated-account data

--- a/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountEnforcements.feature
+++ b/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountEnforcements.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:account-enquiry @R1B
+@Opal @JIRA-LABEL:account-enquiry @R1BDrop1
 Feature: Defendant Account Enforcement Overrides
 
   @cleanUpData @JIRA-STORY:PO-1854 @JIRA-EPIC:PO-1675 @JIRA-TEST-KEY:PO-5620

--- a/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountHeaderSummary.feature
+++ b/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountHeaderSummary.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:account-enquiry @R1B
+@Opal @JIRA-LABEL:account-enquiry @R1BDrop1
 Feature: Defendant Account Header Summary
 
   @cleanUpData @JIRA-STORY:PO-2969 @JIRA-EPIC:PO-2630

--- a/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountHistory.feature
+++ b/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountHistory.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:account-enquiry @R1B
+@Opal @JIRA-LABEL:account-enquiry @R1BDrop1
 Feature: Defendant Account History
 
   @cleanUpData @JIRA-STORY:PO-2622 @JIRA-EPIC:PO-2621 @JIRA-TEST-KEY:PO-8660

--- a/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountSearchFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountSearchFeatureToggles.feature
@@ -10,20 +10,20 @@ Feature: Defendant Account Search Feature Toggles
     Then the request is rejected with status 404
     And the response reports that the feature is disabled
 
-  @R1B @R1COff @R1CWriteOffOff @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
+  @R1BDrop1 @R1COff @R1CWriteOffOff @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
   Scenario: Basic search remains available when release 1c write-off is disabled
     Given a searchable defendant account exists for feature-toggle search
     When I search the created defendant account without consolidation
     Then the basic defendant account search returns the created account
 
-  @R1B @R1COff @R1CWriteOffOff @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
+  @R1BDrop1 @R1COff @R1CWriteOffOff @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685
   Scenario: Consolidated search is unavailable when release 1c write-off is disabled
     Given a searchable defendant account exists for feature-toggle search
     When I search the created defendant account with consolidation
     Then the request is rejected with status 404
     And the response reports that the feature is disabled
 
-  @R1B @R1COff @R1CWriteOff @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685 @JIRA-TEST-KEY:PO-9540
+  @R1BDrop1 @R1COff @R1CWriteOff @JIRA-STORY:PO-3768 @JIRA-EPIC:PO-3685 @JIRA-TEST-KEY:PO-9540
   Scenario: Consolidated search is available when release 1c write-off is enabled
     Given a searchable defendant account exists for feature-toggle search
     When I search the created defendant account with consolidation

--- a/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountSearchRestrictions.feature
+++ b/src/functionalTest/resources/features/opalMode/defendantAccounts/DefendantAccountSearchRestrictions.feature
@@ -1,4 +1,4 @@
-@Opal @R1B @JIRA-LABEL:account-enquiry @JIRA-EPIC:PO-2630 @JIRA-STORY:PO-2970
+@Opal @R1BDrop1 @JIRA-LABEL:account-enquiry @JIRA-EPIC:PO-2630 @JIRA-STORY:PO-2970
 Feature: Defendant Account Search API restrictions
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1bFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/featureToggles/FinesServiceRelease1bFeatureToggles.feature
@@ -102,7 +102,7 @@ Feature: Fines Service Release 1b Feature Toggles
       | endpoint                                   |
       | Get Mappings                               |
 
-  @R1B @JIRA-STORY:PO-2077 @JIRA-EPIC:PO-979 @JIRA-TEST-KEY:PO-9541
+  @R1BDrop1 @JIRA-STORY:PO-2077 @JIRA-EPIC:PO-979 @JIRA-TEST-KEY:PO-9541
   Scenario: Get Defendant Account Impositions is available when release 1b is enabled
     When I call the release 1b gated endpoint "Get Defendant Account Impositions"
     Then the request is rejected as not found

--- a/src/functionalTest/resources/features/opalMode/majorCreditorAccounts/MajorCreditorAccountHeaderSummary.feature
+++ b/src/functionalTest/resources/features/opalMode/majorCreditorAccounts/MajorCreditorAccountHeaderSummary.feature
@@ -1,4 +1,4 @@
-@Opal @JIRA-LABEL:account-enquiry @R1B
+@Opal @JIRA-LABEL:account-enquiry @R1BDrop2
 Feature: Major Creditor Account Header Summary
 
   @JIRA-STORY:PO-2136 @JIRA-EPIC:PO-1286 @JIRA-TEST-KEY:PO-8039

--- a/src/functionalTest/resources/features/opalMode/minorCreditorAccounts/MinorCreditorAccountHistory.feature
+++ b/src/functionalTest/resources/features/opalMode/minorCreditorAccounts/MinorCreditorAccountHistory.feature
@@ -1,4 +1,4 @@
-@Opal @R1B @JIRA-LABEL:account-enquiry @MinorCreditorHistory
+@Opal @R1BDrop2 @JIRA-LABEL:account-enquiry @MinorCreditorHistory
 Feature: Minor Creditor Account History
 
   @cleanUpData @JIRA-STORY:PO-2642 @JIRA-EPIC:PO-2653 @JIRA-TEST-KEY:PO-9546

--- a/src/functionalTest/resources/features/opalMode/minorCreditorAccounts/MinorCreditorAccountSearchRestrictions.feature
+++ b/src/functionalTest/resources/features/opalMode/minorCreditorAccounts/MinorCreditorAccountSearchRestrictions.feature
@@ -1,4 +1,4 @@
-@Opal @R1B @JIRA-LABEL:account-enquiry @JIRA-EPIC:PO-2630 @JIRA-STORY:PO-2971 @MinorCreditorSearch
+@Opal @R1BDrop2 @JIRA-LABEL:account-enquiry @JIRA-EPIC:PO-2630 @JIRA-STORY:PO-2971 @MinorCreditorSearch
 Feature: Minor Creditor Account Search API restrictions
 
   Background:

--- a/src/functionalTest/resources/features/opalMode/referenceData/Mappings.feature
+++ b/src/functionalTest/resources/features/opalMode/referenceData/Mappings.feature
@@ -4,27 +4,27 @@ Feature: Mappings Reference Data
   Background:
     Given I am testing as the "opal-test@dev.platform.hmcts.net" user
 
-  @JIRA-STORY:PO-3871 @JIRA-EPIC:PO-3372 @R1B @JIRA-TEST-KEY:PO-9551
+  @JIRA-STORY:PO-3871 @JIRA-EPIC:PO-3372 @R1BDrop1 @JIRA-TEST-KEY:PO-9551
   Scenario: A mappings request without a token is rejected
     When I call GET "/mappings/defendant-account-status" without a token
     Then the request is rejected as unauthorized
 
-  @JIRA-STORY:PO-3871 @JIRA-EPIC:PO-3372 @R1B @JIRA-TEST-KEY:PO-9552
+  @JIRA-STORY:PO-3871 @JIRA-EPIC:PO-3372 @R1BDrop1 @JIRA-TEST-KEY:PO-9552
   Scenario: A mappings request with an invalid token is rejected
     When I call GET "/mappings/defendant-account-status" with an invalid token
     Then the request is rejected as unauthorized
 
-  @JIRA-STORY:PO-3871 @JIRA-EPIC:PO-3372 @R1B @JIRA-TEST-KEY:PO-9553
+  @JIRA-STORY:PO-3871 @JIRA-EPIC:PO-3372 @R1BDrop1 @JIRA-TEST-KEY:PO-9553
   Scenario: Defendant account status mappings can be retrieved
     When I make a request to the mappings api for type "defendant-account-status"
     Then the defendant account status mappings are returned
 
-  @JIRA-STORY:PO-3871 @JIRA-EPIC:PO-3372 @R1B @JIRA-TEST-KEY:PO-9554
+  @JIRA-STORY:PO-3871 @JIRA-EPIC:PO-3372 @R1BDrop1 @JIRA-TEST-KEY:PO-9554
   Scenario: A mappings request with an unsupported type is rejected as bad request
     When I make a request to the mappings api for type "unsupported-type"
     Then the request is rejected as bad request
 
-  @JIRA-STORY:PO-3871 @JIRA-EPIC:PO-3372 @R1B @JIRA-TEST-KEY:PO-9555
+  @JIRA-STORY:PO-3871 @JIRA-EPIC:PO-3372 @R1BDrop1 @JIRA-TEST-KEY:PO-9555
   Scenario: A mappings request without a type is rejected as bad request
     When I make a request to the mappings api without a type
     Then the request is rejected as bad request

--- a/src/functionalTest/resources/features/opalMode/results/Results.feature
+++ b/src/functionalTest/resources/features/opalMode/results/Results.feature
@@ -60,19 +60,19 @@ Feature: Results Reference Data
       | imposition_creditor         |                                         |
       | imposition_allocation_order |                                         |
 
-  @JIRA-STORY:PO-6425 @JIRA-EPIC:PO-1674 @JIRA-TEST-KEY:PO-7869 @R1B
+  @JIRA-STORY:PO-6425 @JIRA-EPIC:PO-1674 @JIRA-TEST-KEY:PO-7869 @R1BDrop1
   Scenario: Result by ID includes employment data requirement flag
     When I request result with identifier "AEO"
     Then the result response contains
       | result_id                | AEO  |
       | requires_employment_data | true |
 
-  @JIRA-STORY:PO-8973 @JIRA-EPIC:PO-304 @R1B @JIRA-TEST-KEY:PO-10065
+  @JIRA-STORY:PO-8973 @JIRA-EPIC:PO-304 @R1BDrop1 @JIRA-TEST-KEY:PO-10065
   Scenario: Result by ID matches OpenAPI schema
     When I request result with identifier "SC"
     Then the result response matches the documented schema
 
-  @JIRA-STORY:PO-8973 @JIRA-EPIC:PO-304 @R1B @JIRA-TEST-KEY:PO-10066
+  @JIRA-STORY:PO-8973 @JIRA-EPIC:PO-304 @R1BDrop1 @JIRA-TEST-KEY:PO-10066
   Scenario: Result by ID maps response fields
     When I request result with identifier "SC"
     Then the result response contains
@@ -103,18 +103,18 @@ Feature: Results Reference Data
       | manual_enforcement            | true                                                          |
       | enf_next_permitted_actions    | CWN                                                           |
 
-  @JIRA-STORY:PO-8973 @JIRA-EPIC:PO-304 @R1B @JIRA-TEST-KEY:PO-10067
+  @JIRA-STORY:PO-8973 @JIRA-EPIC:PO-304 @R1BDrop1 @JIRA-TEST-KEY:PO-10067
   Scenario: Unknown result by ID returns not found
     When I request result with identifier "ZZZZZZ"
     Then the request is rejected as not found
 
-  @JIRA-STORY:PO-8973 @JIRA-EPIC:PO-2630 @R1B @JIRA-TEST-KEY:PO-10068
+  @JIRA-STORY:PO-8973 @JIRA-EPIC:PO-2630 @R1BDrop1 @JIRA-TEST-KEY:PO-10068
   Scenario: Result by ID omits Welsh parameters by default
     When I request result with identifier "SC"
     Then the result parameters do not contain the following entries
       | cy_paymentterms |
 
-  @JIRA-STORY:PO-2985 @JIRA-EPIC:PO-2630 @R1B @JIRA-TEST-KEY:PO-9560
+  @JIRA-STORY:PO-2985 @JIRA-EPIC:PO-2630 @R1BDrop1 @JIRA-TEST-KEY:PO-9560
   Scenario: Result by ID can include Welsh text result parameters
     When I request result with identifier "SC" including Welsh parameters
     Then the result parameters contain the following entries in order
@@ -122,7 +122,7 @@ Feature: Results Reference Data
       | paymentterms    | text-1000 | true               |                                           |
       | cy_paymentterms | text-1000 | true               | Provide a welsh version for the defendant |
 
-  @JIRA-STORY:PO-9108 @JIRA-EPIC:PO-2630 @R1B @JIRA-TEST-KEY:PO-9561
+  @JIRA-STORY:PO-9108 @JIRA-EPIC:PO-2630 @R1BDrop1 @JIRA-TEST-KEY:PO-9561
   Scenario: Result by ID can include Welsh date result parameters
     When I request result with identifier "CLAMPO" including Welsh parameters
     Then the result parameters contain the following entries in order
@@ -130,12 +130,12 @@ Feature: Results Reference Data
       | effectivedate    | date | true               |                                           |
       | cy_effectivedate | date | true               | Provide a welsh version for the defendant |
 
-  @JIRA-STORY:PO-3765 @Ignore @R1B
+  @JIRA-STORY:PO-3765 @Ignore @R1BDrop1
   Scenario: Result filtering is available when release-1b is enabled
     When I request results for identifiers "NBWT,NAP" using filter "enforcement_override" with value "true"
     Then 1 results are returned
 
-  @JIRA-STORY:PO-3765 @Ignore @R1B
+  @JIRA-STORY:PO-3765 @Ignore @R1BDrop1
   Scenario: Result filtering is rejected when release-1b is disabled
     When I request results using filter "active" with value "true"
     Then the response status code is 404

--- a/src/functionalTest/resources/features/opalMode/results/ResultsFeatureToggles.feature
+++ b/src/functionalTest/resources/features/opalMode/results/ResultsFeatureToggles.feature
@@ -44,7 +44,7 @@ Feature: Results Feature Toggles
     Then the request is rejected with status 404
     And the response reports that the feature is disabled
 
-  @R1B @JIRA-STORY:PO-3765 @JIRA-EPIC:PO-3685 @JIRA-TEST-KEY:PO-9562
+  @R1BDrop1 @JIRA-STORY:PO-3765 @JIRA-EPIC:PO-3685 @JIRA-TEST-KEY:PO-9562
   Scenario: Results filters are available when release 1b is enabled
     When I request results for identifiers "FO,FCOMP,ABDC" with the following filters
       | active                  | true  |


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PO-10493

### Change description ###

Retagged functional tests to r1bdrop1 and r1bdrop2
Updated nightly pipeline yaml and readme

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
